### PR TITLE
ZOOKEEPER-2786: Flaky test: org.apache.zookeeper.test.ClientTest.testNonExistingOpCode

### DIFF
--- a/src/java/test/org/apache/zookeeper/test/ClientTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientTest.java
@@ -774,7 +774,8 @@ public class ClientTest extends ClientBase {
      */
     @Test
     public void testNonExistingOpCode() throws Exception  {
-        TestableZooKeeper zk = createClient();
+        CountdownWatcher watcher = new CountdownWatcher();
+        TestableZooKeeper zk = createClient(watcher);
 
         final String path = "/m1";
 
@@ -785,13 +786,9 @@ public class ClientTest extends ClientBase {
         request.setWatch(false);
         ExistsResponse response = new ExistsResponse();
         ReplyHeader r = zk.submitRequest(h, request, response, null);
-
         Assert.assertEquals(r.getErr(), Code.UNIMPLEMENTED.intValue());
 
-        try {
-            zk.exists("/m1", false);
-            fail("The connection should have been closed");
-        } catch (KeeperException.ConnectionLossException expected) {
-        }
+        // Sending a nonexisting opcode should cause the server to disconnect
+        watcher.waitForDisconnected(5000);
     }
 }


### PR DESCRIPTION
On branch 3.4 we attempt to check that an invalid opcode in a request causes the server to disconnect the client with:

```
        try {
            zk.exists("/m1", false);
            fail("The connection should have been closed");
        } catch (KeeperException.ConnectionLossException expected) {
        }
```

This can run into a race with the reconnection logic in `ClientCnxn.java`https://github.com/apache/zookeeper/blob/branch-3.4/src/java/main/org/apache/zookeeper/ClientCnxn.java#L1052 We should use a watcher instead to track disconnects.