### PR TITLE
ZOOKEEPER-2565: Fix ServerConfigTest#testValidArguments test case.

### DIFF
--- a/src/java/test/org/apache/zookeeper/ServerConfigTest.java
+++ b/src/java/test/org/apache/zookeeper/ServerConfigTest.java
@@ -23,8 +23,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 
 public class ServerConfigTest {
 
@@ -47,7 +49,7 @@ public class ServerConfigTest {
         serverConfig.parse(args);
 
         assertEquals(2181, serverConfig.getClientPortAddress().getPort());
-        assertEquals(new File("/data/dir"), serverConfig.getDataDir());
+        assertTrue(checkEquality("/data/dir", serverConfig.getDataDir()));
         assertEquals(60000, serverConfig.getTickTime());
         assertEquals(10000, serverConfig.getMaxClientCnxns());
     }
@@ -56,5 +58,17 @@ public class ServerConfigTest {
     public void testTooManyArguments() {
         String[] args = {"2181", "/data/dir", "60000", "10000", "9999"};
         serverConfig.parse(args);
+    }
+
+    boolean checkEquality(String a, String b) {
+        return a != null && a.equals(b);
+    }
+
+    boolean checkEquality(String a, File b) {
+        try {
+            return a != null && b != null && new File(a).getCanonicalPath().equals(b.getCanonicalPath());
+        } catch (IOException e) {
+        }
+        return false;
     }
 }


### PR DESCRIPTION
ServerConfig.getDataDir returns type String in branch-3.4 but return type File in branch-3.5 and master. So we need to deal with this difference accordingly in our test.

This PR is intended to be merged in master, branch-3.5, and branch-3.4.

@rakeshadr PTAL
