### PR TITLE
ZOOKEEPER-2349:Update documentation for snapCount

### DIFF
--- a/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
@@ -823,10 +823,10 @@ server.3=zoo3:2888:3888</programlisting>
               role="bold">zookeeper.snapCount</emphasis>)</para>
 
               <para>ZooKeeper logs transactions to a transaction
-              log. After snapCount transactions are written to a log
-              file a snapshot is started and a new transaction log
-              file is created. The default snapCount is
-              100,000.</para>
+              log. After the count of transactions which are written to a log
+              file exceed a runtime-set limit in [snapCount/2, snapCount),a snapshot 
+              is started and a new transaction log file is created. 
+              The default snapCount is 100,000.</para>
             </listitem>
           </varlistentry>
 

--- a/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
@@ -822,11 +822,15 @@ server.3=zoo3:2888:3888</programlisting>
               <para>(Java system property: <emphasis
               role="bold">zookeeper.snapCount</emphasis>)</para>
 
-              <para>ZooKeeper logs transactions to a transaction
-              log. After the count of transactions which are written to a log
-              file exceed a runtime-set limit in [snapCount/2, snapCount),a snapshot 
-              is started and a new transaction log file is created. 
-              The default snapCount is 100,000.</para>
+              <para>ZooKeeper records its transactions using snapshots and
+              a transaction log (think write-ahead log).The number of
+              transactions recorded in the transaction log before a snapshot
+              can be taken (and the transaction log rolled) is determined
+              by snapCount. In order to prevent all of the machines in the quorum
+              from taking a snapshot at the same time, each ZooKeeper server
+              will take a snapshot when the number of transactions in the transaction log
+              reaches a runtime generated random value in the [snapCount/2+1, snapCount] 
+              range.The default snapCount is 100,000.</para>
             </listitem>
           </varlistentry>
 


### PR DESCRIPTION
Origin patch can not apply now and it has something inaccurate.so I give it a new PR.
more details in [JIRA](https://issues.apache.org/jira/browse/ZOOKEEPER-2349)