### PR TITLE
ZOOKEEPER-2680:Correct DataNode.getChildren() inconsistent behaviour.

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/ContainerManager.java
+++ b/src/java/main/org/apache/zookeeper/server/ContainerManager.java
@@ -149,7 +149,7 @@ public class ContainerManager {
                 would be immediately be deleted.
              */
             if ((node != null) && (node.stat.getCversion() > 0) &&
-                    (node.getChildren().size() == 0)) {
+                    (node.getChildren().isEmpty())) {
                 candidates.add(containerPath);
             }
         }
@@ -157,7 +157,7 @@ public class ContainerManager {
             DataNode node = zkDb.getDataTree().getNode(ttlPath);
             if (node != null) {
                 Set<String> children = node.getChildren();
-                if ((children == null) || (children.size() == 0)) {
+                if (children.isEmpty()) {
                     long elapsed = getElapsed(node);
                     long ttl = EphemeralType.getTTL(node.stat.getEphemeralOwner());
                     if ((ttl != 0) && (elapsed > ttl)) {

--- a/src/java/main/org/apache/zookeeper/server/DataNode.java
+++ b/src/java/main/org/apache/zookeeper/server/DataNode.java
@@ -124,7 +124,8 @@ public class DataNode implements Record {
     /**
      * convenience methods to get the children
      * 
-     * @return the children of this datanode
+     * @return the children of this datanode. If the datanode has no children, empty
+     *         set is returned
      */
     public synchronized Set<String> getChildren() {
         if (children == null) {

--- a/src/java/main/org/apache/zookeeper/server/DataNode.java
+++ b/src/java/main/org/apache/zookeeper/server/DataNode.java
@@ -57,6 +57,8 @@ public class DataNode implements Record {
      */
     private Set<String> children = null;
 
+    private static final Set<String> EMPTY_SET = Collections.emptySet();
+
     /**
      * default constructor for the datanode
      */
@@ -126,7 +128,7 @@ public class DataNode implements Record {
      */
     public synchronized Set<String> getChildren() {
         if (children == null) {
-            return children;
+            return EMPTY_SET;
         }
 
         return Collections.unmodifiableSet(children);

--- a/src/java/main/org/apache/zookeeper/server/DataTree.java
+++ b/src/java/main/org/apache/zookeeper/server/DataTree.java
@@ -678,6 +678,7 @@ public class DataTree {
                 n.copyStat(stat);
             }
             List<String> children=new ArrayList<String>(n.getChildren());
+
             if (watcher != null) {
                 childWatches.addWatch(path, watcher);
             }
@@ -1045,18 +1046,16 @@ public class DataTree {
         if (node == null) {
             return;
         }
-        Set<String> children = null;
+        String[] children = null;
         int len = 0;
         synchronized (node) {
-            children = node.getChildren();
+            Set<String> childs = node.getChildren();
+            children = childs.toArray(new String[childs.size()]);
             len = (node.data == null ? 0 : node.data.length);
         }
         // add itself
         counts.count += 1;
         counts.bytes += len;
-        if (children.isEmpty()) {
-            return;
-        }
         for (String child : children) {
             getCounts(path + "/" + child, counts);
         }
@@ -1093,11 +1092,12 @@ public class DataTree {
      */
     private void traverseNode(String path) {
         DataNode node = getNode(path);
-        Set<String> children = null;
+        String children[] = null;
         synchronized (node) {
-            children = node.getChildren();
+            Set<String> childs = node.getChildren();
+            children = childs.toArray(new String[childs.size()]);
         }
-        if (children.isEmpty()) {
+        if (children.length == 0) {
             // this node does not have a child
             // is the leaf node
             // check if its the leaf node
@@ -1147,7 +1147,7 @@ public class DataTree {
         if (node == null) {
             return;
         }
-        Set<String> children = null;
+        String children[] = null;
         DataNode nodeCopy;
         synchronized (node) {
             StatPersisted statCopy = new StatPersisted();
@@ -1155,7 +1155,8 @@ public class DataTree {
             //we do not need to make a copy of node.data because the contents
             //are never changed
             nodeCopy = new DataNode(node.data, node.acl, statCopy);
-            children = node.getChildren();
+            Set<String> childs = node.getChildren();
+            children = childs.toArray(new String[childs.size()]);
         }
         oa.writeString(pathString, "path");
         oa.writeRecord(nodeCopy, "node");

--- a/src/java/main/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -168,8 +168,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
                     synchronized(n) {
                         children = n.getChildren();
                     }
-                    lastChange = new ChangeRecord(-1, path, n.stat,
-                        children != null ? children.size() : 0,
+                    lastChange = new ChangeRecord(-1, path, n.stat, children.size(),
                             zks.getZKDatabase().aclForNode(n));
                 }
             }

--- a/src/java/main/org/apache/zookeeper/server/SnapshotFormatter.java
+++ b/src/java/main/org/apache/zookeeper/server/SnapshotFormatter.java
@@ -94,10 +94,8 @@ public class SnapshotFormatter {
             }
             children = n.getChildren();
         }
-        if (children != null) {
-            for (String child : children) {
-                printZnode(dataTree, name + (name.equals("/") ? "" : "/") + child);
-            }
+        for (String child : children) {
+            printZnode(dataTree, name + (name.equals("/") ? "" : "/") + child);
         }
     }
 

--- a/src/java/test/org/apache/zookeeper/server/DataNodeTest.java
+++ b/src/java/test/org/apache/zookeeper/server/DataNodeTest.java
@@ -52,8 +52,7 @@ public class DataNodeTest {
     }
 
     @Test
-    public void testGetChildrenRetrunsImmutableEmptySet() {
-        // Returned empty set must not be modifiable
+    public void testGetChildrenReturnsImmutableEmptySet() {
         DataNode dataNode = new DataNode();
         Set<String> children = dataNode.getChildren();
         try {

--- a/src/java/test/org/apache/zookeeper/server/DataNodeTest.java
+++ b/src/java/test/org/apache/zookeeper/server/DataNodeTest.java
@@ -51,4 +51,16 @@ public class DataNodeTest {
         }
     }
 
+    @Test
+    public void testGetChildrenRetrunsImmutableEmptySet() {
+        // Returned empty set must not be modifiable
+        DataNode dataNode = new DataNode();
+        Set<String> children = dataNode.getChildren();
+        try {
+            children.add("new child");
+            fail("UnsupportedOperationException is expected");
+        } catch (UnsupportedOperationException e) {
+            // do nothing
+        }
+    }
 }

--- a/src/java/test/org/apache/zookeeper/server/DataNodeTest.java
+++ b/src/java/test/org/apache/zookeeper/server/DataNodeTest.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server;
+
+import static org.junit.Assert.*;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+public class DataNodeTest {
+
+    @Test
+    public void testGetChildrenShouldReturnEmptySetWhenThereAreNoChidren() {
+        // create DataNode and call getChildren
+        DataNode dataNode = new DataNode();
+        Set<String> children = dataNode.getChildren();
+        assertNotNull(children);
+        assertEquals(0, children.size());
+
+        // add child,remove child and then call getChildren
+        String child = "child";
+        dataNode.addChild(child);
+        dataNode.removeChild(child);
+        children = dataNode.getChildren();
+        assertNotNull(children);
+        assertEquals(0, children.size());
+
+        // Returned empty set must not be modifiable
+        children = dataNode.getChildren();
+        try {
+            children.add("new child");
+            fail("UnsupportedOperationException is expected");
+        } catch (UnsupportedOperationException e) {
+            // do nothing
+        }
+    }
+
+}


### PR DESCRIPTION
DataNode.getChildren() API behavior should be changed and it should always return empty set if the node does not have any child. Currently this API returns some times null some times empty set.
