### PR TITLE
[ZOOKEEPER-2169] Enable creation of nodes with TTLs

### DIFF
--- a/docs/zookeeperAdmin.html
+++ b/docs/zookeeperAdmin.html
@@ -1787,7 +1787,7 @@ server.3=zoo3:2888:3888</pre>
 <p>
 <strong>New in 3.6.0:</strong> The
                 time interval in milliseconds for each check of candidate container
-                nodes. Default is "60000".</p>
+                and ttl nodes. Default is "60000".</p>
 </dd>
 
           
@@ -1798,7 +1798,7 @@ server.3=zoo3:2888:3888</pre>
 <p>(Java system property only)</p>
 <p>
 <strong>New in 3.6.0:</strong> The
-                maximum number of container nodes that can be deleted per
+                maximum number of container and ttl nodes that can be deleted per
                 minute. This prevents herding during container deletion.
                 Default is "10000".</p>
 </dd>

--- a/docs/zookeeperProgrammers.html
+++ b/docs/zookeeperProgrammers.html
@@ -219,6 +219,9 @@ document.write("Last Published: " + document.lastModified);
 <li>
 <a href="#Container+Nodes">Container Nodes</a>
 </li>
+<li>
+<a href="#TTL+Nodes">TTL Nodes</a>
+</li>
 </ul>
 </li>
 <li>
@@ -575,15 +578,24 @@ document.write("Last Published: " + document.lastModified);
 <p>
 <strong>Added in 3.6.0</strong>
 </p>
-<p>ZooKeeper has the notion of container nodes. Container nodes are
-          special purpose nodes useful for recipes such as leader, lock, etc.
+<p>ZooKeeper has the notion of container znodes. Container znodes are
+          special purpose znodes useful for recipes such as leader, lock, etc.
           When the last child of a container is deleted, the container becomes
           a candidate to be deleted by the server at some point in the future.</p>
 <p>Given this property, you should be prepared to get
           KeeperException.NoNodeException when creating children inside of
-          container nodes. i.e. when creating child nodes inside of container nodes
+          container znodes. i.e. when creating child znodes inside of container znodes
           always check for KeeperException.NoNodeException and recreate the container
-          node when it occurs.</p>
+          znode when it occurs.</p>
+<a name="TTL+Nodes"></a>
+<h4>TTL Nodes</h4>
+<p>
+<strong>Added in 3.6.0</strong>
+</p>
+<p>When creating PERSISTENT or PERSISTENT_SEQUENTIAL znodes,
+          you can optionally set a TTL in milliseconds for the znode. If the znode
+          is not modified within the TTL and has no children it will become a candidate
+          to be deleted by the server at some point in the future.</p>
 <a name="sc_timeInZk"></a>
 <h3 class="h4">Time in ZooKeeper</h3>
 <p>ZooKeeper tracks time multiple ways:</p>

--- a/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
@@ -1439,7 +1439,7 @@ server.3=zoo3:2888:3888</programlisting>
 
               <para><emphasis role="bold">New in 3.6.0:</emphasis> The
                 time interval in milliseconds for each check of candidate container
-                nodes. Default is "60000".</para>
+                and ttl nodes. Default is "60000".</para>
             </listitem>
           </varlistentry>
 
@@ -1450,7 +1450,7 @@ server.3=zoo3:2888:3888</programlisting>
               <para>(Java system property only)</para>
 
               <para><emphasis role="bold">New in 3.6.0:</emphasis> The
-                maximum number of container nodes that can be deleted per
+                maximum number of container and ttl nodes that can be deleted per
                 minute. This prevents herding during container deletion.
                 Default is "10000".</para>
             </listitem>

--- a/src/docs/src/documentation/content/xdocs/zookeeperProgrammers.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperProgrammers.xml
@@ -249,16 +249,27 @@
 
         <para><emphasis role="bold">Added in 3.6.0</emphasis></para>
 
-        <para>ZooKeeper has the notion of container nodes. Container nodes are
-          special purpose nodes useful for recipes such as leader, lock, etc.
+        <para>ZooKeeper has the notion of container znodes. Container znodes are
+          special purpose znodes useful for recipes such as leader, lock, etc.
           When the last child of a container is deleted, the container becomes
           a candidate to be deleted by the server at some point in the future.</para>
 
         <para>Given this property, you should be prepared to get
           KeeperException.NoNodeException when creating children inside of
-          container nodes. i.e. when creating child nodes inside of container nodes
+          container znodes. i.e. when creating child znodes inside of container znodes
           always check for KeeperException.NoNodeException and recreate the container
