### PR TITLE
ZOOKEEPER-2759: Flaky test: org.apache.zookeeper.server.quorum.QuorumCnxManagerTest.testNoAuthLearnerConnectToAuthRequiredServerWithHigherSid 

### DIFF
--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumCnxManagerTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumCnxManagerTest.java
@@ -251,8 +251,6 @@ public class QuorumCnxManagerTest extends ZKTestCase {
         peer0.connectOne(1);
         peer1.connectOne(0);
 
-        assertEventuallyNotConnected(peer0, 1);
-
         verify(senderWorkerMap0, timeout(10000)).put(eq(1L), any(QuorumCnxManager.SendWorker.class));
         verify(senderWorkerMap0, timeout(10000)).remove(eq(1L), any(QuorumCnxManager.SendWorker.class));
 


### PR DESCRIPTION
Remove extra assertion accidentally added in https://github.com/apache/zookeeper/pull/229 as per @hanm 