### PR TITLE
[ZOOKEEPER-2779] Provide a means to disable setting of the Read Only ACL for the reconfig node

### DIFF
--- a/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
@@ -1379,6 +1379,19 @@ server.3=zoo3:2888:3888</programlisting>
           </varlistentry>
 
           <varlistentry>
+            <term>skipDefaultACLForReconfig</term>
+
+            <listitem>
+              <para>(Java system property: <emphasis
+              role="bold">zookeeper.skipDefaultACLForReconfig</emphasis>)</para>
+
+              <para>The ZooKeeper reconfig node normally is set with a read only ACL. Setting
+              this property to "yes" bypasses this. The reconfig node will not have any ACL.
+              It is strongly recommended that you set an ACL for it early in your usage.</para>
+            </listitem>
+          </varlistentry>
+
+          <varlistentry>
             <term>quorumListenOnAllIPs</term>
 
             <listitem>

--- a/src/docs/src/documentation/content/xdocs/zookeeperReconfig.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperReconfig.xml
@@ -333,7 +333,10 @@ server.3=125.23.63.25:2782:2785:participant</programlisting>
         environment (i.e. behind company firewall). For those users who want to use reconfiguration feature but
         don't want the overhead of configuring an explicit list of authorized user for reconfig access checks,
         they can set <ulink url="zookeeperAdmin.html#sc_authOptions">"skipACL"</ulink> to "yes" which will
-        skip ACL check and allow any user to reconfigure cluster.
+        skip ACL check and allow any user to reconfigure cluster. A more secure mechanism is also provided.
+        Set <ulink url="zookeeperAdmin.html#sc_authOptions">"skipDefaultACLForReconfig"</ulink> to "yes"
+        and the reconfig node will not be assigned an ACL. You should, however, set an ACL of your choice to this
+        node.
       </para>
       <para>
         Overall, ZooKeeper provides flexible configuration options for the reconfigure feature

--- a/src/docs/src/documentation/content/xdocs/zookeeperReconfig.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperReconfig.xml
@@ -333,7 +333,7 @@ server.3=125.23.63.25:2782:2785:participant</programlisting>
         environment (i.e. behind company firewall). For those users who want to use reconfiguration feature but
         don't want the overhead of configuring an explicit list of authorized user for reconfig access checks,
         they can set <ulink url="zookeeperAdmin.html#sc_authOptions">"skipACL"</ulink> to "yes" which will
-        skip ACL check and allow any user to reconfigure cluster. A more secure mechanism is also provided.
+        skip ACL check and allow any user to reconfigure cluster.
         Set <ulink url="zookeeperAdmin.html#sc_authOptions">"skipDefaultACLForReconfig"</ulink> to "yes"
         and the reconfig node will not be assigned an ACL. You should, however, set an ACL of your choice to this
         node.

--- a/src/java/test/org/apache/zookeeper/test/ReconfigExceptionTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReconfigExceptionTest.java
@@ -41,7 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ReconfigExceptionTest extends ZKTestCase {
-    private static final Logger LOG = LoggerFactory
+    protected static final Logger LOG = LoggerFactory
             .getLogger(ReconfigExceptionTest.class);
     private static String authProvider = "zookeeper.DigestAuthenticationProvider.superDigest";
     // Use DigestAuthenticationProvider.base64Encode or
@@ -204,7 +204,7 @@ public class ReconfigExceptionTest extends ZKTestCase {
         }
     }
 
