### PR TITLE
ZOOKEEPER-1846: Always recreate socket addresses for any DNS change.

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
@@ -198,10 +198,10 @@ public class Learner {
         // Find the leader by id
         Vote current = self.getCurrentVote();
         for (QuorumServer s : self.getView().values()) {
-            // ZOOKEEPER-1846: Always recreate socket addresses for any DNS change.
-            // This fix is also related to ZOOKEEPER-1506.
-            s.recreateSocketAddresses();
             if (s.id == current.getId()) {
+                // ZOOKEEPER-1846: Always recreate socket addresses for any DNS change.
+                // This fix is also related to ZOOKEEPER-1506.
+                s.recreateSocketAddresses();
                 addr = s.addr;
                 break;
             }

--- a/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
@@ -198,6 +198,9 @@ public class Learner {
         // Find the leader by id
         Vote current = self.getCurrentVote();
         for (QuorumServer s : self.getView().values()) {
+            // ZOOKEEPER-1846: Always recreate socket addresses for any DNS change.
+            // This fix is also related to ZOOKEEPER-1506.
+            s.recreateSocketAddresses();
             if (s.id == current.getId()) {
                 addr = s.addr;
                 break;


### PR DESCRIPTION
This pull is also related to ZOOKEEPER-1506. The fix allows DNS changes to be applied when ZooKeeper is running. ZOOKEEPER-1506 partially solves this issue, which has already been
applied to ZooKeeper 3.5.1 (RC3). This pull request allows ZOOKEEPER-1846 to be fixed as well.
