### PR TITLE
Fix RPM package creation on recent distros

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1075,7 +1075,7 @@ xmlns:maven="antlib:org.apache.maven.artifact.ant">
           </replacetokens>
         </filterchain>
       </copy>
-      <rpm specFile="zookeeper.spec" command="-ba --buildroot=${package.buildroot}/BUILD" topDir="${package.buildroot}" cleanBuildDir="true" failOnError="true"
+      <rpm specFile="zookeeper.spec" command="-ba" topDir="${package.buildroot}" cleanBuildDir="true" failOnError="true"
 />
       <copy todir="${build.dir}/" flatten="true">
         <fileset dir="${package.buildroot}/RPMS">

--- a/src/contrib/zkpython/build.xml
+++ b/src/contrib/zkpython/build.xml
@@ -141,7 +141,7 @@
         </filterchain>
       </copy>
 
-      <rpm specFile="${name}.spec" command="-ba --buildroot=${package.buildroot}/BUILD" topDir="${package.buildroot}" cleanBuildDir="true" failOnError="true" />
+      <rpm specFile="${name}.spec" command="-ba" topDir="${package.buildroot}" cleanBuildDir="true" failOnError="true" />
       <copy todir="${build.dir}/" flatten="true">
         <fileset dir="${package.buildroot}/RPMS">
           <include name="**/*.rpm" />

--- a/src/contrib/zkpython/src/packages/rpm/spec/zkpython.spec
+++ b/src/contrib/zkpython/src/packages/rpm/spec/zkpython.spec
@@ -68,6 +68,7 @@ tar fxz %{_python_lib} -C %{_build_dir}
 #### INSTALL SECTION ####
 #########################
 %install
