### PR TITLE
ZOOKEEPER-2731: Cleanup findbug warnings in branch-3.4: Malicious code vulnerability Warnings

### DIFF
--- a/src/java/main/org/apache/zookeeper/Environment.java
+++ b/src/java/main/org/apache/zookeeper/Environment.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class Environment {
-    public static String JAAS_CONF_KEY = "java.security.auth.login.config";
+    public static final String JAAS_CONF_KEY = "java.security.auth.login.config";
 
     public static class Entry {
         private String k;

--- a/src/java/main/org/apache/zookeeper/ZooKeeperMain.java
+++ b/src/java/main/org/apache/zookeeper/ZooKeeperMain.java
@@ -50,7 +50,7 @@ import java.util.regex.Pattern;
  */
 public class ZooKeeperMain {
     private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperMain.class);
-    protected static final Map<String,String> commandMap = new HashMap<String,String>( );
+    static final Map<String,String> commandMap = new HashMap<String,String>( );
 
     protected MyCommandOptions cl = new MyCommandOptions();
     protected HashMap<Integer,String> history = new HashMap<Integer,String>( );

--- a/src/java/main/org/apache/zookeeper/server/ServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/ServerCnxn.java
@@ -234,7 +234,7 @@ public abstract class ServerCnxn implements Stats, Watcher {
     protected final static int isroCmd = ByteBuffer.wrap("isro".getBytes())
             .getInt();
 
-    protected final static Map<Integer, String> cmd2String = new HashMap<Integer, String>();
+    final static Map<Integer, String> cmd2String = new HashMap<Integer, String>();
 
     private static final String ZOOKEEPER_4LW_COMMANDS_WHITELIST = "zookeeper.4lw.commands.whitelist";
 

--- a/src/java/test/config/findbugsExcludeFile.xml
+++ b/src/java/test/config/findbugsExcludeFile.xml
@@ -75,6 +75,11 @@
   </Match>
 
   <Match>
+    <Class name="org.apache.zookeeper.server.quorum.QuorumAuthPacket" />
+      <Bug code="EI2, EI" />
+  </Match>
+
+  <Match>
     <Class name="org.apache.zookeeper.ClientCnxn"/>
       <Bug code="EI, EI2" />
   </Match>
@@ -131,4 +136,10 @@
     <Method name="writeLongToFile" />
   </Match>
 
+  <!-- Disable 'Malicious code vulnerability warnings' due to mutable collection types in interface.
+       Undo this when ZOOKEEPER-1362 is done. -->
+  <Match>
+    <Class name="org.apache.zookeeper.ZooDefs$Ids"/>
+      <Bug pattern="MS_MUTABLE_COLLECTION" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
There are two interesting parts to this change.

The first is in the Jute compiler. Fields that are declared buffers (translated to byte[] in java) now perform a clone in the constructor and while "getting and setting", following best practice. This prevents accidental changes to arrays once passed into or out of jute records but may negatively impact memory usage and performance. Would be interested in hearing if people think this is acceptable.

The second is in ZooDefs. We are currently declaring our predefined ACL lists with `new ArrayList<ACL>(Collections.singletonList(new ACL(...`. This seems strange to me as we appear to be converting a List type to an ArrayList. Would be great if someone could shed some light on why we do this. I think this logic can be simplified to `Collections.singletonList(new ACL(...` with the added bonus that the resulting list is immutable (making FindBugs happy). 

Thanks,
Abe