### PR TITLE
ZOOKEEPER-2746: remove the check on the new leader after a dynamic re…

### DIFF
--- a/src/java/test/org/apache/zookeeper/test/ReconfigTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReconfigTest.java
@@ -678,7 +678,6 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
 
         Assert.assertTrue(qu.getPeer(leaderIndex).peer.getQuorumAddress()
                 .getPort() == newQuorumPort);
-        Assert.assertTrue(getLeaderId(qu) != leaderIndex); // the leader changed
 
         joiningServers.clear();
 


### PR DESCRIPTION
…config operation.

This check might not always hold because the nominated leader could fail to lead the quorum during sync phase - for example if sync time out [when waiting for quorum ack](https://github.com/apache/zookeeper/blob/master/src/java/main/org/apache/zookeeper/server/quorum/Leader.java#L1232). I am thinking we should just remove this instead of fixing it because the nominated leader is not an interface level contract / guarantee but a best effort / implementation level details.