### PR TITLE
ZOOKEEPER-2735: fix typos in shell scripts

### DIFF
--- a/bin/zkCleanup.sh
+++ b/bin/zkCleanup.sh
@@ -25,7 +25,7 @@
 # relative to the canonical path of this script.
 #
 
-# use POSTIX interface, symlink is followed automatically
+# use POSIX interface, symlink is followed automatically
 ZOOBIN="${BASH_SOURCE-$0}"
 ZOOBIN="$(dirname "${ZOOBIN}")"
 ZOOBINDIR="$(cd "${ZOOBIN}"; pwd)"

--- a/bin/zkCli.sh
+++ b/bin/zkCli.sh
@@ -25,7 +25,7 @@
 # relative to the canonical path of this script.
 #
 
-# use POSTIX interface, symlink is followed automatically
+# use POSIX interface, symlink is followed automatically
 ZOOBIN="${BASH_SOURCE-$0}"
 ZOOBIN="$(dirname "${ZOOBIN}")"
 ZOOBINDIR="$(cd "${ZOOBIN}"; pwd)"

--- a/bin/zkServer.sh
+++ b/bin/zkServer.sh
@@ -22,7 +22,7 @@
 #
 
 
-# use POSTIX interface, symlink is followed automatically
+# use POSIX interface, symlink is followed automatically
 ZOOBIN="${BASH_SOURCE-$0}"
 ZOOBIN="$(dirname "${ZOOBIN}")"
 ZOOBINDIR="$(cd "${ZOOBIN}"; pwd)"


### PR DESCRIPTION
This PR contains corrections for some spelling typos in shell scripts.

I also create the issue in JIRA [ZOOKEEPER-2735](https://issues.apache.org/jira/browse/ZOOKEEPER-2735)