### PR TITLE
ZOOKEEPER-2822: Wrong `ObjectName` about `MBeanServer` in JMX module

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperJMX.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperJMX.md
@@ -84,7 +84,10 @@ interest is the ability to dynamically change the logging levels
 used by editing the appender and root thresholds. Log4j MBean
 registration can be disabled by passing
 _-Dzookeeper.jmx.log4j.disable=true_ to the JVM
-when starting ZooKeeper.
+when starting ZooKeeper. In addition, we can specify the name of
+the MBean with the _-Dzookeeper.jmx.log4j.mbean=log4j:hierarchy=default_
+option, in case we need to upgrade an integrated system
+using the old MBean name (`log4j:hiearchy = default`).
 
 <a name="ch_reference"></a>
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/jmx/ManagedUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/jmx/ManagedUtil.java
@@ -71,10 +71,7 @@ public class ManagedUtil {
                 // org.apache.log4j.jmx.HierarchyDynamicMBean hdm = new org.apache.log4j.jmx.HierarchyDynamicMBean();
                 Object hdm = Class.forName("org.apache.log4j.jmx.HierarchyDynamicMBean").getConstructor().newInstance();
 
-                String mbean = System.getenv("zookeeper.jmx.log4j.mbean");
-                if (mbean == null || mbean.trim().length() == 0) {
-                    mbean = "log4j:hierarchy=default";
-                }
+                String mbean = System.getProperty("zookeeper.jmx.log4j.mbean", "log4j:hierarchy=default");
                 ObjectName mbo = new ObjectName(mbean);
                 mbs.registerMBean(hdm, mbo);
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/jmx/ManagedUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/jmx/ManagedUtil.java
@@ -33,13 +33,13 @@ import org.slf4j.LoggerFactory;
 public class ManagedUtil {
     private static final Logger LOG = LoggerFactory.getLogger(ManagedUtil.class);
 
-    private static final boolean isLog4jJmxEnabled() {
+    private static boolean isLog4jJmxEnabled() {
         boolean enabled = false;
 
         try {
             Class.forName("org.apache.log4j.spi.LoggerRepository");
 
-            if (Boolean.getBoolean("zookeeper.jmx.log4j.disable") == true) {
+            if (Boolean.getBoolean("zookeeper.jmx.log4j.disable")) {
                 LOG.info("Log4j found but jmx support is disabled.");
             } else {
                 enabled = true;
@@ -71,7 +71,7 @@ public class ManagedUtil {
                 // org.apache.log4j.jmx.HierarchyDynamicMBean hdm = new org.apache.log4j.jmx.HierarchyDynamicMBean();
                 Object hdm = Class.forName("org.apache.log4j.jmx.HierarchyDynamicMBean").getDeclaredConstructor().newInstance();
 
-                ObjectName mbo = new ObjectName("log4j:hiearchy=default");
+                ObjectName mbo = new ObjectName("log4j:hierarchy=default");
                 mbs.registerMBean(hdm, mbo);
 
                 // Add the root logger to the Hierarchy MBean

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/jmx/ManagedUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/jmx/ManagedUtil.java
@@ -69,9 +69,13 @@ public class ManagedUtil {
             try {
                 // Create and Register the top level Log4J MBean
                 // org.apache.log4j.jmx.HierarchyDynamicMBean hdm = new org.apache.log4j.jmx.HierarchyDynamicMBean();
-                Object hdm = Class.forName("org.apache.log4j.jmx.HierarchyDynamicMBean").getDeclaredConstructor().newInstance();
+                Object hdm = Class.forName("org.apache.log4j.jmx.HierarchyDynamicMBean").getConstructor().newInstance();
 
-                ObjectName mbo = new ObjectName("log4j:hierarchy=default");
+                String mbean = System.getenv("zookeeper.jmx.log4j.mbean");
+                if (mbean == null || mbean.trim().length() == 0) {
+                    mbean = "log4j:hierarchy=default";
+                }
+                ObjectName mbo = new ObjectName(mbean);
                 mbs.registerMBean(hdm, mbo);
 
                 // Add the root logger to the Hierarchy MBean


### PR DESCRIPTION
The wrong `ObjectName` about `MBeanServer` in JMX module, should `log4j:hierarchy=default` rather than `log4j:hiearchy=default`.
