### PR TITLE
ZOOKEEPER-2914 compiler warning using java 9

### DIFF
--- a/src/java/main/org/apache/zookeeper/jmx/ManagedUtil.java
+++ b/src/java/main/org/apache/zookeeper/jmx/ManagedUtil.java
@@ -69,7 +69,7 @@ public class ManagedUtil {
             try {
                 // Create and Register the top level Log4J MBean
                 // org.apache.log4j.jmx.HierarchyDynamicMBean hdm = new org.apache.log4j.jmx.HierarchyDynamicMBean();
-                Object hdm = Class.forName("org.apache.log4j.jmx.HierarchyDynamicMBean").newInstance();
+                Object hdm = Class.forName("org.apache.log4j.jmx.HierarchyDynamicMBean").getDeclaredConstructor().newInstance();
 
                 ObjectName mbo = new ObjectName("log4j:hiearchy=default");
                 mbs.registerMBean(hdm, mbo);

--- a/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -251,7 +251,8 @@ public class NIOServerCnxn extends ServerCnxn {
                      * small to hold everything, nothing will be copied,
                      * so we've got to slice the buffer if it's too big.
                      */
-                    b = b.slice().limit(directBuffer.remaining());
+                    b = (ByteBuffer) b.slice().limit(
+                            directBuffer.remaining());
                 }
                 /*
                  * put() is going to modify the positions of both

--- a/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -251,8 +251,7 @@ public class NIOServerCnxn extends ServerCnxn {
                      * small to hold everything, nothing will be copied,
                      * so we've got to slice the buffer if it's too big.
                      */
-                    b = (ByteBuffer) b.slice().limit(
-                        directBuffer.remaining());
+                    b = b.slice().limit(directBuffer.remaining());
                 }
                 /*
                  * put() is going to modify the positions of both

--- a/src/java/main/org/apache/zookeeper/server/ServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/ServerCnxnFactory.java
@@ -130,7 +130,8 @@ public abstract class ServerCnxnFactory {
             serverCnxnFactoryName = NIOServerCnxnFactory.class.getName();
         }
         try {
-            ServerCnxnFactory serverCnxnFactory = (ServerCnxnFactory) Class.forName(serverCnxnFactoryName).newInstance();
+            ServerCnxnFactory serverCnxnFactory = (ServerCnxnFactory) Class.forName(serverCnxnFactoryName)
+                    .getDeclaredConstructor().newInstance();
             LOG.info("Using {} as server connection factory", serverCnxnFactoryName);
             return serverCnxnFactory;
         } catch (Exception e) {

--- a/src/java/main/org/apache/zookeeper/server/auth/ProviderRegistry.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/ProviderRegistry.java
@@ -58,7 +58,7 @@ public class ProviderRegistry {
                     try {
                         Class<?> c = ZooKeeperServer.class.getClassLoader()
                                 .loadClass(className);
-                        AuthenticationProvider ap = (AuthenticationProvider) c
+                        AuthenticationProvider ap = (AuthenticationProvider) c.getDeclaredConstructor()
                                 .newInstance();
                         authenticationProviders.put(ap.getScheme(), ap);
                     } catch (Exception e) {


### PR DESCRIPTION
Replaced deprecated methods (Class.newInstance()) and removed redundant cast