### PR TITLE
Use fake host names to avoid test failures

### DIFF
--- a/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
+++ b/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
@@ -79,15 +79,15 @@ public class StaticHostProviderTest extends ZKTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void testTwoInvalidHostAddresses() {
         ArrayList<InetSocketAddress> list = new ArrayList<InetSocketAddress>();
-        list.add(new InetSocketAddress("a", 2181));
-        list.add(new InetSocketAddress("b", 2181));
+        list.add(new InetSocketAddress("a...", 2181));
+        list.add(new InetSocketAddress("b...", 2181));
         new StaticHostProvider(list);
     }
 
     @Test
     public void testOneInvalidHostAddresses() {
         Collection<InetSocketAddress> addr = getServerAddresses((byte) 1);
-        addr.add(new InetSocketAddress("a", 2181));
+        addr.add(new InetSocketAddress("a...", 2181));
 
         StaticHostProvider sp = new StaticHostProvider(addr);
         InetSocketAddress n1 = sp.next(0);


### PR DESCRIPTION
Some of the ZooKeeper tests use "fake" hostnames to trigger host resolution failures. The problem with this is that it uses valid hostnames which are sometimes configured in VMs. 

At the moment I am unable to build cleanly because I get test failures on the two test methods that do this. The tests work equally well if syntactically invalid hostnames are used, and the test cases become more portable at the same time.