### PR TITLE
ZOOKEEPER-2837: Add a special START_SERVER_JVMFLAGS option only for `start` command to distinguish JVMFLAGS and SERVER_JVMFLAGS

### DIFF
--- a/bin/zkServer.sh
+++ b/bin/zkServer.sh
@@ -155,10 +155,11 @@ start)
          exit 1
       fi
     fi
+    # Add a special START_SERVER_JVMFLAGS option only for `start` command to distinguish JVMFLAGS and SERVER_JVMFLAGS
     nohup "$JAVA" $ZOO_DATADIR_AUTOCREATE "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" \
     "-Dzookeeper.log.file=${ZOO_LOG_FILE}" "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" \
     -XX:+HeapDumpOnOutOfMemoryError -XX:OnOutOfMemoryError='kill -9 %p' \
-    -cp "$CLASSPATH" $JVMFLAGS $ZOOMAIN "$ZOOCFG" > "$_ZOO_DAEMON_OUT" 2>&1 < /dev/null &
+    -cp "$CLASSPATH" $JVMFLAGS $START_SERVER_JVMFLAGS $ZOOMAIN "$ZOOCFG" > "$_ZOO_DAEMON_OUT" 2>&1 < /dev/null &
     if [ $? -eq 0 ]
     then
       case "$OSTYPE" in
@@ -196,13 +197,13 @@ start-foreground)
     "${ZOO_CMD[@]}" $ZOO_DATADIR_AUTOCREATE "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" \
     "-Dzookeeper.log.file=${ZOO_LOG_FILE}" "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" \
     -XX:+HeapDumpOnOutOfMemoryError -XX:OnOutOfMemoryError='kill -9 %p' \
-    -cp "$CLASSPATH" $JVMFLAGS $ZOOMAIN "$ZOOCFG"
+    -cp "$CLASSPATH" $JVMFLAGS $START_SERVER_JVMFLAGS $ZOOMAIN "$ZOOCFG"
     ;;
 print-cmd)
     echo "\"$JAVA\" $ZOO_DATADIR_AUTOCREATE -Dzookeeper.log.dir=\"${ZOO_LOG_DIR}\" \
     -Dzookeeper.log.file=\"${ZOO_LOG_FILE}\" -Dzookeeper.root.logger=\"${ZOO_LOG4J_PROP}\" \
     -XX:+HeapDumpOnOutOfMemoryError -XX:OnOutOfMemoryError='kill -9 %p' \
-    -cp \"$CLASSPATH\" $JVMFLAGS $ZOOMAIN \"$ZOOCFG\" > \"$_ZOO_DAEMON_OUT\" 2>&1 < /dev/null"
+    -cp \"$CLASSPATH\" $JVMFLAGS $START_SERVER_JVMFLAGS $ZOOMAIN \"$ZOOCFG\" > \"$_ZOO_DAEMON_OUT\" 2>&1 < /dev/null"
     ;;
 stop)
     echo -n "Stopping zookeeper ... "


### PR DESCRIPTION
Add a special START_SERVER_JVMFLAGS option only for `start` command to distinguish JVMFLAGS and SERVER_JVMFLAGS.

If we use the normal way to add JVM options with `JVMFLAGS` in `conf/java.env`, then it will effect almost all shell scripts under `bin` directory. Even if using `SERVER_JVMFLAGS` will effect some commands like `zkServer.sh status`, include four-letters commands.

For example, if the JVMFLAGS is 
```bash
export JVMFLAGS="-Xms3G -Xmx3G -Xmn1G -XX:+AlwaysPreTouch -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+PrintGCDetails -XX:-PrintGCTimeStamps -Xloggc:/home/zookeeper/logs/zookeeper_`date '+%Y%m%d%H%M%S'`.gc -XX:-UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=64M"
```
then we will get too many GC log files due to using the `mntr` four-letters command regularly  in some monitor situations.
```bash
$ ls ~/logs
zookeeper_20170704175942.gc
zookeeper_20170704180101.gc
zookeeper_20170704180201.gc
zookeeper_20170704180301.gc
zookeeper_20170704180401.gc
...
```