### PR TITLE
Fixed package-script for chown-error

### DIFF
--- a/src/packages/deb/zookeeper.control/postrm
+++ b/src/packages/deb/zookeeper.control/postrm
@@ -15,5 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-/usr/sbin/userdel zookeeper 2> /dev/null >/dev/null
+case "$1" in
+    remove|purge)
+        /usr/sbin/userdel zookeeper 2> /dev/null >/dev/null
+        ;;
+esac
+
 exit 0

--- a/src/packages/deb/zookeeper.control/preinst
+++ b/src/packages/deb/zookeeper.control/preinst
@@ -17,4 +17,4 @@
 
 getent group hadoop 2>/dev/null >/dev/null || /usr/sbin/groupadd -r hadoop
 
-/usr/sbin/useradd --comment "ZooKeeper" --shell /bin/bash -M -r --groups hadoop --home /usr/share/zookeeper zookeeper 2> /dev/null || :
+/usr/sbin/useradd --comment "ZooKeeper" --shell /bin/bash -r --groups hadoop --home /usr/share/zookeeper zookeeper 2> /dev/null || :


### PR DESCRIPTION
When the package is installed, dpkg outputs "chown: invalid user: `zookeeper:hadoop'".
So fixed debian-package's install script(postrm and preinst).
