### PR TITLE
ZOOKEEPER-2887: define dependency versions in build.xml to be easily …

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -222,6 +222,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
 
     <property name="jetty.version" value="9.2.18.v20160721"/>
     <property name="jackson-mapper-asl.version" value="1.9.11"/>
+    <property name="dependency-check-ant.version" value="2.1.0"/>
 
     <!-- ====================================================== -->
     <!-- Macro definitions                                      -->

--- a/build.xml
+++ b/build.xml
@@ -123,8 +123,6 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="ivy.javacc.lib" value="${build.dir}/javacc/lib"/>
     <property name="ivysettings.xml" value="${basedir}/ivysettings.xml"/>
 
-    <property name="audience-annotations.version" value="0.5.0" />
-
     <property name="mvnrepo" value="https://repo1.maven.org/maven2"/>
     <property name="tsk.org" value="/org/apache/maven/maven-ant-tasks/"/>
     <property name="ant-task.version" value="2.1.3"/>
@@ -193,6 +191,37 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="tests-jar" value="${dist.maven.dir}/${final.name}-tests.jar"/>
     <property name="sources-jar" value="${dist.maven.dir}/${final.name}-sources.jar"/>
     <property name="javadoc-jar" value="${dist.maven.dir}/${final.name}-javadoc.jar"/>
+
+    <!-- ====================================================== -->
+    <!-- Dependency versions                                    -->
+    <!-- ====================================================== -->
+    <property name="slf4j.version" value="1.7.5"/>
+    <property name="commons-cli.version" value="1.2"/>
+
+    <property name="wagon-http.version" value="2.4"/>
+    <property name="maven-ant-tasks.version" value="2.1.3"/>
+    <property name="log4j.version" value="1.2.17"/>
+    <property name="jline.version" value="2.11"/>
+
+    <property name="audience-annotations.version" value="0.5.0" />
+
+    <property name="netty.version" value="3.10.5.Final"/>
+
+    <property name="junit.version" value="4.12"/>
+    <property name="mockito.version" value="1.8.2"/>
+    <property name="checkstyle.version" value="6.13"/>
+    <property name="commons-collections.version" value="3.2.2"/>
+
+    <property name="jdiff.version" value="1.0.9"/>
+    <property name="xerces.version" value="1.4.4"/>
+
+    <property name="apache-rat-tasks.version" value="0.10"/>
+    <property name="commons-lang.version" value="2.6"/>
+
+    <property name="javacc.version" value="5.0"/>
+
+    <property name="jetty.version" value="9.2.18.v20160721"/>
+    <property name="jackson-mapper-asl.version" value="1.9.11"/>
 
     <!-- ====================================================== -->
     <!-- Macro definitions                                      -->

--- a/ivy.xml
+++ b/ivy.xml
@@ -41,51 +41,55 @@
   </publications>
 
   <dependencies>
-    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5"/>
-    <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.7.5" transitive="false"/>
-    <dependency org="commons-cli" name="commons-cli" rev="1.2" />
+    <dependency org="org.slf4j" name="slf4j-api" rev="${slf4j.version}"/>
+    <dependency org="org.slf4j" name="slf4j-log4j12" rev="${slf4j.version}" transitive="false"/>
+    <dependency org="commons-cli" name="commons-cli" rev="${commons-cli.version}" />
   
-    <dependency org="org.apache.maven.wagon" name="wagon-http" rev="2.4" conf="mvn-ant-task->default"/>
-    <dependency org="org.apache.maven" name="maven-ant-tasks" rev="2.1.3" conf="mvn-ant-task->master"/>
+    <dependency org="org.apache.maven.wagon" name="wagon-http" rev="${wagon-http.version}"
+                conf="mvn-ant-task->default"/>
+    <dependency org="org.apache.maven" name="maven-ant-tasks" rev="${maven-ant-tasks.version}"
+                conf="mvn-ant-task->master"/>
     <!-- transitive false turns off dependency checking, log4j deps seem borked -->
