### PR TITLE
Redirecting cd stdout to dev/null in expansions to avoid CDPATH noise

### DIFF
--- a/bin/zkCleanup.sh
+++ b/bin/zkCleanup.sh
@@ -28,7 +28,7 @@
 # use POSTIX interface, symlink is followed automatically
 ZOOBIN="${BASH_SOURCE-$0}"
 ZOOBIN="$(dirname "${ZOOBIN}")"
-ZOOBINDIR="$(cd "${ZOOBIN}"; pwd)"
+ZOOBINDIR="$(cd "${ZOOBIN}" >/dev/null && pwd)"
 
 if [ -e "$ZOOBIN/../libexec/zkEnv.sh" ]; then
   . "$ZOOBINDIR"/../libexec/zkEnv.sh

--- a/bin/zkCli.sh
+++ b/bin/zkCli.sh
@@ -28,7 +28,7 @@
 # use POSTIX interface, symlink is followed automatically
 ZOOBIN="${BASH_SOURCE-$0}"
 ZOOBIN="$(dirname "${ZOOBIN}")"
-ZOOBINDIR="$(cd "${ZOOBIN}"; pwd)"
+ZOOBINDIR="$(cd "${ZOOBIN}" >/dev/null && pwd)"
 
 if [ -e "$ZOOBIN/../libexec/zkEnv.sh" ]; then
   . "$ZOOBINDIR"/../libexec/zkEnv.sh

--- a/bin/zkServer-initialize.sh
+++ b/bin/zkServer-initialize.sh
@@ -24,7 +24,7 @@
 # use POSIX interface, symlink is followed automatically
 ZOOBIN="${BASH_SOURCE-$0}"
 ZOOBIN="$(dirname "${ZOOBIN}")"
-ZOOBINDIR="$(cd "${ZOOBIN}"; pwd)"
+ZOOBINDIR="$(cd "${ZOOBIN}" >/dev/null && pwd)"
 
 if [ -e "$ZOOBIN/../libexec/zkEnv.sh" ]; then
   . "$ZOOBINDIR"/../libexec/zkEnv.sh

--- a/bin/zkServer.sh
+++ b/bin/zkServer.sh
@@ -66,7 +66,7 @@ fi
 # use POSTIX interface, symlink is followed automatically
 ZOOBIN="${BASH_SOURCE-$0}"
 ZOOBIN="$(dirname "${ZOOBIN}")"
-ZOOBINDIR="$(cd "${ZOOBIN}"; pwd)"
+ZOOBINDIR="$(cd "${ZOOBIN}" >/dev/null && pwd)"
 
 if [ -e "$ZOOBIN/../libexec/zkEnv.sh" ]; then
   . "$ZOOBINDIR"/../libexec/zkEnv.sh


### PR DESCRIPTION
CDPATH is an environment variable which alters `cd` behaviour. Its usage is defined by POSIX and when `cd` parameter is found in CDPATH, the `cd` command prints on its stdout the matching directory the shell is entering.

For instance : 

```
$ export CDPATH=/
$ cd /usr
$ cd usr/bin
/usr/bin
```

This can become annoying when one is using cd in backquotes or $() expansion such as `ZOOBINDIR="$(cd "${ZOOBIN}"; pwd)"`.

```
$ bash -x usr/bin/zkCli.sh
+ ZOOBIN=usr/bin/zkCli.sh
++ dirname usr/bin/zkCli.sh
+ ZOOBIN=usr/bin
++ cd usr/bin
++ pwd
+ ZOOBINDIR='/usr/bin
/usr/bin'
+ '[' -e usr/bin/../libexec/zkEnv.sh ']'
+ . '/usr/bin
/usr/bin/../libexec/zkEnv.sh'
usr/bin/zkCli.sh: line 34: /usr/bin
/usr/bin/../libexec/zkEnv.sh: No such file or directory
+ '' -Dzookeeper.log.dir= -Dzookeeper.root.logger= -cp '' org.apache.zookeeper.ZooKeeperMain
usr/bin/zkCli.sh: line 39:  : command not found
zsh: exit 127   bash -x usr/bin/zkCli.sh
```

As you can see, under some circumstances, when CDPATH is set, zk*.sh scripts will define wrong values of ZOOBINDIR. I think it's a bug worth fixing.
