### PR TITLE
ZOOKEEPER-2809: Unnecessary stack-trace in server when the client dis…

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -374,6 +374,9 @@ public class NIOServerCnxn extends ServerCnxn {
             close();
         } catch (EndOfStreamException e) {
             LOG.warn(e.getMessage());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("EndOfStreamException stack trace", e);
+            }
             // expecting close to log session closure
             close();
         } catch (IOException e) {

--- a/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -363,9 +363,8 @@ public class NIOServerCnxn extends ServerCnxn {
                 }
             }
         } catch (CancelledKeyException e) {
-            LOG.warn("Exception causing close of session 0x"
-                    + Long.toHexString(sessionId)
-                    + " due to " + e);
+            LOG.warn("CancelledKeyException causing close of session 0x"
+                     + Long.toHexString(sessionId));
             if (LOG.isDebugEnabled()) {
                 LOG.debug("CancelledKeyException stack trace", e);
             }
@@ -374,14 +373,12 @@ public class NIOServerCnxn extends ServerCnxn {
             // expecting close to log session closure
             close();
         } catch (EndOfStreamException e) {
-            LOG.warn("caught end of stream exception",e); // tell user why
-
+            LOG.warn(e.getMessage());
             // expecting close to log session closure
             close();
         } catch (IOException e) {
             LOG.warn("Exception causing close of session 0x"
-                    + Long.toHexString(sessionId)
-                    + " due to " + e);
+                     + Long.toHexString(sessionId) + ": " + e.getMessage());
             if (LOG.isDebugEnabled()) {
                 LOG.debug("IOException stack trace", e);
             }


### PR DESCRIPTION
Unnecessary stack-trace in server when the client disconnects unexpectedly.

Backport from master, branch-3.5 to branch-3.4. Removes unnecessary stack traces from the catch blocks of method doIO in NIOServerCnxn. For EndOfStreamException stack trace is replaced with logging only the message and also contains the removal of stack traces for exceptions CancelledKeyException and IOException as per commit 6206b495 referenced in the ticket.
This change is necessary as there are projects which consider all stack traces as bugs. 
For CancelledKeyException and IOException developers are still able to see stack traces at log level Debug.
This change is in sync with master and branch-3.5.
