### PR TITLE
ZOOKEEPER-2712: MiniKdc test case intermittently failing due to princ…

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -98,6 +98,10 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     QuorumCnxManager qcm;
     QuorumAuthServer authServer;
     QuorumAuthLearner authLearner;
+    // VisibleForTesting. This flag is used to know whether qLearner's and
+    // qServer's login context has been initialized as ApacheDS has concurrency
+    // issues. Refer https://issues.apache.org/jira/browse/ZOOKEEPER-2712
+    private boolean authInitialized = false;
 
     /* ZKDatabase is a top level member of quorumpeer 
      * which will be used in all the zookeeperservers
@@ -571,6 +575,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
                     quorumServerLoginContext, authzHosts);
             authLearner = new SaslQuorumAuthLearner(isQuorumLearnerSaslAuthRequired(),
                     quorumServicePrincipal, quorumLearnerLoginContext);
+            authInitialized = true;
         } else {
             authServer = new NullQuorumAuthServer();
             authLearner = new NullQuorumAuthLearner();
@@ -1453,6 +1458,12 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
 
     private boolean isQuorumLearnerSaslAuthRequired() {
         return quorumLearnerSaslAuthRequired;
+    }
+
+    // VisibleForTesting. Returns true if both the quorumlearner and
+    // quorumserver login has been finished. Otherwse, false.
+    public boolean hasAuthInitialized(){
+        return authInitialized;
     }
 
     public QuorumCnxManager createCnxnManager() {

--- a/src/java/test/org/apache/zookeeper/server/quorum/auth/MiniKdc.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/auth/MiniKdc.java
@@ -224,7 +224,7 @@ public class MiniKdc {
         DEFAULT_CONFIG.setProperty(TRANSPORT, "TCP");
         DEFAULT_CONFIG.setProperty(MAX_TICKET_LIFETIME, "86400000");
         DEFAULT_CONFIG.setProperty(MAX_RENEWABLE_LIFETIME, "604800000");
-        DEFAULT_CONFIG.setProperty(DEBUG, "false");
+        DEFAULT_CONFIG.setProperty(DEBUG, "true");
     }
 
     /**

--- a/src/java/test/org/apache/zookeeper/server/quorum/auth/QuorumAuthUpgradeTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/auth/QuorumAuthUpgradeTest.java
@@ -83,7 +83,7 @@ public class QuorumAuthUpgradeTest extends QuorumAuthTestBase {
         Map<String, String> authConfigs = new HashMap<String, String>();
         authConfigs.put(QuorumAuth.QUORUM_SASL_AUTH_ENABLED, "false");
 
-        String connectStr = startQuorum(2, authConfigs, 0);
+        String connectStr = startQuorum(2, authConfigs, 0, false);
         CountdownWatcher watcher = new CountdownWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT,
                 watcher);
@@ -103,7 +103,7 @@ public class QuorumAuthUpgradeTest extends QuorumAuthTestBase {
         Map<String, String> authConfigs = new HashMap<String, String>();
         authConfigs.put(QuorumAuth.QUORUM_SASL_AUTH_ENABLED, "true");
 
-        String connectStr = startQuorum(2, authConfigs, 1);
+        String connectStr = startQuorum(2, authConfigs, 1, false);
         CountdownWatcher watcher = new CountdownWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT,
                 watcher);
@@ -123,7 +123,7 @@ public class QuorumAuthUpgradeTest extends QuorumAuthTestBase {
         Map<String, String> authConfigs = new HashMap<String, String>();
         authConfigs.put(QuorumAuth.QUORUM_SASL_AUTH_ENABLED, "true");
 
-        String connectStr = startQuorum(2, authConfigs, 2);
+        String connectStr = startQuorum(2, authConfigs, 2, false);
         CountdownWatcher watcher = new CountdownWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT,
                 watcher);
@@ -145,7 +145,7 @@ public class QuorumAuthUpgradeTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_SERVER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
 
-        String connectStr = startQuorum(2, authConfigs, 2);
+        String connectStr = startQuorum(2, authConfigs, 2, false);
         CountdownWatcher watcher = new CountdownWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT,
                 watcher);
@@ -178,7 +178,7 @@ public class QuorumAuthUpgradeTest extends QuorumAuthTestBase {
         Map<String, String> authConfigs = new HashMap<String, String>();
         authConfigs.put(QuorumAuth.QUORUM_SASL_AUTH_ENABLED, "false");
 
-        String connectStr = startQuorum(3, authConfigs, 0);
+        String connectStr = startQuorum(3, authConfigs, 0, false);
         CountdownWatcher watcher = new CountdownWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT,
                 watcher);

--- a/src/java/test/org/apache/zookeeper/server/quorum/auth/QuorumDigestAuthTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/auth/QuorumDigestAuthTest.java
@@ -87,7 +87,7 @@ public class QuorumDigestAuthTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_SERVER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
 
-        String connectStr = startQuorum(3, authConfigs, 3);
+        String connectStr = startQuorum(3, authConfigs, 3, false);
         CountdownWatcher watcher = new CountdownWatcher();
         zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
@@ -108,7 +108,7 @@ public class QuorumDigestAuthTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_LOGIN_CONTEXT, "QuorumLearnerInvalid");
         authConfigs.put(QuorumAuth.QUORUM_SASL_AUTH_ENABLED, "false");
         authConfigs.put(QuorumAuth.QUORUM_SERVER_SASL_AUTH_REQUIRED, "false");
-        String connectStr = startQuorum(3, authConfigs, 3);
+        String connectStr = startQuorum(3, authConfigs, 3, false);
         CountdownWatcher watcher = new CountdownWatcher();
         zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
@@ -132,7 +132,7 @@ public class QuorumDigestAuthTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
         int serverCount = 2;
         final int[] clientPorts = startQuorum(serverCount, 0,
-                new StringBuilder(), authConfigs, serverCount);
+                new StringBuilder(), authConfigs, serverCount, false);
         for (int i = 0; i < serverCount; i++) {
             boolean waitForServerUp = ClientBase.waitForServerUp(
                     "127.0.0.1:" + clientPorts[i], QuorumPeerTestBase.TIMEOUT);
@@ -262,7 +262,7 @@ public class QuorumDigestAuthTest extends QuorumAuthTestBase {
         // Starting auth enabled 3-node cluster.
         int totalServerCount = 3;
         String connectStr = startQuorum(totalServerCount, authConfigs,
-                totalServerCount);
+                totalServerCount, false);
 
         CountdownWatcher watcher = new CountdownWatcher();
         zk = new ZooKeeper(connectStr.toString(), ClientBase.CONNECTION_TIMEOUT,
@@ -310,7 +310,7 @@ public class QuorumDigestAuthTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_SERVER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
 
-        String connectStr = startQuorum(3, authConfigs, 3);
+        String connectStr = startQuorum(3, authConfigs, 3, false);
         CountdownWatcher watcher = new CountdownWatcher();
         zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);

--- a/src/java/test/org/apache/zookeeper/server/quorum/auth/QuorumKerberosAuthTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/auth/QuorumKerberosAuthTest.java
@@ -46,7 +46,9 @@ public class QuorumKerberosAuthTest extends KerberosSecurityTestcase {
                 + "       keyTab=\"" + keytabFilePath + "\"\n"
                 + "       storeKey=true\n"
                 + "       useTicketCache=false\n"
-                + "       debug=false\n"
+                + "       debug=true\n"
+                + "       doNotPrompt=true\n"
+                + "       refreshKrb5Config=true\n"
                 + "       principal=\"" + KerberosTestUtils.getServerPrincipal() + "\";\n" + "};\n"
                 + "QuorumLearner {\n"
                 + "       com.sun.security.auth.module.Krb5LoginModule required\n"
@@ -54,7 +56,10 @@ public class QuorumKerberosAuthTest extends KerberosSecurityTestcase {
                 + "       keyTab=\"" + keytabFilePath + "\"\n"
                 + "       storeKey=true\n"
                 + "       useTicketCache=false\n"
-                + "       debug=false\n"
+                + "       debug=true\n"
+                + "       doNotPrompt=true\n"
+                + "       refreshKrb5Config=true\n"
+                + "       isInitiator=true\n"
                 + "       principal=\"" + KerberosTestUtils.getLearnerPrincipal() + "\";\n" + "};\n");
         setupJaasConfig(jaasEntries);
     }
@@ -98,7 +103,7 @@ public class QuorumKerberosAuthTest extends KerberosSecurityTestcase {
         authConfigs.put(QuorumAuth.QUORUM_SERVER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_KERBEROS_SERVICE_PRINCIPAL, serverPrincipal);
-        String connectStr = startQuorum(3, authConfigs, 3);
+        String connectStr = startQuorum(3, authConfigs, 3, true);
         CountdownWatcher watcher = new CountdownWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);

--- a/src/java/test/org/apache/zookeeper/server/quorum/auth/QuorumKerberosHostBasedAuthTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/auth/QuorumKerberosHostBasedAuthTest.java
@@ -43,7 +43,7 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
     private static File keytabFile;
     private static String hostServerPrincipal = KerberosTestUtils.getHostServerPrincipal();
     private static String hostLearnerPrincipal = KerberosTestUtils.getHostLearnerPrincipal();
-    private static String hostNamedLearnerPrincipal = KerberosTestUtils.getHostNamedLearnerPrincipal("myHost");
+    private static String hostNamedLearnerPrincipal = KerberosTestUtils.getHostNamedLearnerPrincipal("myhost");
     static {
         setupJaasConfigEntries(hostServerPrincipal, hostLearnerPrincipal, hostNamedLearnerPrincipal);
     }
@@ -58,7 +58,9 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
                 + "       keyTab=\"" + keytabFilePath + "\"\n"
                 + "       storeKey=true\n"
                 + "       useTicketCache=false\n"
-                + "       debug=false\n"
+                + "       debug=true\n"
+                + "       doNotPrompt=true\n"
+                + "       refreshKrb5Config=true\n"
                 + "       principal=\"" + KerberosTestUtils.replaceHostPattern(hostServerPrincipal) + "\";\n" + "};\n"
                 + "QuorumLearner {\n"
                 + "       com.sun.security.auth.module.Krb5LoginModule required\n"
@@ -66,7 +68,10 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
                 + "       keyTab=\"" + keytabFilePath + "\"\n"
                 + "       storeKey=true\n"
                 + "       useTicketCache=false\n"
-                + "       debug=false\n"
+                + "       debug=true\n"
+                + "       doNotPrompt=true\n"
+                + "       refreshKrb5Config=true\n"
+                + "       isInitiator=true\n"
                 + "       principal=\"" + KerberosTestUtils.replaceHostPattern(hostLearnerPrincipal) + "\";\n" + "};\n"
                 + "QuorumLearnerMyHost {\n"
                 + "       com.sun.security.auth.module.Krb5LoginModule required\n"
@@ -74,7 +79,10 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
                 + "       keyTab=\"" + keytabFilePath + "\"\n"
                 + "       storeKey=true\n"
                 + "       useTicketCache=false\n"
-                + "       debug=false\n"
+                + "       debug=true\n"
+                + "       doNotPrompt=true\n"
+                + "       refreshKrb5Config=true\n"
+                + "       isInitiator=true\n"
                 + "       principal=\"" + hostNamedLearnerPrincipal + "\";\n" + "};\n");
         setupJaasConfig(jaasEntries);
     }
@@ -122,7 +130,7 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
         authConfigs.put(QuorumAuth.QUORUM_SERVER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_KERBEROS_SERVICE_PRINCIPAL, serverPrincipal);
-        String connectStr = startQuorum(3, authConfigs, 3);
+        String connectStr = startQuorum(3, authConfigs, 3, true);
         CountdownWatcher watcher = new CountdownWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
@@ -143,7 +151,7 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
         authConfigs.put(QuorumAuth.QUORUM_SERVER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_KERBEROS_SERVICE_PRINCIPAL, serverPrincipal);
-        String connectStr = startQuorum(3, authConfigs, 3);
+        String connectStr = startQuorum(3, authConfigs, 3, true);
         CountdownWatcher watcher = new CountdownWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);


### PR DESCRIPTION
After long long analysis, I have observed concurrency issues at `ApacheDs `(used for unit test) causing the trouble and failing minikdc test cases. Introduced delay between the ZK server's startup to avoid simultaneous login context init across servers. Also, modified few test code for better debugging.