### PR TITLE
ZOOKEEPER-1748: add tcp keepalive option for branch 3.5

### DIFF
--- a/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
@@ -1186,7 +1186,7 @@ server.3=zoo3:2888:3888</programlisting>
               <para>(Java system property: <emphasis
                       role="bold">zookeeper.tcpKeepAlive</emphasisi>)</para>
 
-              <para><emphasis role="bold">New in 3.4.11:</emphasis>
+              <para><emphasis role="bold">New in 3.5.4:</emphasis>
                 Setting this to true sets the TCP keepAlive flag on the
                 sockets used by quorum members to perform elections.
                 This will allow for connections between quorum members to

--- a/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
@@ -1179,6 +1179,29 @@ server.3=zoo3:2888:3888</programlisting>
             </listitem>
           </varlistentry>
 
+          <varlistentry>
+            <term>tcpKeepAlive</term>
+
+            <listitem>
+              <para>(Java system property: <emphasis
+                      role="bold">zookeeper.tcpKeepAlive</emphasisi>)</para>
+
+              <para><emphasis role="bold">New in 3.4.11:</emphasis>
+                Setting this to true sets the TCP keepAlive flag on the
+                sockets used by quorum members to perform elections.
+                This will allow for connections between quorum members to
+                remain up when there is network infrastructure that may
+                otherwise break them. Some NATs and firewalls may terminate
+                or lose state for long running or idle connections.</para>
+
+              <para> Enabling this option relies on OS level settings to work
+                properly, check your operating system's options regarding TCP
+                keepalive for more information.  Defaults to
+                <emphasis role="bold">false</emphasis>.
+              </para>
+            </listitem>
+          </varlistentry>
+
         </variablelist>
         <para></para>
       </section>

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -134,6 +134,12 @@ public class QuorumCnxManager {
      */
     private AtomicInteger threadCnt = new AtomicInteger(0);
 
+    /*
+     * Socket options for TCP keepalive
+     */
+    private final boolean tcpKeepAlive = Boolean.getBoolean("zookeeper.tcpKeepAlive");
+
+
     static public class Message {
         Message(ByteBuffer buffer, long sid) {
             this.buffer = buffer;
@@ -560,6 +566,7 @@ public class QuorumCnxManager {
      */
     private void setSockOpts(Socket sock) throws SocketException {
         sock.setTcpNoDelay(true);
+        sock.setKeepAlive(tcpKeepAlive);
         sock.setSoTimeout(self.tickTime * self.syncLimit);
     }
 


### PR DESCRIPTION
Adding TCP keepalive for branch 3.5, as described in https://issues.apache.org/jira/browse/ZOOKEEPER-1748 and https://github.com/apache/zookeeper/pull/274