### PR TITLE
ZOOKEEPER-2755 Allow to subclass ClientCnxnSocketNetty and NettyServerCnxn

### DIFF
--- a/src/java/main/org/apache/zookeeper/common/SocketAddressUtils.java
+++ b/src/java/main/org/apache/zookeeper/common/SocketAddressUtils.java
@@ -1,0 +1,97 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.common;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Id;
+import org.jboss.netty.channel.local.LocalAddress;
+
+public class SocketAddressUtils {
+
+    public static InetAddress getInetAddress(SocketAddress socketAddress) {
+        if (socketAddress instanceof InetSocketAddress) {
+            return ((InetSocketAddress) socketAddress).getAddress();
+        } else if (socketAddress instanceof LocalAddress) {
+            return InetAddress.getLoopbackAddress();
+        } else {
+            throw new IllegalArgumentException("Unexpected address type " + socketAddress.getClass().getName() + ": " + socketAddress.toString());
+        }
+    }
+
+    public static LocalAddress mapToLocalAddress(InetSocketAddress socketAddress) {
+        if (socketAddress.getAddress().getHostAddress().equals("0.0.0.0")) {
+            return new LocalAddress(InetAddress.getLoopbackAddress().getHostAddress() + ":" + socketAddress.getPort());
+        } else {
+            return new LocalAddress(socketAddress.getAddress().getHostAddress() + ":" + socketAddress.getPort());
+        }
+    }
+
+    public static int getPort(SocketAddress socketAddress) {
+        if (socketAddress instanceof InetSocketAddress) {
+            return ((InetSocketAddress) socketAddress).getPort();
+        } else if (socketAddress instanceof LocalAddress) {
+            LocalAddress local = (LocalAddress) socketAddress;
+            String id = local.getId();
+            try {
+                int colon = id.lastIndexOf(':');
+                return Integer.parseInt(id.substring(colon + 1));
+            } catch (NumberFormatException | IndexOutOfBoundsException err) {
+                throw new IllegalArgumentException("Unexpected local address " + id);
+            }
+        } else {
+            throw new IllegalArgumentException("Unexpected address type " + socketAddress.getClass().getName() + ": " + socketAddress.toString());
+        }
+    }
+
+    public static String getHostString(SocketAddress socketAddress) {
+        if (socketAddress instanceof InetSocketAddress) {
+            return ((InetSocketAddress) socketAddress).getHostString();
+        } else if (socketAddress instanceof LocalAddress) {
+            LocalAddress local = (LocalAddress) socketAddress;
+            String id = local.getId();
+            try {
+                int colon = id.lastIndexOf(':');
+                return id.substring(0, colon);
+            } catch (IndexOutOfBoundsException err) {
+                throw new IllegalArgumentException("Unexpected local address " + id);
+            }
+        } else {
+            throw new IllegalArgumentException("Unexpected address type " + socketAddress.getClass().getName() + ": " + socketAddress.toString());
+        }
+    }
+
+    public static String getHostAddress(SocketAddress socketAddress) {
+
+        if (socketAddress instanceof InetSocketAddress) {
+            return ((InetSocketAddress) socketAddress).getAddress().getHostAddress();
+        } else if (socketAddress instanceof LocalAddress) {
+            LocalAddress local = (LocalAddress) socketAddress;
+            String id = local.getId();
+            try {
+                int colon = id.lastIndexOf(':');
+                return id.substring(0, colon);
+            } catch (IndexOutOfBoundsException err) {
+                throw new IllegalArgumentException("Unexpected local address " + id);
+            }
+        } else {
+            throw new IllegalArgumentException("Unexpected address type " + socketAddress.getClass().getName() + ": " + socketAddress.toString());
+        }
+    }
+}

--- a/src/java/main/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -25,7 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.net.InetSocketAddress;
+import java.net.InetAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.security.cert.Certificate;
@@ -37,6 +37,7 @@ import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.Record;
 import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.common.SocketAddressUtils;
 import org.apache.zookeeper.proto.ReplyHeader;
 import org.apache.zookeeper.proto.WatcherEvent;
 import org.apache.zookeeper.server.command.CommandExecutor;
@@ -107,12 +108,13 @@ public class NettyServerCnxn extends ServerCnxn {
             }
 
             synchronized (factory.ipMap) {
-                Set<NettyServerCnxn> s =
-                    factory.ipMap.get(((InetSocketAddress)channel
-                            .getRemoteAddress()).getAddress());
-                s.remove(this);
+                InetAddress remoteAddress =
+                        SocketAddressUtils.getInetAddress(getRemoteSocketAddress());
+                    Set<NettyServerCnxn> s =
+                        factory.ipMap.get(remoteAddress);
+                    s.remove(this);
+                }
             }