+%{__mv} %{_build_dir}/* %{buildroot}
 
 %pre
 

--- a/src/contrib/zkpython/src/packages/rpm/spec/zkpython.spec
+++ b/src/contrib/zkpython/src/packages/rpm/spec/zkpython.spec
@@ -32,10 +32,10 @@
 
 # Disable brp-java-repack-jars for aspect J
 %define __os_install_post    \
-    /usr/lib/rpm/redhat/brp-compress \
-    %{!?__debug_package:/usr/lib/rpm/redhat/brp-strip %{__strip}} \
-    /usr/lib/rpm/redhat/brp-strip-static-archive %{__strip} \
-    /usr/lib/rpm/redhat/brp-strip-comment-note %{__strip} %{__objdump} \
+    /usr/lib/rpm/brp-compress \
+    %{!?__debug_package:/usr/lib/rpm/brp-strip %{__strip}} \
+    /usr/lib/rpm/brp-strip-static-archive %{__strip} \
+    /usr/lib/rpm/brp-strip-comment-note %{__strip} %{__objdump} \
     /usr/lib/rpm/brp-python-bytecompile %{nil}
 
 # RPM searches perl files for dependancies and this breaks for non packaged perl lib

--- a/src/packages/rpm/spec/zookeeper.spec
+++ b/src/packages/rpm/spec/zookeeper.spec
@@ -70,7 +70,7 @@ Prefix: %{_conf_dir}
 Prefix: %{_log_dir}
 Prefix: %{_pid_dir}
 Prefix: %{_var_dir}
-Requires: sh-utils, textutils, /usr/sbin/useradd, /usr/sbin/usermod, /sbin/chkconfig, /sbin/service, jdk >= 1.6
+Requires: sh-utils, textutils, /usr/sbin/useradd, /usr/sbin/usermod, /sbin/chkconfig, /sbin/service, java >= 1.6
 AutoReqProv: no
 Provides: zookeeper
 
@@ -87,17 +87,14 @@ Provides: zookeeper-lib
 ZooKeeper C client library for communicating with ZooKeeper Server.
 
 %prep
-%setup -D -b 1 -n %{_final_name}
-%setup -D -a 0 -n %{_final_name}
+%setup -q -D -b 1 -n %{_final_name}
+%setup -q -D -a 0 -n %{_final_name}
 
 %build
 mkdir -p ${RPM_BUILD_DIR}%{_prefix}
 mkdir -p ${RPM_BUILD_DIR}%{_bin_dir}
 mkdir -p ${RPM_BUILD_DIR}%{_include_dir}
 mkdir -p ${RPM_BUILD_DIR}%{_lib_dir}
-%ifarch amd64 x86_64
-mkdir -p ${RPM_BUILD_DIR}%{_lib64_dir}
-%endif
 mkdir -p ${RPM_BUILD_DIR}%{_libexec_dir}
 mkdir -p ${RPM_BUILD_DIR}%{_log_dir}
 mkdir -p ${RPM_BUILD_DIR}%{_conf_dir}
@@ -118,14 +115,15 @@ chmod 0755 ${RPM_BUILD_DIR}/etc/init.d/zookeeper
 #########################
 %install
 pushd ${RPM_BUILD_DIR}
-mv ${RPM_BUILD_DIR}/%{_final_name}/bin/* ${RPM_BUILD_DIR}%{_bin_dir}
-mv ${RPM_BUILD_DIR}/%{_final_name}/libexec/* ${RPM_BUILD_DIR}%{_libexec_dir}
-mv ${RPM_BUILD_DIR}/%{_final_name}/share/zookeeper/* ${RPM_BUILD_DIR}%{_share_dir}
-mv ${RPM_BUILD_DIR}/%{_final_name}/conf/* ${RPM_BUILD_DIR}%{_conf_dir}
-mv ${RPM_BUILD_DIR}/%{_final_name}/sbin/* ${RPM_BUILD_DIR}%{_sbin_dir}
-cp -f ${RPM_BUILD_DIR}%{_conf_dir}/zoo_sample.cfg ${RPM_BUILD_DIR}%{_conf_dir}/zoo.cfg
+cp -a ${RPM_BUILD_DIR}/%{_final_name}/bin/*.sh ${RPM_BUILD_DIR}%{_bin_dir}
+cp -a ${RPM_BUILD_DIR}/%{_final_name}/libexec/*.sh ${RPM_BUILD_DIR}%{_libexec_dir}
+cp -a ${RPM_BUILD_DIR}/%{_final_name}/share/zookeeper/* ${RPM_BUILD_DIR}%{_share_dir}
+cp -a ${RPM_BUILD_DIR}/%{_final_name}/conf/* ${RPM_BUILD_DIR}%{_conf_dir}
+cp -a ${RPM_BUILD_DIR}/%{_final_name}/sbin/*.sh ${RPM_BUILD_DIR}%{_sbin_dir}
+rm -r ${RPM_BUILD_DIR}/usr/include
+rm -r ${RPM_BUILD_DIR}/usr/man
+mv etc usr var %{buildroot}
 popd ${RPM_BUILD_DIR}
-rm -rf ${RPM_BUILD_DIR}/%{_final_name}
 
 %pre
 getent group hadoop 2>/dev/null >/dev/null || /usr/sbin/groupadd -r hadoop
@@ -153,9 +151,16 @@ bash ${RPM_INSTALL_PREFIX0}/sbin/update-zookeeper-env.sh \
 %defattr(-,root,root)
 %attr(0755,root,hadoop) %{_log_dir}
 %attr(0775,root,hadoop) %{_pid_dir}
+%attr(0775,root,hadoop) %{_var_dir}
 %attr(0775,root,hadoop) /etc/init.d/zookeeper
+%dir %{_conf_dir}/
 %config(noreplace) %{_conf_dir}/*
-%{_prefix}
+%{_libexec_dir}/*
+%{_sbin_dir}/*
+%{_share_dir}/*
+%{_log_dir}/
+%{_pid_dir}/
+%{_var_dir}/
 
 %post lib
 /sbin/ldconfig
@@ -163,4 +168,4 @@ bash ${RPM_INSTALL_PREFIX0}/sbin/update-zookeeper-env.sh \
 %files lib
 %defattr(-,root,root)
 %{_prefix}/lib/*
-%{_prefix}/bin
+%{_prefix}/bin/*

--- a/src/packages/rpm/spec/zookeeper.spec
+++ b/src/packages/rpm/spec/zookeeper.spec
@@ -62,7 +62,7 @@ Vendor: Apache Software Foundation
 Group: Development/Libraries
 Name: %{name}
 Version: %{version}
-Release: %{release} 
+Release: %{release}
 Source0: %{_final_name}.tar.gz
 Source1: %{_final_name}-lib.tar.gz
 Prefix: %{_prefix}
@@ -123,7 +123,7 @@ cp -a ${RPM_BUILD_DIR}/%{_final_name}/sbin/*.sh ${RPM_BUILD_DIR}%{_sbin_dir}
 rm -r ${RPM_BUILD_DIR}/usr/include
 rm -r ${RPM_BUILD_DIR}/usr/man
 mv etc usr var %{buildroot}
-popd ${RPM_BUILD_DIR}
+popd
 
 %pre
 getent group hadoop 2>/dev/null >/dev/null || /usr/sbin/groupadd -r hadoop
@@ -147,7 +147,7 @@ bash ${RPM_INSTALL_PREFIX0}/sbin/update-zookeeper-env.sh \
        --var-dir=${RPM_INSTALL_PREFIX4} \
        --uninstall
 
-%files 
+%files
 %defattr(-,root,root)
 %attr(0755,root,hadoop) %{_log_dir}
 %attr(0775,root,hadoop) %{_pid_dir}

--- a/src/packages/rpm/spec/zookeeper.spec
+++ b/src/packages/rpm/spec/zookeeper.spec
@@ -45,10 +45,10 @@
 
 # Disable brp-java-repack-jars for aspect J
 %define __os_install_post    \
-    /usr/lib/rpm/redhat/brp-compress \
-    %{!?__debug_package:/usr/lib/rpm/redhat/brp-strip %{__strip}} \
-    /usr/lib/rpm/redhat/brp-strip-static-archive %{__strip} \
-    /usr/lib/rpm/redhat/brp-strip-comment-note %{__strip} %{__objdump} \
+    /usr/lib/rpm/brp-compress \
+    %{!?__debug_package:/usr/lib/rpm/brp-strip %{__strip}} \
+    /usr/lib/rpm/brp-strip-static-archive %{__strip} \
+    /usr/lib/rpm/brp-strip-comment-note %{__strip} %{__objdump} \
     /usr/lib/rpm/brp-python-bytecompile %{nil}
 
 # RPM searches perl files for dependancies and this breaks for non packaged perl lib


### PR DESCRIPTION
The first commit comes from: http://mail-archives.apache.org/mod_mbox/zookeeper-user/201212.mbox/%3C50D2D481.8010507@pt-consulting.eu%3E

The other two are issues I hit next when trying to build an RPM package. 
