### PR TITLE
ZOOKEEPER-2718: fix flaky StandaloneDisabledTest

### DIFF
--- a/src/java/test/org/apache/zookeeper/server/quorum/StandaloneDisabledTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/StandaloneDisabledTest.java
@@ -90,6 +90,9 @@ public class StandaloneDisabledTest extends QuorumPeerTestBase {
         LOG.info("Configuration after removing leader and follower 1:\n"
                 + new String(zkHandles[follower2].getConfig(this, new Stat())));
 
+        // Kill server 1 to avoid it interferences with FLE of the quorum {2, 3, 4}.
+        shutDownServer(follower1);
+
         // Try to remove follower2, which is the only remaining server. This should fail.
         reconfigServers.clear();
         reconfigServers.add(Integer.toString(follower2));


### PR DESCRIPTION
The flaky (that existing for a long time) is caused by a ghost server that although not appear in the quorum's config but still up and running and send requests to the quorum {2, 3, 4}. Fix is simply kill the server 1 after it's used. Verified that with the fix the test survive stress test (100+ runs) while w/o the fix the tests fails frequently, on internal Jenkins machine.

ZOOKEEPER-2718: build bot do something please.