### PR TITLE
ZOOKEEPER-915: Error get propagated back to the client

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/Follower.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Follower.java
@@ -164,7 +164,7 @@ public class Follower extends Learner{
             revalidate(qp);
             break;
         case Leader.SYNC:
-            fzk.sync();
+            fzk.sync((int)qp.getZxid());
             break;
         default:
             LOG.warn("Unknown packet type: {}", LearnerHandler.packetToString(qp));

--- a/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.jute.BinaryOutputArchive;
+import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.ZooDefs.OpCode;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.server.FinalRequestProcessor;
@@ -1115,9 +1116,14 @@ public class Leader {
      * @param f
      * @param r
      */
-
-    public void sendSync(LearnerSyncRequest r){
-        QuorumPacket qp = new QuorumPacket(Leader.SYNC, 0, null, null);
+    public void sendSync(LearnerSyncRequest r) {
+        int err = 0;
+        if (r.getException() != null ) {
+            err = r.getException().code().intValue();
+        } else {
+            err = Code.OK.intValue();
+        }
+        QuorumPacket qp = new QuorumPacket(Leader.SYNC, err, null, null);
         r.fh.queuePacket(qp);
     }
 

--- a/src/java/main/org/apache/zookeeper/server/quorum/Observer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Observer.java
@@ -116,7 +116,7 @@ public class Observer extends Learner{
             revalidate(qp);
             break;
         case Leader.SYNC:
-            ((ObserverZooKeeperServer)zk).sync();
+            ((ObserverZooKeeperServer) zk).sync((int) qp.getZxid());
             break;
         case Leader.INFORM:
             TxnHeader hdr = new TxnHeader();

--- a/src/java/main/org/apache/zookeeper/server/quorum/ObserverZooKeeperServer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/ObserverZooKeeperServer.java
@@ -20,6 +20,8 @@ package org.apache.zookeeper.server.quorum;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.KeeperException.Code;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.server.FinalRequestProcessor;
@@ -115,13 +117,16 @@ public class ObserverZooKeeperServer extends LearnerZooKeeperServer {
     /*
      * Process a sync request
      */
-    synchronized public void sync(){
+    synchronized public void sync(int rc) {
         if(pendingSyncs.size() ==0){
             LOG.warn("Not expecting a sync.");
             return;
         }
-                
         Request r = pendingSyncs.remove();
+        if (rc != Code.OK.intValue()) {
+            KeeperException ke = KeeperException.create(Code.get(rc));
+            r.setException(ke);
+        }
         commitProcessor.commit(r);
     }
     


### PR DESCRIPTION
If an error in sync() processing happens at the leader (SESSION_MOVED for example), they are not propagated back to the client. And use QuorumPacket::Zxid indicates  the exception happens or not.