### PR TITLE
ZOOKEEPER-2806: Flaky test: org.apache.zookeeper.server.quorum.FLEBackwardElectionRoundTest.testBackwardElectionRound

### DIFF
--- a/src/java/test/org/apache/zookeeper/server/quorum/FLEBackwardElectionRoundTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/FLEBackwardElectionRoundTest.java
@@ -117,8 +117,7 @@ public class FLEBackwardElectionRoundTest extends ZKTestCase {
         QuorumCnxManager.Listener listener = cnxManagers[0].listener;
         listener.start();
 
-        ByteBuffer msg = FLETestUtils.createMsg(ServerState.FOLLOWING.ordinal(), 0, 0, 1);
-        cnxManagers[0].toSend(0l, msg);
+        cnxManagers[0].toSend(0l, getMsg());
         
         /*
          * Start mock server 2
@@ -128,7 +127,7 @@ public class FLEBackwardElectionRoundTest extends ZKTestCase {
         listener = cnxManagers[1].listener;
         listener.start();
 
-        cnxManagers[1].toSend(0l, msg);
+        cnxManagers[1].toSend(0l, getMsg());
         
         /*
          * Run another instance of leader election.
@@ -140,8 +139,8 @@ public class FLEBackwardElectionRoundTest extends ZKTestCase {
         /*
          * Send the same messages, this time should not make 0 the leader.
          */
-        cnxManagers[0].toSend(0l, msg);
-        cnxManagers[1].toSend(0l, msg);
+        cnxManagers[0].toSend(0l, getMsg());
+        cnxManagers[1].toSend(0l, getMsg());
         
         
         thread.join(5000);
@@ -150,5 +149,9 @@ public class FLEBackwardElectionRoundTest extends ZKTestCase {
             Assert.fail("Should not have joined");
         }
         
+    }
+
+    private ByteBuffer getMsg() {
+        return FLETestUtils.createMsg(ServerState.FOLLOWING.ordinal(), 0, 0, 1);
     }
 }


### PR DESCRIPTION
Here is an example of a test failure: https://builds.apache.org/job/ZooKeeper_branch34_jdk8/1016/testReport/org.apache.zookeeper.server.quorum/FLEBackwardElectionRoundTest/testBackwardElectionRound/

This flaky test is caused by the reuse of a `ByteBuffer` object between `QuorumCnxManager`s. 

When sending a `ByteBuffer` we reset its position first:

```
        synchronized void send(ByteBuffer b) throws IOException {
            byte[] msgBytes = new byte[b.capacity()];
            try {
                b.position(0);
                b.get(msgBytes);
            } catch (BufferUnderflowException be) {
                LOG.error("BufferUnderflowException ", be);
                return;
            }
            dout.writeInt(b.capacity());
            dout.write(b.array());
            dout.flush();
        }
```

`b.get(msgBytes);` changes the position of the `ByteBuffer`. So we can have a race here that results in a `BufferUnderflowException` causing a message never to be sent and this test to fail. 

The fix is to create a new `ByteBuffer` for each message we send in the test.