-        }
 
         if (channel.isOpen()) {
             channel.close();
@@ -449,8 +451,8 @@ public class NettyServerCnxn extends ServerCnxn {
     }
 
     @Override
-    public InetSocketAddress getRemoteSocketAddress() {
-        return (InetSocketAddress)channel.getRemoteAddress();
+    public SocketAddress getRemoteSocketAddress() {
+        return channel.getRemoteAddress();
     }
 
     /** Send close connection packet to the client.

--- a/src/java/main/org/apache/zookeeper/server/ServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/ServerCnxn.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.security.cert.Certificate;
 import java.util.*;
@@ -259,7 +260,7 @@ public abstract class ServerCnxn implements Stats, Watcher {
         return sw.toString();
     }
 
-    public abstract InetSocketAddress getRemoteSocketAddress();
+    public abstract SocketAddress getRemoteSocketAddress();
     public abstract int getInterestOps();
     public abstract boolean isSecure();
     public abstract Certificate[] getClientCertificateChain();

--- a/src/java/main/org/apache/zookeeper/server/ServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/ServerCnxnFactory.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.server;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Set;
@@ -155,7 +156,7 @@ public abstract class ServerCnxnFactory {
         return factory;
     }
 
-    public abstract InetSocketAddress getLocalAddress();
+    public abstract SocketAddress getLocalAddress();
 
     public abstract void resetAllConnectionStats();
 

--- a/src/java/main/org/apache/zookeeper/server/ZooKeeperServerBean.java
+++ b/src/java/main/org/apache/zookeeper/server/ZooKeeperServerBean.java
@@ -18,9 +18,12 @@
 
 package org.apache.zookeeper.server;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Date;
 
 import org.apache.zookeeper.Version;
+import org.apache.zookeeper.common.SocketAddressUtils;
 import org.apache.zookeeper.jmx.ZKMBeanInfo;
 
 /**
@@ -156,8 +159,10 @@ public class ZooKeeperServerBean implements ZooKeeperServerMXBean, ZKMBeanInfo {
     @Override
     public String getSecureClientAddress() {
         if (zks.secureServerCnxnFactory != null) {
-            return String.format("%s:%d", zks.secureServerCnxnFactory
-                    .getLocalAddress().getHostString(),
+            SocketAddress socketAddress = zks.secureServerCnxnFactory
+                    .getLocalAddress();
+            String hostString = SocketAddressUtils.getHostString(socketAddress);
+            return String.format("%s:%d", hostString,
                     zks.secureServerCnxnFactory.getLocalPort());
         }
         return "";

--- a/src/java/main/org/apache/zookeeper/server/auth/IPAuthenticationProvider.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/IPAuthenticationProvider.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server.auth;
 
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.common.SocketAddressUtils;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.ServerCnxn;
 
@@ -31,7 +32,7 @@ public class IPAuthenticationProvider implements AuthenticationProvider {
     public KeeperException.Code
         handleAuthentication(ServerCnxn cnxn, byte[] authData)
     {
-        String id = cnxn.getRemoteSocketAddress().getAddress().getHostAddress();
+        String id = SocketAddressUtils.getHostAddress(cnxn.getRemoteSocketAddress());
         cnxn.addAuthInfo(new Id(getScheme(), id));
         return KeeperException.Code.OK;
     }

--- a/src/java/main/org/apache/zookeeper/server/quorum/LocalPeerBean.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/LocalPeerBean.java
@@ -18,6 +18,8 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import org.apache.zookeeper.common.SocketAddressUtils;
+
 
 
 /**
@@ -85,8 +87,9 @@ public class LocalPeerBean extends ServerBean implements LocalPeerMXBean {
 
     public String getClientAddress() {
         if (null != peer.cnxnFactory) {
-            return String.format("%s:%d", peer.cnxnFactory.getLocalAddress()
-                    .getHostString(), peer.getClientPort());
+            String hostString =
+                SocketAddressUtils.getHostString(peer.cnxnFactory.getLocalAddress());
+            return String.format("%s:%d", hostString, peer.getClientPort());
         } else {
             return "";
         }

--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.common.SocketAddressUtils;
 import org.apache.zookeeper.server.quorum.QuorumPeer.LearnerType;
 import org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer;
 import org.apache.zookeeper.test.ClientBase;
@@ -61,7 +62,7 @@ public class QuorumPeerTest {
          */
         QuorumPeer peer1 = new QuorumPeer(peersView, dataDir, dataDir, clientPort, electionAlg, myId, tickTime,
                 initLimit, syncLimit);
-        String hostString1 = peer1.cnxnFactory.getLocalAddress().getHostString();
+        String hostString1 = SocketAddressUtils.getHostString(peer1.cnxnFactory.getLocalAddress());
         assertEquals(clientIP.getHostAddress(), hostString1);
 
         // cleanup
@@ -78,7 +79,7 @@ public class QuorumPeerTest {
                         new InetSocketAddress(clientIP, clientPort), LearnerType.PARTICIPANT));
         QuorumPeer peer2 = new QuorumPeer(peersView, dataDir, dataDir, clientPort, electionAlg, myId, tickTime,
                 initLimit, syncLimit);
-        String hostString2 = peer2.cnxnFactory.getLocalAddress().getHostString();
+        String hostString2 = SocketAddressUtils.getHostString(peer2.cnxnFactory.getLocalAddress());
         assertEquals(clientIP.getHostAddress(), hostString2);
         // cleanup
         peer2.shutdown();

--- a/src/java/test/org/apache/zookeeper/test/NettyLocalChannelSuiteBase.java
+++ b/src/java/test/org/apache/zookeeper/test/NettyLocalChannelSuiteBase.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+import org.apache.zookeeper.ClientCnxnSocketNetty;
+import org.apache.zookeeper.client.ZKClientConfig;
+import org.apache.zookeeper.common.SocketAddressUtils;
+import org.apache.zookeeper.server.NettyServerCnxnFactory;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.jboss.netty.bootstrap.ClientBootstrap;
+import org.jboss.netty.bootstrap.ServerBootstrap;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelFactory;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ServerChannelFactory;
+import org.jboss.netty.channel.local.DefaultLocalClientChannelFactory;
+import org.jboss.netty.channel.local.DefaultLocalServerChannelFactory;
+import org.jboss.netty.channel.local.LocalAddress;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Run tests with: Netty Client against Netty server
+ */
+@RunWith(Suite.class)
+public class NettyLocalChannelSuiteBase {
+
+    @BeforeClass
+    public static void setUp() {
+        System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY,
+            LocalAndRealNetworkNettyChannelServerCnxnFactory.class.getName());
+        System.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET,
+            LocalClientCnxnSocketNetty.class.getName());
+        System.setProperty("zookeeper.admin.enableServer", "false");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
+        System.clearProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET);
+    }
+
+    /**
+     * Example of NettyServerCnxnFactory which listens on the real network and on the local Netty network. We have to
+     * listen to real network in order to leverage existing tests.
+     * See {@link NetworklessTest} in order to look a pure networkless implementation
+     */
+    public static final class LocalAndRealNetworkNettyChannelServerCnxnFactory extends NettyServerCnxnFactory {
+
+        private static final Logger LOG = LoggerFactory.getLogger(LocalAndRealNetworkNettyChannelServerCnxnFactory.class);
+
+        private final ServerBootstrap localChannelBootstrap;
+        Channel localParentChannel;
+        LocalAddress localLocalAddress;
+
+        public LocalAndRealNetworkNettyChannelServerCnxnFactory() {
+            super();
+
+            localChannelBootstrap = new ServerBootstrap(
+                new DefaultLocalServerChannelFactory()
+            );
+            initServerBootStrap(localChannelBootstrap);
+        }
+
+        @Override
+        public void configure(InetSocketAddress addr, int maxClientCnxns, boolean secure) throws IOException {
+            super.configure(addr, maxClientCnxns, secure);
+            localLocalAddress = SocketAddressUtils.mapToLocalAddress(addr);
+        }
+
+        @Override
+        public void start() {
+            super.start();
+            localParentChannel = localChannelBootstrap.bind(localLocalAddress);
+            LOG.info("binding to local port " + localLocalAddress);
+        }
+
+        @Override
+        public void shutdown() {
+            super.shutdown();
+
+            if (localParentChannel != null) {
+                localParentChannel.close().awaitUninterruptibly();
+                localChannelBootstrap.releaseExternalResources();
+            }
+        }
+
+    }
+
+    /**
+     * Example of ClientCnxnSocketNetty which connects ONLY to the Local JVM
+     */
+    public static final class LocalClientCnxnSocketNetty extends ClientCnxnSocketNetty {
+
+        private static final Logger LOG = LoggerFactory.getLogger(LocalClientCnxnSocketNetty.class);
+
+        public LocalClientCnxnSocketNetty(ZKClientConfig clientConfig) throws IOException {
+            super(clientConfig);
+        }
+
+        @Override
+        protected ChannelFactory buildChannelFactory() {
+            return new DefaultLocalClientChannelFactory();
+        }
+
+        @Override
+        protected ChannelFuture connect(ClientBootstrap bootstrap, InetSocketAddress addr) {
+            LocalAddress localAddress = SocketAddressUtils.mapToLocalAddress(addr);
+            LOG.info("connect to local " + localAddress + " remote was " + addr);
+            return bootstrap.connect(localAddress);
+        }
+    }
+
+}

