### PR TITLE
ZOOKEEPER-2627:Remove ZRWSERVERFOUND from C client.

### DIFF
--- a/src/c/include/zookeeper.h
+++ b/src/c/include/zookeeper.h
@@ -124,7 +124,6 @@ enum ZOO_ERRORS {
   ZNOTREADONLY = -119, /*!< state-changing request is passed to read-only server */
   ZEPHEMERALONLOCALSESSION = -120, /*!< Attempt to create ephemeral node on a local session */
   ZNOWATCHER = -121, /*!< The watcher couldn't be found */
-  ZRWSERVERFOUND = -122, /*!< r/w server found while in r/o mode */
   ZRECONFIGDISABLED = -123 /*!< Attempts to perform a reconfiguration operation when reconfiguration feature is disabled */
 };
 

--- a/src/c/src/zk_adaptor.h
+++ b/src/c/src/zk_adaptor.h
@@ -194,6 +194,7 @@ struct _zhandle {
     // Hostlist and list of addresses
     char *hostname;                     // hostname contains list of zookeeper servers to connect to
     struct sockaddr_storage addr_cur;   // address of server we're currently connecting/connected to 
+    struct sockaddr_storage addr_rw_server; // address of last known read/write server found.
 
     addrvec_t addrs;                    // current list of addresses we're connected to
     addrvec_t addrs_old;                // old list of addresses that we are no longer connected to


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/ZOOKEEPER-2627

* Remove ZRWSERVERFOUND from C client to maintain consistency of error codes definition between Java / C client.
* Make C client behavior more conforming with Java client in RO mode by having an explicit RW server address and use that address whenever it's available.
