### PR TITLE
ZOOKEEPER-2896: Remove unused imports from org.apache.zookeeper.test.CreateTest.java

### DIFF
--- a/src/java/test/org/apache/zookeeper/test/CreateTest.java
+++ b/src/java/test/org/apache/zookeeper/test/CreateTest.java
@@ -18,14 +18,9 @@
 package org.apache.zookeeper.test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.AsyncCallback.Create2Callback;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.data.Stat;
 import org.junit.Assert;


### PR DESCRIPTION
Remove unused imports from org.apache.zookeeper.test.CreateTest.java
Following imports are not used in the code and do not adhere to code convention and style.
import java.util.ArrayList;
import java.util.Collections;
import java.util.List;
import org.apache.zookeeper.AsyncCallback.Create2Callback;