### PR TITLE
ZOOKEEPER-2905: Don't include `config.h` in `zookeeper.h`

### DIFF
--- a/src/c/include/zookeeper.h
+++ b/src/c/include/zookeeper.h
@@ -21,13 +21,9 @@
 
 #include <stdlib.h>
 
-#include "config.h"
-
-#ifdef HAVE_SYS_SOCKET_H
+/* we must not include config.h as a public header */
+#ifndef WIN32
 #include <sys/socket.h>
-#endif
-
-#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
 

--- a/src/c/src/zookeeper.c
+++ b/src/c/src/zookeeper.c
@@ -24,6 +24,7 @@
 #define USE_IPV6
 #endif
 
+#include "config.h"
 #include <zookeeper.h>
 #include <zookeeper.jute.h>
 #include <proto.h>


### PR DESCRIPTION
In ZOOKEEPER-2841 I fixed the inclusion of project-specific porting code
that were included in the public headers, which then broke upstream
projects (in my case, Mesos).

Unfortunately, I inadvertently created a very similar problem, and it
wasn't evident until the build was coupled with another project with the
same bug. More specifically, when including ZooKeeper in Mesos, and
including Google's Glog in Mesos, both projects define the macros
`VERSION`, `PACKAGE_VERSION`, and `PACKAGE_TARNAME`, and do so publicly.
This is commonly defined in `config.h` by Autotools (and by CMake for
ZooKeeper for compatibility), and is not a problem unless included
publicly, such as in `zookeeper.h`, and by more than one project.

When refactoring, I saw two includes in `zookeeper.h` that instead of
being guarded by e.g. `#ifdef HAVE_SYS_SOCKET_H` were guarded by
`#ifndef WIN32`. I erroneously added `#include "config.h"` and guarded
the includes "properly" with a feature guard. However, configuration
files such as `config.h` and `winconfig.h` etc. must never be included
in publicly in `zookeeper.h`, for the reasons given above.

This patch reverts the bug, and instead includes `config.h` in
`zookeeper.c`, where it is not exposed to other projects.