### PR TITLE
fix typo: resourse -> resource

### DIFF
--- a/docs/zookeeperAdmin.html
+++ b/docs/zookeeperAdmin.html
@@ -813,7 +813,7 @@ server.3=zoo3:2888:3888</pre>
 <a name="Single+Machine+Requirements"></a>
 <h4>Single Machine Requirements</h4>
 <p>If ZooKeeper has to contend with other applications for
-        access to resourses like storage media, CPU, network, or
+        access to resources like storage media, CPU, network, or
         memory, its performance will suffer markedly.  ZooKeeper has
         strong durability guarantees, which means it uses storage
         media to log changes before the operation responsible for the

--- a/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
@@ -386,7 +386,7 @@ server.3=zoo3:2888:3888</programlisting>
       <title>Single Machine Requirements</title>
 
       <para>If ZooKeeper has to contend with other applications for
-        access to resourses like storage media, CPU, network, or
+        access to resources like storage media, CPU, network, or
         memory, its performance will suffer markedly.  ZooKeeper has
         strong durability guarantees, which means it uses storage
         media to log changes before the operation responsible for the


### PR DESCRIPTION
It seems to be a trivial typo. Isn't it?
