### PR TITLE
ZOOKEEPER-2716: fix flaky test testAddSessionAfterSessionExpiry.

### DIFF
--- a/src/java/test/org/apache/zookeeper/server/SessionTrackerTest.java
+++ b/src/java/test/org/apache/zookeeper/server/SessionTrackerTest.java
@@ -143,8 +143,8 @@ public class SessionTrackerTest extends ZKTestCase {
         public void processRequest(Request request) {
             // check session close request
             if (request.type == OpCode.closeSession) {
-                latch.countDown();
                 countOfCloseSessionReq++;
+                latch.countDown();
             }
         }
 


### PR DESCRIPTION
We can't let the gate open until we increase the closed session count. Otherwise depends on timing, the test thread might see old session close count value between gate open and the session count actually gets increased.