### PR TITLE
ZOOKEEPER-2875: Add ant task for running OWASP dependency report

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1528,6 +1528,29 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
                classpathref="releaseaudit-classpath"/>
     </target>
 
+    <target name="owasp-taskdef" depends="ivy-retrieve-releaseaudit">
+        <typedef format="properties" resource="dependency-check-taskdefs.properties" uri="antlib:org.owasp.dependencycheck.anttasks" classpathref="releaseaudit-classpath"/>
+    </target>
+
+    <target name="owasp" depends="owasp-taskdef,ivy-retrieve" description="OWASP dependency check">
+        <property name="owasp.out.dir" value="${test.java.build.dir}/owasp" />
+
+        <owasp:dependency-check xmlns:owasp="antlib:org.owasp.dependencycheck.anttasks"
+                          projectname="ZooKeeper"
+                          reportoutputdirectory="${owasp.out.dir}"
+                          reportformat="ALL"
+                          failBuildOnCVSS="0">
+
+            <fileset dir="${ivy.lib}">
+                <include name="**/*.jar"/>
+            </fileset>
+
+            <fileset dir="${lib.dir}">
+                <include name="**/*.jar"/>
+            </fileset>
+        </owasp:dependency-check>
+    </target>
+
     <target name="releaseaudit" depends="package,rats-taskdef" description="Release Audit activities">
       <rat:report xmlns:rat="antlib:org.apache.rat.anttasks">
         <fileset dir="${dist.dir}">

--- a/ivy.xml
+++ b/ivy.xml
@@ -77,6 +77,8 @@
                 rev="2.6" conf="releaseaudit->default"/>
     <dependency org="commons-collections" name="commons-collections" 
                 rev="3.2.2" conf="releaseaudit->default"/>
+    <dependency org="org.owasp" name="dependency-check-ant"
+                rev="2.1.0" conf="releaseaudit->default"/>
 
     <dependency org="net.java.dev.javacc" name="javacc" rev="5.0"
                 conf="javacc->default" />


### PR DESCRIPTION
Simply run `ant owasp` and a report will be placed in `build/test/owasp`. The task will return a nonzero status code if there are any vulnerabilities in any of the dependencies. 