### PR TITLE
ZOOKEEPER-1669: Operations to server will be timed-out while thousands of sessions expired same time

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -287,18 +287,13 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
         if (LOG.isDebugEnabled()) {
             LOG.debug("closeSession sessionid:0x" + sessionId);
         }
-        NettyServerCnxn[] allCnxns = null;
-        synchronized (cnxns) {
-            allCnxns = cnxns.toArray(new NettyServerCnxn[cnxns.size()]);
-        }
-        for (NettyServerCnxn cnxn : allCnxns) {
-            if (cnxn.getSessionId() == sessionId) {
-                try {
-                    cnxn.close();
-                } catch (Exception e) {
-                    LOG.warn("exception during session close", e);
-                }
-                break;
+
+        NettyServerCnxn cnxn = (NettyServerCnxn) sessionMap.remove(sessionId);
+        if (cnxn != null) {
+            try {
+                cnxn.close();
+            } catch (Exception e) {
+                LOG.warn("exception during session close", e);
             }
         }
     }
@@ -398,6 +393,28 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
                 }
                 s.add(cnxn);
                 ipMap.put(addr,s);
+            }
+        }
+    }
+
+    public void removeCnxn(ServerCnxn cnxn) {
+        synchronized(cnxns){
+            // if this is not in cnxns then it's already closed
+            if (!cnxns.remove(cnxn)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("cnxns size:" + cnxns.size());
+                }
+                return;
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("close in progress for sessionid:0x"
+                        + Long.toHexString(cnxn.getSessionId()));
+            }
+
+            synchronized (ipMap) {
+                Set<NettyServerCnxn> s =
+                        ipMap.get(cnxn.getSocketAddress());
+                s.remove(cnxn);
             }
         }
     }

--- a/src/java/main/org/apache/zookeeper/server/ServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/ServerCnxn.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.server;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -100,6 +101,11 @@ public abstract class ServerCnxn implements Stats, Watcher {
     abstract void disableRecv();
 
     abstract void setSessionTimeout(int sessionTimeout);
+
+    /**
+     * Wrapper method to return the socket address
+     */
+    public abstract InetAddress getSocketAddress();
 
     protected ZooKeeperSaslServer zooKeeperSaslServer = null;
 

--- a/src/java/main/org/apache/zookeeper/server/ServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/ServerCnxnFactory.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginException;
@@ -47,6 +48,10 @@ public abstract class ServerCnxnFactory {
     }
     
     private static final Logger LOG = LoggerFactory.getLogger(ServerCnxnFactory.class);
+
+    // sessionMap is used to speed up closeSession()
+    protected final ConcurrentMap<Long, ServerCnxn> sessionMap =
+            new ConcurrentHashMap<Long, ServerCnxn>();
 
     /**
      * The buffer will cause the connection to be close when we do a send.
@@ -156,6 +161,10 @@ public abstract class ServerCnxnFactory {
             }
         }
 
+    }
+
+    public void addSession(long sessionId, ServerCnxn cnxn) {
+        sessionMap.put(sessionId, cnxn);
     }
 
     /**


### PR DESCRIPTION
The issue is raised while tens thousands of clients try to reconnect ZooKeeper service. Actually, we came across the issue during maintaining our HBase cluster, which used a 5-server ZooKeeper cluster. The HBase cluster was composed of many many regionservers (in thousand order of magnitude), and connected by tens thousands of clients to do massive reads/writes. Because the r/w throughput is very high, ZooKeeper zxid increased quickly as well. Basically, each two or three weeks, Zookeeper would make leader relection triggered by the zxid roll over. The leader relection will cause the clients(HBase regionservers and HBase clients) disconnected and reconnected with Zookeeper servers in the mean time, and try to renew the sessions.

In current implementation of session renew, NIOServerCnxnFactory will clone all the connections at first in order to avoid race condition in multi-threads and go iterate the cloned connection set one by one to find the related session to renew. It's very time consuming. In our case (described above), it caused many region servers can't successfully renew session before session timeout, and eventually the HBase cluster lose these region servers and affect the HBase stability.

The change is to make refactoring to the close session logic and introduce a ConcurrentHashMap to store session id and connection map relation, which is a thread-safe data structure and eliminate the necessary to clone the connection set at first.