### PR TITLE
Fix NULL handling for getlogin() call

### DIFF
--- a/src/c/src/zookeeper.c
+++ b/src/c/src/zookeeper.c
@@ -1045,7 +1045,7 @@ static void log_env(zhandle_t *zh) {
 #endif
 
 #ifdef HAVE_GETLOGIN
-  LOG_INFO(LOGCALLBACK(zh), "Client environment:user.name=%s", getlogin());
+  LOG_INFO(LOGCALLBACK(zh), "Client environment:user.name=%s", (getlogin() != NULL) ? getlogin() : "<unavailable>");
 #else
   LOG_INFO(LOGCALLBACK(zh), "Client environment:user.name=<not implemented>");
 #endif


### PR DESCRIPTION
This patch fixes issues with CoreOs if e.g. go binary is linking to libzookeeper_mt.

The problem here is that:
- in case of statically linked go binaries, they are still relying on glibc
  for fetching the most basic system information (accounts, dns, i.e.)
- there is bug/ambiguity in gcc: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=15685
- libc libraries differ between centos/debian-jessie(golang container base
  image) and CoreOs
- the return code is not checked for getlogin() call: https://github.com/apache/zookeeper/blob/trunk/src/c/src/zookeeper.c#L1048
  (getlogin can return NULL)

So the idea is to actually check exit status from getlogin() call and return
some predefined string if it's NULL.

We may try to fix log_message function itself(i.e. detect NULL pointers to strings)
but I tend to agree with Manuel López-Ibáñez from gcc bug report - NULL strings
should not be permitted/avoided.
