### PR TITLE
ZOOKEEPER-2738 maxClientCnxns not limiting concurrent connections pro…

### DIFF
--- a/src/java/test/org/apache/zookeeper/test/MaxCnxnsTest.java
+++ b/src/java/test/org/apache/zookeeper/test/MaxCnxnsTest.java
@@ -120,15 +120,15 @@ public class MaxCnxnsTest extends ClientBase {
         int numThreads = numCnxns + 5;
         CnxnThread[] threads = new CnxnThread[numThreads];
 
-        for (int i=0;i<numCnxns;++i) {
+    for (int i = 0; i < numThreads; ++i) {
           threads[i] = new CnxnThread(i);
         }
 
-        for (int i=0;i<numCnxns;++i) {
+    for (int i = 0; i < numThreads; ++i) {
             threads[i].start();
         }
 
-        for (int i=0;i<numCnxns;++i) {
+    for (int i = 0; i < numThreads; ++i) {
             threads[i].join();
         }
         Assert.assertSame(numCnxns,numConnected.get());


### PR DESCRIPTION
…perly

The problem was that in branch-3.5+ , because of ZOOKEEPER-1504, we now have one acceptor thread and multiple selector threads.  The acceptor thread was checking the max connections, but adding the connection to the ipMap (used to check maxCnxnCount) was done in the selector threads.  As a result, when many connections come in concurrently, the acceptor thread can potentially accept many connections before the selector threads have a chance to update the ipMap.

This patch updates the ipMap from the acceptor thread immediately.