### PR TITLE
ZOOKEEPER-2798 Fix flaky test: org.apache.zookeeper.test.ReadOnlyModeTest.testConnectionEvents

### DIFF
--- a/src/java/test/org/apache/zookeeper/test/ClientBase.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientBase.java
@@ -100,6 +100,8 @@ public abstract class ClientBase extends ZKTestCase {
         volatile boolean connected;
         // Set to true when connected to a quorum server.
         volatile boolean syncConnected;
+        // Set to true when connected to a quorum server in read-only mode
+        volatile boolean readOnlyConnected;
 
         public CountdownWatcher() {
             reset();
@@ -108,18 +110,22 @@ public abstract class ClientBase extends ZKTestCase {
             clientConnected = new CountDownLatch(1);
             connected = false;
             syncConnected = false;
+            readOnlyConnected = false;
         }
         synchronized public void process(WatchedEvent event) {
             KeeperState state = event.getState();
             if (state == KeeperState.SyncConnected) {
                 connected = true;
                 syncConnected = true;
+                readOnlyConnected = false;
             } else if (state == KeeperState.ConnectedReadOnly) {
                 connected = true;
                 syncConnected = false;
+                readOnlyConnected = true;
             } else {
                 connected = false;
                 syncConnected = false;
+                readOnlyConnected = false;
             }
 
             notifyAll();
@@ -155,6 +161,19 @@ public abstract class ClientBase extends ZKTestCase {
             }
             if (!syncConnected) {
                 throw new TimeoutException("Failed to connect to read-write ZooKeeper server.");
+            }
+        }
+        synchronized public void waitForReadOnlyConnected(long timeout)
+                throws InterruptedException, TimeoutException
+        {
+            long expire = System.currentTimeMillis() + timeout;
+            long left = timeout;
+            while(!readOnlyConnected && left > 0) {
+                wait(left);
+                left = expire - System.currentTimeMillis();
+            }
+            if (!readOnlyConnected) {
+                throw new TimeoutException("Failed to connect in read-only mode to ZooKeeper server.");
             }
         }
         synchronized public void waitForDisconnected(long timeout)


### PR DESCRIPTION
See https://github.com/apache/zookeeper/pull/270 for a description of the bug.