### PR TITLE
fix shebang for deb/init.d/zookeeper

### DIFF
--- a/src/packages/deb/init.d/zookeeper
+++ b/src/packages/deb/init.d/zookeeper
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
Without this (corrected) shebang, ZooKeeper will fail to start when installed via .deb packaging on Ubuntu because dash is invoked instead of bash and zkEnv.sh uses arrays which dash doesn't support.

Shout-out to satmd on freenode in #zookeeper for helping me troubleshoot.

Also a big -1 to relying on BigTop for packaging support.
