### PR TITLE
Removed redundant code for processing PING request

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/FinalRequestProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/FinalRequestProcessor.java
@@ -178,15 +178,8 @@ public class FinalRequestProcessor implements RequestProcessor {
             }
             switch (request.type) {
             case OpCode.ping: {
-                zks.serverStats().updateLatency(request.createTime);
-
                 lastOp = "PING";
-                cnxn.updateStatsForResponse(request.cxid, request.zxid, lastOp,
-                        request.createTime, System.currentTimeMillis());
-
-                cnxn.sendResponse(new ReplyHeader(-2,
-                        zks.getZKDatabase().getDataTreeLastProcessedZxid(), 0), null, "response");
-                return;
+                break;
             }
             case OpCode.createSession: {
                 zks.serverStats().updateLatency(request.createTime);


### PR DESCRIPTION
The code for processing the case of a PING request is redundant of the code following the switch statement. request.cxid = -2 in the case of a PING. 

The difference between `break`ing and `return`ing is that the timing and effective execution order of the following calls is changed to:

```
zks.getZKDatabase().getDataTreeLastProcessedZxid();
zks.serverStats().updateLatency(request.createTime);
cnxn.updateStatsForResponse(request.cxid, lastZxid, lastOp,
                    request.createTime, System.currentTimeMillis());
```

From the current effective execution order:

```
zks.serverStats().updateLatency(request.createTime);
cnxn.updateStatsForResponse(request.cxid, request.zxid, lastOp,
                    request.createTime, System.currentTimeMillis());
zks.getZKDatabase().getDataTreeLastProcessedZxid();
```
