### PR TITLE
Cmake fixes

### DIFF
--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.0)
 
 project(zookeeper VERSION 3.5.3)
 set(email user@zookeeper.apache.org)
 set(description "zookeeper C client")
 
 # general options
-include_directories(include tests generated ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 if(UNIX)
   add_compile_options(-Wall -fPIC)
 elseif(WIN32)
@@ -73,7 +72,7 @@ endfunction()
 
 # include file checks
 foreach(f generated/zookeeper.jute.h generated/zookeeper.jute.c)
-  if(EXISTS "${CMAKE_SOURCE_DIR}/${f}")
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${f}")
     to_have(${f} name)
     set(${name} 1)
   else()
@@ -145,7 +144,7 @@ include(CheckStructHasMember)
 check_struct_has_member("struct sockaddr_in6" sin6_addr "netinet/in.h" ZOO_IPV6_ENABLED)
 
 # configure
-configure_file(cmake_config.h.in ${CMAKE_SOURCE_DIR}/include/config.h)
+configure_file(cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/config.h)
 
 # hashtable library
 set(hashtable_sources src/hashtable/hashtable_itr.c src/hashtable/hashtable.c)
@@ -172,6 +171,7 @@ if(WIN32)
 endif()
 
 add_library(zookeeper STATIC ${zookeeper_sources})
+target_include_directories(zookeeper PUBLIC include ${CMAKE_CURRENT_BINARY_DIR}/include generated)
 target_link_libraries(zookeeper PUBLIC
   hashtable
   $<$<PLATFORM_ID:Linux>:rt> # clock_gettime
@@ -219,8 +219,10 @@ endif()
 
 if(WANT_CPPUNIT)
   add_executable(zktest ${test_sources})
+  target_include_directories(zktest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
   target_compile_definitions(zktest
-    PRIVATE -DZKSERVER_CMD="${CMAKE_SOURCE_DIR}/tests/zkServer.sh")
+    PRIVATE -DZKSERVER_CMD="${CMAKE_CURRENT_SOURCE_DIR}/tests/zkServer.sh")
   # TODO: Use `find_library()` for `cppunit`.
   target_link_libraries(zktest zookeeper cppunit dl)
 
@@ -237,6 +239,6 @@ if(WANT_CPPUNIT)
   enable_testing()
   add_test(NAME zktest_runner COMMAND zktest)
   set_property(TEST zktest_runner PROPERTY ENVIRONMENT
-    "ZKROOT=${CMAKE_SOURCE_DIR}/../.."
+    "ZKROOT=${CMAKE_CURRENT_SOURCE_DIR}/../.."
     "CLASSPATH=$CLASSPATH:$CLOVER_HOME/lib/clover.jar")
 endif()

--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(zookeeper VERSION 3.5.3)
 set(email user@zookeeper.apache.org)


### PR DESCRIPTION
1. decrease cmake version (to allow compile on some old systems)
2. do not use global include_directories (and auto include when linking to external projects)
3. replace CMAKE_SOURCE_DIR with CMAKE_CURRENT_SOURCE_DIR - it allow compile zookeper added to other project with add_subdirectory()