### PR TITLE
ZOOKEEPER-2049. Fixed htonll conflict on OSX Yosemite.

### DIFF
--- a/src/c/configure.ac
+++ b/src/c/configure.ac
@@ -109,6 +109,26 @@ AM_CONDITIONAL([WANT_SYNCAPI],[test "x$with_syncapi" != xno])
 AC_HEADER_STDC
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdlib.h string.h sys/socket.h sys/time.h unistd.h sys/utsname.h])
 
+# Checks for htonll. This was borrowed from librabbitmq.
+AC_MSG_CHECKING([if htonll is defined])
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
+        #include <arpa/inet.h>
+     ]],
+     [[
+       return htonll(0);
+     ]]
+  )],
+  [
+    AC_MSG_RESULT(yes)
+    AC_DEFINE(HAVE_HTONLL, 1, [Define to 1 if the function (or macro) htonll exists.])
+  ],
+  [
+    AC_MSG_RESULT(no)
+  ]
+)
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 AC_C_INLINE

--- a/src/c/include/recordio.h
+++ b/src/c/include/recordio.h
@@ -19,7 +19,10 @@
 #define __RECORDIO_H__
 
 #include <sys/types.h>
-#ifdef WIN32
+#ifndef WIN32
+#include <arpa/inet.h>
+#include "config.h"
+#else
 #include "winconfig.h"
 #endif
 
@@ -70,7 +73,9 @@ void close_buffer_iarchive(struct iarchive **ia);
 char *get_buffer(struct oarchive *);
 int get_buffer_len(struct oarchive *);
 
+#ifndef HAVE_HTONLL
 int64_t htonll(int64_t v);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/c/src/recordio.c
+++ b/src/c/src/recordio.c
@@ -80,6 +80,7 @@ int oa_serialize_int(struct oarchive *oa, const char *tag, const int32_t *d)
     priv->off+=sizeof(i);
     return 0;
 }
+#ifndef HAVE_HTONLL
 int64_t htonll(int64_t v)
 {
     int i = 0;
@@ -95,6 +96,7 @@ int64_t htonll(int64_t v)
 
     return v;
 }
+#endif
 
 int oa_serialize_long(struct oarchive *oa, const char *tag, const int64_t *d)
 {


### PR DESCRIPTION
Fixes htonll conflict on OSX Yosemite by checking if arpa/inet.h declares it within the configuration phase.
