### PR TITLE
ZOOKEEPER-2827: Code refactoring for `JUTE` module

### DIFF
--- a/src/java/main/org/apache/jute/BinaryInputArchive.java
+++ b/src/java/main/org/apache/jute/BinaryInputArchive.java
@@ -27,11 +27,11 @@ import java.io.InputStream;
  *
  */
 public class BinaryInputArchive implements InputArchive {
-    static public final String UNREASONBLE_LENGTH= "Unreasonable length = ";
+    public static final String UNREASONABLE_LENGTH = "Unreasonable length = ";
     private DataInput in;
     
-    static public BinaryInputArchive getArchive(InputStream strm) {
-        return new BinaryInputArchive(new DataInputStream(strm));
+    static public BinaryInputArchive getArchive(InputStream stream) {
+        return new BinaryInputArchive(new DataInputStream(stream));
     }
     
     static private class BinaryIndex implements Index {
@@ -124,7 +124,7 @@ public class BinaryInputArchive implements InputArchive {
     // write buffers larger than we can read from disk!)
     private void checkLength(int len) throws IOException {
         if (len < 0 || len > maxBuffer + 1024) {
-            throw new IOException(UNREASONBLE_LENGTH + len);
+            throw new IOException(UNREASONABLE_LENGTH + len);
         }
     }
 }

--- a/src/java/main/org/apache/jute/BinaryOutputArchive.java
+++ b/src/java/main/org/apache/jute/BinaryOutputArchive.java
@@ -34,8 +34,8 @@ public class BinaryOutputArchive implements OutputArchive {
 
     private DataOutput out;
     
-    public static BinaryOutputArchive getArchive(OutputStream strm) {
-        return new BinaryOutputArchive(new DataOutputStream(strm));
+    public static BinaryOutputArchive getArchive(OutputStream stream) {
+        return new BinaryOutputArchive(new DataOutputStream(stream));
     }
     
     /** Creates a new instance of BinaryOutputArchive */

--- a/src/java/main/org/apache/jute/CsvInputArchive.java
+++ b/src/java/main/org/apache/jute/CsvInputArchive.java
@@ -39,7 +39,7 @@ class CsvInputArchive implements InputArchive {
                 stream.unread(c);
             } catch (IOException ex) {
             }
-            return (c == '}') ? true : false;
+            return c == '}';
         }
         public void incr() {}
     }
@@ -66,9 +66,9 @@ class CsvInputArchive implements InputArchive {
         }
     }
     
-    static CsvInputArchive getArchive(InputStream strm)
+    static CsvInputArchive getArchive(InputStream stream)
     throws UnsupportedEncodingException {
-        return new CsvInputArchive(strm);
+        return new CsvInputArchive(stream);
     }
     
     /** Creates a new instance of CsvInputArchive */
@@ -83,7 +83,7 @@ class CsvInputArchive implements InputArchive {
     
     public boolean readBool(String tag) throws IOException {
         String sval = readField(tag);
-        return "T".equals(sval) ? true : false;
+        return "T".equals(sval);
     }
     
     public int readInt(String tag) throws IOException {
@@ -93,8 +93,7 @@ class CsvInputArchive implements InputArchive {
     public long readLong(String tag) throws IOException {
         String sval = readField(tag);
         try {
-            long lval = Long.parseLong(sval);
-            return lval;
+            return Long.parseLong(sval);
         } catch (NumberFormatException ex) {
             throw new IOException("Error deserializing "+tag);
         }
@@ -107,8 +106,7 @@ class CsvInputArchive implements InputArchive {
     public double readDouble(String tag) throws IOException {
         String sval = readField(tag);
         try {
-            double dval = Double.parseDouble(sval);
-            return dval;
+            return Double.parseDouble(sval);
         } catch (NumberFormatException ex) {
             throw new IOException("Error deserializing "+tag);
         }
@@ -156,8 +154,6 @@ class CsvInputArchive implements InputArchive {
         if (c != ',') {
             stream.unread(c);
         }
-        
-        return;
     }
     
     public Index startVector(String tag) throws IOException {
@@ -178,7 +174,6 @@ class CsvInputArchive implements InputArchive {
         if (c != ',') {
             stream.unread(c);
         }
-        return;
     }
     
     public Index startMap(String tag) throws IOException {
@@ -199,6 +194,5 @@ class CsvInputArchive implements InputArchive {
         if (c != ',') {
             stream.unread(c);
         }
-        return;
     }
 }

--- a/src/java/main/org/apache/jute/CsvOutputArchive.java
+++ b/src/java/main/org/apache/jute/CsvOutputArchive.java
@@ -33,9 +33,9 @@ public class CsvOutputArchive implements OutputArchive {
     private PrintStream stream;
     private boolean isFirst = true;
     
-    static CsvOutputArchive getArchive(OutputStream strm)
+    static CsvOutputArchive getArchive(OutputStream stream)
     throws UnsupportedEncodingException {
-        return new CsvOutputArchive(strm);
+        return new CsvOutputArchive(stream);
     }
     
     private void throwExceptionOnError(String tag) throws IOException {

--- a/src/java/main/org/apache/jute/OutputArchive.java
+++ b/src/java/main/org/apache/jute/OutputArchive.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.TreeMap;
 
 /**
- * Interface that alll the serializers have to implement.
+ * Interface that all the serializers have to implement.
  *
  */
 public interface OutputArchive {

--- a/src/java/main/org/apache/jute/RecordReader.java
+++ b/src/java/main/org/apache/jute/RecordReader.java
@@ -41,32 +41,26 @@ public class RecordReader {
         try {
             archiveFactory.put("binary",
                     BinaryInputArchive.class.getDeclaredMethod(
-                        "getArchive", new Class[]{ InputStream.class } ));
+                        "getArchive", InputStream.class));
             archiveFactory.put("csv",
                     CsvInputArchive.class.getDeclaredMethod(
-                        "getArchive", new Class[]{ InputStream.class }));
+                        "getArchive", InputStream.class));
             archiveFactory.put("xml",
                     XmlInputArchive.class.getDeclaredMethod(
-                        "getArchive", new Class[]{ InputStream.class }));
-        } catch (SecurityException ex) {
-            ex.printStackTrace();
-        } catch (NoSuchMethodException ex) {
+                        "getArchive", InputStream.class));
+        } catch (SecurityException | NoSuchMethodException ex) {
             ex.printStackTrace();
         }
     }
     
     static private InputArchive createArchive(InputStream in, String format)
     throws IOException {
-        Method factory = (Method) archiveFactory.get(format);
+        Method factory = archiveFactory.get(format);
         if (factory != null) {
             Object[] params = { in };
             try {
                 return (InputArchive) factory.invoke(null, params);
-            } catch (IllegalArgumentException ex) {
-                ex.printStackTrace();
-            } catch (InvocationTargetException ex) {
-                ex.printStackTrace();
-            } catch (IllegalAccessException ex) {
+            } catch (IllegalArgumentException | InvocationTargetException | IllegalAccessException ex) {
                 ex.printStackTrace();
             }
         }

--- a/src/java/main/org/apache/jute/RecordWriter.java
+++ b/src/java/main/org/apache/jute/RecordWriter.java
@@ -38,16 +38,14 @@ public class RecordWriter {
         try {
             factory.put("binary",
                     BinaryOutputArchive.class.getDeclaredMethod(
-                        "getArchive", new Class[]{ OutputStream.class }));
+                        "getArchive", OutputStream.class));
             factory.put("csv",
                     CsvOutputArchive.class.getDeclaredMethod(
-                        "getArchive", new Class[]{ OutputStream.class }));
+                        "getArchive", OutputStream.class));
             factory.put("xml",
                     XmlOutputArchive.class.getDeclaredMethod(
-                        "getArchive", new Class[]{ OutputStream.class }));
-        } catch (SecurityException ex) {
-            ex.printStackTrace();
-        } catch (NoSuchMethodException ex) {
+                        "getArchive", OutputStream.class));
+        } catch (SecurityException | NoSuchMethodException ex) {
             ex.printStackTrace();
         }
         return factory;
@@ -58,16 +56,12 @@ public class RecordWriter {
     static private OutputArchive createArchive(OutputStream out,
             String format)
             throws IOException {
-        Method factory = (Method) archiveFactory.get(format);
+        Method factory = archiveFactory.get(format);
         if (factory != null) {
             Object[] params = { out };
             try {
                 return (OutputArchive) factory.invoke(null, params);
-            } catch (IllegalArgumentException ex) {
-                ex.printStackTrace();
-            } catch (InvocationTargetException ex) {
-                ex.printStackTrace();
-            } catch (IllegalAccessException ex) {
+            } catch (IllegalArgumentException | InvocationTargetException | IllegalAccessException ex) {
                 ex.printStackTrace();
             }
         }

--- a/src/java/main/org/apache/jute/Utils.java
+++ b/src/java/main/org/apache/jute/Utils.java
@@ -199,8 +199,8 @@ public class Utils {
             return "";
         }
         StringBuilder sb = new StringBuilder(2*barr.length);
-        for (int idx = 0; idx < barr.length; idx++) {
-            sb.append(Integer.toHexString(barr[idx]));
+        for (byte aBarr : barr) {
+            sb.append(Integer.toHexString(aBarr));
         }
         return sb.toString();
     }
@@ -237,8 +237,8 @@ public class Utils {
         }
         StringBuilder sb = new StringBuilder(barr.length + 1);
         sb.append('#');
-        for(int idx = 0; idx < barr.length; idx++) {
-            sb.append(Integer.toHexString(barr[idx]));
+        for (byte aBarr : barr) {
+            sb.append(Integer.toHexString(aBarr));
         }
         return sb.toString();
     }

--- a/src/java/main/org/apache/jute/XmlInputArchive.java
+++ b/src/java/main/org/apache/jute/XmlInputArchive.java
@@ -132,9 +132,9 @@ class XmlInputArchive implements InputArchive {
         }
     }
     
-    static XmlInputArchive getArchive(InputStream strm)
+    static XmlInputArchive getArchive(InputStream stream)
     throws ParserConfigurationException, SAXException, IOException {
-        return new XmlInputArchive(strm);
+        return new XmlInputArchive(stream);
     }
     
     /** Creates a new instance of BinaryInputArchive */

--- a/src/java/main/org/apache/jute/XmlOutputArchive.java
+++ b/src/java/main/org/apache/jute/XmlOutputArchive.java
@@ -130,8 +130,8 @@ class XmlOutputArchive implements OutputArchive {
         printEndEnvelope(tag);
     }
     
-    static XmlOutputArchive getArchive(OutputStream strm) {
-        return new XmlOutputArchive(strm);
+    static XmlOutputArchive getArchive(OutputStream stream) {
+        return new XmlOutputArchive(stream);
     }
     
     /** Creates a new instance of XmlOutputArchive */

--- a/src/java/main/org/apache/jute/compiler/CGenerator.java
+++ b/src/java/main/org/apache/jute/compiler/CGenerator.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Iterator;
 
 /**
  * C++ Code generator front-end for Hadoop record I/O.
@@ -63,7 +62,7 @@ class CGenerator {
         }
 
         try (FileWriter c = new FileWriter(new File(outputDirectory, mName + ".c"));
-             FileWriter h = new FileWriter(new File(outputDirectory, mName + ".h"));
+             FileWriter h = new FileWriter(new File(outputDirectory, mName + ".h"))
         ) {
             h.write("/**\n");
             h.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
@@ -107,8 +106,7 @@ class CGenerator {
             h.write("#define __" + mName.toUpperCase().replace('.', '_') + "__\n");
 
             h.write("#include \"recordio.h\"\n");
-            for (Iterator<JFile> i = mInclFiles.iterator(); i.hasNext(); ) {
-                JFile f = i.next();
+            for (JFile f : mInclFiles) {
                 h.write("#include \"" + f.getName() + ".h\"\n");
             }
             // required for compilation from C++
@@ -117,8 +115,7 @@ class CGenerator {
             c.write("#include <stdlib.h>\n"); // need it for calloc() & free()
             c.write("#include \"" + mName + ".h\"\n\n");
 
-            for (Iterator<JRecord> i = mRecList.iterator(); i.hasNext(); ) {
-                JRecord jr = i.next();
+            for (JRecord jr : mRecList) {
                 jr.genCCode(h, c);
             }
 

--- a/src/java/main/org/apache/jute/compiler/CppGenerator.java
+++ b/src/java/main/org/apache/jute/compiler/CppGenerator.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Iterator;
 
 /**
  * C++ Code generator front-end for Hadoop record I/O.
@@ -63,7 +62,7 @@ class CppGenerator {
         }
 
         try (FileWriter cc = new FileWriter(new File(outputDirectory, mName + ".cc"));
-             FileWriter hh = new FileWriter(new File(outputDirectory, mName + ".hh"));
+             FileWriter hh = new FileWriter(new File(outputDirectory, mName + ".hh"))
         ) {
             hh.write("/**\n");
             hh.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
@@ -107,14 +106,12 @@ class CppGenerator {
             hh.write("#define __" + mName.toUpperCase().replace('.', '_') + "__\n");
 
             hh.write("#include \"recordio.hh\"\n");
-            for (Iterator<JFile> i = mInclFiles.iterator(); i.hasNext(); ) {
-                JFile f = i.next();
+            for (JFile f : mInclFiles) {
                 hh.write("#include \"" + f.getName() + ".hh\"\n");
             }
             cc.write("#include \"" + mName + ".hh\"\n");
 
-            for (Iterator<JRecord> i = mRecList.iterator(); i.hasNext(); ) {
-                JRecord jr = i.next();
+            for (JRecord jr : mRecList) {
                 jr.genCppCode(hh, cc);
             }
 

--- a/src/java/main/org/apache/jute/compiler/JFile.java
+++ b/src/java/main/org/apache/jute/compiler/JFile.java
@@ -78,7 +78,7 @@ public class JFile {
         	        outputDirectory);
         	gen.genCode();
         } else {
-            throw new IOException("Cannnot recognize language:" + language);
+            throw new IOException("Cannot recognize language:" + language);
         }
     }
 }

--- a/src/java/main/org/apache/jute/compiler/JRecord.java
+++ b/src/java/main/org/apache/jute/compiler/JRecord.java
@@ -74,7 +74,7 @@ public class JRecord extends JCompType {
 
     public String getCsharpNameSpace() {
         String[] parts = mModule.split("\\.");
-        StringBuffer namespace = new StringBuffer();
+        StringBuilder namespace = new StringBuilder();
         for (int i = 0; i < parts.length; i++) {
             String capitalized = parts[i].substring(0, 1).toUpperCase() + parts[i].substring(1).toLowerCase();
             namespace.append(capitalized);
@@ -90,8 +90,8 @@ public class JRecord extends JCompType {
     public String getSignature() {
         StringBuilder sb = new StringBuilder();
         sb.append("L").append(mName).append("(");
-        for (Iterator<JField> i = mFields.iterator(); i.hasNext();) {
-            String s = i.next().getSignature();
+        for (JField mField : mFields) {
+            String s = mField.getSignature();
             sb.append(s);
         }
         sb.append(")");
@@ -282,15 +282,14 @@ public class JRecord extends JCompType {
     public void genCppCode(FileWriter hh, FileWriter cc)
         throws IOException {
         String[] ns = getCppNameSpace().split("::");
-        for (int i = 0; i < ns.length; i++) {
-            hh.write("namespace "+ns[i]+" {\n");
+        for (String n : ns) {
+            hh.write("namespace " + n + " {\n");
         }
 
         hh.write("class "+getName()+" : public ::hadoop::Record {\n");
         hh.write("private:\n");
 
-        for (Iterator<JField> i = mFields.iterator(); i.hasNext();) {
-            JField jf = i.next();
+        for (JField jf : mFields) {
             hh.write(jf.genCppDecl());
         }
         hh.write("  mutable std::bitset<"+mFields.size()+"> bs_;\n");
@@ -361,20 +360,18 @@ public class JRecord extends JCompType {
 
         cc.write("bool "+getCppFQName()+"::operator< (const "+getCppFQName()+"& peer_) const {\n");
         cc.write("  return (1\n");
-        for (Iterator<JField> i = mFields.iterator(); i.hasNext();) {
-            JField jf = i.next();
+        for (JField jf : mFields) {
             String name = jf.getName();
-            cc.write("    && (m"+name+" < peer_.m"+name+")\n");
+            cc.write("    && (m" + name + " < peer_.m" + name + ")\n");
         }
         cc.write("  );\n");
         cc.write("}\n");
 
         cc.write("bool "+getCppFQName()+"::operator== (const "+getCppFQName()+"& peer_) const {\n");
         cc.write("  return (1\n");
-        for (Iterator<JField> i = mFields.iterator(); i.hasNext();) {
-            JField jf = i.next();
+        for (JField jf : mFields) {
             String name = jf.getName();
-            cc.write("    && (m"+name+" == peer_.m"+name+")\n");
+            cc.write("    && (m" + name + " == peer_.m" + name + ")\n");
         }
         cc.write("  );\n");
         cc.write("}\n");
@@ -426,8 +423,7 @@ public class JRecord extends JCompType {
             jj.write("package " + getJavaPackage() + ";\n\n");
             jj.write("import org.apache.jute.*;\n");
             jj.write("public class " + getName() + " implements Record {\n");
-            for (Iterator<JField> i = mFields.iterator(); i.hasNext(); ) {
-                JField jf = i.next();
+            for (JField jf : mFields) {
                 jj.write(jf.genJavaDecl());
             }
             jj.write("  public " + getName() + "() {\n");
@@ -745,7 +741,7 @@ public class JRecord extends JCompType {
 
     public static String getCsharpFQName(String name) {
         String[] packages = name.split("\\.");
-        StringBuffer fQName = new StringBuffer();
+        StringBuilder fQName = new StringBuilder();
         for (int i = 0; i < packages.length; i++) {
             String pack = packages[i];
             pack = capitalize(pack);

--- a/src/java/main/org/apache/jute/compiler/JavaGenerator.java
+++ b/src/java/main/org/apache/jute/compiler/JavaGenerator.java
@@ -21,7 +21,6 @@ package org.apache.jute.compiler;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 
 /**
  * Java Code generator front-end for Hadoop record I/O.
@@ -49,8 +48,7 @@ class JavaGenerator {
      * JRecord, since one file is generated for each record.
      */
     void genCode() throws IOException {
-        for (Iterator<JRecord> i = mRecList.iterator(); i.hasNext(); ) {
-            JRecord rec = i.next();
+        for (JRecord rec : mRecList) {
             rec.genJavaCode(outputDirectory);
         }
     }

--- a/src/java/main/org/apache/zookeeper/KeeperException.java
+++ b/src/java/main/org/apache/zookeeper/KeeperException.java
@@ -342,7 +342,7 @@ public abstract class KeeperException extends Exception {
         OPERATIONTIMEOUT (OperationTimeout),
         /** Invalid arguments */
         BADARGUMENTS (BadArguments),
-        /** No quorum of new config is connected and up-to-date with the leader of last commmitted config - try 
+        /** No quorum of new config is connected and up-to-date with the leader of last committed config - try
          *  invoking reconfiguration after new servers are connected and synced */
         NEWCONFIGNOQUORUM (NewConfigNoQuorum),
         /** Another reconfiguration is in progress -- concurrent reconfigs not supported (yet) */

--- a/src/java/test/org/apache/jute/BinaryInputArchiveTest.java
+++ b/src/java/test/org/apache/jute/BinaryInputArchiveTest.java
@@ -38,7 +38,7 @@ public class BinaryInputArchiveTest {
             Assert.fail("Should have thrown an IOException");
         } catch (IOException e) {
             Assert.assertTrue("Not 'Unreasonable length' exception: " + e,
-                    e.getMessage().startsWith(BinaryInputArchive.UNREASONBLE_LENGTH));
+                    e.getMessage().startsWith(BinaryInputArchive.UNREASONABLE_LENGTH));
         }
     }
 }


### PR DESCRIPTION
* Fix spell issues
* Simplify `return` clause
* Using enhanced `for` loop
* Using `try` clause to release the resource of stream
* Remove unnecessary `new Class[]{...}` boxing
* Remove unnecessary `return` clause
* Remove unnecessary `import`
* Remove unnecessary `;` in `try(...)` clause