### PR TITLE
ZOOKEEPER-2684 commitProcessor does not crash when an unseen commit somes

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/CommitProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/CommitProcessor.java
@@ -257,7 +257,7 @@ public class CommitProcessor extends ZooKeeperCriticalThread implements
                             // we can get commit requests that is not at the queue head when 
                             // session moves (see ZOOKEEPER-2684). We will just pass the 
                             // commit to the next processor and put the pending back with
-                            // a warning, we should not see this often
+                            // a warning, we should not see this often under normal load
                             LOG.warn("Got request " + request + 
                                 " but we are expecting request " + topPending);
                             sessionQueue.addFirst(topPending);

--- a/src/java/main/org/apache/zookeeper/server/quorum/CommitProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/CommitProcessor.java
@@ -254,24 +254,23 @@ public class CommitProcessor extends ZooKeeperCriticalThread implements
                         // If session queue != null, then it is also not empty.
                         Request topPending = sessionQueue.poll();
                         if (request.cxid != topPending.cxid) {
-                            LOG.error(
-                                    "Got cxid 0x"
-                                            + Long.toHexString(request.cxid)
-                                            + " expected 0x" + Long.toHexString(
-                                                    topPending.cxid)
-                                    + " for client session id "
-                                    + Long.toHexString(request.sessionId));
-                            throw new IOException("Error: unexpected cxid for"
-                                    + "client session");
+                            // we can get commit requests that is not at the queue head when 
+                            // session moves (see ZOOKEEPER-2684). We will just pass the 
+                            // commit to the next processor and put the pending back with
+                            // a warning, we should not see this often
+                            LOG.warn("Got request " + request
+                                + " but we are expecting request " + topPending);
+                            sessionQueue.addFirst(topPending);
+                        } else {                            
+                            /*
+                             * We want to send our version of the request. the
+                             * pointer to the connection in the request
+                             */
+                            topPending.setHdr(request.getHdr());
+                            topPending.setTxn(request.getTxn());
+                            topPending.zxid = request.zxid;
+                            request = topPending;
                         }
-                        /*
-                         * We want to send our version of the request. the
-                         * pointer to the connection in the request
-                         */
-                        topPending.setHdr(request.getHdr());
-                        topPending.setTxn(request.getTxn());
-                        topPending.zxid = request.zxid;
-                        request = topPending;
                     }
 
                     sendToNextProcessor(request);

--- a/src/java/main/org/apache/zookeeper/server/quorum/CommitProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/CommitProcessor.java
@@ -258,8 +258,8 @@ public class CommitProcessor extends ZooKeeperCriticalThread implements
                             // session moves (see ZOOKEEPER-2684). We will just pass the 
                             // commit to the next processor and put the pending back with
                             // a warning, we should not see this often
