### PR TITLE
zookeeper: Use PKG_CHECK_MODULES to detect the presence of cppunit

### DIFF
--- a/src/c/configure.ac
+++ b/src/c/configure.ac
@@ -34,7 +34,7 @@ if test "$with_cppunit" = "no" ; then
    CPPUNIT_INCLUDE=
    CPPUNIT_LIBS=
 else
-   AM_PATH_CPPUNIT(1.10.2)
+   PKG_CHECK_MODULES([CPPUNIT], [cppunit >= 1.10.2])
 fi
 
 if test "$CALLER" = "ANT" ; then
@@ -130,11 +130,11 @@ main()
  else
    exit(0);
 }
-], AC_MSG_RESULT(yes) 
-   ipv6=yes, 
-   AC_MSG_RESULT(no) 
-   ipv6=no, 
-   AC_MSG_RESULT(no) 
+], AC_MSG_RESULT(yes)
+   ipv6=yes,
+   AC_MSG_RESULT(no)
+   ipv6=no,
+   AC_MSG_RESULT(no)
    ipv6=no)
 
 if test x"$ipv6" = xyes; then

--- a/src/recipes/lock/src/c/configure.ac
+++ b/src/recipes/lock/src/c/configure.ac
@@ -47,7 +47,7 @@ DX_PDF_FEATURE(OFF)
 DX_PS_FEATURE(OFF)
 DX_INIT_DOXYGEN([zookeeper-locks],[c-doc.Doxyfile],[docs])
 
-  
+
 ZOOKEEPER_PATH=${BUILD_PATH}/../../../../../src/c
 ZOOKEEPER_LD=-L${BUILD_PATH}/../../../../../src/c\ -lzookeeper_mt
 
@@ -71,8 +71,8 @@ AC_HEADER_TIME
 AC_C_VOLATILE
 AC_PROG_CC
 AC_PROG_LIBTOOL
-#check for cppunit 
-AM_PATH_CPPUNIT(1.10.2)
+#check for cppunit
+PKG_CHECK_MODULES([CPPUNIT], [cppunit >= 1.10.2])
 # Checks for library functions.
 AC_FUNC_UTIME_NULL
 AC_CHECK_FUNCS([gettimeofday memset mkdir rmdir strdup strerror strstr strtol strtoul strtoull utime])

--- a/src/recipes/queue/src/c/configure.ac
+++ b/src/recipes/queue/src/c/configure.ac
@@ -47,7 +47,7 @@ DX_PDF_FEATURE(OFF)
 DX_PS_FEATURE(OFF)
 DX_INIT_DOXYGEN([zookeeper-queues],[c-doc.Doxyfile],[docs])
 
-  
+
 ZOOKEEPER_PATH=${BUILD_PATH}/../../../../../src/c
 ZOOKEEPER_LD=-L${BUILD_PATH}/../../../../../src/c\ -lzookeeper_mt
 
@@ -71,8 +71,8 @@ AC_HEADER_TIME
 AC_C_VOLATILE
 AC_PROG_CC
 AC_PROG_LIBTOOL
-#check for cppunit 
-AM_PATH_CPPUNIT(1.10.2)
+#check for cppunit
+PKG_CHECK_MODULES([CPPUNIT], [cppunit >= 1.10.2])
 # Checks for library functions.
 AC_FUNC_UTIME_NULL
 AC_CHECK_FUNCS([gettimeofday memset mkdir rmdir strdup strerror strstr strtol strtoul strtoull utime])


### PR DESCRIPTION
Support for it has been removed from upstream, and 10+ year old
cppunit's support the newer syntax. Move on to that.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1311694