### PR TITLE
ZOOKEEPER-2700 add JMX `takeSnapshot` method and Jetty Admin `snap` command to take snapshot

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/ZooKeeperServerBean.java
+++ b/src/java/main/org/apache/zookeeper/server/ZooKeeperServerBean.java
@@ -162,4 +162,14 @@ public class ZooKeeperServerBean implements ZooKeeperServerMXBean, ZKMBeanInfo {
         }
         return "";
     }
+
+    @Override
+    public boolean takeSnapshot() {
+        return zks.maybeTakeSnapshot();
+    }
+
+    @Override
+    public long getLastSnapshotZxid() {
+        return zks.getLastSnapshotZxid();
+    }
 }

--- a/src/java/main/org/apache/zookeeper/server/ZooKeeperServerMXBean.java
+++ b/src/java/main/org/apache/zookeeper/server/ZooKeeperServerMXBean.java
@@ -125,4 +125,16 @@ public interface ZooKeeperServerMXBean {
      * @return secure client address
      */
     public String getSecureClientAddress();
+
+    /**
+     * Force to generate snapshot
+     *
+     * @return the snapshot is generating
+     */
+    public boolean takeSnapshot();
+
+    /**
+     * @return the last snapshot zxid
+     */
+    public long getLastSnapshotZxid();
 }

--- a/src/java/main/org/apache/zookeeper/server/admin/Commands.java
+++ b/src/java/main/org/apache/zookeeper/server/admin/Commands.java
@@ -125,6 +125,7 @@ public class Commands {
         registerCommand(new WatchCommand());
         registerCommand(new WatchesByPathCommand());
         registerCommand(new WatchSummaryCommand());
+        registerCommand(new TakeSnapshotCommand());
     }
 
     /**
@@ -504,6 +505,23 @@ public class Commands {
             DataTree dt = zkServer.getZKDatabase().getDataTree();
             CommandResponse response = initializeResponse();
             response.putAll(dt.getWatchesSummary().toMap());
+            return response;
+        }
+    }
+
+    /**
+     * Force to take snapshot
+     * @see ZooKeeperServer#takeSnapshot()
+     */
+    public static class TakeSnapshotCommand extends CommandBase {
+        public TakeSnapshotCommand() { super(Arrays.asList("take_snapshot", "snap")); }
+
+        @Override
+        public CommandResponse run(ZooKeeperServer zkServer, Map<String, String> kwargs) {
+            boolean generating = zkServer.maybeTakeSnapshot();
+            CommandResponse response = initializeResponse();
+            response.put("last_zxid", zkServer.getZKDatabase().getDataTreeLastProcessedZxid());
+            response.put("generating", generating);
             return response;
         }
     }


### PR DESCRIPTION
When cold backup or remote offline sync Zookeeper instances, we need the latest snapshot.

Add a four letter `snap` command to force Zookeeper to generate snapshot.