### PR TITLE
ZOOKEEPER-2778: Potential server deadlock between follower sync with leader and follower receiving external connection requests.

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -682,27 +682,19 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     }
 
     public InetSocketAddress getElectionAddress(){
-        synchronized (QV_LOCK) {
-            return myElectionAddr;
-        }
+        return myElectionAddr;
     }
 
     public void setElectionAddress(InetSocketAddress addr){
-        synchronized (QV_LOCK) {
-            myElectionAddr = addr;
-        }
+        myElectionAddr = addr;
     }
     
     public InetSocketAddress getClientAddress(){
-        synchronized (QV_LOCK) {
-            return myClientAddr;
-        }
+        return myClientAddr;
     }
     
     public void setClientAddress(InetSocketAddress addr){
-        synchronized (QV_LOCK) {
-            myClientAddr = addr;
-        }
+        myClientAddr = addr;
     }
     
     private int electionType;


### PR DESCRIPTION
Remove synchronization requirements on certain methods to prevent dead lock. Current analysis indicates these methods don't require synchronization for them to work properly. Patch is stress tested with 1k runs of entire unit test suites.
