### PR TITLE
ZOOKEEPER-2664: ClientPortBindTest#testBindByAddress may fail due to "No such device" exception

### DIFF
--- a/src/java/test/org/apache/zookeeper/test/ClientPortBindTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientPortBindTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.util.Enumeration;
 
 import org.slf4j.Logger;
@@ -51,15 +52,19 @@ public class ClientPortBindTest extends ZKTestCase{
         // if we have a loopback and it has an address use it
         while(intfs.hasMoreElements()) {
             NetworkInterface i = intfs.nextElement();
-            if (i.isLoopback()) {
-                Enumeration<InetAddress> addrs = i.getInetAddresses();
-                while (addrs.hasMoreElements()) {
+            try {
+                if (i.isLoopback()) {
+                  Enumeration<InetAddress> addrs = i.getInetAddresses();
+                  while (addrs.hasMoreElements()) {
                     InetAddress a = addrs.nextElement();
                     if(a.isLoopbackAddress()) {
-                        bindAddress = a.getHostAddress();
-                        break;
+                      bindAddress = a.getHostAddress();
+                      break;
                     }
+                  }
                 }
+            } catch (SocketException se) {
+                LOG.warn("Couldn't find  loopback interface: " + se.getMessage());
             }
         }
         if (bindAddress == null) {


### PR DESCRIPTION
The following stack trace was observed intermittently:
```
Stacktrace

java.net.SocketException: No such device
	at java.net.NetworkInterface.isLoopback0(Native Method)
	at java.net.NetworkInterface.isLoopback(NetworkInterface.java:390)
	at org.apache.zookeeper.test.ClientPortBindTest.testBindByAddress(ClientPortBindTest.java:61)
	at org.apache.zookeeper.JUnit4ZKTestRunner$LoggedInvokeMethod.evaluate(JUnit4ZKTestRunner.java:52)
Standard Output
```
Proposed fix is to catch exception from isLoopback() call and skip the test in that case.