### PR TITLE
[ZOOKEEPER-2642] reconfig() is now named reconfigure() due to ZOOKEEPER-2642

### DIFF
--- a/src/java/main/org/apache/zookeeper/admin/ZooKeeperAdmin.java
+++ b/src/java/main/org/apache/zookeeper/admin/ZooKeeperAdmin.java
@@ -172,8 +172,8 @@ public class ZooKeeperAdmin extends ZooKeeper {
      * @throws InterruptedException If the server transaction is interrupted.
      * @throws KeeperException If the server signals an error with a non-zero error code.
      */
-    public byte[] reconfig(String joiningServers, String leavingServers,
-                           String newMembers, long fromConfig, Stat stat) throws KeeperException, InterruptedException {
+    public byte[] reconfigure(String joiningServers, String leavingServers,
+                              String newMembers, long fromConfig, Stat stat) throws KeeperException, InterruptedException {
         RequestHeader h = new RequestHeader();
         h.setType(ZooDefs.OpCode.reconfig);
         ReconfigRequest request = new ReconfigRequest(joiningServers, leavingServers, newMembers, fromConfig);
@@ -191,13 +191,13 @@ public class ZooKeeperAdmin extends ZooKeeper {
     /**
      * Convenience wrapper around reconfig that takes Lists of strings instead of comma-separated servers.
      *
-     * @see #reconfig
+     * @see #reconfigure
      *
      */
-    public byte[] reconfig(List<String> joiningServers, List<String> leavingServers,
-                           List<String> newMembers, long fromConfig,
-                           Stat stat) throws KeeperException, InterruptedException {
-        return reconfig(StringUtils.joinStrings(joiningServers, ","),
+    public byte[] reconfigure(List<String> joiningServers, List<String> leavingServers,
+                              List<String> newMembers, long fromConfig,
+                              Stat stat) throws KeeperException, InterruptedException {
+        return reconfigure(StringUtils.joinStrings(joiningServers, ","),
                         StringUtils.joinStrings(leavingServers, ","),
                         StringUtils.joinStrings(newMembers, ","),
                         fromConfig, stat);
@@ -206,11 +206,11 @@ public class ZooKeeperAdmin extends ZooKeeper {
     /**
      * The Asynchronous version of reconfig.
      *
-     * @see #reconfig
+     * @see #reconfigure
      *
      **/
-    public void reconfig(String joiningServers, String leavingServers,
-        String newMembers, long fromConfig, DataCallback cb, Object ctx) {
+    public void reconfigure(String joiningServers, String leavingServers,
+                            String newMembers, long fromConfig, DataCallback cb, Object ctx) {
         RequestHeader h = new RequestHeader();
         h.setType(ZooDefs.OpCode.reconfig);
         ReconfigRequest request = new ReconfigRequest(joiningServers, leavingServers, newMembers, fromConfig);
@@ -222,13 +222,13 @@ public class ZooKeeperAdmin extends ZooKeeper {
     /**
      * Convenience wrapper around asynchronous reconfig that takes Lists of strings instead of comma-separated servers.
      *
-     * @see #reconfig
+     * @see #reconfigure
      *
      */
-    public void reconfig(List<String> joiningServers,
-        List<String> leavingServers, List<String> newMembers, long fromConfig,
-        DataCallback cb, Object ctx) {
-        reconfig(StringUtils.joinStrings(joiningServers, ","),
+    public void reconfigure(List<String> joiningServers,
+                            List<String> leavingServers, List<String> newMembers, long fromConfig,
+                            DataCallback cb, Object ctx) {
+        reconfigure(StringUtils.joinStrings(joiningServers, ","),
                  StringUtils.joinStrings(leavingServers, ","),
                  StringUtils.joinStrings(newMembers, ","),
                  fromConfig, cb, ctx);

--- a/src/java/main/org/apache/zookeeper/cli/ReconfigCommand.java
+++ b/src/java/main/org/apache/zookeeper/cli/ReconfigCommand.java
@@ -154,7 +154,7 @@ public class ReconfigCommand extends CliCommand {
                 return false;
             }
 
-            byte[] curConfig = ((ZooKeeperAdmin)zk).reconfig(joining,
+            byte[] curConfig = ((ZooKeeperAdmin)zk).reconfigure(joining,
                     leaving, members, version, stat);
             out.println("Committed new configuration:\n" + new String(curConfig));
             

--- a/src/java/test/org/apache/zookeeper/server/quorum/ReconfigDuringLeaderSyncTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/ReconfigDuringLeaderSyncTest.java
@@ -149,7 +149,7 @@ public class ReconfigDuringLeaderSyncTest extends QuorumPeerTestBase {
         // Leader.NEWLEADER
         while (true) {
             if (qp.isNewLeaderMessage()) {
-                preReconfigClient.reconfig(serverConfig[joinerId], null, null, -1, null, null);
+                preReconfigClient.reconfigure(serverConfig[joinerId], null, null, -1, null, null);
                 break;
             } else {
                 // sleep for 10 millisecond and then again check

--- a/src/java/test/org/apache/zookeeper/server/quorum/ReconfigFailureCasesTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/ReconfigFailureCasesTest.java
@@ -91,7 +91,7 @@ public class ReconfigFailureCasesTest extends QuorumPeerTestBase {
         List<String> leavingServers = new ArrayList<String>();
         leavingServers.add("3");
         try {
-             zkAdminArr[1].reconfig(null, leavingServers, null, -1, null);
+             zkAdminArr[1].reconfigure(null, leavingServers, null, -1, null);
             Assert.fail("Reconfig should have failed since the current config isn't Majority QS");
         } catch (KeeperException.BadArgumentsException e) {
             // We expect this to happen.
@@ -121,7 +121,7 @@ public class ReconfigFailureCasesTest extends QuorumPeerTestBase {
         leavingServers.add("2");
         leavingServers.add("3");
         try {
-             zkAdminArr[1].reconfig(null, leavingServers, null, -1, null);
+             zkAdminArr[1].reconfigure(null, leavingServers, null, -1, null);
             Assert.fail("Reconfig should have failed since the current config version is not 8");
         } catch (KeeperException.BadArgumentsException e) {
             // We expect this to happen.
@@ -147,7 +147,7 @@ public class ReconfigFailureCasesTest extends QuorumPeerTestBase {
         List<String> leavingServers = new ArrayList<String>();
         leavingServers.add("3");
         try {
-             zkAdminArr[1].reconfig(null, leavingServers, null, 8, null);
+             zkAdminArr[1].reconfigure(null, leavingServers, null, 8, null);
             Assert.fail("Reconfig should have failed since the current config version is not 8");
         } catch (KeeperException.BadVersionException e) {
             // We expect this to happen.
@@ -182,7 +182,7 @@ public class ReconfigFailureCasesTest extends QuorumPeerTestBase {
             // We try to remove server 3, which requires a quorum of {1,2,3}
             // (we have that) and of {1,2}, but 2 is down so we won't get a
             // quorum of new config ACKs.
-            zkAdminArr[1].reconfig(null, leavingServers, null, -1, null);
+            zkAdminArr[1].reconfigure(null, leavingServers, null, -1, null);
             Assert.fail("Reconfig should have failed since we don't have quorum of new config");
         } catch (KeeperException.ConnectionLossException e) {
             // We expect leader to lose quorum of proposed config and time out
@@ -255,7 +255,7 @@ public class ReconfigFailureCasesTest extends QuorumPeerTestBase {
         }
 
         try {
-            zkAdmin[1].reconfig("", "", nextQuorumCfgSection, -1, new Stat());
+            zkAdmin[1].reconfigure("", "", nextQuorumCfgSection, -1, new Stat());
             Assert.fail("Reconfig should have failed with NewConfigNoQuorum");
         } catch (NewConfigNoQuorum e) {
             // This is expected case since server 0 is down and 3 can't vote

--- a/src/java/test/org/apache/zookeeper/server/quorum/StandaloneDisabledTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/StandaloneDisabledTest.java
@@ -94,7 +94,7 @@ public class StandaloneDisabledTest extends QuorumPeerTestBase {
         reconfigServers.clear();
         reconfigServers.add(Integer.toString(follower2));
         try {
-            zkAdminHandles[follower2].reconfig(null, reconfigServers, null, -1, new Stat());
+            zkAdminHandles[follower2].reconfigure(null, reconfigServers, null, -1, new Stat());
             Assert.fail("reconfig completed successfully even though there is no quorum up in new config!");
         } catch (KeeperException.BadArgumentsException e) {
             // This is expected.

--- a/src/java/test/org/apache/zookeeper/test/ReconfigExceptionTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReconfigExceptionTest.java
@@ -214,7 +214,7 @@ public class ReconfigExceptionTest extends ZKTestCase {
                 + qu.getPeer(followerId).peer.getQuorumAddress().getPort() /*quorum port*/
                 + ":" + qu.getPeer(followerId).peer.getElectionAddress().getPort() /*election port*/
                 + ":participant;localhost:" + PortAssignment.unique()/* new client port */);
-        zkAdmin.reconfig(joiningServers, null, null, -1, new Stat());
+        zkAdmin.reconfigure(joiningServers, null, null, -1, new Stat());
         return true;
     }
 }

--- a/src/java/test/org/apache/zookeeper/test/ReconfigMisconfigTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReconfigMisconfigTest.java
@@ -123,7 +123,7 @@ public class ReconfigMisconfigTest extends ZKTestCase {
                 + qu.getPeer(followerId).peer.getQuorumAddress().getPort() /*quorum port*/
                 + ":" + qu.getPeer(followerId).peer.getElectionAddress().getPort() /*election port*/
                 + ":participant;localhost:" + PortAssignment.unique()/* new client port */);
-        zkAdmin.reconfig(joiningServers, null, null, -1, new Stat());
+        zkAdmin.reconfigure(joiningServers, null, null, -1, new Stat());
         return true;
     }
 }

--- a/src/java/test/org/apache/zookeeper/test/ReconfigTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReconfigTest.java
@@ -81,7 +81,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         byte[] config = null;
         for (int j = 0; j < 30; j++) {
             try {
-                config = zkAdmin.reconfig(joiningServers, leavingServers,
+                config = zkAdmin.reconfigure(joiningServers, leavingServers,
                         newMembers, fromConfig, new Stat());
                 break;
             } catch (KeeperException.ConnectionLossException e) {
@@ -481,7 +481,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
  
         LinkedList<Integer> results = new LinkedList<Integer>();
         
-        zkAdminArr[1].reconfig(null, leavingServers, null, -1, this, results);
+        zkAdminArr[1].reconfigure(null, leavingServers, null, -1, this, results);
         
         synchronized (results) {
             while (results.size() < 1) {

--- a/src/java/test/org/apache/zookeeper/test/StandaloneTest.java
+++ b/src/java/test/org/apache/zookeeper/test/StandaloneTest.java
@@ -151,7 +151,7 @@ public class StandaloneTest extends QuorumPeerTestBase implements Watcher{
         // generate some transactions that will get logged
         try {
             zkAdmin.addAuthInfo("digest", "super:test".getBytes());
-            zkAdmin.reconfig(joiners, null, null, -1, new Stat());
+            zkAdmin.reconfigure(joiners, null, null, -1, new Stat());
             Assert.fail("Reconfiguration in standalone should trigger " +
                         "UnimplementedException");
         } catch (KeeperException.UnimplementedException ex) {


### PR DESCRIPTION
Was #122