### PR TITLE
ZOOKEEPER-2644: contrib/rest does not include rest.sh when packaged

### DIFF
--- a/src/contrib/rest/build.xml
+++ b/src/contrib/rest/build.xml
@@ -62,6 +62,9 @@
     <copy todir="${dist.dir}${package.share}/contrib/${name}/conf">
       <fileset dir="conf" />
     </copy>
+    <copy todir="${dist.dir}${package.share}/contrib/${name}">
+      <fileset file="${zk.root}/src/contrib/${name}/rest.sh" />
+    </copy>
   </target>
 
   <target name="setjarname">

--- a/src/contrib/rest/rest.sh
+++ b/src/contrib/rest/rest.sh
@@ -29,6 +29,9 @@ else
   ZKREST="$0"
 fi
 ZKREST_HOME=`dirname "$ZKREST"`
+ZKREST_HOME="$(cd "${ZKREST_HOME}"; pwd)"
+
+ZK_HOME="$(cd "${ZKREST_HOME}/../.."; pwd)"
 
 if $cygwin
 then
@@ -54,7 +57,12 @@ do
     CLASSPATH="$i:$CLASSPATH"
 done
 
-for i in "$ZKREST_HOME"/zookeeper-*.jar
+for i in "$ZKREST_HOME"/zookeeper-*-rest.jar
+do
+    CLASSPATH="$i:$CLASSPATH"
+done
+
+for i in ${ZK_HOME}/zookeeper-*.jar
 do
     CLASSPATH="$i:$CLASSPATH"
 done


### PR DESCRIPTION
contrib/rest does not include rest.sh when packaged. I propose to add rest.sh into tar.gz that it make ZooKeeper REST easier to use.

[ZOOKEEPER-2644](https://issues.apache.org/jira/browse/ZOOKEEPER-2644)