### PR TITLE
ZOOKEEPER-2080: Fix deadlock in dynamic reconfiguration.

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -480,16 +480,17 @@ public class QuorumCnxManager {
             self.recreateSocketAddresses(sid);
             Map<Long, QuorumPeer.QuorumServer> lastCommittedView = self.getView();
             QuorumVerifier lastSeenQV = self.getLastSeenQuorumVerifier();
+            Map<Long, QuorumPeer.QuorumServer> lastProposedView = lastSeenQV.getAllMembers();
             if (lastCommittedView.containsKey(sid)) {
                 knownId = true;
                 if (connectOne(sid, lastCommittedView.get(sid).electionAddr))
                     return;
             }
-            if (lastSeenQV != null && lastSeenQV.getAllMembers().containsKey(sid)
-                    && (!knownId || (lastSeenQV.getAllMembers().get(sid).electionAddr !=
+            if (lastSeenQV != null && lastProposedView.containsKey(sid)
+                    && (!knownId || (lastProposedView.get(sid).electionAddr !=
                     lastCommittedView.get(sid).electionAddr))) {
                 knownId = true;
-                if (connectOne(sid, lastSeenQV.getAllMembers().get(sid).electionAddr))
+                if (connectOne(sid, lastProposedView.get(sid).electionAddr))
                     return;
             }
             if (!knownId) {

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -468,12 +468,7 @@ public class QuorumCnxManager {
      * 
      *  @param sid  server id
      */
-    
     synchronized void connectOne(long sid){
-        connectOne(sid, self.getLastSeenQuorumVerifier());
-    }
-
-    synchronized void connectOne(long sid, QuorumVerifier lastSeenQV){
         if (senderWorkerMap.get(sid) != null) {
             LOG.debug("There is a connection already for server " + sid);
             return;
@@ -484,6 +479,7 @@ public class QuorumCnxManager {
             // connect in case the underlying ip address has changed.
             self.recreateSocketAddresses(sid);
             Map<Long, QuorumPeer.QuorumServer> lastCommittedView = self.getView();
+            QuorumVerifier lastSeenQV = self.getLastSeenQuorumVerifier();
             if (lastCommittedView.containsKey(sid)) {
                 knownId = true;
                 if (connectOne(sid, lastCommittedView.get(sid).electionAddr))

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -435,7 +435,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     public QuorumVerifier lastSeenQuorumVerifier = null;
 
     // Lock object that guard access to quorumVerifier and lastSeenQuorumVerifier.
-    private byte[] qvLock = new byte[0];
+    final Object QV_LOCK = new Object();
 
 
     /**
@@ -670,37 +670,37 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     }
 
     public InetSocketAddress getQuorumAddress(){
-        synchronized (qvLock) {
+        synchronized (QV_LOCK) {
             return myQuorumAddr;
         }
     }
     
     public void setQuorumAddress(InetSocketAddress addr){
-        synchronized (qvLock) {
+        synchronized (QV_LOCK) {
             myQuorumAddr = addr;
         }
     }
 
     public InetSocketAddress getElectionAddress(){
-        synchronized (qvLock) {
+        synchronized (QV_LOCK) {
             return myElectionAddr;
         }
     }
 
     public void setElectionAddress(InetSocketAddress addr){
-        synchronized (qvLock) {
+        synchronized (QV_LOCK) {
             myElectionAddr = addr;
         }
     }
     
     public InetSocketAddress getClientAddress(){
-        synchronized (qvLock) {
+        synchronized (QV_LOCK) {
             return myClientAddr;
         }
     }
     
     public void setClientAddress(InetSocketAddress addr){
-        synchronized (qvLock) {
+        synchronized (QV_LOCK) {
             myClientAddr = addr;
         }
     }
@@ -1415,7 +1415,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
      * Return QuorumVerifier object for the last committed configuration.
      */
     public QuorumVerifier getQuorumVerifier(){
-        synchronized (qvLock) {
+        synchronized (QV_LOCK) {
             return quorumVerifier;
         }
     }
@@ -1424,13 +1424,13 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
      * Return QuorumVerifier object for the last proposed configuration.
      */
     public QuorumVerifier getLastSeenQuorumVerifier(){
-        synchronized (qvLock) {
+        synchronized (QV_LOCK) {
             return lastSeenQuorumVerifier;
         }
     }
     
     private void connectNewPeers(){
-        synchronized (qvLock) {
+        synchronized (QV_LOCK) {
             if (qcm != null && quorumVerifier != null && lastSeenQuorumVerifier != null) {
                 Map<Long, QuorumServer> committedView = quorumVerifier.getAllMembers();
                 for (Entry<Long, QuorumServer> e : lastSeenQuorumVerifier.getAllMembers().entrySet()) {
@@ -1455,7 +1455,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     }
     
     public void setLastSeenQuorumVerifier(QuorumVerifier qv, boolean writeToDisk){
-        synchronized (qvLock) {
+        synchronized (QV_LOCK) {
             if (lastSeenQuorumVerifier != null && lastSeenQuorumVerifier.getVersion() > qv.getVersion()) {
                 LOG.error("setLastSeenQuorumVerifier called with stale config " + qv.getVersion() +
                         ". Current version: " + quorumVerifier.getVersion());
@@ -1481,7 +1481,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
      }       
     
     public QuorumVerifier setQuorumVerifier(QuorumVerifier qv, boolean writeToDisk){
-        synchronized (qvLock) {
+        synchronized (QV_LOCK) {
             if ((quorumVerifier != null) && (quorumVerifier.getVersion() >= qv.getVersion())) {
                 // this is normal. For example - server found out about new config through FastLeaderElection gossiping
                 // and then got the same config in UPTODATE message so its already known

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -1435,7 +1435,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
                 Map<Long, QuorumServer> committedView = quorumVerifier.getAllMembers();
                 for (Entry<Long, QuorumServer> e : lastSeenQuorumVerifier.getAllMembers().entrySet()) {
                     if (e.getKey() != getId() && !committedView.containsKey(e.getKey()))
-                        qcm.connectOne(e.getKey(), lastSeenQuorumVerifier);
+                        qcm.connectOne(e.getKey());
                 }
             }
         }


### PR DESCRIPTION
Use explicit fine grained locks for synchronizing access to QuorumVerifier states in QuorumPeer.
