### PR TITLE
ZOOKEEPER-2748: Admin command to voluntarily drop client connections

### DIFF
--- a/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
@@ -1974,6 +1974,31 @@ server.3=zoo3:2888:3888</programlisting>
               </programlisting>
             </listitem>
           </varlistentry>
+
+          <varlistentry>
+            <term>shed</term>
+
+            <listitem>
+              <para>Closes all client connections, forcing them to move to a different server.</para>
+            </listitem>
+          </varlistentry>
+
+          <varlistentry>
+            <term>sh50</term>
+
+            <listitem>
+              <para>Probabilistically closes half of the client connections (i.e. each connection is closed with a probability of 1/2), forcing them to move to a different server.</para>
+            </listitem>
+          </varlistentry>
+
+          <varlistentry>
+            <term>sh50</term>
+
+            <listitem>
+              <para>Probabilistically closes a quarter of the client connection (i.e. each connection is closed with a probability of 1/4), forcing them to move to a different server.</para>
+            </listitem>
+          </varlistentry>
+
         </variablelist>
 
         <para>Here's an example of the <emphasis role="bold">ruok</emphasis>

--- a/src/java/main/org/apache/zookeeper/server/command/CommandExecutor.java
+++ b/src/java/main/org/apache/zookeeper/server/command/CommandExecutor.java
@@ -74,6 +74,12 @@ public class CommandExecutor {
             command = new MonitorCommand(pwriter, serverCnxn);
         } else if (commandCode == FourLetterCommands.isroCmd) {
             command = new IsroCommand(pwriter, serverCnxn);
+        } else if (commandCode == FourLetterCommands.shedAllCmd) {
+            command = new ShedCommand(pwriter, serverCnxn);
+        } else if (commandCode == FourLetterCommands.shed25Cmd) {
+            command = new ShedCommand(pwriter, serverCnxn, 0.25);
+        } else if (commandCode == FourLetterCommands.shed50Cmd) {
+            command = new ShedCommand(pwriter, serverCnxn, 0.5);
         }
         return command;
     }