-    <dependency org="log4j" name="log4j" rev="1.2.17" transitive="false"/>
-    <dependency org="jline" name="jline" rev="2.11" transitive="false" conf="optional->default"/>
+    <dependency org="log4j" name="log4j" rev="${log4j.version}" transitive="false"/>
+    <dependency org="jline" name="jline" rev="${jline.version}" transitive="false"
+                conf="optional->default"/>
 
-    <dependency org="org.apache.yetus" name="audience-annotations" rev="${audience-annotations.version}"/>
+    <dependency org="org.apache.yetus" name="audience-annotations"
+                rev="${audience-annotations.version}"/>
 
-    <dependency org="io.netty" name="netty" conf="default" rev="3.10.5.Final">
+    <dependency org="io.netty" name="netty" conf="default" rev="${netty.version}">
       <artifact name="netty" type="jar" conf="default"/>
     </dependency>
 
-    <dependency org="junit" name="junit" rev="4.12" conf="test->default"/>
-	<dependency org="org.mockito" name="mockito-all" rev="1.8.2"
+    <dependency org="junit" name="junit" rev="${junit.version}" conf="test->default"/>
+	<dependency org="org.mockito" name="mockito-all" rev="${mockito.version}"
                conf="test->default"/>
-    <dependency org="com.puppycrawl.tools" name="checkstyle" rev="6.13"
+    <dependency org="com.puppycrawl.tools" name="checkstyle" rev="${checkstyle.version}"
                 conf="test->default"/>
     <!-- force the tests to pull the latest commons-collections jar -->
     <dependency org="commons-collections" name="commons-collections" 
-                rev="3.2.2" conf="test->default"/>
+                rev="${commons-collections.version}" conf="test->default"/>
 
-    <dependency org="jdiff" name="jdiff" rev="1.0.9"
+    <dependency org="jdiff" name="jdiff" rev="${jdiff.version}"
                 conf="jdiff->default"/>
-    <dependency org="xerces" name="xerces" rev="1.4.4"
+    <dependency org="xerces" name="xerces" rev="${xerces.version}"
                 conf="jdiff->default"/>
 
     <dependency org="org.apache.rat" name="apache-rat-tasks" 
-                rev="0.10" conf="releaseaudit->default"/>
+                rev="${apache-rat-tasks.version}" conf="releaseaudit->default"/>
     <dependency org="commons-lang" name="commons-lang" 
-                rev="2.6" conf="releaseaudit->default"/>
+                rev="${commons-lang.version}" conf="releaseaudit->default"/>
     <dependency org="commons-collections" name="commons-collections" 
-                rev="3.2.2" conf="releaseaudit->default"/>
+                rev="${commons-collections.version}" conf="releaseaudit->default"/>
 
-    <dependency org="net.java.dev.javacc" name="javacc" rev="5.0"
+    <dependency org="net.java.dev.javacc" name="javacc" rev="${javacc.version}"
                 conf="javacc->default" />
 
-    <dependency org="org.eclipse.jetty" name="jetty-server" rev="9.2.18.v20160721"
+    <dependency org="org.eclipse.jetty" name="jetty-server" rev="${jetty.version}"
                 conf="optional->default"/>
-      <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.2.18.v20160721"
+      <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="${jetty.version}"
                   conf="optional->default"/>
-    <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.11"
-                conf="optional->default"/>
+    <dependency org="org.codehaus.jackson" name="jackson-mapper-asl"
+                rev="${jackson-mapper-asl.version}" conf="optional->default"/>
   </dependencies>
 </ivy-module>

--- a/ivy.xml
+++ b/ivy.xml
@@ -81,6 +81,8 @@
                 rev="${commons-lang.version}" conf="releaseaudit->default"/>
     <dependency org="commons-collections" name="commons-collections" 
                 rev="${commons-collections.version}" conf="releaseaudit->default"/>
+    <dependency org="org.owasp" name="dependency-check-ant"
+                rev="${dependency-check-ant.version}" conf="releaseaudit->default"/>
 
     <dependency org="net.java.dev.javacc" name="javacc" rev="${javacc.version}"
                 conf="javacc->default" />


### PR DESCRIPTION
…overridden in build.properties

If the dependency versions are defined in build.xml they can be easily
overridden by re-defining them in build.properties
This process can be useful to avoid classpath clashes among different
Hadoop components