### PR TITLE
ZOOKEEPER-2549 Add exception handling to sendResponse

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -667,7 +667,7 @@ public class NIOServerCnxn extends ServerCnxn {
      *      org.apache.jute.Record, java.lang.String)
      */
     @Override
-    public void sendResponse(ReplyHeader h, Record r, String tag) {
+    public void sendResponse(ReplyHeader h, Record r, String tag) throws IOException {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             // Make space for length
@@ -694,7 +694,7 @@ public class NIOServerCnxn extends ServerCnxn {
                 }
             }
          } catch(Exception e) {
-            LOG.warn("Unexpected exception. Destruction averted.", e);
+            throw new IOException(e);
          }
     }
 
@@ -716,7 +716,12 @@ public class NIOServerCnxn extends ServerCnxn {
         // Convert WatchedEvent to a type that can be sent over the wire
         WatcherEvent e = event.getWrapper();
 
-        sendResponse(h, e, "notification");
+        try {
+            sendResponse(h, e, "notification");
+        } catch (IOException ex) {
+            LOG.debug("Problem sending to " + getRemoteSocketAddress(), ex);
+            close();
+        }
     }
 
     /*

--- a/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -672,16 +672,12 @@ public class NIOServerCnxn extends ServerCnxn {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             // Make space for length
             BinaryOutputArchive bos = BinaryOutputArchive.getArchive(baos);
-            try {
-                baos.write(fourBytes);
-                bos.writeRecord(h, "header");
-                if (r != null) {
-                    bos.writeRecord(r, tag);
-                }
-                baos.close();
-            } catch (IOException e) {
-                LOG.error("Error serializing response");
+            baos.write(fourBytes);
+            bos.writeRecord(h, "header");
+            if (r != null) {
+                bos.writeRecord(r, tag);
             }
+            baos.close();
             byte b[] = baos.toByteArray();
             ByteBuffer bb = ByteBuffer.wrap(b);
             bb.putInt(b.length - 4).rewind();
@@ -720,7 +716,6 @@ public class NIOServerCnxn extends ServerCnxn {
             sendResponse(h, e, "notification");
         } catch (IOException ex) {
             LOG.debug("Problem sending to " + getRemoteSocketAddress(), ex);
-            close();
         }
     }
 

--- a/src/java/main/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -139,9 +139,7 @@ public class NettyServerCnxn extends ServerCnxn {
         try {
             sendResponse(h, e, "notification");
         } catch (IOException e1) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Problem sending to " + getRemoteSocketAddress(), e1);
-            }
+            LOG.debug("Problem sending to " + getRemoteSocketAddress(), e1);
             close();
         }
     }
@@ -165,31 +163,35 @@ public class NettyServerCnxn extends ServerCnxn {
     @Override
     public void sendResponse(ReplyHeader h, Record r, String tag)
             throws IOException {
-        if (!channel.isOpen()) {
-            return;
-        }
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        // Make space for length
-        BinaryOutputArchive bos = BinaryOutputArchive.getArchive(baos);
         try {
-            baos.write(fourBytes);
-            bos.writeRecord(h, "header");
-            if (r != null) {
-                bos.writeRecord(r, tag);
+            if (!channel.isOpen()) {
+                return;
             }
-            baos.close();
-        } catch (IOException e) {
-            LOG.error("Error serializing response");
-        }
-        byte b[] = baos.toByteArray();
-        ByteBuffer bb = ByteBuffer.wrap(b);
-        bb.putInt(b.length - 4).rewind();
-        sendBuffer(bb);
-        if (h.getXid() > 0) {
-            // zks cannot be null otherwise we would not have gotten here!
-            if (!zkServer.shouldThrottle(outstandingCount.decrementAndGet())) {
-                enableRecv();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            // Make space for length
+            BinaryOutputArchive bos = BinaryOutputArchive.getArchive(baos);
+            try {
+                baos.write(fourBytes);
+                bos.writeRecord(h, "header");
+                if (r != null) {
+                    bos.writeRecord(r, tag);
+                }
+                baos.close();
+            } catch (IOException e) {
+                LOG.error("Error serializing response");
             }
+            byte b[] = baos.toByteArray();
+            ByteBuffer bb = ByteBuffer.wrap(b);
+            bb.putInt(b.length - 4).rewind();
+            sendBuffer(bb);
+            if (h.getXid() > 0) {
+                // zks cannot be null otherwise we would not have gotten here!
+                if (!zkServer.shouldThrottle(outstandingCount.decrementAndGet())) {
+                    enableRecv();
+                }
+            }
+        } catch (Exception e) {
+            throw new IOException(e);
         }
     }
 

--- a/src/java/main/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -170,16 +170,12 @@ public class NettyServerCnxn extends ServerCnxn {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             // Make space for length
             BinaryOutputArchive bos = BinaryOutputArchive.getArchive(baos);
-            try {
-                baos.write(fourBytes);
-                bos.writeRecord(h, "header");
-                if (r != null) {
-                    bos.writeRecord(r, tag);
-                }
-                baos.close();
-            } catch (IOException e) {
-                LOG.error("Error serializing response");
+            baos.write(fourBytes);
+            bos.writeRecord(h, "header");
+            if (r != null) {
+                bos.writeRecord(r, tag);
             }
+            baos.close();
             byte b[] = baos.toByteArray();
             ByteBuffer bb = ByteBuffer.wrap(b);
             bb.putInt(b.length - 4).rewind();

--- a/src/java/main/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -71,7 +71,7 @@ public class NettyServerCnxn extends ServerCnxn {
     NettyServerCnxnFactory factory;
     boolean initialized;
     
-    NettyServerCnxn(Channel channel, ZooKeeperServer zks, NettyServerCnxnFactory factory) {
+    public NettyServerCnxn(Channel channel, ZooKeeperServer zks, NettyServerCnxnFactory factory) {
         this.channel = channel;
         this.zkServer = zks;
         this.factory = factory;

--- a/src/java/main/org/apache/zookeeper/server/ServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/ServerCnxnFactory.java
@@ -43,7 +43,12 @@ import org.slf4j.LoggerFactory;
 public abstract class ServerCnxnFactory {
 
     public static final String ZOOKEEPER_SERVER_CNXN_FACTORY = "zookeeper.serverCnxnFactory";
-    
+    /**
+     *  property to be able to overwrite NIO/NettyServerCnxn with it's subclass if needed.
+     *  Used for unit testing
+     */
+    public static final String ZOOKEEPER_SERVER_CNXN = "zookeeper.serverCnxn";
+
     private static final Logger LOG = LoggerFactory.getLogger(ServerCnxnFactory.class);
 
     // Tells whether SSL is enabled on this ServerCnxnFactory

