### PR TITLE
ZOOKEEPER-2687:Deadlock while shutting down the Leader server.

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
@@ -590,8 +590,8 @@ public class Leader {
 
                     // check leader running status
                     if (!this.isRunning()) {
-                        shutdown("Unexpected internal error");
-                        return;
+                        shutdownMessage = "Unexpected internal error";
+                        break;
                     }
 
                     if (!tickSkip && !syncedAckSet.hasAllQuorums()) {

--- a/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
@@ -590,6 +590,7 @@ public class Leader {
 
                     // check leader running status
                     if (!this.isRunning()) {
+                        // set shutdown flag
                         shutdownMessage = "Unexpected internal error";
                         break;
                     }


### PR DESCRIPTION
Leader server enters into deadlock while shutting down itself. Shutdown of the leader server is called from the synchronized block which must be called from outside the synchronized block. For detail pls refer ZOOKEEPER-2380