### PR TITLE
ZOOKEEPER-2826: Code refactoring for `CLI` module

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/AddAuthCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/AddAuthCommand.java
@@ -17,13 +17,11 @@
  */
 package org.apache.zookeeper.cli;
 
-import java.io.IOException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.Parser;
 import org.apache.commons.cli.PosixParser;
-import org.apache.zookeeper.KeeperException;
 
 /**
  * addAuth command for cli

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CliCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CliCommand.java
@@ -45,7 +45,7 @@ abstract public class CliCommand {
     }
 
     /**
-     * Set out printStream (useable for testing)
+     * Set out printStream (usable for testing)
      * @param out 
      */
     public void setOut(PrintStream out) {
@@ -53,7 +53,7 @@ abstract public class CliCommand {
     }
 
     /**
-     * Set err printStream (useable for testing)
+     * Set err printStream (usable for testing)
      * @param err 
      */
     public void setErr(PrintStream err) {
@@ -61,7 +61,7 @@ abstract public class CliCommand {
     }
 
     /**
-     * set the zookeper instance
+     * set the zookeeper instance
      * @param zk the ZooKeeper instance.
      */
     public void setZk(ZooKeeper zk) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/DelQuotaCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/DelQuotaCommand.java
@@ -71,7 +71,7 @@ public class DelQuotaCommand extends CliCommand {
             } else if (cl.hasOption("n")) {
                 delQuota(zk, path, false, true);
             } else if (args.length == 2) {
-                // we dont have an option specified.
+                // we don't have an option specified.
                 // just delete whole quota node
                 delQuota(zk, path, true, true);
             }
@@ -139,7 +139,7 @@ public class DelQuotaCommand extends CliCommand {
      * @param zk the zookeeper client
      * @param path the path to start from and go up and see if their is any
      * unwanted parent in the path.
-     * @return true if sucessful
+     * @return true if successful
      * @throws KeeperException
      * @throws IOException
      * @throws InterruptedException

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/DeleteCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/DeleteCommand.java
@@ -29,7 +29,7 @@ public class DeleteCommand extends CliCommand {
     private String[] args;
     private CommandLine cl;
 
-    {
+    static {
         options.addOption("v", true, "version");
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetAclCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetAclCommand.java
@@ -36,7 +36,7 @@ public class GetAclCommand extends CliCommand {
     private String args[];
     private CommandLine cl;
 
-    {
+    static {
         options.addOption("s", false, "stats");
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
@@ -30,7 +30,7 @@ public class GetCommand extends CliCommand {
     private String args[];
     private CommandLine cl;
 
-    {
+    static {
         options.addOption("s", false, "stats");
         options.addOption("w", false, "watch");
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetConfigCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetConfigCommand.java
@@ -31,7 +31,7 @@ public class GetConfigCommand extends CliCommand {
     private String args[];
     private CommandLine cl;
 
-    {
+    static {
         options.addOption("s", false, "stats");
         options.addOption("w", false, "watch");
         options.addOption("c", false, "client connection string");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ListQuotaCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ListQuotaCommand.java
@@ -24,7 +24,7 @@ import org.apache.zookeeper.StatsTrack;
 import org.apache.zookeeper.data.Stat;
 
 /**
- * listQuta command for cli
+ * listQuota command for cli
  */
 public class ListQuotaCommand extends CliCommand {
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/LsCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/LsCommand.java
@@ -33,7 +33,7 @@ public class LsCommand extends CliCommand {
     private String args[];
     private CommandLine cl;
 
-    {
+    static {
         options.addOption("?", false, "help");
         options.addOption("s", false, "stat");
         options.addOption("w", false, "watch");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ReconfigCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ReconfigCommand.java
@@ -52,12 +52,12 @@ public class ReconfigCommand extends CliCommand {
     private String members;
 
     /* version - version of config from which we want to reconfigure - if current config is different
-     * reconfiguration will fail. Should be ommitted from the CLI to disable this option.
+     * reconfiguration will fail. Should be committed from the CLI to disable this option.
      */
     long version = -1;
     private CommandLine cl;
 
-    {
+    static {
         options.addOption("s", false, "stats");
         options.addOption("v", true, "required current config version");
         options.addOption("file", true, "path of config file to parse for membership");
@@ -106,8 +106,7 @@ public class ReconfigCommand extends CliCommand {
             throw new CliParseException("Can't use -file or -members together with -add or -remove (mixing incremental" +
             		" and non-incremental modes is not allowed)");
         }
-        if (cl.hasOption("file") && cl.hasOption("members"))
-        {
+        if (cl.hasOption("file") && cl.hasOption("members")) {
             throw new CliParseException("Can't use -file and -members together (conflicting non-incremental modes)");
         }
 
@@ -122,13 +121,10 @@ public class ReconfigCommand extends CliCommand {
            members = cl.getOptionValue("members").toLowerCase();
         }
         if (cl.hasOption("file")) {
-            try {           
-                FileInputStream inConfig = new FileInputStream(cl.getOptionValue("file"));
+            try {
                 Properties dynamicCfg = new Properties();
-                try {
+                try (FileInputStream inConfig = new FileInputStream(cl.getOptionValue("file"))) {
                     dynamicCfg.load(inConfig);
-                } finally {
-                    inConfig.close();
                 }
                 //check that membership makes sense; leader will make these checks again
                 //don't check for leader election ports since 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RemoveWatchesCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RemoveWatchesCommand.java
@@ -34,7 +34,7 @@ public class RemoveWatchesCommand extends CliCommand {
     private String[] args;
     private CommandLine cl;
 
-    {
+    static {
         options.addOption("c", false, "child watcher type");
         options.addOption("d", false, "data watcher type");
         options.addOption("a", false, "any watcher type");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetAclCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetAclCommand.java
@@ -37,7 +37,7 @@ public class SetAclCommand extends CliCommand {
     private String[] args;
     private CommandLine cl;
 
-    {
+    static {
         options.addOption("s", false, "stats");
         options.addOption("v", true, "version");
         options.addOption("R", false, "recursive");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
@@ -30,7 +30,7 @@ public class SetCommand extends CliCommand {
     private String[] args;
     private CommandLine cl;
 
-    {
+    static {
         options.addOption("s", false, "stats");
         options.addOption("v", true, "version");
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetQuotaCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetQuotaCommand.java
@@ -109,7 +109,7 @@ public class SetQuotaCommand extends CliCommand {
 
         String quotaPath = Quotas.quotaZookeeper;
         // check for more than 2 children --
-        // if zookeeper_stats and zookeeper_qutoas
+        // if zookeeper_stats and zookeeper_quotas
         // are not the children then this path
         // is an ancestor of some path that
         // already has quota
@@ -148,7 +148,7 @@ public class SetQuotaCommand extends CliCommand {
         StringBuilder sb = new StringBuilder();
         sb.append(quotaPath);
         for (int i = 1; i < splits.length; i++) {
-            sb.append("/" + splits[i]);
+            sb.append("/").append(splits[i]);
             quotaPath = sb.toString();
             try {
                 zk.create(quotaPath, null, ZooDefs.Ids.OPEN_ACL_UNSAFE,

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SyncCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SyncCommand.java
@@ -16,14 +16,12 @@
  */
 package org.apache.zookeeper.cli;
 
-import java.io.IOException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.Parser;
 import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.AsyncCallback;
-import org.apache.zookeeper.KeeperException;
 
 /**
  * sync command for cli


### PR DESCRIPTION
* Fix spell issues
* Remove unnecessary `import`
* Make initialization block that related with `options.addOption` into static
* Standardize `StringBuilder#append` usage
* Using `try` clause to release the resource of stream