### PR TITLE
ZOOKEEPER-2184: Resolve address only on demand.

### DIFF
--- a/src/java/main/org/apache/zookeeper/ClientCnxnSocket.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxnSocket.java
@@ -33,6 +33,7 @@ import org.apache.zookeeper.common.ZKConfig;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.proto.ConnectResponse;
 import org.apache.zookeeper.server.ByteBufferInputStream;
+import org.eclipse.jetty.server.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,6 +69,7 @@ abstract class ClientCnxnSocket {
     protected LinkedBlockingDeque<Packet> outgoingQueue;
     protected ZKClientConfig clientConfig;
     private int packetLen = ZKClientConfig.CLIENT_MAX_PACKET_LENGTH_DEFAULT;
+    private ServerCfg serverCfg = null;
 
     /**
      * The sessionId is only available here for Log and Exception messages.
@@ -155,12 +157,18 @@ abstract class ClientCnxnSocket {
 
     abstract boolean isConnected();
 
-    abstract void connect(InetSocketAddress addr) throws IOException;
+    void connect(final ServerCfg serverCfg) throws IOException {
+        this.serverCfg = serverCfg;
+    }
 
     /**
      * Returns the address to which the socket is connected.
      */
     abstract SocketAddress getRemoteSocketAddress();
+
+    ServerCfg getRemoteServerCfg() {
+        return isConnected() ? this.serverCfg : null;
+    }
 
     /**
      * Returns the address to which the socket is bound.

--- a/src/java/main/org/apache/zookeeper/ClientCnxnSocketNIO.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxnSocketNIO.java
@@ -279,12 +279,13 @@ public class ClientCnxnSocketNIO extends ClientCnxnSocket {
     }
     
     @Override
-    void connect(InetSocketAddress addr) throws IOException {
+    void connect(final ServerCfg serverCfg) throws IOException {
+        super.connect(serverCfg);
         SocketChannel sock = createSock();
         try {
-           registerAndConnect(sock, addr);
+           registerAndConnect(sock, serverCfg.getInetAddress());
       } catch (IOException e) {
-            LOG.error("Unable to open socket to " + addr);
+            LOG.error("Unable to open socket to " + serverCfg.getInetAddress());
             sock.close();
             throw e;
         }

--- a/src/java/main/org/apache/zookeeper/ClientCnxnSocketNetty.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxnSocketNetty.java
@@ -107,16 +107,17 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
     }
 
     @Override
-    void connect(InetSocketAddress addr) throws IOException {
+    void connect(final ServerCfg serverCfg) throws IOException {
+        super.connect(serverCfg);
         firstConnect = new CountDownLatch(1);
 
         ClientBootstrap bootstrap = new ClientBootstrap(channelFactory);
 
-        bootstrap.setPipelineFactory(new ZKClientPipelineFactory());
+        bootstrap.setPipelineFactory(new ZKClientPipelineFactory(serverCfg));
         bootstrap.setOption("soLinger", -1);
         bootstrap.setOption("tcpNoDelay", true);
 
-        connectFuture = bootstrap.connect(addr);
+        connectFuture = bootstrap.connect(serverCfg.getInetAddress());
         connectFuture.addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture channelFuture) throws Exception {
@@ -345,8 +346,13 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
      * connection implementation.
      */
     private class ZKClientPipelineFactory implements ChannelPipelineFactory {
+        private final ServerCfg serverCfg;
         private SSLContext sslContext = null;
         private SSLEngine sslEngine = null;
+
+        public ZKClientPipelineFactory(final ServerCfg serverCfg) {
+            this.serverCfg = serverCfg;
+        }
 
         @Override
         public ChannelPipeline getPipeline() throws Exception {

--- a/src/java/main/org/apache/zookeeper/ServerCfg.java
+++ b/src/java/main/org/apache/zookeeper/ServerCfg.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+public class ServerCfg {
+    private final String hostStr;
+    private final InetSocketAddress address;
+
+    public ServerCfg(final String hostStr, final InetSocketAddress address) {
+        this.hostStr = hostStr;
+        this.address = address;
+    }
+
+    public String getHostStr() {
+        return hostStr;
+    }
+
+    /**
+     * Return a new InetSocketAddress, so that it can be re-resolved again.
+     * @return
+     */
+    public InetSocketAddress getInetAddress() {
+        return new InetSocketAddress(getHostStr(), address.getPort());
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return other instanceof ServerCfg
+                && this.hostStr.equals(((ServerCfg)other).getHostStr())
+                && this.address.getPort() == ((ServerCfg) other).getPort();
+    }
+
+    @Override
+    public int hashCode() {
+        return hostStr.hashCode() ^ this.address.getPort();
+    }
+
+    public String getHostString() {
+        return getHostStr();
+    }
+
+    public int getPort() {
+        return this.address.getPort();
+    }
+}

--- a/src/java/main/org/apache/zookeeper/ZooKeeper.java
+++ b/src/java/main/org/apache/zookeeper/ZooKeeper.java
@@ -206,13 +206,13 @@ public class ZooKeeper implements AutoCloseable {
      * @throws IOException in cases of network failure     
      */
     public void updateServerList(String connectString) throws IOException {
-        ConnectStringParser connectStringParser = new ConnectStringParser(connectString);
-        Collection<InetSocketAddress> serverAddresses = connectStringParser.getServerAddresses();
+        final ConnectStringParser connectStringParser = new ConnectStringParser(connectString);
+        final Collection<ServerCfg> serversCfg = connectStringParser.getServersCfg();
 
         ClientCnxnSocket clientCnxnSocket = cnxn.sendThread.getClientCnxnSocket();
-        InetSocketAddress currentHost = (InetSocketAddress) clientCnxnSocket.getRemoteSocketAddress();
+        final ServerCfg currentHost = clientCnxnSocket.getRemoteServerCfg();
 
-        boolean reconfigMode = hostProvider.updateServerList(serverAddresses, currentHost);
+        boolean reconfigMode = hostProvider.updateServerList(serversCfg, currentHost);
 
         // cause disconnection - this will cause next to be called
         // which will in turn call nextReconfigMode
@@ -1218,7 +1218,7 @@ public class ZooKeeper implements AutoCloseable {
     // default hostprovider
     private static HostProvider createDefaultHostProvider(String connectString) {
         return new StaticHostProvider(
-                new ConnectStringParser(connectString).getServerAddresses());
+                new ConnectStringParser(connectString).getServersCfg());
     }
 
     // VisibleForTesting

--- a/src/java/main/org/apache/zookeeper/client/ConnectStringParser.java
+++ b/src/java/main/org/apache/zookeeper/client/ConnectStringParser.java
@@ -19,9 +19,12 @@
 package org.apache.zookeeper.client;
 
 import org.apache.zookeeper.common.PathUtils;
+import org.apache.zookeeper.ServerCfg;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.zookeeper.common.StringUtils.split;
@@ -41,7 +44,7 @@ public final class ConnectStringParser {
 
     private final String chrootPath;
 
-    private final ArrayList<InetSocketAddress> serverAddresses = new ArrayList<InetSocketAddress>();
+    private final ArrayList<ServerCfg> serverCfgList = new ArrayList<>();
 
     /**
      * 
@@ -76,7 +79,10 @@ public final class ConnectStringParser {
                 }
                 host = host.substring(0, pidx);
             }
-            serverAddresses.add(InetSocketAddress.createUnresolved(host, port));
+            serverCfgList.add(
+                    new ServerCfg(host,
+                            InetSocketAddress.createUnresolved(
+                                    host, port)));
         }
     }
 
@@ -84,7 +90,7 @@ public final class ConnectStringParser {
         return chrootPath;
     }
 
-    public ArrayList<InetSocketAddress> getServerAddresses() {
-        return serverAddresses;
+    public Collection<ServerCfg> getServersCfg() {
+        return Collections.unmodifiableCollection(serverCfgList);
     }
 }

--- a/src/java/main/org/apache/zookeeper/client/HostProvider.java
+++ b/src/java/main/org/apache/zookeeper/client/HostProvider.java
@@ -19,8 +19,9 @@
 package org.apache.zookeeper.client;
 
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.Collection;
+
+import org.apache.zookeeper.ServerCfg;
 
 /**
  * A set of hosts a ZooKeeper client should connect to.
@@ -52,7 +53,7 @@ public interface HostProvider {
      * @param spinDelay
      *            Milliseconds to wait if all hosts have been tried once.
      */
-    public InetSocketAddress next(long spinDelay);
+    public ServerCfg next(long spinDelay);
 
     /**
      * Notify the HostProvider of a successful connection.
@@ -63,10 +64,10 @@ public interface HostProvider {
 
     /**
      * Update the list of servers. This returns true if changing connections is necessary for load-balancing, false otherwise.
-     * @param serverAddresses new host list
+     * @param serversCfg new host list with optional SSL config.
      * @param currentHost the host to which this client is currently connected
      * @return true if changing connections is necessary for load-balancing, false otherwise  
      */
-    boolean updateServerList(Collection<InetSocketAddress> serverAddresses,
-        InetSocketAddress currentHost);
+    boolean updateServerList(final Collection<ServerCfg> serversCfg,
+                             final ServerCfg currentHost);
 }

--- a/src/java/main/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -510,7 +510,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
                                // extract server id x from first part of joiner: server.x
                                Long sid = Long.parseLong(parts[0].substring(parts[0].lastIndexOf('.') + 1));
                                QuorumServer qs = new QuorumServer(sid, parts[1]);
-                               if (qs.clientAddr == null || qs.electionAddr == null || qs.addr == null) {
+                               if (qs.getClientAddr() == null || qs.getElectionAddr() == null || qs.getAddr() == null) {
                                    throw new KeeperException.BadArgumentsException("Wrong format of server string - each server should have 3 ports specified"); 	   
                                }
 

--- a/src/java/main/org/apache/zookeeper/server/quorum/AuthFastLeaderElection.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/AuthFastLeaderElection.java
@@ -42,8 +42,6 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.server.ZooKeeperThread;
-import org.apache.zookeeper.server.quorum.Election;
-import org.apache.zookeeper.server.quorum.Vote;
 import org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer;
 import org.apache.zookeeper.server.quorum.QuorumPeer.ServerState;
 
@@ -728,7 +726,7 @@ public class AuthFastLeaderElection implements Election {
             }
 
             for (QuorumServer server : self.getVotingView().values()) {
-                InetSocketAddress saddr = new InetSocketAddress(server.addr
+                InetSocketAddress saddr = new InetSocketAddress(server.getAddr()
                         .getAddress(), port);
                 addrChallengeMap.put(saddr, new ConcurrentHashMap<Long, Long>());
             }
@@ -759,7 +757,7 @@ public class AuthFastLeaderElection implements Election {
 
     private void starter(QuorumPeer self) {
         this.self = self;
-        port = self.getVotingView().get(self.getId()).electionAddr.getPort();
+        port = self.getVotingView().get(self.getId()).getElectionAddr().getPort();
         proposedLeader = -1;
         proposedZxid = -1;
 
@@ -786,7 +784,7 @@ public class AuthFastLeaderElection implements Election {
             ToSend notmsg = new ToSend(ToSend.mType.notification,
                     AuthFastLeaderElection.sequencer++, proposedLeader,
                     proposedZxid, logicalclock.get(), QuorumPeer.ServerState.LOOKING,
-                    self.getView().get(server.id).electionAddr);
+                    self.getView().get(server.id).getElectionAddr());
 
             sendqueue.offer(notmsg);
         }

--- a/src/java/main/org/apache/zookeeper/server/quorum/Follower.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Follower.java
@@ -19,10 +19,10 @@
 package org.apache.zookeeper.server.quorum;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 
 import org.apache.jute.Record;
+import org.apache.zookeeper.ServerCfg;
 import org.apache.zookeeper.ZooDefs.OpCode;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.server.Request;
@@ -71,9 +71,9 @@ public class Follower extends Learner{
         self.end_fle = 0;
         fzk.registerJMX(new FollowerBean(this, zk), self.jmxLocalPeerBean);
         try {
-            InetSocketAddress addr = findLeader();            
+            final ServerCfg serverCfg = findLeader();
             try {
-                connectToLeader(addr);
+                connectToLeader(serverCfg);
                 long newEpochZxid = registerWithLeader(Leader.FOLLOWERINFO);
                 if (self.isReconfigStateChange())
                    throw new Exception("learned about role change");

--- a/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
@@ -677,7 +677,7 @@ public class Leader {
        //check if I'm in the new configuration with the same quorum address - 
        // if so, I'll remain the leader    
        if (newQVAcksetPair.getQuorumVerifier().getVotingMembers().containsKey(self.getId()) && 
-               newQVAcksetPair.getQuorumVerifier().getVotingMembers().get(self.getId()).addr.equals(self.getQuorumAddress())){  
+               newQVAcksetPair.getQuorumVerifier().getVotingMembers().get(self.getId()).getAddr().equals(self.getQuorumAddress())){
            return self.getId();
        }
        // start with an initial set of candidates that are voters from new config that 

--- a/src/java/main/org/apache/zookeeper/server/quorum/LeaderElection.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/LeaderElection.java
@@ -34,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.zookeeper.jmx.MBeanRegistry;
-import org.apache.zookeeper.server.quorum.Vote;
 import org.apache.zookeeper.server.quorum.QuorumPeer.LearnerType;
 import org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer;
 import org.apache.zookeeper.server.quorum.QuorumPeer.ServerState;
@@ -182,16 +181,16 @@ public class LeaderElection implements Election  {
                 requestPacket.setLength(4);
                 HashSet<Long> heardFrom = new HashSet<Long>();
                 for (QuorumServer server : self.getVotingView().values()) {
-                    LOG.info("Server address: " + server.addr);
+                    LOG.info("Server address: " + server.getAddr());
                     try {
-                        requestPacket.setSocketAddress(server.addr);
+                        requestPacket.setSocketAddress(server.getAddr());
                     } catch (IllegalArgumentException e) {
                         // Sun doesn't include the address that causes this
                         // exception to be thrown, so we wrap the exception
                         // in order to capture this critical detail.
                         throw new IllegalArgumentException(
                                 "Unable to set socket address on packet, msg:"
-                                + e.getMessage() + " with addr:" + server.addr,
+                                + e.getMessage() + " with addr:" + server.getAddr(),
                                 e);
                     }
 

--- a/src/java/main/org/apache/zookeeper/server/quorum/Observer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Observer.java
@@ -19,10 +19,10 @@
 package org.apache.zookeeper.server.quorum;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 
 import org.apache.jute.Record;
+import org.apache.zookeeper.ServerCfg;
 import org.apache.zookeeper.server.ObserverBean;
 import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
@@ -63,10 +63,10 @@ public class Observer extends Learner{
         zk.registerJMX(new ObserverBean(this, zk), self.jmxLocalPeerBean);
 
         try {
-            InetSocketAddress addr = findLeader();
-            LOG.info("Observing " + addr);
+            final ServerCfg serverCfg = findLeader();
+            LOG.info("Observing " + serverCfg.getInetAddress());
             try {
-                connectToLeader(addr);
+                connectToLeader(serverCfg);
                 long newLeaderZxid = registerWithLeader(Leader.OBSERVERINFO);
                 if (self.isReconfigStateChange())
                    throw new Exception("learned about role change");

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -243,7 +243,7 @@ public class QuorumCnxManager {
         LOG.debug("Opening channel to server " + sid);
         Socket sock = new Socket();
         setSockOpts(sock);
-        sock.connect(self.getVotingView().get(sid).electionAddr, cnxTO);
+        sock.connect(self.getVotingView().get(sid).getElectionAddr(), cnxTO);
         initiateConnection(sock, sid);
     }
     
@@ -478,20 +478,19 @@ public class QuorumCnxManager {
             boolean knownId = false;
             // Resolve hostname for the remote server before attempting to
             // connect in case the underlying ip address has changed.
-            self.recreateSocketAddresses(sid);
             Map<Long, QuorumPeer.QuorumServer> lastCommittedView = self.getView();
             QuorumVerifier lastSeenQV = self.getLastSeenQuorumVerifier();
             Map<Long, QuorumPeer.QuorumServer> lastProposedView = lastSeenQV.getAllMembers();
             if (lastCommittedView.containsKey(sid)) {
                 knownId = true;
-                if (connectOne(sid, lastCommittedView.get(sid).electionAddr))
+                if (connectOne(sid, lastCommittedView.get(sid).getElectionAddr()))
                     return;
             }
             if (lastSeenQV != null && lastProposedView.containsKey(sid)
-                    && (!knownId || (lastProposedView.get(sid).electionAddr !=
-                    lastCommittedView.get(sid).electionAddr))) {
+                    && (!knownId || (lastProposedView.get(sid).getElectionAddr() !=
+                    lastCommittedView.get(sid).getElectionAddr()))) {
                 knownId = true;
-                if (connectOne(sid, lastProposedView.get(sid).electionAddr))
+                if (connectOne(sid, lastProposedView.get(sid).getElectionAddr()))
                     return;
             }
             if (!knownId) {
@@ -632,7 +631,6 @@ public class QuorumCnxManager {
                     } else {
                         // Resolve hostname for this server in case the
                         // underlying ip address has changed.
-                        self.recreateSocketAddresses(self.getId());
                         addr = self.getElectionAddress();
                     }
                     LOG.info("My election bind port: " + addr.toString());

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -599,7 +599,7 @@ public class QuorumPeerConfig {
              */            
            if (eAlg != 0) {
                for (QuorumServer s : qv.getVotingMembers().values()) {
-                   if (s.electionAddr == null)
+                   if (s.getElectionAddr() == null)
                        throw new IllegalArgumentException(
                                "Missing election port for server: " + s.id);
                }
@@ -635,16 +635,16 @@ public class QuorumPeerConfig {
             return;
         }
         QuorumServer qs = quorumVerifier.getAllMembers().get(serverId);
-        if (clientPortAddress != null && qs != null && qs.clientAddr != null) {
+        if (clientPortAddress != null && qs != null && qs.getClientAddr() != null) {
             if ((!clientPortAddress.getAddress().isAnyLocalAddress()
-                    && !clientPortAddress.equals(qs.clientAddr)) ||
+                    && !clientPortAddress.equals(qs.getClientAddr())) ||
                     (clientPortAddress.getAddress().isAnyLocalAddress()
-                            && clientPortAddress.getPort() != qs.clientAddr.getPort()))
+                            && clientPortAddress.getPort() != qs.getClientAddr().getPort()))
                 throw new ConfigException("client address for this server (id = " + serverId +
                         ") in static config file is " + clientPortAddress +
-                        " is different from client address found in dynamic file: " + qs.clientAddr);
+                        " is different from client address found in dynamic file: " + qs.getClientAddr());
         }
-        if (qs != null && qs.clientAddr != null) clientPortAddress = qs.clientAddr;
+        if (qs != null && qs.getClientAddr() != null) clientPortAddress = qs.getClientAddr();
     }
 
     private void setupPeerType() {

--- a/src/java/main/org/apache/zookeeper/server/quorum/RemotePeerBean.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/RemotePeerBean.java
@@ -43,19 +43,19 @@ public class RemotePeerBean implements RemotePeerMXBean,ZKMBeanInfo {
     }
 
     public String getQuorumAddress() {
-        return peer.addr.getHostString()+":"+peer.addr.getPort();
+        return peer.getAddr().getHostString()+":"+ peer.getAddr().getPort();
     }
 
     public String getElectionAddress() {
-        return peer.electionAddr.getHostString() + ":" + peer.electionAddr.getPort();
+        return peer.getElectionAddr().getHostString() + ":" + peer.getElectionAddr().getPort();
     }
 
     public String getClientAddress() {
-        if (null == peer.clientAddr) {
+        if (null == peer.getClientAddr()) {
             return "";
         }
-        return peer.clientAddr.getHostString() + ":"
-                + peer.clientAddr.getPort();
+        return peer.getClientAddr().getHostString() + ":"
+                + peer.getClientAddr().getPort();
     }
 
     public String getLearnerType() {

--- a/src/java/main/org/apache/zookeeper/server/util/ConfigUtils.java
+++ b/src/java/main/org/apache/zookeeper/server/util/ConfigUtils.java
@@ -53,9 +53,9 @@ public class ConfigUtils {
              }
              if (!first) sb.append(",");
              else first = false;
-             if (null != qs.clientAddr) {
-                 sb.append(qs.clientAddr.getHostString()
-                         + ":" + qs.clientAddr.getPort());
+             if (null != qs.getClientAddr()) {
+                 sb.append(qs.getClientAddr().getHostString()
+                         + ":" + qs.getClientAddr().getPort());
              }
         }
         return version + " " + sb.toString();

--- a/src/java/systest/org/apache/zookeeper/test/system/BaseSysTest.java
+++ b/src/java/systest/org/apache/zookeeper/test/system/BaseSysTest.java
@@ -25,6 +25,7 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 
+import org.apache.zookeeper.ServerCfg;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
@@ -153,8 +154,9 @@ public class BaseSysTest {
                     fakeBasePort + i);
             InetSocketAddress electionAddr = new InetSocketAddress("127.0.0.1",
                     serverCount + fakeBasePort + i);
-            peers.put(Long.valueOf(i), new QuorumServer(i, peerAddress,
-                    electionAddr));
+            peers.put(Long.valueOf(i), new QuorumServer(i,
+                    new ServerCfg(peerAddress.getHostName(), peerAddress),
+                    new ServerCfg(electionAddr.getHostName(), electionAddr)));
         }
         StringBuilder sb = new StringBuilder();
         for(int i = 0; i < count; i++) {

--- a/src/java/systest/org/apache/zookeeper/test/system/QuorumPeerInstance.java
+++ b/src/java/systest/org/apache/zookeeper/test/system/QuorumPeerInstance.java
@@ -28,6 +28,7 @@ import java.net.Socket;
 import java.util.HashMap;
 import java.util.Properties;
 
+import org.apache.zookeeper.ServerCfg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.KeeperException;
@@ -175,11 +176,14 @@ class QuorumPeerInstance implements Instance {
                 String subparts[] = ((parts[i].split(";"))[0]).split(":");
                 String clientPort = (parts[i].split(";"))[1];
                 peers.put(Long.valueOf(i),
-                          new QuorumServer(
-                                i,
-                                new InetSocketAddress(subparts[0], Integer.parseInt(subparts[1])),
-                                new InetSocketAddress(subparts[0], Integer.parseInt(subparts[2])),
-                                new InetSocketAddress(subparts[0], Integer.parseInt(clientPort))));
+                          new QuorumServer(i,
+                                  new ServerCfg(subparts[0],
+                                        new InetSocketAddress(subparts[0],
+                                                Integer.parseInt(subparts[1]))),
+                                  new ServerCfg(subparts[0], new InetSocketAddress(subparts[0],
+                                          Integer.parseInt(subparts[2]))),
+                                  new ServerCfg(subparts[0], new InetSocketAddress(subparts[0],
+                                          Integer.parseInt(clientPort)))));
             }
             try {
                 if (LOG.isDebugEnabled()) {

--- a/src/java/test/org/apache/zookeeper/ClientReconnectTest.java
+++ b/src/java/test/org/apache/zookeeper/ClientReconnectTest.java
@@ -59,8 +59,9 @@ public class ClientReconnectTest extends ZKTestCase {
     public void testClientReconnect() throws IOException, InterruptedException {
         HostProvider hostProvider = mock(HostProvider.class);
         when(hostProvider.size()).thenReturn(1);
-        InetSocketAddress inaddr = new InetSocketAddress("127.0.0.1", 1111);
-        when(hostProvider.next(anyLong())).thenReturn(inaddr);
+        final ServerCfg serverCfg = new ServerCfg("127.0.0.1:1111",
+                new InetSocketAddress("127.0.0.1", 1111));
+        when(hostProvider.next(anyLong())).thenReturn(serverCfg);
         ZooKeeper zk = mock(ZooKeeper.class);
         when(zk.getClientConfig()).thenReturn(new ZKClientConfig());
         sc =  SocketChannel.open();

--- a/src/java/test/org/apache/zookeeper/CustomHostProviderTest.java
+++ b/src/java/test/org/apache/zookeeper/CustomHostProviderTest.java
@@ -37,15 +37,16 @@ public class CustomHostProviderTest extends ZKTestCase implements Watcher {
             return 1;
         }
         @Override
-        public InetSocketAddress next(long spinDelay) {
-            return new InetSocketAddress("127.0.0.1", 2181);
+        public ServerCfg next(long spinDelay) {
+            return new ServerCfg("127.0.0.1:2181",
+                    new InetSocketAddress("127.0.0 .1", 2181));
         }
         @Override
         public void onConnected() {
         }
         @Override
-        public boolean updateServerList(Collection<InetSocketAddress>
-                serverAddresses, InetSocketAddress currentHost) {
+        public boolean updateServerList(final Collection<ServerCfg> serversCfg,
+                                        final ServerCfg currentHost) {
             counter.decrementAndGet();
             return false;
         }

--- a/src/java/test/org/apache/zookeeper/server/quorum/FLEBackwardElectionRoundTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/FLEBackwardElectionRoundTest.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 
+import org.apache.zookeeper.ServerCfg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
@@ -93,8 +94,8 @@ public class FLEBackwardElectionRoundTest extends ZKTestCase {
             int clientport = PortAssignment.unique();
             peers.put(Long.valueOf(i),
                     new QuorumServer(i,
-                            new InetSocketAddress(clientport),
-                            new InetSocketAddress(PortAssignment.unique())));
+                            new ServerCfg("0.0.0.0", new InetSocketAddress(clientport)),
+                            new ServerCfg("0.0.0.0", new InetSocketAddress(PortAssignment.unique()))));
             tmpdir[i] = ClientBase.createTmpDir();
             port[i] = clientport;
         }

--- a/src/java/test/org/apache/zookeeper/server/quorum/FLELostMessageTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/FLELostMessageTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 
+import org.apache.zookeeper.ServerCfg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
@@ -69,8 +70,8 @@ public class FLELostMessageTest extends ZKTestCase {
             int clientport = PortAssignment.unique();
             peers.put(Long.valueOf(i),
                     new QuorumServer(i,
-                            new InetSocketAddress(clientport),
-                            new InetSocketAddress(PortAssignment.unique())));
+                            new ServerCfg("0.0.0.0", new InetSocketAddress(clientport)),
+                            new ServerCfg("0.0.0.0", new InetSocketAddress(PortAssignment.unique()))));
             tmpdir[i] = ClientBase.createTmpDir();
             port[i] = clientport;
         }

--- a/src/java/test/org/apache/zookeeper/server/quorum/LearnerTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/LearnerTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
+import org.apache.zookeeper.ServerCfg;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
@@ -107,10 +108,10 @@ public class LearnerTest extends ZKTestCase {
         learner.self.setSyncLimit(2);
 
         // this addr won't even be used since we fake the Socket.connect
-        InetSocketAddress addr = new InetSocketAddress(1111);
+        ServerCfg serverCfg = new ServerCfg("any", new InetSocketAddress(1111));
 
         // we expect this to throw an IOException since we're faking socket connect errors every time
-        learner.connectToLeader(addr);
+        learner.connectToLeader(serverCfg);
     }
     @Test
     public void connectionInitLimitTimeoutTest() throws Exception {
@@ -121,7 +122,7 @@ public class LearnerTest extends ZKTestCase {
         learner.self.setSyncLimit(2);
 
         // this addr won't even be used since we fake the Socket.connect
-        InetSocketAddress addr = new InetSocketAddress(1111);
+        ServerCfg serverCfg = new ServerCfg("any", new InetSocketAddress(1111));
         
         // pretend each connect attempt takes 4000 milliseconds
         learner.setTimeMultiplier((long)4000 * 1000000);
@@ -130,7 +131,7 @@ public class LearnerTest extends ZKTestCase {
 
         // we expect this to throw an IOException since we're faking socket connect errors every time
         try {
-            learner.connectToLeader(addr);
+            learner.connectToLeader(serverCfg);
             Assert.fail("should have thrown IOException!");
         } catch (IOException e) {
             //good, wanted to see that, let's make sure we ran out of time

--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ServerCfg;
 import org.apache.zookeeper.server.quorum.QuorumPeer.LearnerType;
 import org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer;
 import org.apache.zookeeper.test.ClientBase;
@@ -52,9 +53,11 @@ public class QuorumPeerTest {
         InetAddress clientIP = InetAddress.getLoopbackAddress();
 
         peersView.put(Long.valueOf(myId),
-                new QuorumServer(myId, new InetSocketAddress(clientIP, PortAssignment.unique()),
-                        new InetSocketAddress(clientIP, PortAssignment.unique()),
-                        new InetSocketAddress(clientIP, clientPort), LearnerType.PARTICIPANT));
+                new QuorumServer(myId,
+                        new ServerCfg(clientIP.getHostName(), new InetSocketAddress(clientIP, PortAssignment.unique())),
+                        new ServerCfg(clientIP.getHostName(), new InetSocketAddress(clientIP, PortAssignment.unique())),
+                        new ServerCfg(clientIP.getHostName(), new InetSocketAddress(clientIP, clientPort)),
+                        LearnerType.PARTICIPANT));
 
         /**
          * QuorumPeer constructor without QuorumVerifier
@@ -73,9 +76,11 @@ public class QuorumPeerTest {
         peersView.clear();
         clientPort = PortAssignment.unique();
         peersView.put(Long.valueOf(myId),
-                new QuorumServer(myId, new InetSocketAddress(clientIP, PortAssignment.unique()),
-                        new InetSocketAddress(clientIP, PortAssignment.unique()),
-                        new InetSocketAddress(clientIP, clientPort), LearnerType.PARTICIPANT));
+                new QuorumServer(myId,
+                        new ServerCfg(clientIP.getHostName(), new InetSocketAddress(clientIP, PortAssignment.unique())),
+                        new ServerCfg(clientIP.getHostName(), new InetSocketAddress(clientIP, PortAssignment.unique())),
+                        new ServerCfg(clientIP.getHostName(), new InetSocketAddress(clientIP, clientPort)),
+                        LearnerType.PARTICIPANT));
         QuorumPeer peer2 = new QuorumPeer(peersView, dataDir, dataDir, clientPort, electionAlg, myId, tickTime,
                 initLimit, syncLimit);
         String hostString2 = peer2.cnxnFactory.getLocalAddress().getHostString();

--- a/src/java/test/org/apache/zookeeper/server/quorum/RemotePeerBeanTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/RemotePeerBeanTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.net.InetSocketAddress;
 
+import org.apache.zookeeper.ServerCfg;
 import org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class RemotePeerBeanTest {
      */
     @Test
     public void testGetClientAddressShouldReturnEmptyStringWhenClientAddressIsNull() {
-        InetSocketAddress peerCommunicationAddress = null;
+        ServerCfg peerCommunicationAddress = null;
         // Here peerCommunicationAddress is null, also clientAddr is null
         QuorumServer peer = new QuorumServer(1, peerCommunicationAddress);
         RemotePeerBean remotePeerBean = new RemotePeerBean(peer);

--- a/src/java/test/org/apache/zookeeper/server/quorum/Zab1_0Test.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/Zab1_0Test.java
@@ -45,6 +45,7 @@ import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
 import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ServerCfg;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.EventType;
@@ -1277,8 +1278,8 @@ public class Zab1_0Test extends ZKTestCase {
         }
         
         @Override
-        protected InetSocketAddress findLeader() {
-            return leaderAddr;
+        protected ServerCfg findLeader() {
+            return new ServerCfg(leaderAddr.getHostName(), leaderAddr);
         }
     }
     private ConversableFollower createFollower(File tmpDir, QuorumPeer peer)
@@ -1303,8 +1304,8 @@ public class Zab1_0Test extends ZKTestCase {
         }
 
         @Override
-        protected InetSocketAddress findLeader() {
-            return leaderAddr;
+        protected ServerCfg findLeader() {
+            return new ServerCfg(leaderAddr.getHostName(), leaderAddr);
         }
     }
 
@@ -1325,18 +1326,27 @@ public class Zab1_0Test extends ZKTestCase {
         peer.initLimit = 2;
         peer.tickTime = 2000;
         
-        peers.put(0L, new QuorumServer(
-            0, new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-               new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-               new InetSocketAddress("127.0.0.1", PortAssignment.unique())));
-        peers.put(1L, new QuorumServer(
-            1, new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-               new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-               new InetSocketAddress("127.0.0.1", PortAssignment.unique())));
-        peers.put(2L, new QuorumServer(
-            2, new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-               new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-               new InetSocketAddress("127.0.0.1", PortAssignment.unique())));
+        peers.put(0L, new QuorumServer(0,
+                new ServerCfg("127.0.0.1",
+                        new InetSocketAddress("127.0.0.1", PortAssignment.unique())),
+                new ServerCfg("127.0.0.1",
+                        new InetSocketAddress("127.0.0.1", PortAssignment.unique())),
+                new ServerCfg("127.0.0.1",
+                        new InetSocketAddress("127.0.0.1", PortAssignment.unique()))));
+        peers.put(1L, new QuorumServer(1,
+                new ServerCfg("127.0.0.1",
+                        new InetSocketAddress("127.0.0.1", PortAssignment.unique())),
+                new ServerCfg("127.0.0.1",
+                        new InetSocketAddress("127.0.0.1", PortAssignment.unique())),
+                new ServerCfg("127.0.0.1",
+                        new InetSocketAddress("127.0.0.1", PortAssignment.unique()))));
+        peers.put(2L, new QuorumServer(2,
+                new ServerCfg("127.0.0.1",
+                        new InetSocketAddress("127.0.0.1", PortAssignment.unique())),
+                new ServerCfg("127.0.0.1",
+                        new InetSocketAddress("127.0.0.1", PortAssignment.unique())),
+                new ServerCfg("127.0.0.1",
+                        new InetSocketAddress("127.0.0.1", PortAssignment.unique()))));
         
         peer.setQuorumVerifier(new QuorumMaj(peers), false);
         peer.setCnxnFactory(new NullServerCnxnFactory());

--- a/src/java/test/org/apache/zookeeper/test/CnxManagerTest.java
+++ b/src/java/test/org/apache/zookeeper/test/CnxManagerTest.java
@@ -187,15 +187,13 @@ public class CnxManagerTest extends ZKTestCase {
     @Test
     public void testCnxManagerTimeout() throws Exception {
         Random rand = new Random();
-        byte b = (byte) rand.nextInt();
-        int deadPort = PortAssignment.unique();
-        String deadAddress = "10.1.1." + b;
+        String deadAddress = "10.1.1." + (rand.nextInt(254) + 1);
 
         LOG.info("This is the dead address I'm trying: " + deadAddress);
 
         peers.put(Long.valueOf(2),
                 new QuorumServer(2,
-                        new ServerCfg(deadAddress, new InetSocketAddress(deadAddress, deadPort)),
+                        new ServerCfg(deadAddress, new InetSocketAddress(deadAddress, PortAssignment.unique())),
                         new ServerCfg(deadAddress, new InetSocketAddress(deadAddress, PortAssignment.unique())),
                         new ServerCfg(deadAddress, new InetSocketAddress(deadAddress, PortAssignment.unique()))));
         peerTmpdir[2] = ClientBase.createTmpDir();
@@ -213,7 +211,7 @@ public class CnxManagerTest extends ZKTestCase {
         cnxManager.toSend(2L, createMsg(ServerState.LOOKING.ordinal(), 1, -1, 1));
         long end = Time.currentElapsedTime();
 
-        if((end - begin) > 6000) Assert.fail("Waited more than necessary");
+        if((end - begin) > 15000) Assert.fail("Waited more than necessary");
         cnxManager.halt();
         Assert.assertFalse(cnxManager.listener.isAlive());
     }

--- a/src/java/test/org/apache/zookeeper/test/ConnectStringParserTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ConnectStringParserTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.test;
 
+import org.apache.zookeeper.ServerCfg;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.client.ConnectStringParser;
 import org.junit.Assert;
@@ -46,8 +47,10 @@ public class ConnectStringParserTest extends ZKTestCase{
         String servers = "10.10.10.1,10.10.10.2";
         ConnectStringParser parser = new ConnectStringParser(servers);
 
-        Assert.assertEquals("10.10.10.1", parser.getServerAddresses().get(0).getHostString());
-        Assert.assertEquals("10.10.10.2", parser.getServerAddresses().get(1).getHostString());
+        ServerCfg[] serverCfgs =  parser.getServersCfg()
+                .toArray(new ServerCfg[parser.getServersCfg().size()]);
+        Assert.assertEquals("10.10.10.1", serverCfgs[0].getHostString());
+        Assert.assertEquals("10.10.10.2", serverCfgs[1].getHostString());
     }
 
     @Test
@@ -55,11 +58,13 @@ public class ConnectStringParserTest extends ZKTestCase{
         String servers = "10.10.10.1:112,10.10.10.2:110";
         ConnectStringParser parser = new ConnectStringParser(servers);
 
-        Assert.assertEquals("10.10.10.1", parser.getServerAddresses().get(0).getHostString());
-        Assert.assertEquals("10.10.10.2", parser.getServerAddresses().get(1).getHostString());
+        ServerCfg[] serverCfgs =  parser.getServersCfg()
+                .toArray(new ServerCfg[parser.getServersCfg().size()]);
+        Assert.assertEquals("10.10.10.1", serverCfgs[0].getHostString());
+        Assert.assertEquals("10.10.10.2", serverCfgs[1].getHostString());
 
-        Assert.assertEquals(112, parser.getServerAddresses().get(0).getPort());
-        Assert.assertEquals(110, parser.getServerAddresses().get(1).getPort());
+        Assert.assertEquals(112, serverCfgs[0].getPort());
+        Assert.assertEquals(110, serverCfgs[1].getPort());
     }
 
     private void assertChrootPath(String expected, ConnectStringParser parser){

--- a/src/java/test/org/apache/zookeeper/test/FLENewEpochTest.java
+++ b/src/java/test/org/apache/zookeeper/test/FLENewEpochTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.concurrent.Semaphore;
 
+import org.apache.zookeeper.ServerCfg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
@@ -156,10 +157,10 @@ public class FLENewEpochTest extends ZKTestCase {
           for(int i = 0; i < count; i++) {
               peers.put(Long.valueOf(i),
                   new QuorumServer(i,
-                      new InetSocketAddress(
-                          "127.0.0.1", PortAssignment.unique()),
-                      new InetSocketAddress(
-                          "127.0.0.1", PortAssignment.unique())));
+                      new ServerCfg("127.0.0.1", new InetSocketAddress(
+                          "127.0.0.1", PortAssignment.unique())),
+                          new ServerCfg("127.0.0.1", new InetSocketAddress(
+                          "127.0.0.1", PortAssignment.unique()))));
               tmpdir[i] = ClientBase.createTmpDir();
               port[i] = PortAssignment.unique();
           }

--- a/src/java/test/org/apache/zookeeper/test/FLEPredicateTest.java
+++ b/src/java/test/org/apache/zookeeper/test/FLEPredicateTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 
+import org.apache.zookeeper.ServerCfg;
 import org.apache.zookeeper.server.quorum.FastLeaderElection;
 import org.apache.zookeeper.server.quorum.QuorumCnxManager;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
@@ -63,10 +64,10 @@ public class FLEPredicateTest extends ZKTestCase {
         for(int i = 0; i < 3; i++) {
             peers.put(Long.valueOf(i),
                 new QuorumServer(i,
-                    new InetSocketAddress(
-                        "127.0.0.1", PortAssignment.unique()),
-                    new InetSocketAddress(
-                        "127.0.0.1", PortAssignment.unique())));
+                        new ServerCfg("127.0.0.1",
+                                new InetSocketAddress("127.0.0.1", PortAssignment.unique())),
+                        new ServerCfg("127.0.0.1",
+                                new InetSocketAddress("127.0.0.1", PortAssignment.unique()))));
         }
 
         /*

--- a/src/java/test/org/apache/zookeeper/test/FLERestartTest.java
+++ b/src/java/test/org/apache/zookeeper/test/FLERestartTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.concurrent.Semaphore;
 
+import org.apache.zookeeper.ServerCfg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
@@ -160,10 +161,10 @@ public class FLERestartTest extends ZKTestCase {
         for(int i = 0; i < count; i++) {
             peers.put(Long.valueOf(i),
                 new QuorumServer(i,
-                    new InetSocketAddress(
-                        "127.0.0.1", PortAssignment.unique()),
-                    new InetSocketAddress(
-                        "127.0.0.1", PortAssignment.unique())));
+                    new ServerCfg("127.0.0.1", new InetSocketAddress(
+                        "127.0.0.1", PortAssignment.unique())),
+                    new ServerCfg("127.0.0.1", new InetSocketAddress(
+                        "127.0.0.1", PortAssignment.unique()))));
             tmpdir[i] = ClientBase.createTmpDir();
             port[i] = PortAssignment.unique();
         }

--- a/src/java/test/org/apache/zookeeper/test/FLETest.java
+++ b/src/java/test/org/apache/zookeeper/test/FLETest.java
@@ -27,6 +27,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.zookeeper.ServerCfg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
@@ -309,12 +310,12 @@ public class FLETest extends ZKTestCase {
             port[i] = PortAssignment.unique();
             peers.put(Long.valueOf(i),
                 new QuorumServer(i,
-                    new InetSocketAddress(
-                        "127.0.0.1", PortAssignment.unique()),
-                    new InetSocketAddress(
-                        "127.0.0.1", PortAssignment.unique()),
-                    new InetSocketAddress(
-                        "127.0.0.1", port[i])));
+                        new ServerCfg("127.0.0.1", new InetSocketAddress(
+                        "127.0.0.1", PortAssignment.unique())),
+                        new ServerCfg("127.0.0.1", new InetSocketAddress(
+                        "127.0.0.1", PortAssignment.unique())),
+                        new ServerCfg("127.0.0.1", new InetSocketAddress(
+                        "127.0.0.1", port[i]))));
             tmpdir[i] = ClientBase.createTmpDir();           
         }
 
@@ -417,12 +418,12 @@ public class FLETest extends ZKTestCase {
             port[sid] = PortAssignment.unique();
             peers.put(Long.valueOf(sid),
                 new QuorumServer(sid,
-                    new InetSocketAddress(
-                        "127.0.0.1", PortAssignment.unique()),
-                    new InetSocketAddress(
-                        "127.0.0.1", PortAssignment.unique()),
-                    new InetSocketAddress(
-                        "127.0.0.1", port[sid])));
+                        new ServerCfg("127.0.0.1", new InetSocketAddress(
+                        "127.0.0.1", PortAssignment.unique())),
+                        new ServerCfg("127.0.0.1", new InetSocketAddress(
+                        "127.0.0.1", PortAssignment.unique())),
+                        new ServerCfg("127.0.0.1", new InetSocketAddress(
+                        "127.0.0.1", port[sid]))));
             tmpdir[sid] = ClientBase.createTmpDir();          
         }
         // start 2 peers and verify if they form the cluster
@@ -477,10 +478,10 @@ public class FLETest extends ZKTestCase {
         for(sid = 0; sid < 3; sid++) {
             peers.put(Long.valueOf(sid),
                 new QuorumServer(sid,
-                    new InetSocketAddress(
-                        "127.0.0.1", PortAssignment.unique()),
-                    new InetSocketAddress(
-                        "127.0.0.1", PortAssignment.unique())));
+                        new ServerCfg("127.0.0.1", new InetSocketAddress(
+                        "127.0.0.1", PortAssignment.unique())),
+                        new ServerCfg("127.0.0.1", new InetSocketAddress(
+                        "127.0.0.1", PortAssignment.unique()))));
             tmpdir[sid] = ClientBase.createTmpDir();
             port[sid] = PortAssignment.unique();
         }

--- a/src/java/test/org/apache/zookeeper/test/FLEZeroWeightTest.java
+++ b/src/java/test/org/apache/zookeeper/test/FLEZeroWeightTest.java
@@ -23,6 +23,8 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Properties;
+
+import org.apache.zookeeper.ServerCfg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
@@ -142,9 +144,12 @@ public class FLEZeroWeightTest extends ZKTestCase {
     public void testZeroWeightQuorum() throws Exception {
         LOG.info("TestZeroWeightQuorum: " + getTestName()+ ", " + count);
         for(int i = 0; i < count; i++) {
-            InetSocketAddress addr1 = new InetSocketAddress("127.0.0.1",PortAssignment.unique());
-            InetSocketAddress addr2 = new InetSocketAddress("127.0.0.1",PortAssignment.unique());
-            InetSocketAddress addr3 = new InetSocketAddress("127.0.0.1",PortAssignment.unique());
+            ServerCfg addr1 = new ServerCfg("127.0.0.1",
+                    new InetSocketAddress("127.0.0.1",PortAssignment.unique()));
+            ServerCfg addr2 = new ServerCfg("127.0.0.1",
+                    new InetSocketAddress("127.0.0.1",PortAssignment.unique()));
+            ServerCfg addr3 = new ServerCfg("127.0.0.1",
+                    new InetSocketAddress("127.0.0.1",PortAssignment.unique()));
             port[i] = addr3.getPort();
             qp.setProperty("server."+i, "127.0.0.1:"+addr1.getPort()+":"+addr2.getPort()+";"+port[i]);
             peers.put(Long.valueOf(i), new QuorumServer(i, addr1, addr2, addr3));

--- a/src/java/test/org/apache/zookeeper/test/HierarchicalQuorumTest.java
+++ b/src/java/test/org/apache/zookeeper/test/HierarchicalQuorumTest.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashSet;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.zookeeper.ServerCfg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
@@ -146,28 +147,28 @@ public class HierarchicalQuorumTest extends ClientBase {
         int initLimit = 3;
         int syncLimit = 3;
         HashMap<Long,QuorumServer> peers = new HashMap<Long,QuorumServer>();
-        peers.put(Long.valueOf(1), new QuorumServer(1, 
-                new InetSocketAddress("127.0.0.1", port1),
-                new InetSocketAddress("127.0.0.1", leport1),
-                new InetSocketAddress("127.0.0.1", clientport1)));        
-        peers.put(Long.valueOf(2), new QuorumServer(2, 
-                new InetSocketAddress("127.0.0.1", port2),
-                new InetSocketAddress("127.0.0.1", leport2),
-                new InetSocketAddress("127.0.0.1", clientport2)));
-        peers.put(Long.valueOf(3), new QuorumServer(3, 
-                new InetSocketAddress("127.0.0.1", port3),
-                new InetSocketAddress("127.0.0.1", leport3),
-                new InetSocketAddress("127.0.0.1", clientport3)));
+        peers.put(Long.valueOf(1), new QuorumServer(1,
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", port1)),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", leport1)),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", clientport1))));
+        peers.put(Long.valueOf(2), new QuorumServer(2,
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", port2)),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", leport2)),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", clientport2))));
+        peers.put(Long.valueOf(3), new QuorumServer(3,
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", port3)),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", leport3)),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", clientport3))));
         peers.put(Long.valueOf(4), new QuorumServer(4,
-                new InetSocketAddress("127.0.0.1", port4),
-                new InetSocketAddress("127.0.0.1", leport4),
-                new InetSocketAddress("127.0.0.1", clientport4),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", port4)),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", leport4)),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", clientport4)),
                 withObservers ? QuorumPeer.LearnerType.OBSERVER
                         : QuorumPeer.LearnerType.PARTICIPANT));
         peers.put(Long.valueOf(5), new QuorumServer(5,
-                new InetSocketAddress("127.0.0.1", port5),
-                new InetSocketAddress("127.0.0.1", leport5),
-                new InetSocketAddress("127.0.0.1", clientport5),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", port5)),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", leport5)),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1", clientport5)),
                 withObservers ? QuorumPeer.LearnerType.OBSERVER
                         : QuorumPeer.LearnerType.PARTICIPANT));
 

--- a/src/java/test/org/apache/zookeeper/test/LENonTerminateTest.java
+++ b/src/java/test/org/apache/zookeeper/test/LENonTerminateTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.zookeeper.ServerCfg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
@@ -99,16 +100,16 @@ public class LENonTerminateTest extends ZKTestCase {
                 for (QuorumServer server :
                     self.getVotingView().values())
                 {
-                    LOG.info("Server address: " + server.addr);
+                    LOG.info("Server address: " + server.getAddr());
                     try {
-                        requestPacket.setSocketAddress(server.addr);
+                        requestPacket.setSocketAddress(server.getAddr());
                     } catch (IllegalArgumentException e) {
                         // Sun doesn't include the address that causes this
                         // exception to be thrown, so we wrap the exception
                         // in order to capture this critical detail.
                         throw new IllegalArgumentException(
                                 "Unable to set socket address on packet, msg:"
-                                + e.getMessage() + " with addr:" + server.addr,
+                                + e.getMessage() + " with addr:" + server.getAddr(),
                                 e);
                     }
 
@@ -300,8 +301,12 @@ public class LENonTerminateTest extends ZKTestCase {
             int clientport = PortAssignment.unique();
             peers.put(Long.valueOf(i),
                     new QuorumServer(i,
-                            new InetSocketAddress("127.0.0.1", clientport),
-                            new InetSocketAddress("127.0.0.1", PortAssignment.unique())));
+                            new ServerCfg("127.0.0.1",
+                                    new InetSocketAddress("127.0.0.1",
+                                            clientport)),
+                            new ServerCfg("127.0.0.1",
+                                    new InetSocketAddress("127.0.0.1",
+                                            PortAssignment.unique()))));
             tmpdir[i] = ClientBase.createTmpDir();
             port[i] = clientport;
         }
@@ -356,7 +361,7 @@ public class LENonTerminateTest extends ZKTestCase {
         ByteBuffer responseBuffer = ByteBuffer.wrap(b);
         DatagramPacket packet = new DatagramPacket(b, b.length);
         QuorumServer server = peers.get(Long.valueOf(2));
-        DatagramSocket udpSocket = new DatagramSocket(server.addr.getPort());
+        DatagramSocket udpSocket = new DatagramSocket(server.getAddr().getPort());
         LOG.info("In MockServer");
         mockLatch.countDown();
         Vote current = new Vote(2, 1);

--- a/src/java/test/org/apache/zookeeper/test/LETest.java
+++ b/src/java/test/org/apache/zookeeper/test/LETest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Random;
 
+import org.apache.zookeeper.ServerCfg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
@@ -100,8 +101,9 @@ public class LETest extends ZKTestCase {
         for(int i = 0; i < count; i++) {
             peers.put(Long.valueOf(i),
                     new QuorumServer(i,
-                            new InetSocketAddress("127.0.0.1",
-                                    PortAssignment.unique())));
+                            new ServerCfg("127.0.0.1",
+                                    new InetSocketAddress("127.0.0.1",
+                                    PortAssignment.unique()))));
             tmpdir[i] = ClientBase.createTmpDir();
             port[i] = PortAssignment.unique();
         }

--- a/src/java/test/org/apache/zookeeper/test/QuorumBase.java
+++ b/src/java/test/org/apache/zookeeper/test/QuorumBase.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.apache.zookeeper.ServerCfg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
@@ -138,29 +139,29 @@ public class QuorumBase extends ClientBase {
         int syncLimit = 3;
         HashMap<Long,QuorumServer> peers = new HashMap<Long,QuorumServer>();
         peers.put(Long.valueOf(1), new QuorumServer(1, 
-                new InetSocketAddress(LOCALADDR, port1),
-                new InetSocketAddress(LOCALADDR, portLE1),
-                new InetSocketAddress(LOCALADDR, portClient1),
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, port1)),
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portLE1)),
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portClient1)),
                 LearnerType.PARTICIPANT));
-        peers.put(Long.valueOf(2), new QuorumServer(2, 
-                new InetSocketAddress(LOCALADDR, port2),
-                new InetSocketAddress(LOCALADDR, portLE2),
-                new InetSocketAddress(LOCALADDR, portClient2),
+        peers.put(Long.valueOf(2), new QuorumServer(2,
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, port2)),
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portLE2)),
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portClient2)),
                 LearnerType.PARTICIPANT));
-        peers.put(Long.valueOf(3), new QuorumServer(3, 
-                new InetSocketAddress(LOCALADDR, port3),
-                new InetSocketAddress(LOCALADDR, portLE3),
-                new InetSocketAddress(LOCALADDR, portClient3),
+        peers.put(Long.valueOf(3), new QuorumServer(3,
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, port3)),
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portLE3)),
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portClient3)),
                 LearnerType.PARTICIPANT));
-        peers.put(Long.valueOf(4), new QuorumServer(4, 
-                new InetSocketAddress(LOCALADDR, port4),
-                new InetSocketAddress(LOCALADDR, portLE4),
-                new InetSocketAddress(LOCALADDR, portClient4),
+        peers.put(Long.valueOf(4), new QuorumServer(4,
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, port4)),
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portLE4)),
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portClient4)),
                 LearnerType.PARTICIPANT));
-        peers.put(Long.valueOf(5), new QuorumServer(5, 
-                new InetSocketAddress(LOCALADDR, port5),
-                new InetSocketAddress(LOCALADDR, portLE5),
-                new InetSocketAddress(LOCALADDR, portClient5),
+        peers.put(Long.valueOf(5), new QuorumServer(5,
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, port5)),
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portLE5)),
+                new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portClient5)),
                 LearnerType.PARTICIPANT));
         
         if (withObservers) {
@@ -302,30 +303,30 @@ public class QuorumBase extends ClientBase {
         if(peers == null){
             peers = new HashMap<Long,QuorumServer>();
 
-            peers.put(Long.valueOf(1), new QuorumServer(1, 
-                new InetSocketAddress(LOCALADDR, port1),
-                new InetSocketAddress(LOCALADDR, portLE1),
-                new InetSocketAddress(LOCALADDR, portClient1),
+            peers.put(Long.valueOf(1), new QuorumServer(1,
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, port1)),
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portLE1)),
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portClient1)),
                 LearnerType.PARTICIPANT));
-            peers.put(Long.valueOf(2), new QuorumServer(2, 
-                new InetSocketAddress(LOCALADDR, port2),
-                new InetSocketAddress(LOCALADDR, portLE2),
-                new InetSocketAddress(LOCALADDR, portClient2),
+            peers.put(Long.valueOf(2), new QuorumServer(2,
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, port2)),
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portLE2)),
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portClient2)),
                 LearnerType.PARTICIPANT));
-            peers.put(Long.valueOf(3), new QuorumServer(3, 
-                new InetSocketAddress(LOCALADDR, port3),
-                new InetSocketAddress(LOCALADDR, portLE3),
-                new InetSocketAddress(LOCALADDR, portClient3),
+            peers.put(Long.valueOf(3), new QuorumServer(3,
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, port3)),
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portLE3)),
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portClient3)),
                 LearnerType.PARTICIPANT));
-            peers.put(Long.valueOf(4), new QuorumServer(4, 
-                new InetSocketAddress(LOCALADDR, port4),
-                new InetSocketAddress(LOCALADDR, portLE4),
-                new InetSocketAddress(LOCALADDR, portClient4),
+            peers.put(Long.valueOf(4), new QuorumServer(4,
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, port4)),
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portLE4)),
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portClient4)),
                 LearnerType.PARTICIPANT));
-            peers.put(Long.valueOf(5), new QuorumServer(5, 
-                new InetSocketAddress(LOCALADDR, port5),
-                new InetSocketAddress(LOCALADDR, portLE5),
-                new InetSocketAddress(LOCALADDR, portClient5),
+            peers.put(Long.valueOf(5), new QuorumServer(5,
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, port5)),
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portLE5)),
+                    new ServerCfg(LOCALADDR, new InetSocketAddress(LOCALADDR, portClient5)),
                 LearnerType.PARTICIPANT));
         }
         

--- a/src/java/test/org/apache/zookeeper/test/QuorumUtil.java
+++ b/src/java/test/org/apache/zookeeper/test/QuorumUtil.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ServerCfg;
 import org.apache.zookeeper.server.quorum.Election;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.server.quorum.QuorumPeer.LearnerType;
@@ -105,9 +106,12 @@ public class QuorumUtil {
                 peers.put(i, ps);
 
                 peersView.put(Long.valueOf(i), new QuorumServer(i, 
-                               new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-                               new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-                               new InetSocketAddress("127.0.0.1", ps.clientPort), 
+                        new ServerCfg("127.0.0.1",
+                                new InetSocketAddress("127.0.0.1", PortAssignment.unique())),
+                        new ServerCfg("127.0.0.1",
+                                new InetSocketAddress("127.0.0.1", PortAssignment.unique())),
+                        new ServerCfg("127.0.0.1",
+                                new InetSocketAddress("127.0.0.1", ps.clientPort)),
                                LearnerType.PARTICIPANT));
                 hostPort += "127.0.0.1:" + ps.clientPort + ((i == ALL) ? "" : ",");
             }

--- a/src/java/test/org/apache/zookeeper/test/ReconfigTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReconfigTest.java
@@ -807,8 +807,8 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
     	}
     	String server = "server.0=localhost:" + ports[0] + ":" + ports[1] + ";" + ports[2];
     	QuorumServer qs = new QuorumServer(0, server);
-    	Assert.assertEquals(qs.clientAddr.getHostString(), "0.0.0.0");
-    	Assert.assertEquals(qs.clientAddr.getPort(), ports[2]);
+    	Assert.assertEquals(qs.getClientAddr().getHostString(), "0.0.0.0");
+    	Assert.assertEquals(qs.getClientAddr().getPort(), ports[2]);
     }
     
     @Test
@@ -1100,13 +1100,13 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         Assert.assertEquals("Mismatches LearnerType!", qs.type.name(),
                 JMXEnv.ensureBeanAttribute(beanName, "LearnerType"));
         Assert.assertEquals("Mismatches ClientAddress!",
-                getNumericalAddrPort(qs.clientAddr.getHostString() + ":" + qs.clientAddr.getPort()),
+                getNumericalAddrPort(qs.getClientAddr().getHostString() + ":" + qs.getClientAddr().getPort()),
                 getAddrPortFromBean(beanName, "ClientAddress") );
         Assert.assertEquals("Mismatches ElectionAddress!",
-                getNumericalAddrPort(qs.electionAddr.getHostString() + ":" + qs.electionAddr.getPort()),
+                getNumericalAddrPort(qs.getElectionAddr().getHostString() + ":" + qs.getElectionAddr().getPort()),
                 getAddrPortFromBean(beanName, "ElectionAddress") );
         Assert.assertEquals("Mismatches QuorumAddress!",
-                getNumericalAddrPort(qs.addr.getHostString() + ":" + qs.addr.getPort()),
+                getNumericalAddrPort(qs.getAddr().getHostString() + ":" + qs.getAddr().getPort()),
                 getAddrPortFromBean(beanName, "QuorumAddress") );
     }
 }

--- a/src/java/test/org/apache/zookeeper/test/TruncateTest.java
+++ b/src/java/test/org/apache/zookeeper/test/TruncateTest.java
@@ -27,6 +27,7 @@ import org.apache.jute.Record;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ServerCfg;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
@@ -191,17 +192,26 @@ public class TruncateTest extends ZKTestCase {
         // Start up two of the quorum and add 10 txns
         HashMap<Long,QuorumServer> peers = new HashMap<Long,QuorumServer>();
         peers.put(Long.valueOf(1), new QuorumServer(1,
-                       new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-                       new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-                       new InetSocketAddress("127.0.0.1", port1)));
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1",
+                        PortAssignment.unique())),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1",
+                        PortAssignment.unique())),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1",
+                        port1))));
         peers.put(Long.valueOf(2), new QuorumServer(2,
-                       new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-                       new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-                       new InetSocketAddress("127.0.0.1", port2)));
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1",
+                        PortAssignment.unique())),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1",
+                        PortAssignment.unique())),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1",
+                        port2))));
         peers.put(Long.valueOf(3), new QuorumServer(3,
-                       new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-                       new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
-                       new InetSocketAddress("127.0.0.1", port3)));
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1",
+                        PortAssignment.unique())),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1",
+                        PortAssignment.unique())),
+                new ServerCfg("127.0.0.1", new InetSocketAddress("127.0.0.1",
+                        port3))));
 
         QuorumPeer s2 = new QuorumPeer(peers, dataDir2, dataDir2, port2, 0, 2, tickTime, initLimit, syncLimit);
         s2.start();


### PR DESCRIPTION
Wrap hostname and port into a new ServerCfg class and fix
all the places to use it instead of InetSocketAddress.

This class can be used in the future to encapsulate other
nice config information for example certificate
fingerprint associated with the host etc.