### PR TITLE
ZOOKEEPER-2807: Flaky test: org.apache.zookeeper.test.WatchEventWhenAutoResetTest.testNodeDataChanged

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/CommitProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/CommitProcessor.java
@@ -263,7 +263,6 @@ public class CommitProcessor extends ZooKeeperCriticalThread implements
         Request request = committedRequests.peek();
 
         if (request == null) {
-            committedRequests.poll();
             throw new IOException("Error: committed head is null");
         }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -625,6 +625,8 @@ public class Learner {
             // New server type need to handle in-flight packets
             throw new UnsupportedOperationException("Unknown server type");
         }
+
+        zk.waitForCommits();
     }
     
     protected void revalidate(QuorumPacket qp) throws IOException {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerZooKeeperServer.java
@@ -177,4 +177,8 @@ public abstract class LearnerZooKeeperServer extends QuorumZooKeeperServer {
                     e);
         }
     }
+
+    public void waitForCommits() throws InterruptedException {
+        commitProcessor.waitForCommittedRequests();
+    }
 }

--- a/zookeeper-server/src/test/resources/findbugsExcludeFile.xml
+++ b/zookeeper-server/src/test/resources/findbugsExcludeFile.xml
@@ -149,6 +149,18 @@
     </Or>
   </Match>
 
+  <!-- We perform synchronization on a LinkedBlockingQueue in order to track when it becomes empty
+       See: ZOOKEEPER-2807-->
+  <Match>
+     <Class name="org.apache.zookeeper.server.quorum.CommitProcessor"/>
+     <Bug code="JLM"/>
+     <Or>
+         <Method name="halt" />
+         <Method name="run" />
+         <Method name="waitForCommittedRequests" />
+     </Or>
+  </Match>
+
   <!-- Synchronize on the AtomicInteger to do wait/notify, but not relying
        on the synchronization to control the AtomicInteger value update,
        so it's not a problem -->
@@ -163,8 +175,6 @@
     <Bug code="JLM" />
     <Method name="doWork" />
   </Match>
-
-
 
   <Match>
     <Class name="org.apache.zookeeper.server.quorum.QuorumPeer"/>


### PR DESCRIPTION
This failure appears to be related to ZOOKEEPER-2024. When a follower is syncing with the leader and logging "the stuff that came in between the snapshot and the uptodate" we do not wait for those commits to hit the db before starting the follower.

In 3.6, we now have two separate queues in the CommitProcessor, it is possible that the follower can serve requests before all of the commits from the leader have been applied. In the case of this test failure we can set a watch in between a create and delete call. This patch makes sure that the "delete" call will be committed before attempting to handle a client's watcher request.

Would be interested in your review @shralex 