### PR TITLE
ZOOKEEPER-2874: Windows Debug builds don't link with `/MTd`

### DIFF
--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -40,7 +40,9 @@ option(WANT_SYNCAPI "Enables Sync API support" ON)
 if(WANT_SYNCAPI)
   add_definitions(-DTHREADED)
   if(WIN32)
-    add_compile_options(/MT)
+    # Note that the generator expression ensures that `/MTd` is used when Debug
+    # configurations are built.
+    add_compile_options(/MT$<$<CONFIG:Debug>:d>)
   endif()
 endif()
 


### PR DESCRIPTION
When building in Debug configuration, this logic ensures that `/MTd` is
used instead of just `/MT`, which on Windows means to link to the
multi-threaded (debug) version of the standard library.

When the user does not add `/MT` as a compile option manually, CMake
would otherwise link to the correct one. Because we are overriding it
for threaded compilations, we also must ensure that Debug configurations
are specially handled.

Furthermore, this must be done using a generator expression over
configuration time logic because the Visual Studio CMake generators are
"multi-configuration generators", that is, the configuration is chosen
at build time instead of compile time. The generator expression handles
this scenario, but checking `CMAKE_BUILD_TYPE` would not.