-          node when it occurs.</para>
+          znode when it occurs.</para>
+      </section>
+
+      <section>
+        <title>TTL Nodes</title>
+
+        <para><emphasis role="bold">Added in 3.6.0</emphasis></para>
+
+        <para>When creating PERSISTENT or PERSISTENT_SEQUENTIAL znodes,
+          you can optionally set a TTL in milliseconds for the znode. If the znode
+          is not modified within the TTL and has no children it will become a candidate
+          to be deleted by the server at some point in the future.</para>
       </section>
     </section>
 

--- a/src/java/main/org/apache/zookeeper/CreateMode.java
+++ b/src/java/main/org/apache/zookeeper/CreateMode.java
@@ -28,21 +28,21 @@ public enum CreateMode {
     /**
      * The znode will not be automatically deleted upon client's disconnect.
      */
-    PERSISTENT (0, false, false, false),
+    PERSISTENT (0, false, false, false, false),
     /**
     * The znode will not be automatically deleted upon client's disconnect,
     * and its name will be appended with a monotonically increasing number.
     */
-    PERSISTENT_SEQUENTIAL (2, false, true, false),
+    PERSISTENT_SEQUENTIAL (2, false, true, false, false),
     /**
      * The znode will be deleted upon the client's disconnect.
      */
-    EPHEMERAL (1, true, false, false),
+    EPHEMERAL (1, true, false, false, false),
     /**
      * The znode will be deleted upon the client's disconnect, and its name
      * will be appended with a monotonically increasing number.
      */
-    EPHEMERAL_SEQUENTIAL (3, true, true, false),
+    EPHEMERAL_SEQUENTIAL (3, true, true, false, false),
     /**
      * The znode will be a container node. Container
      * nodes are special purpose nodes useful for recipes such as leader, lock,
@@ -52,7 +52,20 @@ public enum CreateMode {
      * {@link org.apache.zookeeper.KeeperException.NoNodeException}
      * when creating children inside of this container node.
      */
-    CONTAINER (4, false, false, true);
+    CONTAINER (4, false, false, true, false),
+    /**
+     * The znode will not be automatically deleted upon client's disconnect.
+     * However if the znode has not been modified within the given TTL, it
+     * will be deleted once it has no children.
+     */
+    PERSISTENT_WITH_TTL(5, false, false, false, true),
+    /**
+     * The znode will not be automatically deleted upon client's disconnect,
+     * and its name will be appended with a monotonically increasing number.
+     * However if the znode has not been modified within the given TTL, it
+     * will be deleted once it has no children.
+     */
+    PERSISTENT_SEQUENTIAL_WITH_TTL(6, false, true, false, true);
 
     private static final Logger LOG = LoggerFactory.getLogger(CreateMode.class);
 
@@ -60,13 +73,15 @@ public enum CreateMode {
     private boolean sequential;
     private final boolean isContainer;
     private int flag;
+    private boolean isTTL;
 
     CreateMode(int flag, boolean ephemeral, boolean sequential,
-               boolean isContainer) {
+               boolean isContainer, boolean isTTL) {
         this.flag = flag;
         this.ephemeral = ephemeral;
         this.sequential = sequential;
         this.isContainer = isContainer;
+        this.isTTL = isTTL;
     }
 
     public boolean isEphemeral() { 
@@ -79,6 +94,10 @@ public enum CreateMode {
 
     public boolean isContainer() {
         return isContainer;
+    }
+
+    public boolean isTTL() {
+        return isTTL;
     }
 
     public int toFlag() {
@@ -99,6 +118,10 @@ public enum CreateMode {
         case 3: return CreateMode.EPHEMERAL_SEQUENTIAL ;
 
         case 4: return CreateMode.CONTAINER;
+
+        case 5: return CreateMode.PERSISTENT_WITH_TTL;
+
+        case 6: return CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL;
 
         default:
             String errMsg = "Received an invalid flag value: " + flag
@@ -127,6 +150,12 @@ public enum CreateMode {
 
             case 4:
                 return CreateMode.CONTAINER;
+
+            case 5:
+                return CreateMode.PERSISTENT_WITH_TTL;
+
+            case 6:
+                return CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL;
 
             default:
                 return defaultMode;

--- a/src/java/main/org/apache/zookeeper/MultiTransactionRecord.java
+++ b/src/java/main/org/apache/zookeeper/MultiTransactionRecord.java
@@ -68,6 +68,7 @@ public class MultiTransactionRecord implements Record, Iterable<Op> {
             switch (op.getType()) {
                 case ZooDefs.OpCode.create:
                 case ZooDefs.OpCode.create2:
+                case ZooDefs.OpCode.createTTL:
                 case ZooDefs.OpCode.createContainer:
                 case ZooDefs.OpCode.delete:
                 case ZooDefs.OpCode.setData:
@@ -96,6 +97,11 @@ public class MultiTransactionRecord implements Record, Iterable<Op> {
                     CreateRequest cr = new CreateRequest();
                     cr.deserialize(archive, tag);
                     add(Op.create(cr.getPath(), cr.getData(), cr.getAcl(), cr.getFlags()));
+                    break;
+                case ZooDefs.OpCode.createTTL:
+                    CreateTTLRequest crTtl = new CreateTTLRequest();
+                    crTtl.deserialize(archive, tag);
+                    add(Op.create(crTtl.getPath(), crTtl.getData(), crTtl.getAcl(), crTtl.getFlags(), crTtl.getTtl()));
                     break;
                 case ZooDefs.OpCode.delete:
                     DeleteRequest dr = new DeleteRequest();

--- a/src/java/main/org/apache/zookeeper/ZooDefs.java
+++ b/src/java/main/org/apache/zookeeper/ZooDefs.java
@@ -69,6 +69,8 @@ public class ZooDefs {
 
         public final int deleteContainer = 20;
 
+        public final int createTTL = 21;
+
         public final int auth = 100;
 
         public final int setWatches = 101;

--- a/src/java/main/org/apache/zookeeper/server/ContainerManager.java
+++ b/src/java/main/org/apache/zookeeper/server/ContainerManager.java
@@ -153,6 +153,24 @@ public class ContainerManager {
                 candidates.add(containerPath);
             }
         }
+        for (String ttlPath : zkDb.getDataTree().getTtls()) {
+            DataNode node = zkDb.getDataTree().getNode(ttlPath);
+            if (node != null) {
+                Set<String> children = node.getChildren();
+                if ((children == null) || (children.size() == 0)) {
+                    long elapsed = getElapsed(node);
+                    long ttl = EphemeralType.getTTL(node.stat.getEphemeralOwner());
+                    if ((ttl != 0) && (elapsed > ttl)) {
+                        candidates.add(ttlPath);
+                    }
+                }
+            }
+        }
         return candidates;
+    }
+
+    // VisibleForTesting
+    protected long getElapsed(DataNode node) {
+        return Time.currentWallTime() - node.stat.getMtime();
     }
 }

--- a/src/java/main/org/apache/zookeeper/server/DataNode.java
+++ b/src/java/main/org/apache/zookeeper/server/DataNode.java
@@ -159,8 +159,11 @@ public class DataNode implements Record {
     }
 
     private static long getClientEphemeralOwner(StatPersisted stat) {
-        return (stat.getEphemeralOwner() == DataTree.CONTAINER_EPHEMERAL_OWNER)
-                ? 0 : stat.getEphemeralOwner();
+        EphemeralType ephemeralType = EphemeralType.get(stat.getEphemeralOwner());
+        if (ephemeralType != EphemeralType.NORMAL) {
+            return 0;
+        }
+        return stat.getEphemeralOwner();
     }
 
     synchronized public void deserialize(InputArchive archive, String tag)

--- a/src/java/main/org/apache/zookeeper/server/EphemeralType.java
+++ b/src/java/main/org/apache/zookeeper/server/EphemeralType.java
@@ -20,8 +20,6 @@ package org.apache.zookeeper.server;
 
 import org.apache.zookeeper.CreateMode;
 
-import static org.jboss.netty.handler.codec.rtsp.RtspHeaders.Values.TTL;
-
 public enum EphemeralType {
     /**
      * Not ephemeral

--- a/src/java/main/org/apache/zookeeper/server/EphemeralType.java
+++ b/src/java/main/org/apache/zookeeper/server/EphemeralType.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server;
+
+import org.apache.zookeeper.CreateMode;
+
+import static org.jboss.netty.handler.codec.rtsp.RtspHeaders.Values.TTL;
+
+public enum EphemeralType {
+    /**
+     * Not ephemeral
+     */
+    VOID,
+    /**
+     * Standard, pre-3.5.x EPHEMERAL
+     */
+    NORMAL,
+    /**
+     * Container node
+     */
+    CONTAINER,
+    /**
+     * TTL node
+     */
+    TTL;
+
+    public static final long CONTAINER_EPHEMERAL_OWNER = Long.MIN_VALUE;
+    public static final long MAX_TTL = 0x0fffffffffffffffL;
+    public static final long TTL_MASK = 0x8000000000000000L;
+
+    public static EphemeralType get(long ephemeralOwner) {
+        if (ephemeralOwner == CONTAINER_EPHEMERAL_OWNER) {
+            return CONTAINER;
+        }
+        if (ephemeralOwner < 0) {
+            return TTL;
+        }
+        return (ephemeralOwner == 0) ? VOID : NORMAL;
+    }
+
+    public static void validateTTL(CreateMode mode, long ttl) {
+        if (mode.isTTL()) {
+            ttlToEphemeralOwner(ttl);
+        } else if (ttl >= 0) {
+            throw new IllegalArgumentException("ttl not valid for mode: " + mode);
+        }
+    }
+
+    public static long getTTL(long ephemeralOwner) {
+        if ((ephemeralOwner < 0) && (ephemeralOwner != CONTAINER_EPHEMERAL_OWNER)) {
+            return (ephemeralOwner & MAX_TTL);
+        }
+        return 0;
+    }
+
+    public static long ttlToEphemeralOwner(long ttl) {
+        if ((ttl > MAX_TTL) || (ttl <= 0)) {
+            throw new IllegalArgumentException("ttl must be positive and cannot be larger than: " + MAX_TTL);
+        }
+        return TTL_MASK | ttl;
+    }
+}

--- a/src/java/main/org/apache/zookeeper/server/FinalRequestProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/FinalRequestProcessor.java
@@ -215,6 +215,7 @@ public class FinalRequestProcessor implements RequestProcessor {
                             subResult = new CreateResult(subTxnResult.path);
                             break;
                         case OpCode.create2:
+                        case OpCode.createTTL:
                         case OpCode.createContainer:
                             subResult = new CreateResult(subTxnResult.path, subTxnResult.stat);
                             break;
@@ -244,6 +245,7 @@ public class FinalRequestProcessor implements RequestProcessor {
                 break;
             }
             case OpCode.create2:
+            case OpCode.createTTL:
             case OpCode.createContainer: {
                 lastOp = "CREA";
                 rsp = new Create2Response(rc.path, rc.stat);

--- a/src/java/main/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -36,6 +36,7 @@ import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.data.StatPersisted;
 import org.apache.zookeeper.proto.CheckVersionRequest;
 import org.apache.zookeeper.proto.CreateRequest;
+import org.apache.zookeeper.proto.CreateTTLRequest;
 import org.apache.zookeeper.proto.DeleteRequest;
 import org.apache.zookeeper.proto.ReconfigRequest;
 import org.apache.zookeeper.proto.SetACLRequest;
@@ -53,6 +54,7 @@ import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
 import org.apache.zookeeper.txn.CheckVersionTxn;
 import org.apache.zookeeper.txn.CreateContainerTxn;
 import org.apache.zookeeper.txn.CreateSessionTxn;
+import org.apache.zookeeper.txn.CreateTTLTxn;
 import org.apache.zookeeper.txn.CreateTxn;
 import org.apache.zookeeper.txn.DeleteTxn;
 import org.apache.zookeeper.txn.ErrorTxn;
@@ -364,53 +366,9 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
         switch (type) {
             case OpCode.create:
             case OpCode.create2:
+            case OpCode.createTTL:
             case OpCode.createContainer: {
-                CreateRequest createRequest = (CreateRequest)record;
-                if (deserialize) {
-                    ByteBufferInputStream.byteBuffer2Record(request.request, createRequest);
-                }
-                CreateMode createMode = CreateMode.fromFlag(createRequest.getFlags());
-                validateCreateRequest(createMode, request);
-                String path = createRequest.getPath();
-                String parentPath = validatePathForCreate(path, request.sessionId);
-
-                List<ACL> listACL = fixupACL(path, request.authInfo, createRequest.getAcl());
-                ChangeRecord parentRecord = getRecordForPath(parentPath);
-
-                checkACL(zks, parentRecord.acl, ZooDefs.Perms.CREATE, request.authInfo);
-                int parentCVersion = parentRecord.stat.getCversion();
-                if (createMode.isSequential()) {
-                    path = path + String.format(Locale.ENGLISH, "%010d", parentCVersion);
-                }
-                validatePath(path, request.sessionId);
-                try {
-                    if (getRecordForPath(path) != null) {
-                        throw new KeeperException.NodeExistsException(path);
-                    }
-                } catch (KeeperException.NoNodeException e) {
-                    // ignore this one
-                }
-                boolean ephemeralParent = (parentRecord.stat.getEphemeralOwner() != 0) &&
-                        (parentRecord.stat.getEphemeralOwner() != DataTree.CONTAINER_EPHEMERAL_OWNER);
-                if (ephemeralParent) {
-                    throw new KeeperException.NoChildrenForEphemeralsException(path);
-                }
-                int newCversion = parentRecord.stat.getCversion()+1;
-                if (type == OpCode.createContainer) {
-                    request.setTxn(new CreateContainerTxn(path, createRequest.getData(), listACL, newCversion));
-                } else {
-                    request.setTxn(new CreateTxn(path, createRequest.getData(), listACL, createMode.isEphemeral(),
-                            newCversion));
-                }
-                StatPersisted s = new StatPersisted();
-                if (createMode.isEphemeral()) {
-                    s.setEphemeralOwner(request.sessionId);
-                }
-                parentRecord = parentRecord.duplicate(request.getHdr().getZxid());
-                parentRecord.childCount++;
-                parentRecord.stat.setCversion(newCversion);
-                addChangeRecord(parentRecord);
-                addChangeRecord(new ChangeRecord(request.getHdr().getZxid(), path, s, 0, listACL));
+                pRequest2TxnCreate(type, request, record, deserialize);
                 break;
             }
             case OpCode.deleteContainer: {
@@ -421,7 +379,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
                 if (nodeRecord.childCount > 0) {
                     throw new KeeperException.NotEmptyException(path);
                 }
-                if (nodeRecord.stat.getEphemeralOwner() != DataTree.CONTAINER_EPHEMERAL_OWNER) {
+                if (EphemeralType.get(nodeRecord.stat.getEphemeralOwner()) == EphemeralType.NORMAL) {
                     throw new KeeperException.BadVersionException(path);
                 }
                 request.setTxn(new DeleteTxn(path));
@@ -665,6 +623,75 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
         }
     }
 
+    private void pRequest2TxnCreate(int type, Request request, Record record, boolean deserialize) throws IOException, KeeperException {
+        if (deserialize) {
+            ByteBufferInputStream.byteBuffer2Record(request.request, record);
+        }
+
+        int flags;
+        String path;
+        List<ACL> acl;
+        byte[] data;
+        long ttl;
+        if (type == OpCode.createTTL) {
+            CreateTTLRequest createTtlRequest = (CreateTTLRequest)record;
+            flags = createTtlRequest.getFlags();
+            path = createTtlRequest.getPath();
+            acl = createTtlRequest.getAcl();
+            data = createTtlRequest.getData();
+            ttl = createTtlRequest.getTtl();
+        } else {
+            CreateRequest createRequest = (CreateRequest)record;
+            flags = createRequest.getFlags();
+            path = createRequest.getPath();
+            acl = createRequest.getAcl();
+            data = createRequest.getData();
+            ttl = 0;
+        }
+        CreateMode createMode = CreateMode.fromFlag(flags);
+        validateCreateRequest(createMode, request);
+        String parentPath = validatePathForCreate(path, request.sessionId);
+
+        List<ACL> listACL = fixupACL(path, request.authInfo, acl);
+        ChangeRecord parentRecord = getRecordForPath(parentPath);
+
+        checkACL(zks, parentRecord.acl, ZooDefs.Perms.CREATE, request.authInfo);
+        int parentCVersion = parentRecord.stat.getCversion();
+        if (createMode.isSequential()) {
+            path = path + String.format(Locale.ENGLISH, "%010d", parentCVersion);
+        }
+        validatePath(path, request.sessionId);
+        try {
+            if (getRecordForPath(path) != null) {
+                throw new KeeperException.NodeExistsException(path);
+            }
+        } catch (KeeperException.NoNodeException e) {
+            // ignore this one
+        }
+        boolean ephemeralParent = EphemeralType.get(parentRecord.stat.getEphemeralOwner()) == EphemeralType.NORMAL;
+        if (ephemeralParent) {
+            throw new KeeperException.NoChildrenForEphemeralsException(path);
+        }
+        int newCversion = parentRecord.stat.getCversion()+1;
+        if (type == OpCode.createContainer) {
+            request.setTxn(new CreateContainerTxn(path, data, listACL, newCversion));
+        } else if (type == OpCode.createTTL) {
+            request.setTxn(new CreateTTLTxn(path, data, listACL, newCversion, ttl));
+        } else {
+            request.setTxn(new CreateTxn(path, data, listACL, createMode.isEphemeral(),
+                    newCversion));
+        }
+        StatPersisted s = new StatPersisted();
+        if (createMode.isEphemeral()) {
+            s.setEphemeralOwner(request.sessionId);
+        }
+        parentRecord = parentRecord.duplicate(request.getHdr().getZxid());
+        parentRecord.childCount++;
+        parentRecord.stat.setCversion(newCversion);
+        addChangeRecord(parentRecord);
+        addChangeRecord(new ChangeRecord(request.getHdr().getZxid(), path, s, 0, listACL));
+    }
+
     private void validatePath(String path, long sessionId) throws BadArgumentsException {
         try {
             PathUtils.validatePath(path);
@@ -712,6 +739,10 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
             case OpCode.create2:
                 CreateRequest create2Request = new CreateRequest();
                 pRequest2Txn(request.type, zks.getNextZxid(), request, create2Request, true);
+                break;
+            case OpCode.createTTL:
+                CreateTTLRequest createTtlRequest = new CreateTTLRequest();
+                pRequest2Txn(request.type, zks.getNextZxid(), request, createTtlRequest, true);
                 break;
             case OpCode.deleteContainer:
             case OpCode.delete:

--- a/src/java/main/org/apache/zookeeper/server/Request.java
+++ b/src/java/main/org/apache/zookeeper/server/Request.java
@@ -137,6 +137,7 @@ public class Request {
         case OpCode.closeSession:
         case OpCode.create:
         case OpCode.create2:
+        case OpCode.createTTL:
         case OpCode.createContainer:
         case OpCode.createSession:
         case OpCode.delete:
@@ -171,6 +172,7 @@ public class Request {
             return false;
         case OpCode.create:
         case OpCode.create2:
+        case OpCode.createTTL:
         case OpCode.createContainer:
         case OpCode.error:
         case OpCode.delete:
@@ -197,6 +199,8 @@ public class Request {
             return "create";
         case OpCode.create2:
             return "create2";
+        case OpCode.createTTL:
+            return "createTtl";
         case OpCode.createContainer:
             return "createContainer";
         case OpCode.setWatches:

--- a/src/java/main/org/apache/zookeeper/server/TraceFormatter.java
+++ b/src/java/main/org/apache/zookeeper/server/TraceFormatter.java
@@ -37,6 +37,8 @@ public class TraceFormatter {
             return "create";
         case OpCode.create2:
             return "create2";
+        case OpCode.createTTL:
+            return "createTtl";
         case OpCode.createContainer:
             return "createContainer";
         case OpCode.delete:

--- a/src/java/main/org/apache/zookeeper/server/quorum/CommitProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/CommitProcessor.java
@@ -133,6 +133,7 @@ public class CommitProcessor extends ZooKeeperCriticalThread implements
         switch (request.type) {
             case OpCode.create:
             case OpCode.create2:
+            case OpCode.createTTL:
             case OpCode.createContainer:
             case OpCode.delete:
             case OpCode.deleteContainer:

--- a/src/java/main/org/apache/zookeeper/server/quorum/FollowerRequestProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/FollowerRequestProcessor.java
@@ -84,6 +84,7 @@ public class FollowerRequestProcessor extends ZooKeeperCriticalThread implements
                     break;
                 case OpCode.create:
                 case OpCode.create2:
+                case OpCode.createTTL:
                 case OpCode.createContainer:
                 case OpCode.delete:
                 case OpCode.deleteContainer:

--- a/src/java/main/org/apache/zookeeper/server/quorum/ObserverRequestProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/ObserverRequestProcessor.java
@@ -93,6 +93,7 @@ public class ObserverRequestProcessor extends ZooKeeperCriticalThread implements
                     break;
                 case OpCode.create:
                 case OpCode.create2:
+                case OpCode.createTTL:
                 case OpCode.createContainer:
                 case OpCode.delete:
                 case OpCode.deleteContainer:

--- a/src/java/main/org/apache/zookeeper/server/quorum/ReadOnlyRequestProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/ReadOnlyRequestProcessor.java
@@ -82,6 +82,7 @@ public class ReadOnlyRequestProcessor extends ZooKeeperCriticalThread implements
                 case OpCode.sync:
                 case OpCode.create:
                 case OpCode.create2:
+                case OpCode.createTTL:
                 case OpCode.createContainer:
                 case OpCode.delete:
                 case OpCode.deleteContainer:

--- a/src/java/main/org/apache/zookeeper/server/util/SerializeUtils.java
+++ b/src/java/main/org/apache/zookeeper/server/util/SerializeUtils.java
@@ -27,6 +27,7 @@ import org.apache.zookeeper.server.DataTree;
 import org.apache.zookeeper.server.ZooTrace;
 import org.apache.zookeeper.txn.CreateContainerTxn;
 import org.apache.zookeeper.txn.CreateSessionTxn;
+import org.apache.zookeeper.txn.CreateTTLTxn;
 import org.apache.zookeeper.txn.CreateTxn;
 import org.apache.zookeeper.txn.CreateTxnV0;
 import org.apache.zookeeper.txn.DeleteTxn;
@@ -67,6 +68,9 @@ public class SerializeUtils {
         case OpCode.create:
         case OpCode.create2:
             txn = new CreateTxn();
+            break;
+        case OpCode.createTTL:
+            txn = new CreateTTLTxn();
             break;
         case OpCode.createContainer:
             txn = new CreateContainerTxn();

--- a/src/java/test/org/apache/zookeeper/server/CreateTTLTest.java
+++ b/src/java/test/org/apache/zookeeper/server/CreateTTLTest.java
@@ -1,0 +1,213 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server;
+
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Op;
+import org.apache.zookeeper.OpResult;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class CreateTTLTest extends ClientBase {
+    private ZooKeeper zk;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        zk = createClient();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        zk.close();
+    }
+
+    @Test
+    public void testCreate()
+            throws IOException, KeeperException, InterruptedException {
+        Stat stat = new Stat();
+        zk.create("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_WITH_TTL, stat, 100);
+        Assert.assertEquals(0, stat.getEphemeralOwner());
+
+        final AtomicLong fakeElapsed = new AtomicLong(0);
+        ContainerManager containerManager = newContainerManager(fakeElapsed);
+        containerManager.checkContainers();
+        Assert.assertNotNull("Ttl node should not have been deleted yet", zk.exists("/foo", false));
+
+        fakeElapsed.set(1000);
+        containerManager.checkContainers();
+        Assert.assertNull("Ttl node should have been deleted", zk.exists("/foo", false));
+    }
+
+    @Test
+    public void testCreateSequential()
+            throws IOException, KeeperException, InterruptedException {
+        Stat stat = new Stat();
+        String path = zk.create("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL, stat, 100);
+        Assert.assertEquals(0, stat.getEphemeralOwner());
+
+        final AtomicLong fakeElapsed = new AtomicLong(0);
+        ContainerManager containerManager = newContainerManager(fakeElapsed);
+        containerManager.checkContainers();
+        Assert.assertNotNull("Ttl node should not have been deleted yet", zk.exists(path, false));
+
+        fakeElapsed.set(1000);
+        containerManager.checkContainers();
+        Assert.assertNull("Ttl node should have been deleted", zk.exists(path, false));
+    }
+
+    @Test
+    public void testCreateAsync()
+            throws IOException, KeeperException, InterruptedException {
+        AsyncCallback.Create2Callback callback = new AsyncCallback.Create2Callback() {
+            @Override
+            public void processResult(int rc, String path, Object ctx, String name, Stat stat) {
+                // NOP
+            }
+        };
+        zk.create("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_WITH_TTL, callback, null, 100);
+
+        final AtomicLong fakeElapsed = new AtomicLong(0);
+        ContainerManager containerManager = newContainerManager(fakeElapsed);
+        containerManager.checkContainers();
+        Assert.assertNotNull("Ttl node should not have been deleted yet", zk.exists("/foo", false));
+
+        fakeElapsed.set(1000);
+        containerManager.checkContainers();
+        Assert.assertNull("Ttl node should have been deleted", zk.exists("/foo", false));
+    }
+
+    @Test
+    public void testModifying()
+            throws IOException, KeeperException, InterruptedException {
+        Stat stat = new Stat();
+        zk.create("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_WITH_TTL, stat, 100);
+        Assert.assertEquals(0, stat.getEphemeralOwner());
+
+        final AtomicLong fakeElapsed = new AtomicLong(0);
+        ContainerManager containerManager = newContainerManager(fakeElapsed);
+        containerManager.checkContainers();
+        Assert.assertNotNull("Ttl node should not have been deleted yet", zk.exists("/foo", false));
+
+        for ( int i = 0; i < 10; ++i ) {
+            fakeElapsed.set(50);
+            zk.setData("/foo", new byte[i + 1], -1);
+            containerManager.checkContainers();
+            Assert.assertNotNull("Ttl node should not have been deleted yet", zk.exists("/foo", false));
+        }
+
+        fakeElapsed.set(200);
+        containerManager.checkContainers();
+        Assert.assertNull("Ttl node should have been deleted", zk.exists("/foo", false));
+    }
+
+    @Test
+    public void testMulti()
+            throws IOException, KeeperException, InterruptedException {
+        Op createTtl = Op.create("/a", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_WITH_TTL, 100);
+        Op createTtlSequential = Op.create("/b", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL, 200);
+        Op createNonTtl = Op.create("/c", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        List<OpResult> results = zk.multi(Arrays.asList(createTtl, createTtlSequential, createNonTtl));
+        String sequentialPath = ((OpResult.CreateResult)results.get(1)).getPath();
+
+        final AtomicLong fakeElapsed = new AtomicLong(0);
+        ContainerManager containerManager = newContainerManager(fakeElapsed);
+        containerManager.checkContainers();
+        Assert.assertNotNull("node should not have been deleted yet", zk.exists("/a", false));
+        Assert.assertNotNull("node should not have been deleted yet", zk.exists(sequentialPath, false));
+        Assert.assertNotNull("node should never be deleted", zk.exists("/c", false));
+
+        fakeElapsed.set(110);
+        containerManager.checkContainers();
+        Assert.assertNull("node should have been deleted", zk.exists("/a", false));
+        Assert.assertNotNull("node should not have been deleted yet", zk.exists(sequentialPath, false));
+        Assert.assertNotNull("node should never be deleted", zk.exists("/c", false));
+
+        fakeElapsed.set(210);
+        containerManager.checkContainers();
+        Assert.assertNull("node should have been deleted", zk.exists("/a", false));
+        Assert.assertNull("node should have been deleted", zk.exists(sequentialPath, false));
+        Assert.assertNotNull("node should never be deleted", zk.exists("/c", false));
+    }
+
+    @Test
+    public void testBadUsage() throws KeeperException, InterruptedException {
+        for ( CreateMode createMode : CreateMode.values() ) {
+            try {
+                zk.create("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, createMode, new Stat(), createMode.isTTL() ? 0 : 100);
+                Assert.fail("should have thrown IllegalArgumentException");
+            } catch (IllegalArgumentException dummy) {
+                // correct
+            }
+        }
+
+        for ( CreateMode createMode : CreateMode.values() ) {
+            AsyncCallback.Create2Callback callback = new AsyncCallback.Create2Callback() {
+                @Override
+                public void processResult(int rc, String path, Object ctx, String name, Stat stat) {
+                    // NOP
+                }
+            };
+            try {
+                zk.create("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, createMode, callback, null, createMode.isTTL() ? 0 : 100);
+                Assert.fail("should have thrown IllegalArgumentException");
+            } catch (IllegalArgumentException dummy) {
+                // correct
+            }
+        }
+
+        try {
+            Op op = Op.create("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_WITH_TTL, 0);
+            zk.multi(Collections.singleton(op));
+            Assert.fail("should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException dummy) {
+            // correct
+        }
+        try {
+            Op op = Op.create("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL, 0);
+            zk.multi(Collections.singleton(op));
+            Assert.fail("should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException dummy) {
+            // correct
+        }
+    }
+
+    private ContainerManager newContainerManager(final AtomicLong fakeElapsed) {
+        return new ContainerManager(serverFactory.getZooKeeperServer()
+                .getZKDatabase(), serverFactory.getZooKeeperServer().firstProcessor, 1, 100) {
+            @Override
+            protected long getElapsed(DataNode node) {
+                return fakeElapsed.get();
+            }
+        };
+    }
+}

--- a/src/java/test/org/apache/zookeeper/server/EphemeralTypeTest.java
+++ b/src/java/test/org/apache/zookeeper/server/EphemeralTypeTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server;
+
+import org.apache.zookeeper.CreateMode;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EphemeralTypeTest {
+    @Test
+    public void testTtls() {
+        long ttls[] = {100, 1, EphemeralType.MAX_TTL};
+        for (long ttl : ttls) {
+            long ephemeralOwner = EphemeralType.ttlToEphemeralOwner(ttl);
+            Assert.assertEquals(EphemeralType.TTL, EphemeralType.get(ephemeralOwner));
+            Assert.assertEquals(ttl, EphemeralType.getTTL(ephemeralOwner));
+        }
+
+        EphemeralType.validateTTL(CreateMode.PERSISTENT_WITH_TTL, 100);
+        EphemeralType.validateTTL(CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL, 100);
+
+        try {
+            EphemeralType.validateTTL(CreateMode.EPHEMERAL, 100);
+            Assert.fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException dummy) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testContainerValue() {
+        Assert.assertEquals(Long.MIN_VALUE, EphemeralType.CONTAINER_EPHEMERAL_OWNER);
+        Assert.assertEquals(EphemeralType.CONTAINER, EphemeralType.get(EphemeralType.CONTAINER_EPHEMERAL_OWNER));
+    }
+
+    @Test
+    public void testNonSpecial() {
+        Assert.assertEquals(EphemeralType.VOID, EphemeralType.get(0));
+        Assert.assertEquals(EphemeralType.NORMAL, EphemeralType.get(1));
+        Assert.assertEquals(EphemeralType.NORMAL, EphemeralType.get(Long.MAX_VALUE));
+    }
+}

--- a/src/zookeeper.jute
+++ b/src/zookeeper.jute
@@ -127,6 +127,13 @@ module org.apache.zookeeper.proto {
         vector<org.apache.zookeeper.data.ACL> acl;
         int flags;
     }
+    class CreateTTLRequest {
+        ustring path;
+        buffer data;
+        vector<org.apache.zookeeper.data.ACL> acl;
+        int flags;
+        long ttl;
+    }
     class DeleteRequest {
         ustring path;
         int version;
@@ -259,6 +266,13 @@ module org.apache.zookeeper.txn {
         vector<org.apache.zookeeper.data.ACL> acl;
         boolean ephemeral;
         int parentCVersion;
+    }
+    class CreateTTLTxn {
+        ustring path;
+        buffer data;
+        vector<org.apache.zookeeper.data.ACL> acl;
+        int parentCVersion;
+        long ttl;
     }
     class CreateContainerTxn {
         ustring path;


### PR DESCRIPTION
This patch takes advantage of 3.5's container support. Most of the work needed to support TTLs is there already.

In order not to break on-disk and protocol compatibility the ephemeralOwner is yet-again overloaded to have special meaning. New opcodes and transaction records had to be added in a similar manner to Containers

NOTE: This patch was originally in Review Board and was moved to Github for ease/convenience. RB link: https://reviews.apache.org/r/46983/#comment214810
