### PR TITLE
ZOOKEEPER-2856 ZooKeeperSaslClient#respondToServer should log exception

### DIFF
--- a/src/java/main/org/apache/zookeeper/client/ZooKeeperSaslClient.java
+++ b/src/java/main/org/apache/zookeeper/client/ZooKeeperSaslClient.java
@@ -361,7 +361,7 @@ public class ZooKeeperSaslClient {
                 }
             } catch (SaslException e) {
                 LOG.error("SASL authentication failed using login context '" +
-                        this.getLoginContext() + "'.");
+                        this.getLoginContext() + "' with exception: {}", e);
                 saslState = SaslState.FAILED;
                 gotLastPacket = true;
             }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/ZOOKEEPER-2856 for details.

When upstream like HBase call ZooKeeperSaslClient with security enabled, we sometimes get error in HBase logs like:
`SASL authentication failed using login context 'Client'.`
This error occures when getting SaslException in ZooKeeperSaslClient#respondToServer :
`catch (SaslException e) {`
                `LOG.error("SASL authentication failed using login context '" +`
                       ` this.getLoginContext() + "'.");`
                `saslState = SaslState.FAILED;`
                `gotLastPacket = true;`
`  }`
This error makes user confused without explicit exception message. So I think we can add exception message to the log.

The patch uses  parameterized logging to add the exception message to the log.