### PR TITLE
ZOOKEEPER-2777: There is a typo in zk.py which prevents from using/compiling it.

### DIFF
--- a/src/contrib/zkpython/src/python/zk.py
+++ b/src/contrib/zkpython/src/python/zk.py
@@ -52,7 +52,7 @@ except:
     pass
 
 def pp_zk(handle,root, indent = 0):
-    """Pretty print(a zookeeper tree, starting at root""")
+    """Pretty print(a zookeeper tree, starting at root)"""
     def make_path(child):
         if root == "/":
             return "/" + child


### PR DESCRIPTION
ZOOKEEPER-2777: There is a typo in zk.py which prevents from using/compiling it.