### PR TITLE
ZOOKEEPER-2842:Optimize the finish() of Send/RecvWorker in QuorumCnxManager

### DIFF
--- a/src/java/test/org/apache/zookeeper/test/CnxManagerTest.java
+++ b/src/java/test/org/apache/zookeeper/test/CnxManagerTest.java
@@ -131,8 +131,9 @@ public class CnxManagerTest extends ZKTestCase {
                     failed = true;
                     return;
                 }
-
-                cnxManager.testInitiateConnection(sid);
+                Socket socket = new Socket();
+                cnxManager.establishConnection(sid, socket);
+                cnxManager.initiateConnection(sid, socket);
 
                 m = cnxManager.pollRecvQueue(3000, TimeUnit.MILLISECONDS);
                 if(m == null){


### PR DESCRIPTION
1.    the **finish()** of **Send/RecvWorker** in **QuorumCnxManager** changes to [**double-checked lock**](https://en.wikipedia.org/wiki/Double-checked_locking) style 
     ,a trivial code changes implement a smaller granularity lock to have a better perfermance in too fierce multithread situation. 
2.    **testInitiateConnection()** is redundant test function which is only used in TestCase,so I refactor it.  
3.    some codes don't abide to Java Programme Specification ,so I lift a finger to format them