-    private boolean reconfigPort() throws KeeperException, InterruptedException {
+    protected boolean reconfigPort() throws KeeperException, InterruptedException {
         List<String> joiningServers = new ArrayList<String>();
         int leaderId = 1;
         while (qu.getPeer(leaderId).peer.leader == null)

--- a/src/java/test/org/apache/zookeeper/test/ReconfigExceptionTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReconfigExceptionTest.java
@@ -18,75 +18,18 @@
 
 package org.apache.zookeeper.test;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeoutException;
-
-import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.PortAssignment;
-import org.apache.zookeeper.admin.ZooKeeperAdmin;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
-import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class ReconfigExceptionTest extends ZKTestCase {
-    protected static final Logger LOG = LoggerFactory
-            .getLogger(ReconfigExceptionTest.class);
-    private static String authProvider = "zookeeper.DigestAuthenticationProvider.superDigest";
-    // Use DigestAuthenticationProvider.base64Encode or
-    // run ZooKeeper jar with org.apache.zookeeper.server.auth.DigestAuthenticationProvider to generate password.
-    // An example:
-    // java -cp zookeeper-3.6.0-SNAPSHOT.jar:lib/log4j-1.2.17.jar:lib/slf4j-log4j12-1.7.5.jar:
-    // lib/slf4j-api-1.7.5.jar org.apache.zookeeper.server.auth.DigestAuthenticationProvider super:test
-    // The password here is 'test'.
-    private static String superDigest = "super:D/InIHSb7yEEbrWz8b9l71RjZJU=";
-    private QuorumUtil qu;
-    private ZooKeeperAdmin zkAdmin;
+import java.util.ArrayList;
+import java.util.Collections;
 
-    @Before
-    public void setup() throws InterruptedException {
-        System.setProperty(authProvider, superDigest);
-        QuorumPeerConfig.setReconfigEnabled(false);
-
-        // Get a three server quorum.
-        qu = new QuorumUtil(1);
-        qu.disableJMXTest = true;
-
-        try {
-            qu.startAll();
-        } catch (IOException e) {
-            Assert.fail("Fail to start quorum servers.");
-        }
-
-        resetZKAdmin();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        System.clearProperty(authProvider);
-        try {
-            if (qu != null) {
-                qu.tearDown();
-            }
-            if (zkAdmin != null) {
-                zkAdmin.close();
-            }
-        } catch (Exception e) {
-            // Ignore.
-        }
-    }
-
+public class ReconfigExceptionTest extends ReconfigExceptionTestCase {
     @Test(timeout = 10000)
     public void testReconfigDisabledByDefault() throws InterruptedException {
         try {
@@ -178,43 +121,5 @@ public class ReconfigExceptionTest extends ZKTestCase {
         } catch (KeeperException e) {
             Assert.fail("Reconfig should not fail, but failed with exception : " + e.getMessage());
         }
-    }
-
-    // Utility method that recreates a new ZooKeeperAdmin handle, and wait for the handle to connect to
-    // quorum servers.
-    private void resetZKAdmin() throws InterruptedException {
-        String cnxString;
-        ClientBase.CountdownWatcher watcher = new ClientBase.CountdownWatcher();
-        try {
-            cnxString = "127.0.0.1:" + qu.getPeer(1).peer.getClientPort();
-            if (zkAdmin != null) {
-                zkAdmin.close();
-            }
-            zkAdmin = new ZooKeeperAdmin(cnxString,
-                    ClientBase.CONNECTION_TIMEOUT, watcher);
-        } catch (IOException e) {
-            Assert.fail("Fail to create ZooKeeperAdmin handle.");
-            return;
-        }
-
-        try {
-            watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
-        } catch (InterruptedException | TimeoutException e) {
-            Assert.fail("ZooKeeper admin client can not connect to " + cnxString);
-        }
-    }
-
-    protected boolean reconfigPort() throws KeeperException, InterruptedException {
-        List<String> joiningServers = new ArrayList<String>();
-        int leaderId = 1;
-        while (qu.getPeer(leaderId).peer.leader == null)
-            leaderId++;
-        int followerId = leaderId == 1 ? 2 : 1;
-        joiningServers.add("server." + followerId + "=localhost:"
-                + qu.getPeer(followerId).peer.getQuorumAddress().getPort() /*quorum port*/
-                + ":" + qu.getPeer(followerId).peer.getElectionAddress().getPort() /*election port*/
-                + ":participant;localhost:" + PortAssignment.unique()/* new client port */);
-        zkAdmin.reconfigure(joiningServers, null, null, -1, new Stat());
-        return true;
     }
 }

--- a/src/java/test/org/apache/zookeeper/test/ReconfigExceptionTestCase.java
+++ b/src/java/test/org/apache/zookeeper/test/ReconfigExceptionTestCase.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.admin.ZooKeeperAdmin;
+import org.apache.zookeeper.data.Stat;
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+public class ReconfigExceptionTestCase extends ZKTestCase {
+    protected static final Logger LOG = LoggerFactory
+            .getLogger(ReconfigExceptionTestCase.class);
+    private static String authProvider = "zookeeper.DigestAuthenticationProvider.superDigest";
+    // Use DigestAuthenticationProvider.base64Encode or
+    // run ZooKeeper jar with org.apache.zookeeper.server.auth.DigestAuthenticationProvider to generate password.
+    // An example:
+    // java -cp zookeeper-3.6.0-SNAPSHOT.jar:lib/log4j-1.2.17.jar:lib/slf4j-log4j12-1.7.5.jar:
+    // lib/slf4j-api-1.7.5.jar org.apache.zookeeper.server.auth.DigestAuthenticationProvider super:test
+    // The password here is 'test'.
+    private static final String superDigest = "super:D/InIHSb7yEEbrWz8b9l71RjZJU=";
+    private QuorumUtil qu;
+    protected ZooKeeperAdmin zkAdmin;
+
+    @Before
+    public void setup() throws InterruptedException {
+        System.setProperty(authProvider, superDigest);
+        QuorumPeerConfig.setReconfigEnabled(false);
+
+        // Get a three server quorum.
+        qu = new QuorumUtil(1);
+        qu.disableJMXTest = true;
+
+        try {
+            qu.startAll();
+        } catch (IOException e) {
+            Assert.fail("Fail to start quorum servers.");
+        }
+
+        resetZKAdmin();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty(authProvider);
+        try {
+            if (qu != null) {
+                qu.tearDown();
+            }
+            if (zkAdmin != null) {
+                zkAdmin.close();
+            }
+        } catch (Exception e) {
+            // Ignore.
+        }
+    }
+
+    // Utility method that recreates a new ZooKeeperAdmin handle, and wait for the handle to connect to
+    // quorum servers.
+    protected void resetZKAdmin() throws InterruptedException {
+        String cnxString;
+        ClientBase.CountdownWatcher watcher = new ClientBase.CountdownWatcher();
+        try {
+            cnxString = "127.0.0.1:" + qu.getPeer(1).peer.getClientPort();
+            if (zkAdmin != null) {
+                zkAdmin.close();
+            }
+            zkAdmin = new ZooKeeperAdmin(cnxString,
+                    ClientBase.CONNECTION_TIMEOUT, watcher);
+        } catch (IOException e) {
+            Assert.fail("Fail to create ZooKeeperAdmin handle.");
+            return;
+        }
+
+        try {
+            watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
+        } catch (InterruptedException | TimeoutException e) {
+            Assert.fail("ZooKeeper admin client can not connect to " + cnxString);
+        }
+    }
+
+    protected boolean reconfigPort() throws KeeperException, InterruptedException {
+        List<String> joiningServers = new ArrayList<String>();
+        int leaderId = 1;
+        while (qu.getPeer(leaderId).peer.leader == null)
+            leaderId++;
+        int followerId = leaderId == 1 ? 2 : 1;
+        joiningServers.add("server." + followerId + "=localhost:"
+                + qu.getPeer(followerId).peer.getQuorumAddress().getPort() /*quorum port*/
+                + ":" + qu.getPeer(followerId).peer.getElectionAddress().getPort() /*election port*/
+                + ":participant;localhost:" + PortAssignment.unique()/* new client port */);
+        zkAdmin.reconfigure(joiningServers, null, null, -1, new Stat());
+        return true;
+    }
+}

--- a/src/java/test/org/apache/zookeeper/test/SkipACLReconfigExceptionTest.java
+++ b/src/java/test/org/apache/zookeeper/test/SkipACLReconfigExceptionTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SkipACLReconfigExceptionTest extends ReconfigExceptionTest {
+    private static final String skipDefaultACLForReconfig = "zookeeper.skipDefaultACLForReconfig";
+
+    @Override
+    public void setup() throws InterruptedException {
+        System.setProperty(skipDefaultACLForReconfig, "yes");
+        super.setup();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        System.clearProperty(skipDefaultACLForReconfig);
+    }
+
+    @Test(timeout = 10000)
+    public void testReconfigSuccessWithoutAuth() throws InterruptedException {
+        // Now enable reconfig feature by turning on the switch.
+        QuorumPeerConfig.setReconfigEnabled(true);
+
+        try {
+            reconfigPort();
+        } catch (KeeperException e) {
+            Assert.fail("Should've succeeded: " + e.getMessage());
+        }
+    }
+}

--- a/src/java/test/org/apache/zookeeper/test/SkipACLReconfigExceptionTest.java
+++ b/src/java/test/org/apache/zookeeper/test/SkipACLReconfigExceptionTest.java
@@ -23,7 +23,7 @@ import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class SkipACLReconfigExceptionTest extends ReconfigExceptionTest {
+public class SkipACLReconfigExceptionTest extends ReconfigExceptionTestCase {
     private static final String skipDefaultACLForReconfig = "zookeeper.skipDefaultACLForReconfig";
 
     @Override


### PR DESCRIPTION
Provide a means to disable setting of the Read Only ACL for the reconfig node added in ZOOKEEPER-2014. That change made it very cumbersome to use the reconfig feature and also could worsen security as the entire ZK database is open to "super" user while the reconfig node is being changed (the only possible method as of ZOOKEEPER-2014).