### PR TITLE
ZOOKEEPER-2817: Using `Collections.singletonList` instead of `Arrays.asList(oneElement)`

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/admin/Commands.java
+++ b/src/java/main/org/apache/zookeeper/server/admin/Commands.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server.admin;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -184,7 +185,7 @@ public class Commands {
      */
     public static class DirsCommand extends CommandBase {
         public DirsCommand() {
-            super(Arrays.asList("dirs"));
+            super(Collections.singletonList("dirs"));
         }
 
         @Override
@@ -207,7 +208,7 @@ public class Commands {
      */
     public static class DumpCommand extends CommandBase {
         public DumpCommand() {
-            super(Arrays.asList("dump"));
+            super(Collections.singletonList("dump"));
         }
 
         @Override
@@ -346,7 +347,7 @@ public class Commands {
      */
     public static class RuokCommand extends CommandBase {
         public RuokCommand() {
-            super(Arrays.asList("ruok"));
+            super(Collections.singletonList("ruok"));
         }
 
         @Override

--- a/src/java/main/org/apache/zookeeper/server/command/FourLetterCommands.java
+++ b/src/java/main/org/apache/zookeeper/server/command/FourLetterCommands.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.HashSet;
@@ -231,8 +232,8 @@ public class FourLetterCommands {
         // zkServer.sh depends on "srvr".
         whiteListedCommands.add("srvr");
         whiteListInitialized = true;
-        LOG.info("The list of known four letter word commands is : {}", Arrays.asList(cmd2String));
-        LOG.info("The list of enabled four letter word commands is : {}", Arrays.asList(whiteListedCommands));
+        LOG.info("The list of known four letter word commands is : {}", Collections.singletonList(cmd2String));
+        LOG.info("The list of enabled four letter word commands is : {}", Collections.singletonList(whiteListedCommands));
         return whiteListedCommands.contains(command);
     }
 

--- a/src/java/test/org/apache/zookeeper/server/PrepRequestProcessorTest.java
+++ b/src/java/test/org/apache/zookeeper/server/PrepRequestProcessorTest.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,7 +109,7 @@ public class PrepRequestProcessorTest extends ClientBase {
         record.serialize(boa, "request");
         baos.close();
         // Id
-        List<Id> ids = Arrays.asList(Ids.ANYONE_ID_UNSAFE);
+        List<Id> ids = Collections.singletonList(Ids.ANYONE_ID_UNSAFE);
         return new Request(null, 1l, 0, opCode, ByteBuffer.wrap(baos.toByteArray()), ids);
     }
 
@@ -133,7 +134,7 @@ public class PrepRequestProcessorTest extends ClientBase {
 
         Assert.assertNull(zks.outstandingChangesForPath.get("/foo"));
 
-        process(Arrays.asList(
+        process(Collections.singletonList(
                 Op.setData("/foo", new byte[0], -1)));
 
         ChangeRecord cr = zks.outstandingChangesForPath.get("/foo");
@@ -141,7 +142,7 @@ public class PrepRequestProcessorTest extends ClientBase {
         Assert.assertEquals("Record zxid wasn't set correctly",
                 1, cr.zxid);
 
-        process(Arrays.asList(
+        process(Collections.singletonList(
                 Op.delete("/foo", -1)));
         cr = zks.outstandingChangesForPath.get("/foo");
         Assert.assertEquals("Record zxid wasn't set correctly",
@@ -149,7 +150,7 @@ public class PrepRequestProcessorTest extends ClientBase {
 
 
         // It should fail and shouldn't change outstanding record.
-        process(Arrays.asList(
+        process(Collections.singletonList(
                 Op.delete("/foo", -1)));
         cr = zks.outstandingChangesForPath.get("/foo");
         // zxid should still be previous result because record's not changed.

--- a/src/java/test/org/apache/zookeeper/test/MultiTransactionTest.java
+++ b/src/java/test/org/apache/zookeeper/test/MultiTransactionTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -260,7 +261,7 @@ public class MultiTransactionTest extends ClientBase {
         ZooKeeper epheZk = createClient();
         epheZk.create("/foo/bar", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
 
-        List<Op> opList = Arrays.asList(Op.delete("/foo", -1));
+        List<Op> opList = Collections.singletonList(Op.delete("/foo", -1));
         try {
             zk.multi(opList);
             Assert.fail("multi delete should failed for not empty directory");
@@ -348,7 +349,7 @@ public class MultiTransactionTest extends ClientBase {
         zk_chroot = createClient(this.hostPort + chRoot);
         Op createChild = Op.create("/myid", new byte[0],
                 Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-        multi(zk_chroot, Arrays.asList(createChild));
+        multi(zk_chroot, Collections.singletonList(createChild));
         
         Assert.assertNotNull("zNode is not created under chroot:" + chRoot, zk
                 .exists(chRoot + "/myid", false));
@@ -359,7 +360,7 @@ public class MultiTransactionTest extends ClientBase {
         
         // Deleting child using chRoot client.
         Op deleteChild = Op.delete("/myid", 0);
-        multi(zk_chroot, Arrays.asList(deleteChild));
+        multi(zk_chroot, Collections.singletonList(deleteChild));
         Assert.assertNull("zNode exists under chroot:" + chRoot, zk.exists(
                 chRoot + "/myid", false));
         Assert.assertNull("zNode exists under chroot:" + chRoot, zk_chroot
@@ -448,7 +449,7 @@ public class MultiTransactionTest extends ClientBase {
         String chRoot = "/appsX";
         Op createChRoot = Op.create(chRoot, new byte[0], Ids.OPEN_ACL_UNSAFE,
                 CreateMode.PERSISTENT);
-        multi(zk, Arrays.asList(createChRoot));
+        multi(zk, Collections.singletonList(createChRoot));
         return chRoot;
     }
 
@@ -562,7 +563,7 @@ public class MultiTransactionTest extends ClientBase {
     @Test
     public void testDeleteUpdateConflict() throws Exception {
 
-        /* Delete of a node folowed by an update of the (now) deleted node */
+        /* Delete of a node followed by an update of the (now) deleted node */
         try {
             multi(zk, Arrays.asList(
                 Op.create("/multi", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT),
@@ -580,7 +581,7 @@ public class MultiTransactionTest extends ClientBase {
 
     @Test
     public void testGetResults() throws Exception {
-        /* Delete of a node folowed by an update of the (now) deleted node */
+        /* Delete of a node followed by an update of the (now) deleted node */
         Iterable<Op> ops = Arrays.asList(
                 Op.create("/multi", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT),
                 Op.delete("/multi", 0),


### PR DESCRIPTION
Using `Collections.singletonList` instead of `Arrays.asList(oneElement)` for reusing a immutable object instead of creating a new object.