### PR TITLE
ZOOKEEPER-2737: close netty connection when exceptions occur during w…

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -144,8 +144,8 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
             if (cnxn != null) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Closing " + cnxn);
-                    cnxn.close();
                 }
+                cnxn.close();
             }
         }
 


### PR DESCRIPTION
…rite to channel to prevent resource leak.

I am OK to add some contrived test case to test this but I'd like to do that later if needed, so this fix can get in upcoming releases..