-                            LOG.warn("Got request " + request
-                                + " but we are expecting request " + topPending);
+                            LOG.warn("Got request " + request + 
+                                " but we are expecting request " + topPending);
                             sessionQueue.addFirst(topPending);
                         } else {                            
                             /*

--- a/src/java/test/org/apache/zookeeper/server/quorum/CommitProcessorConcurrencyTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/CommitProcessorConcurrencyTest.java
@@ -473,7 +473,8 @@ public class CommitProcessorConcurrencyTest extends ZKTestCase {
         processor.committedRequests.add(orphanCommittedReq);
         processor.run();
         //We verify that the commit processor processed the old commit prior to the newer messages
-        Assert.assertTrue(processedRequests.peek() == otherSessionCommittedReq);
+        Assert.assertTrue(processedRequests.size() == 1);
+        Assert.assertTrue(processedRequests.contains(otherSessionCommittedReq));
         processor.run();
         //We verify that the commit processor handle all messages.
         Assert.assertTrue(processedRequests.containsAll(localRequests));

--- a/src/java/test/org/apache/zookeeper/server/quorum/CommitProcessorConcurrencyTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/CommitProcessorConcurrencyTest.java
@@ -106,6 +106,7 @@ public class CommitProcessorConcurrencyTest extends ZKTestCase {
 
                 @Override
                 public void notifyStopping(String threadName, int errorCode) {
+                    Assert.fail("Commit processor crashed " + errorCode);
                 }
             });
         }
@@ -373,5 +374,108 @@ public class CommitProcessorConcurrencyTest extends ZKTestCase {
             Assert.assertTrue("Processed additional committed request",
                     !processedRequests.contains(r));
         }
+    }
+
+    /**
+     * In the following test, we verify that we can handle the case that we got a commit 
+     * of a request we never seen since the session that we just established. This can happen
+     * when a session is just established and there is request waiting to be commited in the 
+     * in the session queue but it sees a commit for a request in the previous connection
+     */
+    @Test(timeout = 1000)
+    public void noCrashOnCommittedRequestsOfUnSeenRequestTest() throws Exception {
+        final String path = "/noCrash/OnCommittedRequests/OfUnSeenRequestTest";
+        final int numberofReads = 10;
+        final int sessionid = 0x123456;
+        final int firstCXid = 0x100;
+        int readReqId = firstCXid;
+        processor.stoppedMainLoop = true;
+        HashSet<Request> localRequests = new HashSet<Request>();
+        // queue the blocking write request to queuedRequests
+        Request firstCommittedReq = newRequest(
+            new CreateRequest(path, new byte[0], Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT_SEQUENTIAL.toFlag()),
+            OpCode.create, sessionid, readReqId++);
+        processor.queuedRequests.add(firstCommittedReq);
+        localRequests.add(firstCommittedReq);
+        // queue read requests to queuedRequests
+        for (; readReqId <= numberofReads+firstCXid; ++readReqId) {
+            Request readReq = newRequest(new GetDataRequest(path, false),
+                OpCode.getData, sessionid, readReqId);
+            processor.queuedRequests.add(readReq);
+            localRequests.add(readReq);
+        }
+        //run once
+        Assert.assertTrue(processor.queuedRequests.containsAll(localRequests));
+        processor.initThreads(numberofReads* 2);
+        processor.run();
+        //We verify that the processor is waiting for the commit
+        Assert.assertTrue(processedRequests.isEmpty());
+        // We add a commit that belongs to the same session but with smaller cxid, 
+        // i.e., commit of an update from previous connection of this session.
+        Request preSessionCommittedReq = newRequest(
+            new CreateRequest(path, new byte[0], Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT_SEQUENTIAL.toFlag()),
+            OpCode.create, sessionid, firstCXid - 2);
+        processor.committedRequests.add(preSessionCommittedReq);
+        processor.committedRequests.add(firstCommittedReq);
+        processor.run();
+        //We verify that the commit processor processed the old commit prior to the newer messages
+        Assert.assertTrue(processedRequests.peek() == preSessionCommittedReq);
+        processor.run();
+        //We verify that the commit processor handle all messages.
+        Assert.assertTrue(processedRequests.containsAll(localRequests));
+    }
+
+    /**
+     * In the following test, we verify that we can handle the case that we got a commit 
+     * of a request that has higher Cxid than the one we are waiting. This can happen
+     * when a session connection is lost but there is request waiting to be commited in the 
+     * in the session queue. However, since the session has moved, the requests now can get to
+     * the leader out of order. Hence, the commits can also arrive out of order. We should just
+     * commit the out of order requests and wait for the right commit
+     */
+    @Test(timeout = 1000)
+    public void noCrashOnOutofOrderCommittedRequestTest() throws Exception {
+        final String path = "/noCrash/OnCommittedRequests/OfUnSeenRequestTest";
+        final int sessionid = 0x123456;
+        final int lastCXid = 0x100;
+        final int numberofReads = 10;
+        int readReqId = lastCXid;
+        processor.stoppedMainLoop = true;
+        HashSet<Request> localRequests = new HashSet<Request>();
+        // queue the blocking write request to queuedRequests
+        Request orphanCommittedReq = newRequest(
+            new CreateRequest(path, new byte[0], Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT_SEQUENTIAL.toFlag()),
+            OpCode.create, sessionid, lastCXid);
+        processor.queuedRequests.add(orphanCommittedReq);
+        localRequests.add(orphanCommittedReq);
+        // queue read requests to queuedRequests
+        for (; readReqId <= numberofReads+lastCXid; ++readReqId) {
+            Request readReq = newRequest(new GetDataRequest(path, false),
+                OpCode.getData, sessionid, readReqId);
+            processor.queuedRequests.add(readReq);
+            localRequests.add(readReq);
+        }
+        //run once
+        processor.initThreads(numberofReads* 2);
+        processor.run();
+        //We verify that the processor is waiting for the commit
+        Assert.assertTrue(processedRequests.isEmpty());
+        // We add a commit that belongs to the same session but with larger cxid, 
+        // i.e., commit of an update from the next connection of this session.
+        Request otherSessionCommittedReq = newRequest(
+            new CreateRequest(path, new byte[0], Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT_SEQUENTIAL.toFlag()),
+            OpCode.create, sessionid, lastCXid+10);
+        processor.committedRequests.add(otherSessionCommittedReq);
+        processor.committedRequests.add(orphanCommittedReq);
+        processor.run();
+        //We verify that the commit processor processed the old commit prior to the newer messages
+        Assert.assertTrue(processedRequests.peek() == otherSessionCommittedReq);
+        processor.run();
+        //We verify that the commit processor handle all messages.
+        Assert.assertTrue(processedRequests.containsAll(localRequests));
     }
 }


### PR DESCRIPTION
commitProcessor with the zookeeper-2024 improvement patch throws an exception when it sees a commit request that is not at the queue head.  It turned out that it is actually a valid case when there is session movement. After discussion with the community, I submit this pull request to mitigate this issue by passing those commits to the next processor instead.