### PR TITLE
ZOOKEEPER-2759: Flaky test: org.apache.zookeeper.server.quorum.QuorumCnxManagerTest.testNoAuthLearnerConnectToAuthRequiredServerWithHigherSid

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -56,7 +56,7 @@
     <dependency org="org.vafer" name="jdeb" rev="0.8" conf="package->master"/>
 
     <dependency org="junit" name="junit" rev="4.8.1" conf="test->default"/>
-     <dependency org="org.mockito" name="mockito-all" rev="1.8.2"
+     <dependency org="org.mockito" name="mockito-all" rev="1.8.5"
                conf="test->default"/>
     <dependency org="com.puppycrawl.tools" name="checkstyle" rev="6.1.1"
                 conf="test->default"/>

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -175,11 +175,25 @@ public class QuorumCnxManager {
                             boolean listenOnAllIPs,
                             int quorumCnxnThreadsSize,
                             boolean quorumSaslAuthEnabled) {
+        this(mySid, view, authServer, authLearner, socketTimeout, listenOnAllIPs,
+                quorumCnxnThreadsSize, quorumSaslAuthEnabled, new ConcurrentHashMap<Long, SendWorker>());
+    }
+
+    // visible for testing
+    public QuorumCnxManager(final long mySid,
+                            Map<Long,QuorumPeer.QuorumServer> view,
+                            QuorumAuthServer authServer,
+                            QuorumAuthLearner authLearner,
+                            int socketTimeout,
+                            boolean listenOnAllIPs,
+                            int quorumCnxnThreadsSize,
+                            boolean quorumSaslAuthEnabled,
+                            ConcurrentHashMap<Long, SendWorker> senderWorkerMap) {
+        this.senderWorkerMap = senderWorkerMap;
+
         this.recvQueue = new ArrayBlockingQueue<Message>(RECV_CAPACITY);
         this.queueSendMap = new ConcurrentHashMap<Long, ArrayBlockingQueue<ByteBuffer>>();
-        this.senderWorkerMap = new ConcurrentHashMap<Long, SendWorker>();
         this.lastMessageSent = new ConcurrentHashMap<Long, ByteBuffer>();
-        
         String cnxToValue = System.getProperty("zookeeper.cnxTimeout");
         if(cnxToValue != null){
             this.cnxTO = new Integer(cnxToValue); 

--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumCnxManagerTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumCnxManagerTest.java
@@ -227,6 +227,9 @@ public class QuorumCnxManagerTest extends ZKTestCase {
                                                        "QuorumLearner", true, true);
         peer0.connectOne(1);
         peer1.connectOne(0);
+
+        peer0.halt();
+
         assertEventuallyNotConnected(peer0, 1);
     }
 

--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumCnxManagerTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumCnxManagerTest.java
@@ -251,8 +251,6 @@ public class QuorumCnxManagerTest extends ZKTestCase {
         peer0.connectOne(1);
         peer1.connectOne(0);
 
-        assertEventuallyNotConnected(peer0, 1);
-
         verify(senderWorkerMap0, timeout(10000)).put(eq(1L), any(QuorumCnxManager.SendWorker.class));
         verify(senderWorkerMap0, timeout(10000)).remove(eq(1L), any(QuorumCnxManager.SendWorker.class));
 


### PR DESCRIPTION
I noticed some inconsistent test results from `testNoAuthLearnerConnectToAuthRequiredServerWithHigherSid`. It can be seen failing on Apache infra here: http://mail-archives.apache.org/mod_mbox/zookeeper-dev/201701.mbox/%3c374175863.2852.1485127554310.JavaMail.jenkins@crius%3e

The problem can be "reproduced" by adding a `Thread.sleep(4000)` as the first line of the finally block   for `RecvWorker.run` in `QuorumCnxManager.java`.

The issue is caused by a race condition between the removal of the relevant `sid` from `senderWorkerMap` for `peer0` and the 3 second delay from `assertEventuallyNotConnected`. 

Other tests in this class do not experience the same problem because `testNoAuthLearnerConnectToAuthRequiredServerWithHigherSid` is unique in that it is the only test using `assertEventuallyNotConnected` where the peer with the lower `sid` is not using SASL. This means that the peer with the lower `sid` will always create send and receive workers in `handleConnection` (as it will not throw an exception on `authServer.authenticate(sock, din)`) and may not destroy them in time for the test assertion.

