### PR TITLE
ps -p command doesnt work in all distros like Alpine:3.2

### DIFF
--- a/bin/zkServer.sh
+++ b/bin/zkServer.sh
@@ -172,7 +172,7 @@ start)
       then
         sleep 1
         pid=$(cat "${ZOOPIDFILE}")
-        if ps -p "${pid}" > /dev/null 2>&1; then
+        if ps -o pid | grep "${pid}" > /dev/null 2>&1; then
           echo STARTED
         else
           echo FAILED TO START


### PR DESCRIPTION
When you use Zookeeper in Linux Alpine 3.2, it doesn't work correctly when you use the command `ps -p` in the start up, it could be replaced for another generic approach like `ps -o pid ...`

Signed-off-by: Marcelo Salazar R chelosalazar@gmail.com