--- a/src/java/main/org/apache/zookeeper/server/command/FourLetterCommands.java
+++ b/src/java/main/org/apache/zookeeper/server/command/FourLetterCommands.java
@@ -151,6 +151,17 @@ public class FourLetterCommands {
             .getInt();
 
     /*
+     * See <a href="{@docRoot}/../../../docs/zookeeperAdmin.html#sc_zkCommands">
+     * Zk Admin</a>. this link is for all the commands.
+     */
+    public final static int shedAllCmd = ByteBuffer.wrap("shed".getBytes())
+            .getInt();
+    public final static int shed25Cmd = ByteBuffer.wrap("sh25".getBytes())
+            .getInt();
+    public final static int shed50Cmd = ByteBuffer.wrap("sh50".getBytes())
+            .getInt();
+
+    /*
      * The control sequence sent by the telnet program when it closes a
      * connection. Include simply to keep the logs cleaner (the server would
      * close the connection anyway because it would parse this as a negative
@@ -255,6 +266,9 @@ public class FourLetterCommands {
         cmd2String.put(wchsCmd, "wchs");
         cmd2String.put(mntrCmd, "mntr");
         cmd2String.put(isroCmd, "isro");
+        cmd2String.put(shedAllCmd, "shed");
+        cmd2String.put(shed25Cmd, "sh25");
+        cmd2String.put(shed50Cmd, "sh50");
         cmd2String.put(telnetCloseCmd, "telnet close");
     }
 }

--- a/src/java/main/org/apache/zookeeper/server/command/ShedCommand.java
+++ b/src/java/main/org/apache/zookeeper/server/command/ShedCommand.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.command;
+
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.ServerCnxn;
+
+import java.io.PrintWriter;
+import java.util.HashSet;
+
+public class ShedCommand extends AbstractFourLetterCommand {
+    private final HashSet<ServerCnxn> filter;
+    private final double shedProbability;
+
+    public ShedCommand(PrintWriter pw, ServerCnxn sourceServerCnxn) {
+        this(pw, sourceServerCnxn, 1.0);
+    }
+
+    public ShedCommand(PrintWriter pw, ServerCnxn sourceServerCnxn, double shedProbability) {
+        super(pw, sourceServerCnxn);
+        this.shedProbability = shedProbability;
+        this.filter = new HashSet<>();
+
+        // Do not close the connection issuing the command
+        filter.add(sourceServerCnxn);
+    }
+
+    @Override
+    public void commandRun() {
+        if (zkServer == null) {
+            pw.print("server is null");
+        } else {
+            pw.print("Shedding clients (" + (shedProbability == 1.0 ? "all" : String.valueOf(shedProbability)) + ")");
+            zkServer.getServerCnxnFactory().closeSome(filter, shedProbability);
+        }
+        pw.println();
+    }
+}

--- a/src/java/test/org/apache/zookeeper/server/quorum/Zab1_0Test.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/Zab1_0Test.java
@@ -37,6 +37,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 
@@ -319,6 +320,11 @@ public class Zab1_0Test extends ZKTestCase {
         }
         public void closeAll() {
         }
+
+        @Override
+        public void closeSome(Set<ServerCnxn> filter, double shedProbability) {
+        }
+
         @Override
         public int getNumAliveConnections() {
             return 0;

--- a/src/java/test/org/apache/zookeeper/test/FourLetterWordsTest.java
+++ b/src/java/test/org/apache/zookeeper/test/FourLetterWordsTest.java
@@ -113,6 +113,7 @@ public class FourLetterWordsTest extends ClientBase {
         verify("stat", "Connections");
         verify("srvr", "Connections");
         verify("dirs", "size");
+        verify("shed", "Shedding clients (all)");
     }
 
     private String sendRequest(String cmd) throws IOException, SSLContextException {

--- a/src/java/test/org/apache/zookeeper/test/ShedClientsTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ShedClientsTest.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.client.FourLetterWordMain;
+import org.apache.zookeeper.server.NIOServerCnxnFactory;
+import org.apache.zookeeper.server.NettyServerCnxnFactory;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ShedClientsTest extends ClientBase {
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        // Prevent super.setUp() from doing anything.
+        // We first want to run setUpWithCustomCnxnFactory.
+        // This hack is required because the JUnit Parametrized runner cannot be used for Zookeeper tests :-(
+    }
+
+    public void setUpWithCustomCnxnFactory(String cnxnFactoryClassName) throws Exception {
+        System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY, cnxnFactoryClassName);
+        super.setUp();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
+        super.tearDown();
+    }
+
+    @Test(timeout = 60000)
+    public void testShedAllClientsNIO() throws Exception {
+        setUpWithCustomCnxnFactory(NIOServerCnxnFactory.class.getCanonicalName());
+        testShedAllClients();
+    }
+
+    @Test(timeout = 60000)
+    public void testShedSomeClientsNIO() throws Exception {
+        setUpWithCustomCnxnFactory(NIOServerCnxnFactory.class.getCanonicalName());
+        testShedSomeClients();
+    }
+
+    @Test(timeout = 60000)
+    public void testShedAllClientsNetty() throws Exception {
+        setUpWithCustomCnxnFactory(NettyServerCnxnFactory.class.getCanonicalName());
+        testShedAllClients();
+    }
+
+    @Test(timeout = 60000)
+    public void testShedSomeClientsNetty() throws Exception {
+        setUpWithCustomCnxnFactory(NettyServerCnxnFactory.class.getCanonicalName());
+        testShedSomeClients();
+    }
+
+    public void testShedAllClients() throws Exception {
+
+        HostPort hpobj = ClientBase.parseHostPortList(hostPort).get(0);
+
+        DisconnectionCountingWatcher watcher = new DisconnectionCountingWatcher();
+        ZooKeeper zk = new ZooKeeper(hostPort, CONNECTION_TIMEOUT, watcher);
+
+        watcher.waitForState(Watcher.Event.KeeperState.SyncConnected);
+
+        for (int i = 0; i < 10; i++) {
+
+            FourLetterWordMain.send4LetterWord(hpobj.host, hpobj.port, "shed");
+
+            watcher.waitForState(Watcher.Event.KeeperState.Disconnected);
+
+            watcher.waitForState(Watcher.Event.KeeperState.SyncConnected);
+        }
+
+        Assert.assertEquals(10, watcher.disconnections.get());
+
+        zk.close();
+    }
+
+    public void testShedSomeClients() throws Exception {
+
+        HostPort hpobj = ClientBase.parseHostPortList(hostPort).get(0);
+
+        DisconnectionCountingWatcher watcher = new DisconnectionCountingWatcher();
+        ZooKeeper zk = new ZooKeeper(hostPort, CONNECTION_TIMEOUT, watcher);
+
+        watcher.waitForState(Watcher.Event.KeeperState.SyncConnected);
+
+        for (int i = 0; i < 10; i++) {
+
+            FourLetterWordMain.send4LetterWord(hpobj.host, hpobj.port, "sh50");
+
+            // Client has a 50% chance of getting dropped in each iterations.
+            // We cannot block and see. Just give it some time:
+            Thread.currentThread().sleep(500);
+        }
+
+        LOG.info("Client got disconnection count: " + watcher.disconnections.get());
+
+        // Not guaranteed but very very likely true (P=0.999)
+        Assert.assertTrue(watcher.disconnections.get() > 0);
+
+        zk.close();
+    }
+
+    private class DisconnectionCountingWatcher implements Watcher {
+
+        Event.KeeperState currentState = Event.KeeperState.Disconnected;
+        private AtomicInteger disconnections = new AtomicInteger(0);
+
+        @Override
+        public void process(WatchedEvent event) {
+            LOG.info("Setting client state: " + event.getState().name());
+            synchronized (this) {
+
+                if (!currentState.equals(Event.KeeperState.Disconnected) && event.getState().equals(Event.KeeperState.Disconnected)) {
+                    disconnections.incrementAndGet();
+                }
+
+                currentState = event.getState();
+                notifyAll();
+            }
+        }
+
+        void waitForState(Event.KeeperState state) {
+            try {
+                synchronized (this) {
+                    while (!currentState.equals(state)) {
+                        this.wait(100);
+                    }
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for state: " + state.name());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduce 3 new 4-letter commands:
 - shed: close all client connections
 - sh25: close approximatively 1/4 of client connections
 - sh50: close approximatively half of client connections

In clusters with large number of clients, a rolling bounce (or multiple) can lead to a situation of severe connection imbalance.

In these situations, restarting clients is the only solution to rebalance the load among servers.

This change introduces server admin command that voluntarily close client connections.
Clients should be able to migrate transparently to another server, just like in case of actual disconnection or server crash.

https://issues.apache.org/jira/browse/ZOOKEEPER-2748