### PR TITLE
ZOOKEEPER-2796: Fix broken test testCreateNodeWithoutData caused by ZK-2757.

### DIFF
--- a/src/java/test/org/apache/zookeeper/ZooKeeperTest.java
+++ b/src/java/test/org/apache/zookeeper/ZooKeeperTest.java
@@ -293,7 +293,7 @@ public class ZooKeeperTest extends ClientBase {
                     .processZKCmd(zkMain.cl));
             Assert.fail("Created the node with wrong option should "
                     + "throw Exception.");
-        } catch (IllegalArgumentException e) {
+        } catch (MalformedPathException e) {
             Assert.assertEquals("Path must start with / character", e
                     .getMessage());
         }


### PR DESCRIPTION
ZK-2757 introduces a new MalformedPathException which intercepts and wraps the IllegalArgumentException that this test was expecting.