### PR TITLE
ZOOKEEPER-2887: define dependency versions in build.xml to be easily …

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -120,8 +120,6 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     <property name="ivy.owasp.lib" value="${build.dir}/owasp/lib"/>
     <property name="ivysettings.xml" value="${basedir}/ivysettings.xml"/>
 
-    <property name="audience-annotations.version" value="0.5.0" />
-
     <property name="mvnrepo" value="https://repo1.maven.org/maven2"/>
     <property name="tsk.org" value="/org/apache/maven/maven-ant-tasks/"/>
     <property name="ant-task.version" value="2.1.3"/>
@@ -205,6 +203,39 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     <property name="tests-jar" value="${dist.maven.dir}/${final.name}-tests.jar"/>
     <property name="sources-jar" value="${dist.maven.dir}/${final.name}-sources.jar"/>
     <property name="javadoc-jar" value="${dist.maven.dir}/${final.name}-javadoc.jar"/>
+
+    <!-- ====================================================== -->
+    <!-- Dependency versions                                    -->
+    <!-- ====================================================== -->
+    <property name="slf4j.version" value="1.6.1"/>
+
+    <property name="wagon-http.version" value="2.4"/>
+    <property name="maven-ant-tasks.version" value="2.1.3"/>
+    <property name="log4j.version" value="1.2.16"/>
+    <property name="jline.version" value="0.9.94"/>
+
+    <property name="jdeb.version" value="0.8"/>
+
+    <property name="audience-annotations.version" value="0.5.0" />
+
+    <property name="netty.version" value="3.10.5.Final"/>
+
+    <property name="junit.version" value="4.8.1"/>
+    <property name="mockito.version" value="1.8.5"/>
+    <property name="checkstyle.version" value="6.1.1"/>
+    <property name="commons-collections.version" value="3.2.2"/>
+    <property name="commons-io.version" value="2.4"/>
+
+    <property name="apache-directory-server.version" value="2.0.0-M15"/>
+    <property name="apache-directory-api.version" value="1.0.0-M20"/>
+
+    <property name="jdiff.version" value="1.0.9"/>
+    <property name="xerces.version" value="1.4.4"/>
+
+    <property name="apache-rat-tasks.version" value="0.6"/>
+    <property name="commons-lang.version" value="2.4"/>
+
+    <property name="dependency-check-ant.version" value="2.1.0"/>
 
     <!-- ====================================================== -->
     <!-- Macro definitions                                      -->

--- a/ivy.xml
+++ b/ivy.xml
@@ -41,78 +41,80 @@
   </publications>
 
   <dependencies>
-    <dependency org="org.slf4j" name="slf4j-api" rev="1.6.1"/>
-    <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.6.1" transitive="false"/>
-  
-    <dependency org="org.apache.maven.wagon" name="wagon-http" rev="2.4" conf="mvn-ant-task->default"/>
-    <dependency org="org.apache.maven" name="maven-ant-tasks" rev="2.1.3" conf="mvn-ant-task->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="${slf4j.version}"/>
+    <dependency org="org.slf4j" name="slf4j-log4j12" rev="${slf4j.version}" transitive="false"/>
+
+    <dependency org="org.apache.maven.wagon" name="wagon-http" rev="${wagon-http.version}"
+                conf="mvn-ant-task->default"/>
+    <dependency org="org.apache.maven" name="maven-ant-tasks" rev="${maven-ant-tasks.version}"
+                conf="mvn-ant-task->default"/>
     <!-- transitive false turns off dependency checking, log4j deps seem borked -->
-    <dependency org="log4j" name="log4j" rev="1.2.16" transitive="false" conf="default"/>
-    <dependency org="jline" name="jline" rev="0.9.94" transitive="false" conf="default"/>
+    <dependency org="log4j" name="log4j" rev="${log4j.version}" transitive="false" conf="default"/>
+    <dependency org="jline" name="jline" rev="${jline.version}" transitive="false" conf="default"/>
 
     <dependency org="org.apache.yetus" name="audience-annotations" rev="${audience-annotations.version}"/>
 
-    <dependency org="io.netty" name="netty" conf="default" rev="3.10.5.Final">
+    <dependency org="io.netty" name="netty" conf="default" rev="${netty.version}">
       <artifact name="netty" type="jar" conf="default"/>
     </dependency>
 
-    <dependency org="org.vafer" name="jdeb" rev="0.8" conf="package->master"/>
+    <dependency org="org.vafer" name="jdeb" rev="${jdeb.version}" conf="package->master"/>
 
-    <dependency org="junit" name="junit" rev="4.8.1" conf="test->default"/>
-     <dependency org="org.mockito" name="mockito-all" rev="1.8.5"
+    <dependency org="junit" name="junit" rev="${junit.version}" conf="test->default"/>
+    <dependency org="org.mockito" name="mockito-all" rev="${mockito.version}"
                conf="test->default"/>
-    <dependency org="com.puppycrawl.tools" name="checkstyle" rev="6.1.1"
+    <dependency org="com.puppycrawl.tools" name="checkstyle" rev="${checkstyle.version}"
                 conf="test->default"/>
     <dependency org="commons-collections" name="commons-collections" 
-                rev="3.2.2" conf="test->default"/>
+                rev="${commons-collections.version}" conf="test->default"/>
 
-    <dependency org="jdiff" name="jdiff" rev="1.0.9"
+    <dependency org="jdiff" name="jdiff" rev="${jdiff.version}"
                 conf="jdiff->default"/>
-    <dependency org="xerces" name="xerces" rev="1.4.4"
+    <dependency org="xerces" name="xerces" rev="${xerces.version}"
                 conf="jdiff->default"/>
 
     <dependency org="org.apache.rat" name="apache-rat-tasks" 
