### PR TITLE
ZOOKEEPER-2797 Defend against bad TTLs from misbehaving clients

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -658,10 +658,10 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
             path = createRequest.getPath();
             acl = createRequest.getAcl();
             data = createRequest.getData();
-            ttl = 0;
+            ttl = -1;
         }
         CreateMode createMode = CreateMode.fromFlag(flags);
-        validateCreateRequest(createMode, request);
+        validateCreateRequest(path, createMode, request, ttl);
         String parentPath = validatePathForCreate(path, request.sessionId);
 
         List<ACL> listACL = fixupACL(path, request.authInfo, acl);
@@ -925,8 +925,14 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
         return retval;
     }
     
-    private void validateCreateRequest(CreateMode createMode, Request request)
+    private void validateCreateRequest(String path, CreateMode createMode, Request request, long ttl)
             throws KeeperException {
+        try {
+            EphemeralType.validateTTL(createMode, ttl);
+        } catch (IllegalArgumentException e) {
+            BadArgumentsException bae = new BadArgumentsException(path);
+            throw bae;
+        }
         if (createMode.isEphemeral()) {
             // Exception is set when local session failed to upgrade
             // so we just need to report the error

--- a/src/java/test/org/apache/zookeeper/server/CreateTTLTest.java
+++ b/src/java/test/org/apache/zookeeper/server/CreateTTLTest.java
@@ -75,9 +75,7 @@ public class CreateTTLTest extends ClientBase {
     }
 
     @Test
-    public void testBadTTLs()
-            throws IOException, KeeperException, InterruptedException {
-        Stat stat = new Stat();
+    public void testBadTTLs() throws InterruptedException, KeeperException {
         RequestHeader h = new RequestHeader(1, ZooDefs.OpCode.createTTL);
 
         String path = "/bad_ttl";

--- a/src/java/test/org/apache/zookeeper/server/CreateTTLTest.java
+++ b/src/java/test/org/apache/zookeeper/server/CreateTTLTest.java
@@ -23,9 +23,15 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Op;
 import org.apache.zookeeper.OpResult;
+import org.apache.zookeeper.TestableZooKeeper;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.data.Stat;
+import org.apache.zookeeper.proto.CreateResponse;
+import org.apache.zookeeper.proto.CreateTTLRequest;
+import org.apache.zookeeper.proto.ReplyHeader;
+import org.apache.zookeeper.proto.RequestHeader;
 import org.apache.zookeeper.test.ClientBase;
 import org.junit.Assert;
 import org.junit.Test;
@@ -37,7 +43,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class CreateTTLTest extends ClientBase {
-    private ZooKeeper zk;
+    private TestableZooKeeper zk;
 
     @Override
     public void setUp() throws Exception {
@@ -66,6 +72,23 @@ public class CreateTTLTest extends ClientBase {
         fakeElapsed.set(1000);
         containerManager.checkContainers();
         Assert.assertNull("Ttl node should have been deleted", zk.exists("/foo", false));
+    }
+
+    @Test
+    public void testBadTTLs()
+            throws IOException, KeeperException, InterruptedException {
+        Stat stat = new Stat();
+        RequestHeader h = new RequestHeader(1, ZooDefs.OpCode.createTTL);
+
+        String path = "/bad_ttl";
+        CreateTTLRequest request = new CreateTTLRequest(path, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE,
+                                                        CreateMode.PERSISTENT_WITH_TTL.toFlag(), -100);
+        CreateResponse response = new CreateResponse();
+        ReplyHeader r = zk.submitRequest(h, request, response, null);
+        Assert.assertEquals("An invalid CreateTTLRequest should throw BadArguments",
+                            r.getErr(), Code.BADARGUMENTS.intValue());
+        Assert.assertNull("An invalid CreateTTLRequest should not result in znode creation",
+                          zk.exists(path, false));
     }
 
     @Test


### PR DESCRIPTION
Validate the TTL before it makes it to the commit processor to prevent blowing up ZK