### PR TITLE
ZOOKEEPER-761: Remove *synchronous* calls from the *single-threaded* C client API

### DIFF
--- a/src/c/include/zookeeper.h
+++ b/src/c/include/zookeeper.h
@@ -1505,6 +1505,41 @@ ZOOAPI void zoo_set_log_callback(zhandle_t *zh, log_callback_fn callback);
 ZOOAPI void zoo_deterministic_conn_order(int yesOrNo);
 
 /**
+ * Type of watchers: used to select which type of watchers should be removed
+ */
+typedef enum {
+  ZWATCHERTYPE_CHILDREN = 1,
+  ZWATCHERTYPE_DATA = 2,
+  ZWATCHERTYPE_ANY = 3
+} ZooWatcherType;
+
+/**
+ * \brief removes the watchers for the given path and watcher type.
+ *
+ * \param zh the zookeeper handle obtained by a call to \ref zookeeper_init
+ * \param path the path for which watchers will be removed
+ * \param wtype the watcher type to be removed
+ * \param watcher the watcher to be removed, if null all watchers for that
+ * path (and watcher type) will be removed
+ * \param watcherCtx the contex associated with the watcher to be removed
+ * \param local whether the watchers will be removed locally even if there is
+ * no server connection
+ * \return the return code for the function call.
+ * ZOK - operation completed successfully
+ * ZNOWATCHER - the watcher couldn't be found.
+ * ZINVALIDSTATE - if !local, zhandle state is either ZOO_SESSION_EXPIRED_STATE
+ * or ZOO_AUTH_FAILED_STATE
+ * ZBADARGUMENTS - invalid input parameters
+ * ZMARSHALLINGERROR - failed to marshall a request; possibly, out of memory
+ * ZSYSTEMERROR - a system error occured
+ */
+ZOOAPI int zoo_aremove_watchers(zhandle_t *zh, const char *path,
+        ZooWatcherType wtype, watcher_fn watcher, void *watcherCtx, int local,
+        void_completion_t *completion, const void *data);
+
+
+#ifdef THREADED
+/**
  * \brief create a node synchronously.
  *
  * This method will create a node in ZooKeeper. A node can only be created if
@@ -2002,15 +2037,6 @@ ZOOAPI int zoo_set_acl(zhandle_t *zh, const char *path, int version,
 ZOOAPI int zoo_multi(zhandle_t *zh, int count, const zoo_op_t *ops, zoo_op_result_t *results);
 
 /**
- * Type of watchers: used to select which type of watchers should be removed
- */
-typedef enum {
-  ZWATCHERTYPE_CHILDREN = 1,
-  ZWATCHERTYPE_DATA = 2,
-  ZWATCHERTYPE_ANY = 3
-} ZooWatcherType;
-
-/**
  * \brief removes the watchers for the given path and watcher type.
  *
  * \param zh the zookeeper handle obtained by a call to \ref zookeeper_init
@@ -2032,31 +2058,7 @@ typedef enum {
  */
 ZOOAPI int zoo_remove_watchers(zhandle_t *zh, const char *path,
         ZooWatcherType wtype, watcher_fn watcher, void *watcherCtx, int local);
-
-/**
- * \brief removes the watchers for the given path and watcher type.
- *
- * \param zh the zookeeper handle obtained by a call to \ref zookeeper_init
- * \param path the path for which watchers will be removed
- * \param wtype the watcher type to be removed
- * \param watcher the watcher to be removed, if null all watchers for that
- * path (and watcher type) will be removed
- * \param watcherCtx the contex associated with the watcher to be removed
- * \param local whether the watchers will be removed locally even if there is
- * no server connection
- * \return the return code for the function call.
- * ZOK - operation completed successfully
- * ZNOWATCHER - the watcher couldn't be found.
- * ZINVALIDSTATE - if !local, zhandle state is either ZOO_SESSION_EXPIRED_STATE
- * or ZOO_AUTH_FAILED_STATE
- * ZBADARGUMENTS - invalid input parameters
- * ZMARSHALLINGERROR - failed to marshall a request; possibly, out of memory
- * ZSYSTEMERROR - a system error occured
- */
-ZOOAPI int zoo_aremove_watchers(zhandle_t *zh, const char *path,
-        ZooWatcherType wtype, watcher_fn watcher, void *watcherCtx, int local,
-        void_completion_t *completion, const void *data);
-
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/src/c/src/cli.c
+++ b/src/c/src/cli.c
@@ -504,13 +504,8 @@ void processline(char *line) {
         }
         *ptr = '\0';
         ptr++;