-                rev="0.6" conf="releaseaudit->default"/>
+                rev="${apache-rat-tasks.version}" conf="releaseaudit->default"/>
     <dependency org="commons-lang" name="commons-lang" 
-                rev="2.4" conf="releaseaudit->default"/>
-    <dependency org="commons-collections" name="commons-collections" 
-                rev="3.2.2" conf="releaseaudit->default"/>
+                rev="${commons-lang.version}" conf="releaseaudit->default"/>
+    <dependency org="commons-collections" name="commons-collections"
+                rev="${commons-collections.version}" conf="releaseaudit->default"/>
     <dependency org="org.owasp" name="dependency-check-ant"
-                rev="2.1.0" conf="owasp->default"/>
+                rev="${dependency-check-ant.version}" conf="owasp->default"/>
 
-    <dependency org="commons-io" name="commons-io" rev="2.4"
+    <dependency org="commons-io" name="commons-io" rev="${commons-io.version}"
                 conf="test->default"/>
 
 
     <!-- Apache directory server project, org.apache.directory.* packages for miniKdc tests -->
-    <dependency org="org.apache.directory.server" name="apacheds-core-api" rev="2.0.0-M15" conf="test->default">
+    <dependency org="org.apache.directory.server" name="apacheds-core-api" rev="${apache-directory-server.version}" conf="test->default">
         <exclude org="org.apache.directory.api" name="api-ldap-schema-data"/>
     </dependency>
-    <dependency org="org.apache.directory.server" name="apacheds-interceptor-kerberos" rev="2.0.0-M15" conf="test->default">
+    <dependency org="org.apache.directory.server" name="apacheds-interceptor-kerberos" rev="${apache-directory-server.version}" conf="test->default">
         <exclude org="org.apache.directory.api" name="api-ldap-schema-data"/>
     </dependency>
-    <dependency org="org.apache.directory.server" name="apacheds-protocol-shared" rev="2.0.0-M15" conf="test->default">
+    <dependency org="org.apache.directory.server" name="apacheds-protocol-shared" rev="${apache-directory-server.version}" conf="test->default">
         <exclude org="org.apache.directory.api" name="api-ldap-schema-data"/>
     </dependency>
-    <dependency org="org.apache.directory.server" name="apacheds-protocol-kerberos" rev="2.0.0-M15" conf="test->default">
+    <dependency org="org.apache.directory.server" name="apacheds-protocol-kerberos" rev="${apache-directory-server.version}" conf="test->default">
         <exclude org="org.apache.directory.api" name="api-ldap-schema-data"/>
     </dependency>
-    <dependency org="org.apache.directory.server" name="apacheds-ldif-partition" rev="2.0.0-M15" conf="test->default">
+    <dependency org="org.apache.directory.server" name="apacheds-ldif-partition" rev="${apache-directory-server.version}" conf="test->default">
         <exclude org="org.apache.directory.api" name="api-ldap-schema-data"/>
     </dependency>
-    <dependency org="org.apache.directory.server" name="apacheds-mavibot-partition" rev="2.0.0-M15" conf="test->default">
+    <dependency org="org.apache.directory.server" name="apacheds-mavibot-partition" rev="${apache-directory-server.version}" conf="test->default">
         <exclude org="org.apache.directory.api" name="api-ldap-schema-data"/>
         <exclude org="org.slf4j" name="slf4j-log4j12"/>
     </dependency>
-    <dependency org="org.apache.directory.api" name="api-all" rev="1.0.0-M20" conf="test->default">
+    <dependency org="org.apache.directory.api" name="api-all" rev="${apache-directory-api.version}" conf="test->default">
         <exclude org="xml-apis" name="xml-apis"/>
         <exclude org="xpp3" name="xpp3"/>
         <exclude org="dom4j" name="dom4j"/>
     </dependency>
-    <dependency org="org.apache.directory.server" name="apacheds-jdbm-partition" rev="2.0.0-M15" conf="test->default">
+    <dependency org="org.apache.directory.server" name="apacheds-jdbm-partition" rev="${apache-directory-server.version}" conf="test->default">
         <exclude org="org.apache.directory.api" name="api-ldap-schema-data"/>
     </dependency>
-    <dependency org="org.apache.directory.server" name="apacheds-protocol-ldap" rev="2.0.0-M15" conf="test->default">
+    <dependency org="org.apache.directory.server" name="apacheds-protocol-ldap" rev="${apache-directory-server.version}" conf="test->default">
         <exclude org="org.apache.directory.api" name="api-ldap-schema-data"/>
     </dependency>
 


### PR DESCRIPTION
…overridden in build.properties

Backported to branch 3.4.
If the dependency versions are defined in build.xml they can be easily
overridden by re-defining them in build.properties
This process can be useful to avoid classpath clashes among different
Hadoop components

Author: Tamas Penzes <tamaas@cloudera.com>
Author: Tamás Pénzes <penzes.tamas@gmail.com>

Reviewers: Patrick Hunt <phunt@apache.org>, Michael Han <hanm@apache.org>

Closes #357 from tamaashu/ZOOKEEPER-2887 and squashes the following commits:

5e2f43fb [Tamás Pénzes] Merge branch 'master' into ZOOKEEPER-2887
65558c09 [Tamas Penzes] ZOOKEEPER-2887: define dependency versions in build.xml to be easily overridden in build.properties
6cf315fd [Tamas Penzes] ZOOKEEPER-2887: define dependency versions in build.xml to be easily overridden in build.properties

Change-Id: Ic19d67cc68ed4595ae0636d8200287400e98e2a1

# Conflicts:
#	ivy.xml