### PR TITLE
ZOOKEEPER-2763: Utils.toCsvBuffer() omits leading 0 for bytes < 0x10

### DIFF
--- a/src/java/main/org/apache/jute/Utils.java
+++ b/src/java/main/org/apache/jute/Utils.java
@@ -200,14 +200,8 @@ public class Utils {
         if (barr == null || barr.length == 0) {
             return "";
         }
-        
-        StringBuilder sb = new StringBuilder(2*barr.length);
-        for(int idx = 0; idx < barr.length; idx++) {
-            byte b = barr[idx];
-            sb.append(hexchars[(b & 0xf0) >> 4]);
-            sb.append(hexchars[b & 0x0f]);
-        }
-        return sb.toString().toLowerCase();
+
+        return DatatypeConverter.printHexBinary(barr);
     }
     
     /**

--- a/src/java/main/org/apache/jute/Utils.java
+++ b/src/java/main/org/apache/jute/Utils.java
@@ -216,7 +216,7 @@ public class Utils {
      * @return 
      */
     static String toXMLBuffer(byte barr[]) {
-        return DatatypeConverter.printHexBinary(barr).toLowerCase();
+        return toHexString(barr).toLowerCase();
     }
     
     /**
@@ -246,7 +246,7 @@ public class Utils {
      * @return 
      */
     static String toCSVBuffer(byte barr[]) {
-        return '#' + DatatypeConverter.printHexBinary(barr).toLowerCase();
+        return '#' + toHexString(barr).toLowerCase();
     }
 
     /**

--- a/src/java/main/org/apache/jute/Utils.java
+++ b/src/java/main/org/apache/jute/Utils.java
@@ -20,6 +20,7 @@ package org.apache.jute;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import javax.xml.bind.DatatypeConverter;
 
 /**
  * Various utility functions for Hadoop record I/O runtime.
@@ -215,7 +216,7 @@ public class Utils {
      * @return 
      */
     static String toXMLBuffer(byte barr[]) {
-        return toHexString(barr);
+        return DatatypeConverter.printHexBinary(barr).toLowerCase();
     }
     
     /**
@@ -245,7 +246,7 @@ public class Utils {
      * @return 
      */
     static String toCSVBuffer(byte barr[]) {
-        return '#' + toHexString(barr);
+        return '#' + DatatypeConverter.printHexBinary(barr).toLowerCase();
     }
 
     /**

--- a/src/java/main/org/apache/jute/Utils.java
+++ b/src/java/main/org/apache/jute/Utils.java
@@ -190,19 +190,32 @@ public class Utils {
     }
     
     /**
+     * convert byte array to a string in hex format
+     * 
+     * @param barr
+     * @return
+     */
+    private static String toHexString(byte barr[]) {
+        if (barr == null || barr.length == 0) {
+            return "";
+        }
+        
+        StringBuilder sb = new StringBuilder(2*barr.length);
+        for(int idx = 0; idx < barr.length; idx++) {
+            byte b = barr[idx];
+            sb.append(hexchars[(b & 0xf0) >> 4]);
+            sb.append(hexchars[b & 0x0f]);
+        }
+        return sb.toString().toLowerCase();
+    }
+    
+    /**
      * 
      * @param s 
      * @return 
      */
     static String toXMLBuffer(byte barr[]) {
-        if (barr == null || barr.length == 0) {
-            return "";
-        }
-        StringBuilder sb = new StringBuilder(2*barr.length);
-        for (int idx = 0; idx < barr.length; idx++) {
-            sb.append(Integer.toHexString(barr[idx]));
-        }
-        return sb.toString();
+        return toHexString(barr);
     }
     
     /**
@@ -232,17 +245,9 @@ public class Utils {
      * @return 
      */
     static String toCSVBuffer(byte barr[]) {
-        if (barr == null || barr.length == 0) {
-            return "";
-        }
-        StringBuilder sb = new StringBuilder(barr.length + 1);
-        sb.append('#');
-        for(int idx = 0; idx < barr.length; idx++) {
-            sb.append(Integer.toHexString(barr[idx]));
-        }
-        return sb.toString();
+        return '#' + toHexString(barr);
     }
-    
+
     /**
      * Converts a CSV-serialized representation of buffer to a new
      * ByteArrayOutputStream.


### PR DESCRIPTION
1. fix toCsvBuffer() and toXMLBuffer()
2. reduce duplicate code