### PR TITLE
ZOOKEEPER-2914: Clear or suppress Java 9 compiler warning messages

### DIFF
--- a/src/java/main/org/apache/zookeeper/JLineZNodeCompletor.java
+++ b/src/java/main/org/apache/zookeeper/JLineZNodeCompletor.java
@@ -29,7 +29,7 @@ class JLineZNodeCompletor implements Completor {
         this.zk = zk;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings(value={"unchecked", "rawtypes"})
     public int complete(String buffer, int cursor, List candidates) {
         // Guarantee that the final token is the one we're expanding
         buffer = buffer.substring(0,cursor);

--- a/src/java/main/org/apache/zookeeper/Shell.java
+++ b/src/java/main/org/apache/zookeeper/Shell.java
@@ -274,6 +274,7 @@ abstract public class Shell {
   /**
    * This is an IOException with exit code added.
    */
+  @SuppressWarnings("serial")
   public static class ExitCodeException extends IOException {
     int exitCode;
     

--- a/src/java/main/org/apache/zookeeper/ZooKeeper.java
+++ b/src/java/main/org/apache/zookeeper/ZooKeeper.java
@@ -1839,7 +1839,7 @@ public class ZooKeeper {
             clientCnxnSocketName = ClientCnxnSocketNIO.class.getName();
         }
         try {
-            return (ClientCnxnSocket) Class.forName(clientCnxnSocketName)
+            return (ClientCnxnSocket) Class.forName(clientCnxnSocketName).getDeclaredConstructor()
                     .newInstance();
         } catch (Exception e) {
             IOException ioe = new IOException("Couldn't instantiate "

--- a/src/java/main/org/apache/zookeeper/ZooKeeperMain.java
+++ b/src/java/main/org/apache/zookeeper/ZooKeeperMain.java
@@ -41,7 +41,6 @@ import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.data.Stat;
-import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -312,8 +311,8 @@ public class ZooKeeperMain {
             boolean jlinemissing = false;
             // only use jline if it's in the classpath
             try {
-                Class consoleC = Class.forName("jline.ConsoleReader");
-                Class completorC =
+                Class<?> consoleC = Class.forName("jline.ConsoleReader");
+                Class<?> completorC =
                     Class.forName("org.apache.zookeeper.JLineZNodeCompletor");
 
                 System.out.println("JLine support is enabled");

--- a/src/java/main/org/apache/zookeeper/jmx/ManagedUtil.java
+++ b/src/java/main/org/apache/zookeeper/jmx/ManagedUtil.java
@@ -39,6 +39,7 @@ public class ManagedUtil {
      * @see http://logging.apache.org/log4j/1.2/apidocs/index.html?org/apache/log4j/jmx/package-summary.html
      * @throws JMException if registration fails
      */
+    @SuppressWarnings("rawtypes")
     public static void registerLog4jMBeans() throws JMException {
         if (Boolean.getBoolean("zookeeper.jmx.log4j.disable") == true) {
             return;

--- a/src/java/main/org/apache/zookeeper/server/ServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/ServerCnxn.java
@@ -321,8 +321,8 @@ public abstract class ServerCnxn implements Stats, Watcher {
         // zkServer.sh depends on "srvr".
         whiteListedCommands.add("srvr");
         whiteListInitialized = true;
-        LOG.info("The list of known four letter word commands is : {}", Arrays.asList(cmd2String));
-        LOG.info("The list of enabled four letter word commands is : {}", Arrays.asList(whiteListedCommands));
+        LOG.info("The list of known four letter word commands is : {}", Collections.singletonList(cmd2String));
+        LOG.info("The list of enabled four letter word commands is : {}", Collections.singletonList(whiteListedCommands));
         return whiteListedCommands.contains(command);
     }
 

--- a/src/java/main/org/apache/zookeeper/server/ServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/ServerCnxnFactory.java
@@ -112,7 +112,8 @@ public abstract class ServerCnxnFactory {
             serverCnxnFactoryName = NIOServerCnxnFactory.class.getName();
         }
         try {
-            ServerCnxnFactory serverCnxnFactory = (ServerCnxnFactory) Class.forName(serverCnxnFactoryName).newInstance();
+            ServerCnxnFactory serverCnxnFactory = (ServerCnxnFactory) Class.forName(serverCnxnFactoryName)
+                    .getDeclaredConstructor().newInstance();
             LOG.info("Using {} as server connection factory", serverCnxnFactoryName);
             return serverCnxnFactory;
         } catch (Exception e) {

--- a/src/java/main/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/src/java/main/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -587,7 +587,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                 DataTree.copyStatPersisted(this.stat, stat);
             }
             return new ChangeRecord(zxid, path, stat, childCount,
-                    acl == null ? new ArrayList<ACL>() : new ArrayList(acl));
+                    acl == null ? new ArrayList<ACL>() : new ArrayList<ACL>(acl));
         }
     }
 

--- a/src/java/main/org/apache/zookeeper/server/auth/ProviderRegistry.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/ProviderRegistry.java
@@ -50,7 +50,7 @@ public class ProviderRegistry {
                         Class<?> c = ZooKeeperServer.class.getClassLoader()
                                 .loadClass(className);
                         AuthenticationProvider ap = (AuthenticationProvider) c
-                                .newInstance();
+                                .getDeclaredConstructor().newInstance();
                         authenticationProviders.put(ap.getScheme(), ap);
                     } catch (Exception e) {
                         LOG.warn("Problems loading " + className,e);

--- a/src/java/main/org/apache/zookeeper/server/util/KerberosUtil.java
+++ b/src/java/main/org/apache/zookeeper/server/util/KerberosUtil.java
@@ -36,10 +36,9 @@ public class KerberosUtil {
     } else {
       classRef = Class.forName("sun.security.krb5.Config");
     }
-    getInstanceMethod = classRef.getMethod("getInstance", new Class[0]);
-    kerbConf = getInstanceMethod.invoke(classRef, new Object[0]);
-    getDefaultRealmMethod = classRef.getDeclaredMethod("getDefaultRealm",
-         new Class[0]);
+    getInstanceMethod = classRef.getMethod("getInstance");
+    kerbConf = getInstanceMethod.invoke(classRef);
+    getDefaultRealmMethod = classRef.getDeclaredMethod("getDefaultRealm");
     return (String)getDefaultRealmMethod.invoke(kerbConf, new Object[0]);
   }
 }

--- a/src/java/main/org/apache/zookeeper/server/util/OSMXBean.java
+++ b/src/java/main/org/apache/zookeeper/server/util/OSMXBean.java
@@ -85,8 +85,7 @@ public class OSMXBean
         try {
             classRef = Class.forName("com.sun.management.UnixOperatingSystemMXBean");
             if (classRef.isInstance(osMbean)) {
-                mBeanMethod = classRef.getDeclaredMethod(mBeanMethodName,
-                new Class[0]);
+                mBeanMethod = classRef.getDeclaredMethod(mBeanMethodName);
                 unixos = classRef.cast(osMbean);
                 return (Long)mBeanMethod.invoke(unixos);
             }

--- a/src/java/systest/org/apache/zookeeper/test/system/BaseSysTest.java
+++ b/src/java/systest/org/apache/zookeeper/test/system/BaseSysTest.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.test.system;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -221,11 +222,17 @@ public class BaseSysTest extends TestCase {
         fakeBaseClients = new Instance[count];
         for(int i = 0; i < count; i++) {
             try {
-                fakeBaseClients[i] = clazz.newInstance();
+                fakeBaseClients[i] = clazz.getDeclaredConstructor().newInstance();
             } catch (InstantiationException e) {
                 e.printStackTrace();
                 return;
             } catch (IllegalAccessException e) {
+                e.printStackTrace();
+                return;
+            } catch (NoSuchMethodException e) {
+                e.printStackTrace();
+                return;
+            } catch (InvocationTargetException e) {
                 e.printStackTrace();
                 return;
             }

--- a/src/java/systest/org/apache/zookeeper/test/system/InstanceContainer.java
+++ b/src/java/systest/org/apache/zookeeper/test/system/InstanceContainer.java
@@ -269,7 +269,7 @@ public class InstanceContainer implements Watcher, AsyncCallback.ChildrenCallbac
                     }
                     try {
                         Class c = Class.forName(clazz);
-                        i = (Instance)c.newInstance();
+                        i = (Instance)c.getDeclaredConstructor().newInstance();
                         Reporter reporter = new MyReporter(child);
                         i.setReporter(reporter);
                         i.configure(conf);

--- a/src/java/test/org/apache/zookeeper/test/LoadFromLogTest.java
+++ b/src/java/test/org/apache/zookeeper/test/LoadFromLogTest.java
@@ -297,7 +297,7 @@ public class LoadFromLogTest extends ZKTestCase implements  Watcher {
 		String[] tokens = lastPath.split("-");
 		String expectedPath = "/invalidsnap/test-"
 				+ String.format("%010d",
-						(new Integer(tokens[1])).intValue() + 1);
+                Integer.parseInt(tokens[1]) + 1);
 		long eZxid = zks.getZKDatabase().getDataTreeLastProcessedZxid();
 		// force the zxid to be behind the content
 		zks.getZKDatabase().setlastProcessedZxid(


### PR DESCRIPTION
It was a little bit trickier than trunk, but I've tried to do my best to remove almost all warnings.