### PR TITLE
ZOOKEEPER-2184: Zookeeper Client should re-resolve hosts when connection attempts fail

### DIFF
--- a/src/java/main/org/apache/zookeeper/client/StaticHostProvider.java
+++ b/src/java/main/org/apache/zookeeper/client/StaticHostProvider.java
@@ -87,7 +87,7 @@ public final class StaticHostProvider implements HostProvider {
         String hostString;
         InetAddress ia = addr.getAddress();
 
-        if ( ia != null ) {
+        if (ia != null) {
             // If the string starts with '/', then it has no hostname
             // and we want to avoid the reverse lookup, so we return
             // the string representation of the address.
@@ -100,7 +100,7 @@ public final class StaticHostProvider implements HostProvider {
             // According to the Java 6 documentation, if the hostname is
             // unresolved, then the string before the colon is the hostname.
             String addrString = addr.toString();
-            hostString = addrString.substring(0, addrString.indexOf( ':' ));
+            hostString = addrString.substring(0, addrString.lastIndexOf(':'));
         }
 
         return hostString;

--- a/src/java/main/org/apache/zookeeper/client/StaticHostProvider.java
+++ b/src/java/main/org/apache/zookeeper/client/StaticHostProvider.java
@@ -122,11 +122,11 @@ public final class StaticHostProvider implements HostProvider {
     private int nextAdded = 0;
     private int nextRemoved = 0;
 
-    public int getNextAdded() {
+    int getNextAdded() {
         return nextAdded;
     }
 
-    public int getNextRemoved() {
+    int getNextRemoved() {
         return nextRemoved;
     }
 
@@ -134,6 +134,7 @@ public final class StaticHostProvider implements HostProvider {
         // Handle possible connection error by re-resolving hostname if possible
         if (!connectedSinceNext) {
             InetSocketAddress curAddr = serverAddresses.get(currentIndex);
+            String curHostString = getHostString(curAddr);
             if (!getHostString(curAddr).equals(curAddr.getAddress().getHostAddress())) {
                 LOG.info("Resolving again hostname: {}", getHostString(curAddr));
                 try {
@@ -147,8 +148,9 @@ public final class StaticHostProvider implements HostProvider {
                         LOG.debug("Newly resolved address: {}", resolvedAddresses[0]);
                     } else {
                         int i = 0;
-                        while(i < serverAddresses.size()) {
-                            if(getHostString(serverAddresses.get(i)) == getHostString(curAddr)) {
+                        while (i < serverAddresses.size()) {
+                            if (getHostString(serverAddresses.get(i)).equals(curHostString) &&
+                                    serverAddresses.get(i).getPort() == curAddr.getPort()) {
                                 LOG.debug("Removing address: {}", serverAddresses.get(i));
                                 serverAddresses.remove(i);
                                 nextRemoved++;

--- a/src/java/main/org/apache/zookeeper/client/StaticHostProvider.java
+++ b/src/java/main/org/apache/zookeeper/client/StaticHostProvider.java
@@ -88,7 +88,7 @@ public final class StaticHostProvider implements HostProvider {
     private String getHostString(InetSocketAddress addr) {
         String hostString = "";
 
-        if(addr == null) {
+        if (addr == null) {
             return hostString;
         }
         if (!addr.isUnresolved()) {
@@ -135,11 +135,11 @@ public final class StaticHostProvider implements HostProvider {
         if (!connectedSinceNext) {
             InetSocketAddress curAddr = serverAddresses.get(currentIndex);
             String curHostString = getHostString(curAddr);
-            if (!getHostString(curAddr).equals(curAddr.getAddress().getHostAddress())) {
+            if (!curHostString.equals(curAddr.getAddress().getHostAddress())) {
                 LOG.info("Resolving again hostname: {}", getHostString(curAddr));
                 try {
                     int thePort = curAddr.getPort();
-                    InetAddress resolvedAddresses[] = InetAddress.getAllByName(getHostString(curAddr));
+                    InetAddress resolvedAddresses[] = InetAddress.getAllByName(curHostString);
                     nextAdded = 0;
                     nextRemoved = 0;
                     if (resolvedAddresses.length == 1) {

--- a/src/java/main/org/apache/zookeeper/client/StaticHostProvider.java
+++ b/src/java/main/org/apache/zookeeper/client/StaticHostProvider.java
@@ -81,7 +81,7 @@ public final class StaticHostProvider implements HostProvider {
      * string representation of the IP address.
      *
      * @param addr
-     * @return
+     * @return Hostname string of address parameter
      */
     private String getHostString(InetSocketAddress addr) {
         String hostString;
@@ -134,11 +134,8 @@ public final class StaticHostProvider implements HostProvider {
                 }
             }
         }
-        ++currentIndex;
         connectedSinceNext = false;
-        if (currentIndex == serverAddresses.size()) {
-            currentIndex = 0;
-        }
+        currentIndex = ++currentIndex % serverAddresses.size();
         if (currentIndex == lastIndex && spinDelay > 0) {
             try {
                 Thread.sleep(spinDelay);

--- a/src/java/test/org/apache/zookeeper/client/StaticHostProviderTest.java
+++ b/src/java/test/org/apache/zookeeper/client/StaticHostProviderTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.zookeeper.test;
+package org.apache.zookeeper.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;

--- a/src/java/test/org/apache/zookeeper/client/StaticHostProviderTest.java
+++ b/src/java/test/org/apache/zookeeper/client/StaticHostProviderTest.java
@@ -134,6 +134,22 @@ public class StaticHostProviderTest extends ZKTestCase {
         assertTrue("No address was added", hostProvider.getNextAdded() > 0);
     }
 
+    @Test
+    public void testReResolvingLocalhost() throws UnknownHostException {
+        byte size = 2;
+        ArrayList<InetSocketAddress> list = new ArrayList<InetSocketAddress>(size);
+
+        // Test a hostname that resolves to multiple addresses
+        list.add(InetSocketAddress.createUnresolved("localhost", 1234));
+        list.add(InetSocketAddress.createUnresolved("localhost", 1235));
+        StaticHostProvider hostProvider = new StaticHostProvider(list);
+        int sizeBefore = hostProvider.size();
+        InetSocketAddress next = hostProvider.next(0);
+        next = hostProvider.next(0);
+        assertTrue("Different number of addresses in the list: " + hostProvider.size() +
+                " (after), " + sizeBefore + " (before)", hostProvider.size() == sizeBefore);
+    }
+
     private StaticHostProvider getHostProviderUnresolved(byte size)
             throws UnknownHostException {
         return new StaticHostProvider(getUnresolvedServerAddresses(size));

--- a/src/java/test/org/apache/zookeeper/test/ClientPortBindTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientPortBindTest.java
@@ -99,7 +99,7 @@ public class ClientPortBindTest extends ZKTestCase implements Watcher {
         try {
             startSignal.await(CONNECTION_TIMEOUT,
                     TimeUnit.MILLISECONDS);
-            Assert.assertTrue("count == 0", startSignal.getCount() == 0);
+            Assert.assertTrue("count == " + startSignal.getCount(), startSignal.getCount() == 0);
             zk.close();
         } finally {
             f.shutdown();

--- a/src/java/test/org/apache/zookeeper/test/ReadOnlyModeTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReadOnlyModeTest.java
@@ -29,7 +29,6 @@ import junit.framework.Assert;
 
 import org.apache.log4j.Layout;
 import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.apache.log4j.WriterAppender;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -42,12 +41,19 @@ import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.ZooKeeper.States;
+import org.apache.zookeeper.client.StaticHostProviderTest;
 import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
 public class ReadOnlyModeTest extends ZKTestCase {
+    private static final Logger LOG = LoggerFactory.getLogger(ReadOnlyModeTest.class);
     private static int CONNECTION_TIMEOUT = QuorumBase.CONNECTION_TIMEOUT;
     private QuorumUtil qu = new QuorumUtil(1);
 
@@ -201,6 +207,7 @@ public class ReadOnlyModeTest extends ZKTestCase {
         qu.shutdown(2);
 
         CountdownWatcher watcher = new CountdownWatcher();
+        LOG.debug("Connection string: {}", qu.getConnString());
         ZooKeeper zk = new ZooKeeper(qu.getConnString(), CONNECTION_TIMEOUT,
                 watcher, true);
         watcher.waitForConnected(CONNECTION_TIMEOUT);
@@ -230,13 +237,13 @@ public class ReadOnlyModeTest extends ZKTestCase {
     public void testSeekForRwServer() throws Exception {
 
         // setup the logger to capture all logs
-        Layout layout = Logger.getRootLogger().getAppender("CONSOLE")
+        Layout layout = org.apache.log4j.Logger.getRootLogger().getAppender("CONSOLE")
                 .getLayout();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         WriterAppender appender = new WriterAppender(layout, os);
         appender.setImmediateFlush(true);
         appender.setThreshold(Level.INFO);
-        Logger zlogger = Logger.getLogger("org.apache.zookeeper");
+        org.apache.log4j.Logger zlogger = org.apache.log4j.Logger.getLogger("org.apache.zookeeper");
         zlogger.addAppender(appender);
 
         try {

--- a/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
+++ b/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
@@ -102,9 +102,10 @@ public class StaticHostProviderTest extends ZKTestCase {
             InetSocketAddress next = hostProvider.next(0);
             assertTrue(next instanceof InetSocketAddress);
             assertTrue(!next.isUnresolved());
-            assertTrue("Did not match "+ next.toString(), !next.toString().startsWith("/"));
+            assertTrue("InetSocketAddress must not have hostname part" +
+                       next.toString(), next.toString().startsWith("/"));
             // Do NOT trigger the reverse name service lookup.
-            String hostname = next.getHostName();
+            String hostname = next.getHostString();
             // In this case, the hostname equals literal IP address.
             hostname.equals(next.getAddress().getHostAddress());
         }
@@ -118,7 +119,7 @@ public class StaticHostProviderTest extends ZKTestCase {
     private Collection<InetSocketAddress> getUnresolvedServerAddresses(byte size) {
         ArrayList<InetSocketAddress> list = new ArrayList<InetSocketAddress>(size);
         while (size > 0) {
-            list.add(InetSocketAddress.createUnresolved("10.10.10." + size, 1234 + size));
+            list.add(InetSocketAddress.createUnresolved("192.0.2." + size, 1234 + size));
             --size;
         }
         return list;
@@ -130,7 +131,7 @@ public class StaticHostProviderTest extends ZKTestCase {
                 size);
         while (size > 0) {
             try {
-                list.add(new InetSocketAddress(InetAddress.getByAddress(new byte[]{10, 10, 10, size}), 1234 + size));
+                list.add(new InetSocketAddress(InetAddress.getByAddress(new byte[]{-64, 0, 2, size}), 1234 + size));
             } catch (UnknownHostException e) {
                 LOG.error("Exception while resolving address", e);
                 fail("Failed to resolve address");

--- a/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
+++ b/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
@@ -102,10 +102,10 @@ public class StaticHostProviderTest extends ZKTestCase {
             InetSocketAddress next = hostProvider.next(0);
             assertTrue(next instanceof InetSocketAddress);
             assertTrue(!next.isUnresolved());
-            assertTrue("InetSocketAddress must not have hostname part" +
+            assertTrue("InetSocketAddress must not have hostname part " +
                        next.toString(), next.toString().startsWith("/"));
             // Do NOT trigger the reverse name service lookup.
-            String hostname = next.getHostString();
+            String hostname = next.getHostName();
             // In this case, the hostname equals literal IP address.
             hostname.equals(next.getAddress().getHostAddress());
         }

--- a/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
+++ b/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
@@ -111,6 +111,29 @@ public class StaticHostProviderTest extends ZKTestCase {
         }
     }
 
+    @Test
+    public void testReResolving() throws UnknownHostException {
+        byte size = 1;
+        ArrayList<InetSocketAddress> list = new ArrayList<InetSocketAddress>(size);
+
+        // Test a hostname that resolves to multiple addresses
+        list.add(InetSocketAddress.createUnresolved("www.apache.org", 1234));
+        StaticHostProvider hostProvider = new StaticHostProvider(list);
+        InetSocketAddress next = hostProvider.next(0);
+        next = hostProvider.next(0);
+        assertTrue("No address was removed", hostProvider.getNextRemoved() > 0);
+        assertTrue("No address was added", hostProvider.getNextAdded() > 0);
+
+        // Test a hostname that resolves to a single address
+        list.clear();
+        list.add(InetSocketAddress.createUnresolved("issues.apache.org", 1234));
+        hostProvider = new StaticHostProvider(list);
+        next = hostProvider.next(0);
+        next = hostProvider.next(0);
+        assertTrue("No address was removed", hostProvider.getNextRemoved() > 0);
+        assertTrue("No address was added", hostProvider.getNextAdded() > 0);
+    }
+
     private StaticHostProvider getHostProviderUnresolved(byte size)
             throws UnknownHostException {
         return new StaticHostProvider(getUnresolvedServerAddresses(size));


### PR DESCRIPTION
This is a version of the patch for ZK-2184 for the 3.4 branch, compatible with Java 6.