### PR TITLE
ZOOKEEPER-2696: Eclipse ant ask no longer determines correct classpath for tests after ZOOKEEPER-2689

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1797,7 +1797,7 @@ xmlns:maven="antlib:org.apache.maven.artifact.ant">
              description="Create eclipse project files">
        <ivy:resolve useOrigin="true" conf="test"/>
        <ivy:cachepath pathid="default.path.id" conf="default" />
-       <ivy:cachepath pathid="junit.path.id" conf="test" transitive="false"/>
+       <ivy:cachepath pathid="junit.path.id" conf="test" />
        <taskdef name="eclipse"
                 classname="prantl.ant.eclipse.EclipseTask"
                 classpathref="java.classpath" />


### PR DESCRIPTION
After pulling branch-3.4 i noticed that I could no longer compile and run the tests within my IDE. 

The .classpath file generated by the eclipse ant task was missing necessary dependencies. These missing dependencies all appear to be transitive from dependencies brought in by ZOOKEEPER-2689 (which is why ant is able to run the tests). There were two possible ways to fix this, this patch explicitly lists the new transitive dependencies that are required by our test code. Another solution would be to remove `transitive="false"` from `<ivy:cachepath pathid="junit.path.id" conf="test" transitive="false"/>` in the eclipse target of our `build.xml`. This solution would introduce even more transitive dependencies to the .classpath.