### PR TITLE
ZOOKEEPER-2697 Handle graceful stop of ZookKeeper client

### DIFF
--- a/src/java/main/org/apache/zookeeper/ZooKeeper.java
+++ b/src/java/main/org/apache/zookeeper/ZooKeeper.java
@@ -1298,6 +1298,11 @@ public class ZooKeeper implements AutoCloseable {
      * <p>
      * Added in 3.5.3: <a href="https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html">try-with-resources</a>
      * may be used instead of calling close directly.
+     * </p>
+     * <p>
+     * This method does not wait for all internal threads to exit.
+     * Use the {@link #close(int) } method to wait for all resources to be released
+     * </p>
      *
      * @throws InterruptedException
      */
@@ -1322,6 +1327,22 @@ public class ZooKeeper implements AutoCloseable {
         }
 
         LOG.info("Session: 0x" + Long.toHexString(getSessionId()) + " closed");
+    }
+
+    /**
+     * Close this client object as the {@link #close() } method.
+     * This method will wait for internal resources to be released.
+     *
+     * @param waitForShutdownTimeoutMs timeout (in milliseconds) to wait for resources to be released.
+     * Use zero or a negative value to skip the wait
+     * @throws InterruptedException
+     * @return true if waitForShutdownTimeout is greater than zero and all of the resources have been released
+     *
+     * @since 3.5.4
+     */
+    public boolean close(int waitForShutdownTimeoutMs) throws InterruptedException {
+        close();
+        return testableWaitForShutdown(waitForShutdownTimeoutMs);
     }
 
     /**

--- a/src/java/test/org/apache/zookeeper/test/AsyncHammerTest.java
+++ b/src/java/test/org/apache/zookeeper/test/AsyncHammerTest.java
@@ -103,8 +103,7 @@ public class AsyncHammerTest extends ZKTestCase
             } finally {
                 if (zk != null) {
                     try {
-                        zk.close();
-                        if (!zk.testableWaitForShutdown(CONNECTION_TIMEOUT)) {
+                        if (!zk.close(CONNECTION_TIMEOUT)) {
                             failed = true;
                             LOG.error("Client did not shutdown");
                         }

--- a/src/java/test/org/apache/zookeeper/test/ClientTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientTest.java
@@ -47,6 +47,7 @@ import org.apache.zookeeper.proto.ReplyHeader;
 import org.apache.zookeeper.proto.RequestHeader;
 import org.apache.zookeeper.server.PrepRequestProcessor;
 import org.apache.zookeeper.server.util.OSMXBean;
+import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -113,8 +114,7 @@ public class ClientTest extends ClientBase {
             LOG.info("{}",zk.testableRemoteSocketAddress());
             LOG.info("{}",zk.toString());
         } finally {
-            zk.close();
-            zk.testableWaitForShutdown(CONNECTION_TIMEOUT);
+            zk.close(CONNECTION_TIMEOUT);
             LOG.info("{}",zk.testableLocalSocketAddress());
             LOG.info("{}",zk.testableRemoteSocketAddress());
             LOG.info("{}",zk.toString());
@@ -759,11 +759,10 @@ public class ClientTest extends ClientBase {
             try {
                 for (; current < count; current++) {
                     TestableZooKeeper zk = createClient();
-                    zk.close();
                     // we've asked to close, wait for it to finish closing
                     // all the sub-threads otw the selector may not be
                     // closed when we check (false positive on test Assert.failure
-                    zk.testableWaitForShutdown(CONNECTION_TIMEOUT);
+                    zk.close(CONNECTION_TIMEOUT);
                 }
             } catch (Throwable t) {
                 LOG.error("test Assert.failed", t);


### PR DESCRIPTION
Add a ZooKeeper.close(int timeout) method which waits for internal resources to be released