### PR TITLE
ZOOKEEPER-2471: ZK Java client should not count sleep time as connect time

### DIFF
--- a/src/java/main/org/apache/zookeeper/ClientCnxn.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxn.java
@@ -1118,7 +1118,6 @@ public class ClientCnxn {
         @Override
         public void run() {
             clientCnxnSocket.introduce(this, sessionId, outgoingQueue);
-            clientCnxnSocket.updateNow();
             clientCnxnSocket.updateLastSendAndHeard();
             int to;
             long lastPingRwServer = Time.currentElapsedTime();
@@ -1249,7 +1248,6 @@ public class ClientCnxn {
                                     Event.KeeperState.Disconnected,
                                     null));
                         }
-                        clientCnxnSocket.updateNow();
                         clientCnxnSocket.updateLastSendAndHeard();
                     }
                 }

--- a/src/java/main/org/apache/zookeeper/ClientCnxnSocket.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxnSocket.java
@@ -82,11 +82,11 @@ abstract class ClientCnxnSocket {
     }
 
     int getIdleRecv() {
-        return (int) (System.currentTimeMillis() - lastHeard);
+        return (int) (Time.currentElapsedTime() - lastHeard);
     }
 
     int getIdleSend() {
-        return (int) (System.currentTimeMillis() - lastSend);
+        return (int) (Time.currentElapsedTime() - lastSend);
     }
 
     long getSentCount() {
@@ -98,15 +98,15 @@ abstract class ClientCnxnSocket {
     }
 
     void updateLastHeard() {
-        this.lastHeard = System.currentTimeMillis();
+        this.lastHeard = Time.currentElapsedTime();
     }
 
     void updateLastSend() {
-        this.lastSend = System.currentTimeMillis();
+        this.lastSend = Time.currentElapsedTime();
     }
 
     void updateLastSendAndHeard() {
-        long now = System.currentTimeMillis();
+        long now = Time.currentElapsedTime();
         this.lastSend = now;
         this.lastHeard = now;
     }

--- a/src/java/main/org/apache/zookeeper/ClientCnxnSocket.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxnSocket.java
@@ -63,7 +63,6 @@ abstract class ClientCnxnSocket {
     protected long recvCount = 0;
     protected long lastHeard;
     protected long lastSend;
-    protected long now;
     protected ClientCnxn.SendThread sendThread;
     protected LinkedBlockingDeque<Packet> outgoingQueue;
     protected ZKClientConfig clientConfig;
@@ -82,16 +81,12 @@ abstract class ClientCnxnSocket {
         this.outgoingQueue = outgoingQueue;
     }
 
-    void updateNow() {
-        now = Time.currentElapsedTime();
-    }
-
     int getIdleRecv() {
-        return (int) (now - lastHeard);
+        return (int) (System.currentTimeMillis() - lastHeard);
     }
 
     int getIdleSend() {
-        return (int) (now - lastSend);
+        return (int) (System.currentTimeMillis() - lastSend);
     }
 
     long getSentCount() {
@@ -103,14 +98,15 @@ abstract class ClientCnxnSocket {
     }
 
     void updateLastHeard() {
-        this.lastHeard = now;
+        this.lastHeard = System.currentTimeMillis();
     }
 
     void updateLastSend() {
-        this.lastSend = now;
+        this.lastSend = System.currentTimeMillis();
     }
 
     void updateLastSendAndHeard() {
+        long now = System.currentTimeMillis();
         this.lastSend = now;
         this.lastHeard = now;
     }

--- a/src/java/main/org/apache/zookeeper/ClientCnxnSocketNIO.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxnSocketNIO.java
@@ -347,10 +347,6 @@ public class ClientCnxnSocketNIO extends ClientCnxnSocket {
         synchronized (this) {
             selected = selector.selectedKeys();
         }
-        // Everything below and until we get back to the select is
-        // non blocking, so time is effectively a constant. That is
-        // Why we just have to do this once, here
-        updateNow();
         for (SelectionKey k : selected) {
             SocketChannel sc = ((SocketChannel) k.channel());
             if ((k.readyOps() & SelectionKey.OP_CONNECT) != 0) {


### PR DESCRIPTION
ClientCnxnSocket uses a member variable "now" to track the current time, but does not update it at all potentially-blocking times: in particular, it does not update it after the random sleep introduced if an initial connect attempt fails. This results in the random sleep time being counted towards connect time, resulting in incorrect application of connection timeout currently, and if ZOOKEEPER-2869 is taken, a very real possibility (we have seen it in production) of wedging the Zookeeper client so that it can never successfully reconnect, because its sleep time may grow beyond its connection timeout, especially in scenarios where there is a big gap between negotiated session timeout and client-requested session timeout.

Rather than fixing the bug by adding another "updateNow()" call, keeping the brittle "updateNow()" implementation which led to the bug in the first place, I have deleted updateNow() and replaced usage of that member variable with actually getting the current system timestamp whenever the implementation needs to know the current time.

Regarding unit testing, this is, IMO, too difficult to test without introducing a lot of invasive changes to ClientCnxn.java, seeing as the only effective change is that, on connection retry, the random sleep time is no longer counted towards a time budget. I can throw a lot of mocks at this, like ClientReconnectTest, but I'm still going to be stuck depending on the behavior of that randomly-generated sleep time, which is going to be inherently unreliable. If a fix is taken for ZOOKEEPER-2869, this should become much easier to test, since I will then be able to inject a different backoff sleep behavior, and since I'm planning to submit a pull request for that ticket as well, so maybe as a compromise I can submit a test for this bug fix at that time?