### PR TITLE
Solve variable in zkCleanup.sh  contains whitespace in its tail

### DIFF
--- a/bin/zkCleanup.sh
+++ b/bin/zkCleanup.sh
@@ -36,8 +36,8 @@ else
   . "$ZOOBINDIR"/zkEnv.sh
 fi
 
-ZOODATADIR="$(grep "^[[:space:]]*dataDir=" "$ZOOCFG" | sed -e 's/.*=//')"
-ZOODATALOGDIR="$(grep "^[[:space:]]*dataLogDir=" "$ZOOCFG" | sed -e 's/.*=//')"
+ZOODATADIR="$(grep "^[[:space:]]*dataDir=" "$ZOOCFG" | sed -e 's/.*=//' | sed -e 's/[[:space:]]*$//')"
+ZOODATALOGDIR="$(grep "^[[:space:]]*dataLogDir=" "$ZOOCFG" | sed -e 's/.*=//' | sed -e 's/[[:space:]]*$//')"
 
 ZOO_LOG_FILE=zookeeper-$USER-cleanup-$HOSTNAME.log
 


### PR DESCRIPTION
it solved a stupid, however, sometimes annoying question, that is the variable ZOODATADIR or ZOODATALOGDIR contains whitespace in its tail. Senario and tested as below:

hadoop@DPFTMP06:/usr/local/zookeeper-3.4.8> bin/zkCleanup.sh -n 20
Path '/hadoop/zookeeper/logs ' does not exist. 
Usage:
PurgeTxnLog dataLogDir [snapDir] -n count
dataLogDir -- path to the txn log directory
snapDir -- path to the snapshot directory
count -- the number of old snaps/logs you want to keep, value should be greater than or equal to 3
hadoop@DPFTMP06:/usr/local/zookeeper-3.4.8> vim bin/zkCleanup.sh 
hadoop@DPFTMP06:/usr/local/zookeeper-3.4.8> cat bin/zkCleanup.sh |grep ZOODATALOGDIR |grep sed
ZOODATALOGDIR="$(grep "^[[:space:]]dataLogDir=" "$ZOOCFG" | sed -e 's/.=//' | sed -e 's/[[:space:]]*$//')"
hadoop@DPFTMP06:/usr/local/zookeeper-3.4.8> bin/zkCleanup.sh -n 20
hadoop@DPFTMP06:/usr/local/zookeeper-3.4.8>
