### PR TITLE
ZOOKEEPER-2811: PurgeTxnLog#validateAndGetFile: return tag has no argument.

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/PurgeTxnLog.java
+++ b/src/java/main/org/apache/zookeeper/server/PurgeTxnLog.java
@@ -209,7 +209,7 @@ public class PurgeTxnLog {
      * error and usage and then exits
      *
      * @param number
-     * @return
+     * @return count
      */
     private static int validateAndGetCount(String number) {
         int result = 0;


### PR DESCRIPTION
With this fix branch-3.4 pre-commit should generate a green build when all unit tests pass.