### PR TITLE
Added ability to Provide SSLContext to Zookeeper Client

### DIFF
--- a/src/java/main/org/apache/zookeeper/client/ZKClientConfig.java
+++ b/src/java/main/org/apache/zookeeper/client/ZKClientConfig.java
@@ -78,6 +78,7 @@ public class ZKClientConfig extends ZKConfig {
         /**
          * backward compatibility for client specific properties
          */
+        setProperty(CLIENT_SSL_CONTEXT, System.getProperty(CLIENT_SSL_CONTEXT));
         setProperty(ZK_SASL_CLIENT_USERNAME, System.getProperty(ZK_SASL_CLIENT_USERNAME));
         setProperty(LOGIN_CONTEXT_NAME_KEY, System.getProperty(LOGIN_CONTEXT_NAME_KEY));
         setProperty(ENABLE_CLIENT_SASL_KEY, System.getProperty(ENABLE_CLIENT_SASL_KEY));

--- a/src/java/main/org/apache/zookeeper/common/ZKConfig.java
+++ b/src/java/main/org/apache/zookeeper/common/ZKConfig.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 public class ZKConfig {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZKConfig.class);
+	public static final String CLIENT_SSL_CONTEXT = "zookeeper.client.ssl.context";
     @SuppressWarnings("deprecation")
     public static final String SSL_KEYSTORE_LOCATION = X509Util.SSL_KEYSTORE_LOCATION;
     @SuppressWarnings("deprecation")
@@ -138,6 +139,16 @@ public class ZKConfig {
     public String getProperty(String key, String defaultValue) {
         String value = properties.get(key);
         return (value == null) ? defaultValue : value;
+    }
+    
+    /**
+     * Check if a given property is in this config class
+     * 
+     * @param key Property key
+     * @return True if exists, otherwise false.
+     */
+    public boolean containsProperty(String key) {
+    	return properties.containsKey(key);
     }
 
     /**

--- a/src/java/main/org/apache/zookeeper/common/ZKSSLContext.java
+++ b/src/java/main/org/apache/zookeeper/common/ZKSSLContext.java
@@ -1,0 +1,11 @@
+package org.apache.zookeeper.common;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.zookeeper.common.X509Exception.SSLContextException;
+
+public interface ZKSSLContext {
+	
+	SSLContext getSSLContext() throws SSLContextException;
+
+}

--- a/src/java/test/org/apache/zookeeper/test/SSLProvidedContextTest.java
+++ b/src/java/test/org/apache/zookeeper/test/SSLProvidedContextTest.java
@@ -1,0 +1,118 @@
+package org.apache.zookeeper.test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.TestableZooKeeper;
+import org.apache.zookeeper.client.ZKClientConfig;
+import org.apache.zookeeper.common.ZKConfig;
+import org.apache.zookeeper.common.ZKSSLContext;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.apache.zookeeper.common.X509Exception.SSLContextException;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+
+public class SSLProvidedContextTest extends ClientBase {
+
+	@Before
+	public void setUp() throws Exception {
+		String testDataPath = System.getProperty("test.data.dir", "build/test/data");
+		System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY,
+				"org.apache.zookeeper.server.NettyServerCnxnFactory");
+		System.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET, "org.apache.zookeeper.ClientCnxnSocketNetty");
+		System.setProperty(ZKClientConfig.SECURE_CLIENT, "true");
+		System.setProperty(ZKConfig.CLIENT_SSL_CONTEXT,
+				"org.apache.zookeeper.test.SSLProvidedContextTest.TestSSLContext");
+
+		System.setProperty(ZKConfig.SSL_AUTHPROVIDER, "x509");
+		System.setProperty(ZKConfig.SSL_KEYSTORE_LOCATION, testDataPath + "/ssl/testKeyStore.jks");
+		System.setProperty(ZKConfig.SSL_KEYSTORE_PASSWD, "testpass");
+		System.setProperty(ZKConfig.SSL_TRUSTSTORE_LOCATION, testDataPath + "/ssl/testTrustStore.jks");
+		System.setProperty(ZKConfig.SSL_TRUSTSTORE_PASSWD, "testpass");
+		System.setProperty("javax.net.debug", "ssl");
+		System.setProperty("zookeeper.authProvider.x509",
+				"org.apache.zookeeper.server.auth.X509AuthenticationProvider");
+
+		String host = "localhost";
+		int port = PortAssignment.unique();
+		hostPort = host + ":" + port;
+
+		serverFactory = ServerCnxnFactory.createFactory();
+		serverFactory.configure(new InetSocketAddress(host, port), maxCnxns, true);
+
+		super.setUp();
+	}
+
+	@After
+	public void teardown() throws Exception {
+		System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
+		System.clearProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET);
+		System.clearProperty(ZKClientConfig.SECURE_CLIENT);
+		System.clearProperty(ZKConfig.CLIENT_SSL_CONTEXT);
+		System.clearProperty(ZKConfig.SSL_AUTHPROVIDER);
+		System.clearProperty(ZKConfig.SSL_KEYSTORE_LOCATION);
+		System.clearProperty(ZKConfig.SSL_KEYSTORE_PASSWD);
+		System.clearProperty(ZKConfig.SSL_TRUSTSTORE_LOCATION);
+		System.clearProperty(ZKConfig.SSL_TRUSTSTORE_PASSWD);
+		System.clearProperty("javax.net.debug");
+		System.clearProperty("zookeeper.authProvider.x509");
+	}
+
+	@Test
+	public void testRejection() throws Exception {
+		CountdownWatcher watcher = new CountdownWatcher();
+
+		// Handshake will take place, and then X509AuthenticationProvider should
+		// reject the untrusted cert
+		new TestableZooKeeper(hostPort, CONNECTION_TIMEOUT, watcher);
+		Assert.assertFalse("Untrusted certificate should not result in successful connection",
+				watcher.clientConnected.await(1000, TimeUnit.MILLISECONDS));
+	}
+
+	public class TestSSLContext implements ZKSSLContext {
+
+		@Override
+		public SSLContext getSSLContext() throws SSLContextException {
+			String testDataPath = System.getProperty("test.data.dir", "build/test/data");
+			FileInputStream inputStream = null;
+			try {
+				SSLContext sslContext = SSLContext.getDefault();
+				KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+				inputStream = new FileInputStream(new File(testDataPath + "/ssl/testUntrustedKeyStore.jks"));
+				keystore.load(inputStream, "testpass".toCharArray());
+				KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+				kmf.init(keystore, "testpass".toCharArray());
+				sslContext.init(kmf.getKeyManagers(), null, null);
+				return sslContext;
+			} catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException
+					| UnrecoverableKeyException | KeyManagementException e) {
+				throw new SSLContextException("could not generate default SSLContext", e);
+			} finally {
+				if (inputStream != null) {
+					try {
+						inputStream.close();
+					} catch (IOException e) {
+						e.printStackTrace();
+					}
+				}
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
- Set CLIENT_SSL_CONTEXT property on ZKClientConfig
- X509Util.createSSlContext() if CLIENT_SSL_CONTEXT property is set
attempt to load class name provided in the property and retrieve the
SSLContext from that.
- Define CLIENT_SSL_CONTEXT property name
- ZKSSLContext interface for developers to implement and provide their
own SSLContext
- Added test


We have a use case here where we need to build a SSLContext up front and be able to pass it into the ZKClient connection as we need to support both hardware and software certificates.

I added an interface called ZKSSLContext that should encapsulate the creation/retrieval of a SSLContext that can be used for the ZKClient connection.

To use this a develop would just need to provide the following properties:

-Dzookeeper.client.secure=true
-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
-Dzookeeper.client.ssl.context=fully qualified name of class implementing ZKSSLContext

