### PR TITLE
ZOOKEEPER-2727: WARN and stacktrace for normally closed socket

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -373,7 +373,7 @@ public class NIOServerCnxn extends ServerCnxn {
             // expecting close to log session closure
             close();
         } catch (EndOfStreamException e) {
-            LOG.warn(e.getMessage());
+            LOG.info(e.getMessage());
             if (LOG.isDebugEnabled()) {
                 LOG.debug("EndOfStreamException stack trace", e);
             }


### PR DESCRIPTION

ZOOKEEPER-2727: WARN and stacktrace for normally closed socket

Log level reduced to info for EndOfStreamException as asked in the Jira.
Logging stack trace for EndOfStreamException has been already moved to debug level in an earlier commit:
https://github.com/apache/zookeeper/commit/34665cd5bdbcb6aaeecb6b204028ef1ffab9f2d8

