### PR TITLE
ZOOKEEPER-2633: contrib/zkfuse build fix with gcc 6.2.

### DIFF
--- a/src/contrib/zkfuse/src/event.h
+++ b/src/contrib/zkfuse/src/event.h
@@ -213,7 +213,7 @@ class GenericEvent {
         /**
          * The event represented as abstract wrapper.
          */
-        shared_ptr<AbstractEventWrapper> m_eventWrapper;
+        boost::shared_ptr<AbstractEventWrapper> m_eventWrapper;
         
 };
     

--- a/src/contrib/zkfuse/src/zkadapter.cc
+++ b/src/contrib/zkfuse/src/zkadapter.cc
@@ -673,7 +673,7 @@ ZooKeeperAdapter::deleteNode(const string &path,
             LOG_WARN( LOG, "Error %d for %s", rc, path.c_str() );
             //get all children and delete them recursively...
             vector<string> nodeList;
-            getNodeChildren( nodeList, path, false );
+            getNodeChildren( nodeList, path, NULL );
             for (vector<string>::const_iterator i = nodeList.begin();
                  i != nodeList.end();
                  ++i) {


### PR DESCRIPTION
The build fails in two places: https://gist.github.com/ronin13/3e08569dd6c69bf2ad92fa39fa85f7ee

One is boost related, and other is due to false being passed where NULL is
required.

JIRA: https://issues.apache.org/jira/browse/ZOOKEEPER-2633

Author: Raghavendra Prabhu <me@rdprabhu.com>