### PR TITLE
ZOOKEEPER-2908: quorum.auth.MiniKdcTest.testKerberosLogin failing wit…

### DIFF
--- a/src/java/test/org/apache/zookeeper/server/quorum/auth/MiniKdcTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/auth/MiniKdcTest.java
@@ -175,7 +175,8 @@ public class MiniKdcTest extends KerberosSecurityTestcase {
             loginContext.logout();
 
         } finally {
-            if (loginContext != null) {
+            if (loginContext != null && loginContext.getSubject() != null
+                    && !loginContext.getSubject().getPrincipals().isEmpty()) {
                 loginContext.logout();
             }
         }


### PR DESCRIPTION

ZOOKEEPER-2908: quorum.auth.MiniKdcTest.testKerberosLogin failing with NPE on Java 9

Cause:

The NPE exception in the MiniKdcTest.testKerberosLogin() unit test is caused by a duplicate loginContext.logout() call: one logout() call at the end of the test inside the try block and another logout() call in the finally block. When the test finishes, the first logout() call removes the kerbClientPrinc KerberosPrincipal in Krb5LoginModule, so when logout() is called for the second time in the finally block, it tries to remove a null kerbClientPrinc at Krb5LoginModule.java:1193:

subject.getPrincipals().remove(kerbClientPrinc);

where subject is a javax.security.auth.Subject, 
getPrincipals() returns Set<Principal> 
and the Set implementation is a javax.security.auth.Subject.SecureSet.

In Java 9, SecureSet's remove() method has introduced a new requireNonNull check for its parameter Object o, which fails if someone tries to remove a null from a SecureSet:

Objects.requireNonNull(o,ResourcesMgr.getString(“invalid.null.input.s.”));

Java 8 (and before) did not have this check in the SecureSet.remove() method, and this is the reason why this NPE appeared in Java 9.

Solution:

The unit test was fixed by adding an additional condition before running the logout() call in the finally block: logout() is called only if the Set of Principals is not empty i.e. logout() was not already called inside the try block.

Note: Inside ZK, LoginContext logout() is called only once in the org.apache.zookeeper.Login reLogin() method, when ZK does a re-login after refreshing the Kerberos tickets.
