### PR TITLE
ZOOKEEPER-2814: Ignore space after comma in connection string

### DIFF
--- a/src/java/main/org/apache/zookeeper/client/ConnectStringParser.java
+++ b/src/java/main/org/apache/zookeeper/client/ConnectStringParser.java
@@ -22,6 +22,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 
 import org.apache.zookeeper.common.PathUtils;
+import static org.apache.zookeeper.common.StringUtils.split;
 
 /**
  * A parser for ZooKeeper Client connect strings.
@@ -62,7 +63,7 @@ public final class ConnectStringParser {
             this.chrootPath = null;
         }
 
-        String hostsList[] = connectString.split(",");
+        List<String> hostsList = split(connectString,",");
         for (String host : hostsList) {
             int port = DEFAULT_PORT;
             int pidx = host.lastIndexOf(':');

--- a/src/java/main/org/apache/zookeeper/common/StringUtils.java
+++ b/src/java/main/org/apache/zookeeper/common/StringUtils.java
@@ -1,0 +1,44 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.common;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Collections;
+
+public class StringUtils {
+
+    private StringUtils() {/** non instantiable and non inheritable **/}
+
+    /**
+     * This method returns an immutable List<String>, but different from String's split()
+     * it trims the results in the input String, and removes any empty string from
+     * the resulting List.
+     *
+     */
+    public static List<String> split(String value, String separator) {
+        String[] splits = value.split(separator);
+        List<String> results = new ArrayList<String>();
+        for (int i = 0; i < splits.length; i++) {
+            splits[i] = splits[i].trim();
+            if (splits[i].length() > 0) {
+               results.add(splits[i]);
+            }
+        }
+        return Collections.unmodifiableList(results);
+    }
+}

--- a/src/java/test/org/apache/zookeeper/test/ConnectStringParserTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ConnectStringParserTest.java
@@ -61,6 +61,18 @@ public class ConnectStringParserTest extends ZKTestCase{
         Assert.assertEquals(112, parser.getServerAddresses().get(0).getPort());
         Assert.assertEquals(110, parser.getServerAddresses().get(1).getPort());
     }
+    
+    @Test
+    public void testParseServersWithPort(){
+        String servers = "10.10.10.1:112,10.10.10.2:110";
+        ConnectStringParser parser = new ConnectStringParser(servers);
+
+        Assert.assertEquals("10.10.10.1", parser.getServerAddresses().get(0).getHostString());
+        Assert.assertEquals("10.10.10.2", parser.getServerAddresses().get(1).getHostString());
+
+        Assert.assertEquals(112, parser.getServerAddresses().get(0).getPort());
+        Assert.assertEquals(110, parser.getServerAddresses().get(1).getPort());
+    }
 
     private void assertChrootPath(String expected, ConnectStringParser parser){
         Assert.assertEquals(expected, parser.getChrootPath());

--- a/src/java/test/org/apache/zookeeper/test/StringUtilTest.java
+++ b/src/java/test/org/apache/zookeeper/test/StringUtilTest.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.test;
+
+
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.common.StringUtils;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class StringUtilTest extends ZKTestCase {
+
+    @Test
+    public void testStrings() {
+
+        String s1 = "   a  ,   b  , ";
+        assertEquals("[a, b]", StringUtils.split(s1, ",").toString());
+
+        String s2 = "";
+        assertEquals(0, StringUtils.split(s2, ",").size());
+
+        String s3 = "1, , 2";
+        assertEquals("[1, 2]", StringUtils.split(s3, ",").toString());
+
+    }
+}


### PR DESCRIPTION
Ported ZOOKEEPER-2814 from master to branch 3.4.

Added files 
 src/java/main/org/apache/zookeeper/common/StringUtils.java
src/java/test/org/apache/zookeeper/test/StringUtilTest.java

Modified Files:
src/java/main/org/apache/zookeeper/client/ConnectStringParser.java
src/java/test/org/apache/zookeeper/test/ConnectStringParserTest.java