--- a/src/java/test/org/apache/zookeeper/server/MockNettyServerCnxn.java
+++ b/src/java/test/org/apache/zookeeper/server/MockNettyServerCnxn.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server;
+
+import org.apache.jute.Record;
+import org.apache.zookeeper.proto.ReplyHeader;
+import org.jboss.netty.channel.Channel;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+/**
+ * Helper class to test different scenarios in NettyServerCnxn
+ */
+public class MockNettyServerCnxn extends NettyServerCnxn {
+
+  public MockNettyServerCnxn(Channel channel, ZooKeeperServer zks, NettyServerCnxnFactory factory) {
+    super(channel, zks, factory);
+  }
+
+  @Override
+  public void sendResponse(ReplyHeader h, Record r, String tag) throws IOException {
+    String exceptionType = System.getProperty("exception.type", "IOException");
+    switch(exceptionType) {
+      case "IOException":
+        throw new IOException("test IOException");
+      case "NoException":
+        super.sendResponse(h,r,tag);
+        break;
+      case "RunTimeException":
+        try {
+          Field zkServerField = NettyServerCnxn.class.getDeclaredField("zkServer");
+          zkServerField.setAccessible(true);
+          Field modifiersField = Field.class.getDeclaredField("modifiers");
+          modifiersField.setAccessible(true);
+          modifiersField.setInt(zkServerField, zkServerField.getModifiers() & ~Modifier.FINAL);
+          zkServerField.set((NettyServerCnxn)this, null);
+          super.sendResponse(h,r,tag);
+        } catch (NoSuchFieldException e) {
+          e.printStackTrace();
+        } catch (IllegalAccessException e) {
+          e.printStackTrace();
+        }
+        break;
+      default:
+        break;
+    }
+  }
+}

