### PR TITLE
read all the stat info, even when it exceeds 2048 bytes.

### DIFF
--- a/src/contrib/monitoring/ganglia/zookeeper_ganglia.py
+++ b/src/contrib/monitoring/ganglia/zookeeper_ganglia.py
@@ -56,7 +56,12 @@ class ZooKeeperServer(object):
         s.connect(self._address)
         s.send(cmd)
 
-        data = s.recv(2048)
+        data = ""
+        newdata = s.recv(2048)
+        while newdata:
+            data += newdata
+            newdata = s.recv(2048)
+
         s.close()
 
         return data


### PR DESCRIPTION
More details in https://issues.apache.org/jira/browse/ZOOKEEPER-1826
