### PR TITLE
enable TCP keepalive for the leadership election/quorum socket

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -561,6 +561,7 @@ public class QuorumCnxManager {
      */
     private void setSockOpts(Socket sock) throws SocketException {
         sock.setTcpNoDelay(true);
+        sock.setKeepAlive(true);
         sock.setSoTimeout(self.tickTime * self.syncLimit);
     }
 


### PR DESCRIPTION
Use TCP keep-alives for election/quorum peer connections.

This is the shortest edit distance to address [ZOOKEEPER-1748](https://issues.apache.org/jira/browse/ZOOKEEPER-1748), and is required to avoid silent packet delivery failures for a long-lived connection in AWS (amongst other environments). 

See also:
- [VPC security group connection tracking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#security-group-connection-tracking)
- [Using TCP keepalives](http://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html)
- [Zookeeper internals](https://zookeeper.apache.org/doc/r3.4.8/zookeeperInternals.html)
