### PR TITLE
Fixed the syntax error. Arguments were not properly quoted.

### DIFF
--- a/bin/zkEnv.cmd
+++ b/bin/zkEnv.cmd
@@ -39,10 +39,10 @@ if not defined JAVA_HOME (
   goto :eof
 )
 
-if not exist %JAVA_HOME%\bin\java.exe (
+if not exist "%JAVA_HOME%\bin\java.exe" (
   echo Error: JAVA_HOME is incorrectly set.
   goto :eof
 )
 
-set JAVA=%JAVA_HOME%\bin\java
+set JAVA="%JAVA_HOME%\bin\java"
 


### PR DESCRIPTION
The trunk doesn't run on Windows. Fixed the syntax errors in zkEnv.cmd.