-        if (async) {
-            rc = zoo_aset(zh, line, ptr, strlen(ptr), -1, my_stat_completion,
-                    strdup(line));
-        } else {
-            struct Stat stat;
-            rc = zoo_set2(zh, line, ptr, strlen(ptr), -1, &stat);
-        }
+        rc = zoo_aset(zh, line, ptr, strlen(ptr), -1, my_stat_completion,
+                strdup(line));
         if (rc) {
             fprintf(stderr, "Error %d for %s\n", rc, line);
         }
@@ -579,11 +574,7 @@ void processline(char *line) {
             fprintf(stderr, "Path must start with /, found: %s\n", line);
             return;
         }
-        if (async) {
-            rc = zoo_adelete(zh, line, -1, my_void_completion, strdup(line));
-        } else {
-            rc = zoo_delete(zh, line, -1);
-        }
+        rc = zoo_adelete(zh, line, -1, my_void_completion, strdup(line));
         if (rc) {
             fprintf(stderr, "Error %d for %s\n", rc, line);
         }

--- a/src/c/src/st_adaptor.c
+++ b/src/c/src/st_adaptor.c
@@ -48,24 +48,6 @@ int unlock_completion_list(completion_head_t *l)
 {
     return 0;
 }
-struct sync_completion *alloc_sync_completion(void)
-{
-    return (struct sync_completion*)calloc(1, sizeof(struct sync_completion));
-}
-int wait_sync_completion(struct sync_completion *sc)
-{
-    return 0;
-}
-
-void free_sync_completion(struct sync_completion *sc)
-{
-    free(sc);
-}
-
-void notify_sync_completion(struct sync_completion *sc)
-{
-}
-
 int process_async(int outstanding_sync)
 {
     return outstanding_sync == 0;

--- a/src/c/src/zk_adaptor.h
+++ b/src/c/src/zk_adaptor.h
@@ -273,10 +273,12 @@ struct _zhandle {
 int adaptor_init(zhandle_t *zh);
 void adaptor_finish(zhandle_t *zh);
 void adaptor_destroy(zhandle_t *zh);
+#if THREADED
 struct sync_completion *alloc_sync_completion(void);
 int wait_sync_completion(struct sync_completion *sc);
 void free_sync_completion(struct sync_completion *sc);
 void notify_sync_completion(struct sync_completion *sc);
+#endif
 int adaptor_send_queue(zhandle_t *zh, int timeout);
 int process_async(int outstanding_sync);
 void process_completions(zhandle_t *zh);

--- a/src/c/tests/TestClient.cc
+++ b/src/c/tests/TestClient.cc
@@ -49,7 +49,7 @@ struct buff_struct_2 {
 
 // TODO(br33d): the vast majority of this test is not usable with single threaded.
 //              it needs a overhaul to work properly with both threaded and single
-//              threaded
+//              threaded (ZOOKEEPER-2640)
 #ifdef THREADED
 // For testing LogMessage Callback functionality
 list<string> logMessages;

--- a/src/c/tests/TestClient.cc
+++ b/src/c/tests/TestClient.cc
@@ -47,6 +47,10 @@ struct buff_struct_2 {
     char *buffer;
 };
 
+// TODO(br33d): the vast majority of this test is not usable with single threaded.
+//              it needs a overhaul to work properly with both threaded and single
+//              threaded
+#ifdef THREADED
 // For testing LogMessage Callback functionality
 list<string> logMessages;
 void logMessageHandler(const char* message) {
@@ -1415,3 +1419,4 @@ volatile int Zookeeper_simpleSystem::count;
 zhandle_t *Zookeeper_simpleSystem::async_zk;
 const char Zookeeper_simpleSystem::hostPorts[] = "127.0.0.1:22181";
 CPPUNIT_TEST_SUITE_REGISTRATION(Zookeeper_simpleSystem);
+#endif

--- a/src/c/tests/TestMulti.cc
+++ b/src/c/tests/TestMulti.cc
@@ -160,12 +160,12 @@ public:
     }
 } watchctx_t;
 
+#ifdef THREADED
 class Zookeeper_multi : public CPPUNIT_NS::TestFixture
 {
     CPPUNIT_TEST_SUITE(Zookeeper_multi);
 //FIXME: None of these tests pass in single-threaded mode. It seems to be a
 //flaw in the test suite setup.
-#ifdef THREADED
     CPPUNIT_TEST(testCreate);
     CPPUNIT_TEST(testCreateDelete);
     CPPUNIT_TEST(testInvalidVersion);
@@ -178,7 +178,6 @@ class Zookeeper_multi : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testCheck);
     CPPUNIT_TEST(testWatch);
     CPPUNIT_TEST(testSequentialNodeCreateInAsyncMulti);
-#endif
     CPPUNIT_TEST_SUITE_END();
 
     static void watcher(zhandle_t *, int type, int state, const char *path,void*v){
@@ -701,3 +700,4 @@ public:
 volatile int Zookeeper_multi::count;
 const char Zookeeper_multi::hostPorts[] = "127.0.0.1:22181";
 CPPUNIT_TEST_SUITE_REGISTRATION(Zookeeper_multi);
+#endif

--- a/src/c/tests/TestReadOnlyClient.cc
+++ b/src/c/tests/TestReadOnlyClient.cc
@@ -27,11 +27,10 @@
 #include "Util.h"
 #include "WatchUtil.h"
 
+#ifdef THREADED
 class Zookeeper_readOnly : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST_SUITE(Zookeeper_readOnly);
-#ifdef THREADED
     CPPUNIT_TEST(testReadOnly);
-#endif
     CPPUNIT_TEST_SUITE_END();
 
     static void watcher(zhandle_t* zh, int type, int state,
@@ -108,3 +107,4 @@ public:
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(Zookeeper_readOnly);
+#endif

--- a/src/c/tests/TestReconfigServer.cc
+++ b/src/c/tests/TestReconfigServer.cc
@@ -22,13 +22,12 @@
 #include "Util.h"
 #include "ZooKeeperQuorumServer.h"
 
+#ifdef THREADED
 class TestReconfigServer : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST_SUITE(TestReconfigServer);
-#ifdef THREADED
     CPPUNIT_TEST(testNonIncremental);
     CPPUNIT_TEST(testRemoveConnectedFollower);
     CPPUNIT_TEST(testRemoveFollower);
-#endif
     CPPUNIT_TEST_SUITE_END();
 
   public:
@@ -325,3 +324,4 @@ testRemoveConnectedFollower() {
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestReconfigServer);
+#endif

--- a/src/java/main/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/src/java/main/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -31,12 +31,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.Set;
-
 import javax.security.sasl.SaslException;
-
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.Record;
@@ -69,7 +67,6 @@ import org.apache.zookeeper.txn.CreateSessionTxn;
 import org.apache.zookeeper.txn.TxnHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * This class implements a simple standalone ZooKeeperServer. It sets up the


### PR DESCRIPTION
the synchronous calls from a single-threaded client do not work. this patch
makes using them in a single-threaded client a compilation error.
