### PR TITLE
Update netty to 3.7.1.Final

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -50,7 +50,7 @@
     <dependency org="log4j" name="log4j" rev="1.2.17" transitive="false" conf="test->default"/>
     <dependency org="jline" name="jline" rev="2.11" transitive="false" conf="optional->default"/>
 
-    <dependency org="io.netty" name="netty" conf="default" rev="3.7.0.Final">
+    <dependency org="io.netty" name="netty" conf="default" rev="3.7.1.Final">
       <artifact name="netty" type="jar" conf="default"/>
     </dependency>
 


### PR DESCRIPTION
Hopefully hadoop will also update to netty 3.7.x (https://github.com/apache/hadoop/pull/85, HADOOP-9991)