### PR TITLE
ZOOKEEPER-2823: 1. Fix spell issues; 2. Standardize `StringBuilder#append` usage; 3. Using `try` clause for releasing I/O stream for `COMMON` module

### DIFF
--- a/src/java/main/org/apache/zookeeper/common/AtomicFileOutputStream.java
+++ b/src/java/main/org/apache/zookeeper/common/AtomicFileOutputStream.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * destination once it has been entirely written and flushed to disk. While
  * being written, it will use a .tmp suffix.
  * 
- * When the output stream is closed, it is flushed, fsynced, and will be moved
+ * When the output stream is closed, it is flushed, synced, and will be moved
  * into place, overwriting any file that already exists at that location.
  * 
  * <b>NOTE</b>: on Windows platforms, it will not atomically replace the target

--- a/src/java/main/org/apache/zookeeper/common/IOUtils.java
+++ b/src/java/main/org/apache/zookeeper/common/IOUtils.java
@@ -69,7 +69,7 @@ public class IOUtils {
      * Copies from one stream to another.
      * 
      * @param in
-     *            InputStrem to read from
+     *            InputStream to read from
      * @param out
      *            OutputStream to write to
      * @param buffSize
@@ -100,7 +100,7 @@ public class IOUtils {
      * Copies from one stream to another.
      * 
      * @param in
-     *            InputStrem to read from
+     *            InputStream to read from
      * @param out
      *            OutputStream to write to
      * @param buffSize

--- a/src/java/main/org/apache/zookeeper/common/PathTrie.java
+++ b/src/java/main/org/apache/zookeeper/common/PathTrie.java
@@ -174,7 +174,7 @@ public class PathTrie {
             sb.append("Children of trienode: ");
             synchronized(children) {
                 for (String str: children.keySet()) {
-                    sb.append(" " + str);
+                    sb.append(" ").append(str);
                 }
             }
             return sb.toString();
@@ -261,14 +261,14 @@ public class PathTrie {
         int i = 1;
         String part = null;
         StringBuilder sb = new StringBuilder();
-        int lastindex = -1;
+        int lastIndex = -1;
         while((i < pathComponents.length)) {
             if (parent.getChild(pathComponents[i]) != null) {
                 part = pathComponents[i];
                 parent = parent.getChild(part);
                 components.add(part);
                 if (parent.getProperty()) {
-                    lastindex = i-1;
+                    lastIndex = i - 1;
                 }
             }
             else {
@@ -276,8 +276,8 @@ public class PathTrie {
             }
             i++;
         }
-        for (int j=0; j< (lastindex+1); j++) {
-            sb.append("/" + components.get(j));
+        for (int j = 0; j <= lastIndex; j++) {
+            sb.append("/").append(components.get(j));
         }
         return sb.toString();
     }

--- a/src/java/main/org/apache/zookeeper/common/PathUtils.java
+++ b/src/java/main/org/apache/zookeeper/common/PathUtils.java
@@ -90,7 +90,7 @@ public class PathUtils {
                     || c >= '\u007f' && c <= '\u009F'
                     || c >= '\ud800' && c <= '\uf8ff'
                     || c >= '\ufff0' && c <= '\uffff') {
-                reason = "invalid charater @" + i;
+                reason = "invalid character @" + i;
                 break;
             }
         }

--- a/src/java/main/org/apache/zookeeper/common/ZKConfig.java
+++ b/src/java/main/org/apache/zookeeper/common/ZKConfig.java
@@ -183,11 +183,8 @@ public class ZKConfig {
             configFile = (new VerifyingFileFactory.Builder(LOG).warnForRelativePath().failForNonExistingPath().build())
                     .validate(configFile);
             Properties cfg = new Properties();
-            FileInputStream in = new FileInputStream(configFile);
-            try {
+            try (FileInputStream in = new FileInputStream(configFile)) {
                 cfg.load(in);
-            } finally {
-                in.close();
             }
             parseProperties(cfg);
         } catch (IOException | IllegalArgumentException e) {


### PR DESCRIPTION
* Fix spell issues
* Standardize `StringBuilder#append` usage
* Using `try` clause for releasing I/O stream for `COMMON` module