### PR TITLE
ZOOKEEPER-2795 Change log level for "ZKShutdownHandler is not registered" error message

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/src/java/main/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -502,7 +502,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         if (zkShutdownHandler != null) {
             zkShutdownHandler.handle(state);
         } else {
-            LOG.error("ZKShutdownHandler is not registered, so ZooKeeper server "
+            LOG.debug("ZKShutdownHandler is not registered, so ZooKeeper server "
                     + "won't take any action on ERROR or SHUTDOWN server state changes");
         }
     }


### PR DESCRIPTION
`ZKShutdownHandler` may not be registered if the user creates a `ZooKeeperServer` object outside of `ZooKeeperServerMain.runFromConfig`.

We should change the log level of the message that is printed on state changes of `ZooKeeperServer` when `ZKShutdownHandler` is missing to something lower.