--- a/src/java/test/org/apache/zookeeper/test/NettyLocalSuiteTest.java
+++ b/src/java/test/org/apache/zookeeper/test/NettyLocalSuiteTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.test;
+
+import org.junit.runners.Suite;
+
+/**
+ * Run tests with: Netty Client against Netty server
+ */
+@Suite.SuiteClasses({
+    ACLTest.class,
+    AsyncOpsTest.class,
+    ChrootClientTest.class,
+    ClientTest.class,
+    NullDataTest.class,
+    SessionTest.class,
+    WatcherTest.class
+})
+public class NettyLocalSuiteTest extends NettyLocalChannelSuiteBase {
+}

--- a/src/java/test/org/apache/zookeeper/test/NetworklessTest.java
+++ b/src/java/test/org/apache/zookeeper/test/NetworklessTest.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.zookeeper.test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.zookeeper.ClientCnxnSocketNetty;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.client.ZKClientConfig;
+import org.apache.zookeeper.common.SocketAddressUtils;
+import org.apache.zookeeper.server.NettyServerCnxnFactory;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
+import org.jboss.netty.bootstrap.ClientBootstrap;
+import org.jboss.netty.channel.ChannelFactory;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ServerChannelFactory;
+import org.jboss.netty.channel.local.DefaultLocalClientChannelFactory;
+import org.jboss.netty.channel.local.DefaultLocalServerChannelFactory;
+import org.jboss.netty.channel.local.LocalAddress;
+
+import org.junit.AfterClass;
+import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Example of using ZooKeeper for internal testing without a real network.
+ */
+public class NetworklessTest extends QuorumPeerTestBase {
+
+    @BeforeClass
+    public static void setUp() {
+        System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY,
+            LocalNettyChannelServerCnxnFactory.class.getName());
+        System.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET,
+            LocalClientCnxnSocketNetty.class.getName());
+        System.setProperty("zookeeper.admin.enableServer", "false");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
+        System.clearProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET);
+    }
+
+    @Test
+    public void testLocalStandaloneServer() throws Exception {
+        int clientPort = PortAssignment.unique();
+        MainThread mt = new MainThread(MainThread.UNSET_MYID, clientPort, "");
+        mt.start();
+
+        assertTrue("ServerCnxnFactory did not start in time",
+            LocalNettyChannelServerCnxnFactory.listening.await(1, TimeUnit.MINUTES));
+        ZooKeeper zk = ClientBase.createZKClient("127.0.0.1:" + clientPort, 60000);
+        zk.create("/test", "".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        zk.delete("/test", -1);
+
+        zk.close();
+        mt.shutdown();
+    }
+
+    /**
+     * Example of ClientCnxnSocketNetty which connects ONLY to the Local JVM
+     */
+    public static final class LocalClientCnxnSocketNetty extends ClientCnxnSocketNetty {
+
+        private static final Logger LOG = LoggerFactory.getLogger(LocalClientCnxnSocketNetty.class);
+
+        public LocalClientCnxnSocketNetty(ZKClientConfig clientConfig) throws IOException {
+            super(clientConfig);
+        }
+
+        @Override
+        protected ChannelFactory buildChannelFactory() {
+            return new DefaultLocalClientChannelFactory();
+        }
+
+        @Override
+        protected ChannelFuture connect(ClientBootstrap bootstrap, InetSocketAddress addr) {
+            LocalAddress localAddress = SocketAddressUtils.mapToLocalAddress(addr);
+            LOG.info("connect to local " + localAddress + " remote was " + addr);
+            return bootstrap.connect(localAddress);
+        }
+    }
+
+    /**
+     * Example of NettyServerCnxnFactory which listens only the local Netty network.
+     */
+    public static final class LocalNettyChannelServerCnxnFactory extends NettyServerCnxnFactory {
+
+        static CountDownLatch listening = new CountDownLatch(1);
+
+        @Override
+        protected ServerChannelFactory buildSocketChannelFactory() {
+            return new DefaultLocalServerChannelFactory();
+        }
+
+        public LocalNettyChannelServerCnxnFactory() {
+        }
+
+        @Override
+        public void configure(InetSocketAddress addr, int maxClientCnxns, boolean secure) throws IOException {
+            super.configure(addr, maxClientCnxns, secure);
+            localAddress = SocketAddressUtils.mapToLocalAddress(addr);
+        }
+
+        @Override
+        public void start() {
+            super.start();
+            listening.countDown();
+        }
+
+    }
+}


### PR DESCRIPTION
Little refactoring to use only SocketAddress instead of RemoteSocketAddress and make it possible to create subclasses of ClientCnxnSocketNetty and NettyServerCnxn which leverage built-in Netty 'local' channels.

Such Netty local channels do not create real sockets and so allow a simple standalone ZooKeeper server + ZooKeeper client to be run on the same JVM without binding to real TCP endpoints and run concurrent test processes of the same application without dealing with random ports.