--- a/src/java/test/org/apache/zookeeper/server/ServerCxnExceptionsTest.java
+++ b/src/java/test/org/apache/zookeeper/server/ServerCxnExceptionsTest.java
@@ -1,0 +1,170 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests to test different exceptions scenarious in sendResponse
+ */
+public class ServerCxnExceptionsTest extends ClientBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ServerCxnExceptionsTest.class);
+
+  private String exceptionType;
+
+  private void NettySetup() throws Exception {
+    System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY,
+      "org.apache.zookeeper.server.NettyServerCnxnFactory");
+    System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN, "org.apache.zookeeper.server.MockNettyServerCnxn");
+    System.setProperty("exception.type", "NoException");
+  }
+
+  private void NIOSetup() throws Exception {
+    System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY,
+      "org.apache.zookeeper.server.NIOServerCnxnFactory");
+    System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN, "org.apache.zookeeper.server.MockNIOServerCnxn");
+    System.setProperty("exception.type", "NoException");
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
+    System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN);
+    System.clearProperty("exception.type");
+  }
+
+  @Test (timeout = 60000)
+  public void testNettyIOException() throws Exception {
+    tearDown();
+    NettySetup();
+    testIOExceptionHelper();
+  }
+
+  @Test (timeout = 60000)
+  public void testNIOIOException() throws Exception {
+    tearDown();
+    NIOSetup();
+    testIOExceptionHelper();
+  }
+
+  private void testIOExceptionHelper() throws Exception {
+    System.setProperty("exception.type", "IOException");
+    super.setUp();
+    final ZooKeeper zk = createClient();
+    final String path = "/a";
+    try {
+      // make sure zkclient works
+      zk.create(path, "test".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+        CreateMode.EPHEMERAL);
+      fail("Should not come here");
+      Stat stats = zk.exists(path, false);
+      if (stats != null) {
+        int length = stats.getDataLength();
+      }
+    } catch (KeeperException.ConnectionLossException cle) {
+      LOG.info("ConnectionLossException: {}", cle);
+    } finally {
+      zk.close();
+    }
+  }
+
+  @Test (timeout = 10000)
+  public void testNettyNoException() throws Exception {
+    tearDown();
+    NettySetup();
+    testZKNoExceptionHelper();
+  }
+
+  @Test (timeout = 10000)
+  public void testNIONoException() throws Exception {
+    tearDown();
+    NIOSetup();
+    testZKNoExceptionHelper();
+  }
+
+  private void testZKNoExceptionHelper() throws Exception {
+    System.setProperty("exception.type", "NoException");
+    super.setUp();
+    final ZooKeeper zk = createClient();
+    final String path = "/a";
+    try {
+      // make sure zkclient works
+      zk.create(path, "test".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+        CreateMode.EPHEMERAL);
+      Stat stats = zk.exists(path, false);
+      if ( stats != null ) {
+        int length = stats.getDataLength();
+      }
+    } catch (KeeperException.ConnectionLossException cle) {
+      LOG.error("ConnectionLossException: {}", cle);
+      fail("No exception should be thrown");
+    } catch (Throwable t) {
+      // error
+      LOG.error("Throwable {}", t);
+      fail("No exception should be thrown");
+    } finally {
+      zk.close();
+    }
+  }
+  @Test (timeout = 10000)
+  public void testNettyRunTimeException() throws Exception {
+    tearDown();
+    NettySetup();
+    testZKRunTimeExceptionHelper();
+  }
+
+  @Test (timeout = 10000)
+  public void testNIORunTimeException() throws Exception {
+    tearDown();
+    NIOSetup();
+    testZKRunTimeExceptionHelper();
+  }
+
+  private void testZKRunTimeExceptionHelper() throws Exception {
+    System.setProperty("exception.type", "RunTimeException");
+    super.setUp();
+    final ZooKeeper zk = createClient();
+    final String path = "/a";
+    try {
+      // make sure zkclient works
+      String returnPath = zk.create(path, "test".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+        CreateMode.EPHEMERAL);
+      Stat stats = zk.exists(returnPath, false);
+      if ( stats != null ) {
+        int length = stats.getDataLength();
+      }
+      fail("should not reach here");
+    } catch (KeeperException.ConnectionLossException cle) {
+      LOG.info("ConnectionLossException: {}", cle);
+    } finally {
+      zk.close();
+    }
+  }
+}


### PR DESCRIPTION
Fix for:
As NettyServerCnxn.sendResponse() allows all the exception to bubble up it can stop main ZK requests processing thread
Same changes done for NIOServerCnxn