### PR TITLE
ZOOKEEPER-2724: Skip cert files for releaseaudit target.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1523,6 +1523,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <target name="releaseaudit" depends="package,rats-taskdef" description="Release Audit activities">
       <rat:report xmlns:rat="antlib:org.apache.rat.anttasks">
         <fileset dir="${dist.dir}">
+          <exclude name="**/*.cer"/>
           <exclude name="**/*.m4"/>
           <exclude name="**/*.md5"/>
           <exclude name="**/*.pom"/>


### PR DESCRIPTION
Skip the cert files as they are not source files, plus we already do the same for master branch..