### PR TITLE
process crash when zookeeper_close in callback

### DIFF
--- a/src/c/src/mt_adaptor.c
+++ b/src/c/src/mt_adaptor.c
@@ -478,8 +478,8 @@ void *do_completion(void *v)
         pthread_mutex_unlock(&zh->completions_to_process.lock);
         process_completions(zh);
     }
-    api_epilog(zh, 0);    
     LOG_DEBUG(LOGCALLBACK(zh), "completion thread terminated");
+    api_epilog(zh, 0);    
     return 0;
 }
 


### PR DESCRIPTION
when call  zookeeper_close in watcher callback,  the completion thread will be detached. and then api_epilog  call zookeeper_close again, the zh is not avaailable when call LOG_DEBUG(LOGCALLBACK(zh), "completion thread terminated");
