### PR TITLE
ZOOKEEPER-2630: Use interface type instead of implementation type whe…

### DIFF
--- a/docs/zookeeperReconfig.html
+++ b/docs/zookeeperReconfig.html
@@ -1015,7 +1015,7 @@ System.out.println(configStr);</pre>
           example, you may specify a Hierarchical Quorum System even if the
           current ensemble uses a Majority Quorum System.</p>
 <p>Bulk mode - example using the Java API:</p>
-<pre class="code">ArrayList&lt;String&gt; newMembers = new ArrayList&lt;String&gt;();
+<pre class="code">List&lt;String&gt; newMembers = new ArrayList&lt;String&gt;();
 newMembers.add("server.1=1111:1234:1235;1236");
 newMembers.add("server.2=1112:1237:1238;1239");
 newMembers.add("server.3=1114:1240:1241:observer;1242");

--- a/src/contrib/fatjar/src/java/org/apache/zookeeper/util/FatJarMain.java
+++ b/src/contrib/fatjar/src/java/org/apache/zookeeper/util/FatJarMain.java
@@ -26,6 +26,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This is a generic Main class that is completely driven by the
@@ -48,8 +50,8 @@ public class FatJarMain {
         String clazz;
         String desc;
     }
-    static HashMap<String, Cmd> cmds = new HashMap<String, Cmd>();
-    static ArrayList<String> order = new ArrayList<String>();
+    static Map<String, Cmd> cmds = new HashMap<String, Cmd>();
+    static List<String> order = new ArrayList<String>();
     
     /**
      * @param args the first parameter of args will be used as an

--- a/src/contrib/loggraph/src/java/org/apache/zookeeper/graph/FilterOp.java
+++ b/src/contrib/loggraph/src/java/org/apache/zookeeper/graph/FilterOp.java
@@ -18,11 +18,12 @@
 package org.apache.zookeeper.graph;
 
 import java.util.ArrayList;
+import java.util.List;
 import org.apache.zookeeper.graph.filterops.*;
 
 public abstract class FilterOp {
-    protected ArrayList<FilterOp> subOps;
-    protected ArrayList<Arg> args;
+    protected List<FilterOp> subOps;
+    protected List<Arg> args;
 
     public enum ArgType {
 	STRING, NUMBER, SYMBOL

--- a/src/contrib/loggraph/src/java/org/apache/zookeeper/graph/JsonGenerator.java
+++ b/src/contrib/loggraph/src/java/org/apache/zookeeper/graph/JsonGenerator.java
@@ -31,10 +31,11 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.ListIterator;
+import java.util.Set;
 
 public class JsonGenerator {
     private JSONObject root;
-    private HashSet<Integer> servers;
+    private Set<Integer> servers;
 
     private class Message {
 	private int from;

--- a/src/contrib/loggraph/src/java/org/apache/zookeeper/graph/LogEntry.java
+++ b/src/contrib/loggraph/src/java/org/apache/zookeeper/graph/LogEntry.java
@@ -19,9 +19,10 @@ package org.apache.zookeeper.graph;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.Map;
 
 public abstract class LogEntry implements Serializable {
-    private HashMap attributes;
+    private Map attributes;
 
     public enum Type { UNKNOWN, LOG4J, TXN };
         

--- a/src/contrib/loggraph/src/java/org/apache/zookeeper/graph/MeasureThroughput.java
+++ b/src/contrib/loggraph/src/java/org/apache/zookeeper/graph/MeasureThroughput.java
@@ -24,6 +24,7 @@ import java.io.DataOutputStream;
 import java.io.PrintStream;
 
 import java.util.HashSet;
+import java.util.Set;
 
 public class MeasureThroughput {
     private static final int MS_PER_SEC = 1000;
@@ -45,7 +46,7 @@ public class MeasureThroughput {
 	long currentsec = 0;
 	long currentmin = 0;
 	long currenthour = 0;
-	HashSet<Long> zxids_ms = new HashSet<Long>();
+	Set<Long> zxids_ms = new HashSet<Long>();
 	long zxid_sec = 0;
 	long zxid_min = 0;
 	long zxid_hour = 0;

--- a/src/contrib/loggraph/src/java/org/apache/zookeeper/graph/servlets/Throughput.java
+++ b/src/contrib/loggraph/src/java/org/apache/zookeeper/graph/servlets/Throughput.java
@@ -25,6 +25,7 @@ import java.io.PrintStream;
 
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.Set;
 
 import org.apache.zookeeper.graph.*;
 import org.slf4j.Logger;
@@ -80,7 +81,7 @@ public class Throughput extends JsonServlet
 	
 	long current = 0;
 	long currentms = 0;
-	HashSet<Long> zxids_ms = new HashSet<Long>();
+	Set<Long> zxids_ms = new HashSet<Long>();
 	long zxidcount = 0;
 
 	JSONArray events = new JSONArray();

--- a/src/contrib/zooinspector/src/java/org/apache/zookeeper/inspector/gui/ZooInspectorConnectionPropertiesDialog.java
+++ b/src/contrib/zooinspector/src/java/org/apache/zookeeper/inspector/gui/ZooInspectorConnectionPropertiesDialog.java
@@ -51,7 +51,7 @@ import org.apache.zookeeper.inspector.manager.Pair;
  */
 public class ZooInspectorConnectionPropertiesDialog extends JDialog {
 
-    private final HashMap<String, JComponent> components;
+    private final Map<String, JComponent> components;
 
     /**
      * @param lastConnectionProps

--- a/src/contrib/zooinspector/src/java/org/apache/zookeeper/inspector/gui/ZooInspectorPanel.java
+++ b/src/contrib/zooinspector/src/java/org/apache/zookeeper/inspector/gui/ZooInspectorPanel.java
@@ -64,7 +64,7 @@ public class ZooInspectorPanel extends JPanel implements
         this.zooInspectorManager = zooInspectorManager;
         this.iconResource = iconResource;
         toolbar = new Toolbar(iconResource);
-        final ArrayList<ZooInspectorNodeViewer> nodeViewers = new ArrayList<ZooInspectorNodeViewer>();
+        final List<ZooInspectorNodeViewer> nodeViewers = new ArrayList<ZooInspectorNodeViewer>();
         try {
             List<String> defaultNodeViewersClassNames = this.zooInspectorManager
                     .getDefaultNodeViewerConfiguration();

--- a/src/docs/src/documentation/content/xdocs/zookeeperReconfig.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperReconfig.xml
@@ -698,7 +698,7 @@ System.out.println(configStr);]]></programlisting>
           example, you may specify a Hierarchical Quorum System even if the
           current ensemble uses a Majority Quorum System.</para>
         <para>Bulk mode - example using the Java API:</para>
-        <programlisting><![CDATA[ArrayList<String> newMembers = new ArrayList<String>();
+        <programlisting><![CDATA[List<String> newMembers = new ArrayList<String>();
 newMembers.add("server.1=1111:1234:1235;1236");
 newMembers.add("server.2=1112:1237:1238;1239");
 newMembers.add("server.3=1114:1240:1241:observer;1242");

--- a/src/java/main/org/apache/jute/compiler/CGenerator.java
+++ b/src/java/main/org/apache/jute/compiler/CGenerator.java
@@ -18,19 +18,19 @@
 
 package org.apache.jute.compiler;
 
-import java.util.ArrayList;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * C++ Code generator front-end for Hadoop record I/O.
  */
 class CGenerator {
     private String mName;
-    private ArrayList<JFile> mInclFiles;
-    private ArrayList<JRecord> mRecList;
+    private List<JFile> mInclFiles;
+    private List<JRecord> mRecList;
     private final File outputDirectory;
 
     /** Creates a new instance of CppGenerator
@@ -40,7 +40,7 @@ class CGenerator {
      * @param rlist List of records defined within this file
      * @param outputDirectory
      */
-    CGenerator(String name, ArrayList<JFile> ilist, ArrayList<JRecord> rlist,
+    CGenerator(String name, List<JFile> ilist, List<JRecord> rlist,
             File outputDirectory)
     {
         this.outputDirectory = outputDirectory;

--- a/src/java/main/org/apache/jute/compiler/CSharpGenerator.java
+++ b/src/java/main/org/apache/jute/compiler/CSharpGenerator.java
@@ -20,10 +20,10 @@ package org.apache.jute.compiler;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.List;
 
 public class CSharpGenerator {
-    private ArrayList<JRecord> mRecList;
+    private List<JRecord> mRecList;
     private final File outputDirectory;
 
     /** Creates a new instance of CSharpGenerator
@@ -33,7 +33,7 @@ public class CSharpGenerator {
      * @param rlist List of records defined within this file
      * @param outputDirectory
      */
-    CSharpGenerator(String name, ArrayList<JFile> ilist, ArrayList<JRecord> rlist,
+    CSharpGenerator(String name, List<JFile> ilist, List<JRecord> rlist,
             File outputDirectory)
      {
         this.outputDirectory = outputDirectory;

--- a/src/java/main/org/apache/jute/compiler/CppGenerator.java
+++ b/src/java/main/org/apache/jute/compiler/CppGenerator.java
@@ -18,19 +18,19 @@
 
 package org.apache.jute.compiler;
 
-import java.util.ArrayList;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * C++ Code generator front-end for Hadoop record I/O.
  */
 class CppGenerator {
     private String mName;
-    private ArrayList<JFile> mInclFiles;
-    private ArrayList<JRecord> mRecList;
+    private List<JFile> mInclFiles;
+    private List<JRecord> mRecList;
     private final File outputDirectory;
 
     /** Creates a new instance of CppGenerator
@@ -40,7 +40,7 @@ class CppGenerator {
      * @param rlist List of records defined within this file
      * @param outputDirectory
      */
-    CppGenerator(String name, ArrayList<JFile> ilist, ArrayList<JRecord> rlist,
+    CppGenerator(String name, List<JFile> ilist, List<JRecord> rlist,
             File outputDirectory)
      {
         this.outputDirectory = outputDirectory;

--- a/src/java/main/org/apache/jute/compiler/JFile.java
+++ b/src/java/main/org/apache/jute/compiler/JFile.java
@@ -21,6 +21,7 @@ package org.apache.jute.compiler;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Container for the Hadoop Record DDL.
@@ -31,8 +32,8 @@ import java.util.ArrayList;
 public class JFile {
     
     private String mName;
-    private ArrayList<JFile> mInclFiles;
-    private ArrayList<JRecord> mRecords;
+    private List<JFile> mInclFiles;
+    private List<JRecord> mRecords;
     
     /** Creates a new instance of JFile
      *

--- a/src/java/main/org/apache/jute/compiler/JRecord.java
+++ b/src/java/main/org/apache/jute/compiler/JRecord.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -33,7 +35,7 @@ public class JRecord extends JCompType {
     private String mFQName;
     private String mName;
     private String mModule;
-    private ArrayList<JField> mFields;
+    private List<JField> mFields;
 
     /**
      * Creates a new instance of JRecord
@@ -83,7 +85,7 @@ public class JRecord extends JCompType {
         return namespace.toString();
     }
 
-    public ArrayList<JField> getFields() {
+    public List<JField> getFields() {
         return mFields;
     }
 
@@ -139,7 +141,7 @@ public class JRecord extends JCompType {
         return "    a_.WriteRecord("+fname+",\""+tag+"\");\n";
     }
 
-    static HashMap<String, String> vectorStructs = new HashMap<String, String>();
+    static Map<String, String> vectorStructs = new HashMap<String, String>();
     public void genCCode(FileWriter h, FileWriter c) throws IOException {
         for (JField f : mFields) {
             if (f.getType() instanceof JVector) {

--- a/src/java/main/org/apache/jute/compiler/JavaGenerator.java
+++ b/src/java/main/org/apache/jute/compiler/JavaGenerator.java
@@ -20,14 +20,14 @@ package org.apache.jute.compiler;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Java Code generator front-end for Hadoop record I/O.
  */
 class JavaGenerator {
-    private ArrayList<JRecord> mRecList;
+    private List<JRecord> mRecList;
     private final File outputDirectory;
     
     /** Creates a new instance of JavaGenerator
@@ -37,8 +37,8 @@ class JavaGenerator {
      * @param records List of records defined within this file
      * @param outputDirectory 
      */
-    JavaGenerator(String name, ArrayList<JFile> incl,
-            ArrayList<JRecord> records, File outputDirectory)
+    JavaGenerator(String name, List<JFile> incl,
+            List<JRecord> records, File outputDirectory)
     {
         mRecList = records;
         this.outputDirectory = outputDirectory;

--- a/src/java/main/org/apache/zookeeper/Environment.java
+++ b/src/java/main/org/apache/zookeeper/Environment.java
@@ -48,12 +48,12 @@ public class Environment {
         }
     }
 
-    private static void put(ArrayList<Entry> l, String k, String v) {
+    private static void put(List<Entry> l, String k, String v) {
         l.add(new Entry(k,v));
     }
 
     public static List<Entry> list() {
-        ArrayList<Entry> l = new ArrayList<Entry>();
+        List<Entry> l = new ArrayList<Entry>();
         put(l, "zookeeper.version", Version.getFullVersion());
 
         try {

--- a/src/java/main/org/apache/zookeeper/common/PathTrie.java
+++ b/src/java/main/org/apache/zookeeper/common/PathTrie.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.common;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +54,7 @@ public class PathTrie {
     
     static class TrieNode {
         boolean property = false;
-        final HashMap<String, TrieNode> children;
+        final Map<String, TrieNode> children;
         TrieNode parent = null;
         /**
          * create a trienode with parent

--- a/src/java/main/org/apache/zookeeper/server/DataTree.java
+++ b/src/java/main/org/apache/zookeeper/server/DataTree.java
@@ -150,7 +150,7 @@ public class DataTree {
         if (retv == null) {
             return new HashSet<String>();
         }
-        HashSet<String> cloned = null;
+        Set<String> cloned = null;
         synchronized (retv) {
             cloned = (HashSet<String>) retv.clone();
         }
@@ -549,7 +549,7 @@ public class DataTree {
             } else if (ephemeralType == EphemeralType.TTL) {
                 ttls.remove(path);
             } else if (eowner != 0) {
-                HashSet<String> nodes = ephemerals.get(eowner);
+                Set<String> nodes = ephemerals.get(eowner);
                 if (nodes != null) {
                     synchronized (nodes) {
                         nodes.remove(path);
@@ -1002,7 +1002,7 @@ public class DataTree {
         // so there is no need for synchronization. The list is not
         // changed here. Only create and delete change the list which
         // are again called from FinalRequestProcessor in sequence.
-        HashSet<String> list = ephemerals.remove(session);
+        Set<String> list = ephemerals.remove(session);
         if (list != null) {
             for (String path : list) {
                 try {
@@ -1286,7 +1286,7 @@ public class DataTree {
         for (Entry<Long, HashSet<String>> entry : ephemerals.entrySet()) {
             pwriter.print("0x" + Long.toHexString(entry.getKey()));
             pwriter.println(":");
-            HashSet<String> tmp = entry.getValue();
+            Set<String> tmp = entry.getValue();
             if (tmp != null) {
                 synchronized (tmp) {
                     for (String path : tmp) {
@@ -1303,7 +1303,7 @@ public class DataTree {
      * @return map of session ID to sets of ephemeral znodes
      */
     public Map<Long, Set<String>> getEphemerals() {
-        HashMap<Long, Set<String>> ephemeralsCopy = new HashMap<Long, Set<String>>();
+        Map<Long, Set<String>> ephemeralsCopy = new HashMap<Long, Set<String>>();
         for (Entry<Long, HashSet<String>> e : ephemerals.entrySet()) {
             synchronized (e.getValue()) {
                 ephemeralsCopy.put(e.getKey(), new HashSet<String>(e.getValue()));

--- a/src/java/main/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -74,7 +74,7 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
     ServerBootstrap bootstrap;
     Channel parentChannel;
     ChannelGroup allChannels = new DefaultChannelGroup("zkServerCnxns");
-    HashMap<InetAddress, Set<NettyServerCnxn>> ipMap =
+    Map<InetAddress, Set<NettyServerCnxn>> ipMap =
         new HashMap<InetAddress, Set<NettyServerCnxn>>( );
     InetSocketAddress localAddress;
     int maxClientCnxns = 60;
@@ -547,7 +547,7 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
 
     @Override
     public Iterable<Map<String, Object>> getAllConnectionInfo(boolean brief) {
-        HashSet<Map<String,Object>> info = new HashSet<Map<String,Object>>();
+        Set<Map<String,Object>> info = new HashSet<Map<String,Object>>();
         // No need to synchronize since cnxns is backed by a ConcurrentHashMap
         for (ServerCnxn c : cnxns) {
             info.add(c.getConnectionInfo(brief));

--- a/src/java/main/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -201,7 +201,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
      *         rolled back in any failure.
      */
     private Map<String, ChangeRecord> getPendingChanges(MultiTransactionRecord multiRequest) {
-        HashMap<String, ChangeRecord> pendingChangeRecords = new HashMap<String, ChangeRecord>();
+        Map<String, ChangeRecord> pendingChangeRecords = new HashMap<String, ChangeRecord>();
 
         for (Op op : multiRequest) {
             String path = op.getPath();
@@ -908,7 +908,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
 
     private List<ACL> removeDuplicates(List<ACL> acl) {
 
-        LinkedList<ACL> retval = new LinkedList<ACL>();
+        List<ACL> retval = new LinkedList<ACL>();
         for (ACL a : acl) {
             if (!retval.contains(a)) {
                 retval.add(a);
@@ -953,7 +953,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
         // check for well formed ACLs
         // This resolves https://issues.apache.org/jira/browse/ZOOKEEPER-1877
         List<ACL> uniqacls = removeDuplicates(acls);
-        LinkedList<ACL> rv = new LinkedList<ACL>();
+        List<ACL> rv = new LinkedList<ACL>();
         if (uniqacls == null || uniqacls.size() == 0) {
             throw new KeeperException.InvalidACLException(path);
         }

--- a/src/java/main/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/src/java/main/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -115,7 +115,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
     private final AtomicInteger requestsInProcess = new AtomicInteger(0);
     final List<ChangeRecord> outstandingChanges = new ArrayList<ChangeRecord>();
     // this data structure must be accessed under the outstandingChanges lock
-    final HashMap<String, ChangeRecord> outstandingChangesForPath =
+    final Map<String, ChangeRecord> outstandingChangesForPath =
         new HashMap<String, ChangeRecord>();
 
     protected ServerCnxnFactory serverCnxnFactory;
@@ -284,7 +284,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         }
         
         // Clean up dead sessions
-        LinkedList<Long> deadSessions = new LinkedList<Long>();
+        List<Long> deadSessions = new LinkedList<Long>();
         for (Long session : zkDb.getSessions()) {
             if (zkDb.getSessionWithTimeOuts().get(session) == null) {
                 deadSessions.add(session);

--- a/src/java/main/org/apache/zookeeper/server/auth/ProviderRegistry.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/ProviderRegistry.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.server.auth;
 
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,8 +31,8 @@ public class ProviderRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(ProviderRegistry.class);
 
     private static boolean initialized = false;
-    private static HashMap<String, AuthenticationProvider> authenticationProviders =
-        new HashMap<String, AuthenticationProvider>();
+    private static Map<String, AuthenticationProvider> authenticationProviders =
+        new HashMap<>();
 
     public static void initialize() {
         synchronized (ProviderRegistry.class) {

--- a/src/java/main/org/apache/zookeeper/server/quorum/AuthFastLeaderElection.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/AuthFastLeaderElection.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -801,7 +802,7 @@ public class AuthFastLeaderElection implements Election {
 
     }
 
-    private boolean termPredicate(HashMap<InetSocketAddress, Vote> votes,
+    private boolean termPredicate(Map<InetSocketAddress, Vote> votes,
             long l, long zxid) {
 
 

--- a/src/java/main/org/apache/zookeeper/server/quorum/FastLeaderElection.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/FastLeaderElection.java
@@ -733,7 +733,7 @@ public class FastLeaderElection implements Election {
      * @param vote
      *            Identifier of the vote received last
      */
-    private boolean termPredicate(HashMap<Long, Vote> votes, Vote vote) {
+    private boolean termPredicate(Map<Long, Vote> votes, Vote vote) {
         SyncedLearnerTracker voteSet = new SyncedLearnerTracker();
         voteSet.addQuorumVerifier(self.getQuorumVerifier());
         if (self.getLastSeenQuorumVerifier() != null
@@ -767,7 +767,7 @@ public class FastLeaderElection implements Election {
      * @param   electionEpoch   epoch id
      */
     private boolean checkLeader(
-            HashMap<Long, Vote> votes,
+            Map<Long, Vote> votes,
             long leader,
             long electionEpoch){
 
@@ -880,9 +880,9 @@ public class FastLeaderElection implements Election {
            self.start_fle = Time.currentElapsedTime();
         }
         try {
-            HashMap<Long, Vote> recvset = new HashMap<Long, Vote>();
+            Map<Long, Vote> recvset = new HashMap<Long, Vote>();
 
-            HashMap<Long, Vote> outofelection = new HashMap<Long, Vote>();
+            Map<Long, Vote> outofelection = new HashMap<Long, Vote>();
 
             int notTimeout = finalizeWait;
 

--- a/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -151,7 +152,7 @@ public class Leader {
     }
 
     // Pending sync requests. Must access under 'this' lock.
-    private final HashMap<Long,List<LearnerSyncRequest>> pendingSyncs =
+    private final Map<Long,List<LearnerSyncRequest>> pendingSyncs =
         new HashMap<Long,List<LearnerSyncRequest>>();
 
     synchronized public int getNumPendingSyncs() {

--- a/src/java/main/org/apache/zookeeper/server/quorum/flexible/QuorumMaj.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/flexible/QuorumMaj.java
@@ -35,8 +35,8 @@ import org.apache.zookeeper.server.quorum.QuorumPeerConfig.ConfigException;
  */
 public class QuorumMaj implements QuorumVerifier {
     private Map<Long, QuorumServer> allMembers = new HashMap<Long, QuorumServer>();
-    private HashMap<Long, QuorumServer> votingMembers = new HashMap<Long, QuorumServer>();
-    private HashMap<Long, QuorumServer> observingMembers = new HashMap<Long, QuorumServer>();
+    private Map<Long, QuorumServer> votingMembers = new HashMap<Long, QuorumServer>();
+    private Map<Long, QuorumServer> observingMembers = new HashMap<Long, QuorumServer>();
     private long version = 0;
     private int half;
 

--- a/src/java/systest/org/apache/zookeeper/test/system/BaseSysTest.java
+++ b/src/java/systest/org/apache/zookeeper/test/system/BaseSysTest.java
@@ -24,6 +24,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
@@ -143,7 +144,7 @@ public class BaseSysTest {
 
     private QuorumPeer qps[];
     private File qpsDirs[];
-    HashMap<Long,QuorumServer> peers;
+    Map<Long,QuorumServer> peers;
     private void fakeConfigureServers(int count) throws IOException {
         peers = new HashMap<Long,QuorumServer>();
         qps = new QuorumPeer[count];

--- a/src/java/systest/org/apache/zookeeper/test/system/InstanceContainer.java
+++ b/src/java/systest/org/apache/zookeeper/test/system/InstanceContainer.java
@@ -225,7 +225,7 @@ public class InstanceContainer implements Watcher, AsyncCallback.ChildrenCallbac
         }
     }
 
-    HashMap<String, Instance> instances = new HashMap<String, Instance>();
+    Map<String, Instance> instances = new HashMap<String, Instance>();
 
     @Override
     public void processResult(int rc, String path, Object ctx, List<String> children) {
@@ -234,7 +234,7 @@ public class InstanceContainer implements Watcher, AsyncCallback.ChildrenCallbac
             zk.getChildren(assignmentsNode, true, this, null);
             return;
         }
-        HashMap<String, Instance> newList = new HashMap<String, Instance>();
+        Map<String, Instance> newList = new HashMap<String, Instance>();
         // check for differences
         Stat stat = new Stat();
         for(String child: children) {

--- a/src/java/systest/org/apache/zookeeper/test/system/InstanceManager.java
+++ b/src/java/systest/org/apache/zookeeper/test/system/InstanceManager.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.slf4j.Logger;
@@ -79,8 +80,8 @@ public class InstanceManager implements AsyncCallback.ChildrenCallback, Watcher 
             System.err.println("Preferred List is empty");
         }
     }
-    private HashMap<String, HashSet<Assigned>> assignments = new HashMap<String, HashSet<Assigned>>();
-    private HashMap<String, Assigned> instanceToAssignment = new HashMap<String, Assigned>();
+    private Map<String, HashSet<Assigned>> assignments = new HashMap<String, HashSet<Assigned>>();
+    private Map<String, Assigned> instanceToAssignment = new HashMap<String, Assigned>();
     public InstanceManager(ZooKeeper zk, String prefix) throws KeeperException, InterruptedException {
         this.zk = zk;
         this.prefixNode = prefix;
@@ -137,7 +138,7 @@ public class InstanceManager implements AsyncCallback.ChildrenCallback, Watcher 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Got " + children + " children from " + path);
         }
-        HashMap<String, HashSet<Assigned>> newAssignments = new HashMap<String, HashSet<Assigned>>();
+        Map<String, HashSet<Assigned>> newAssignments = new HashMap<String, HashSet<Assigned>>();
         for(String c: children) {
             HashSet<Assigned> a = assignments.remove(c);
             if (a != null) {

--- a/src/java/systest/org/apache/zookeeper/test/system/QuorumPeerInstance.java
+++ b/src/java/systest/org/apache/zookeeper/test/system/QuorumPeerInstance.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import org.slf4j.Logger;
@@ -55,7 +56,7 @@ class QuorumPeerInstance implements Instance {
     InetSocketAddress clientAddr;
     InetSocketAddress quorumLeaderAddr;
     InetSocketAddress quorumLeaderElectionAddr;
-    HashMap<Long, QuorumServer> peers;
+    Map<Long, QuorumServer> peers;
     File snapDir, logDir;
 
     public QuorumPeerInstance() {

--- a/src/java/test/org/apache/zookeeper/server/quorum/FLEBackwardElectionRoundTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/FLEBackwardElectionRoundTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,7 @@ public class FLEBackwardElectionRoundTest extends ZKTestCase {
     protected static final Logger LOG = LoggerFactory.getLogger(FLELostMessageTest.class);
 
     int count;
-    HashMap<Long,QuorumServer> peers;
+    Map<Long,QuorumServer> peers;
     File tmpdir[];
     int port[];
 

--- a/src/java/test/org/apache/zookeeper/server/quorum/LearnerHandlerTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/LearnerHandlerTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.net.Socket;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -91,7 +92,7 @@ public class LearnerHandlerTest extends ZKTestCase {
             return 0;
         }
 
-        public LinkedList<Proposal> getCommittedLog() {
+        public List<Proposal> getCommittedLog() {
             return committedLog;
         }
 

--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumRequestPipelineTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumRequestPipelineTest.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.server.quorum;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -47,7 +48,7 @@ public class QuorumRequestPipelineTest extends QuorumBase {
     protected final CountDownLatch callComplete = new CountDownLatch(1);
     protected boolean complete = false;
     protected final static String PARENT_PATH = "/foo";
-    protected final static HashSet<String> CHILDREN = new HashSet<String>(Arrays.asList("1", "2", "3"));
+    protected final static Set<String> CHILDREN = new HashSet<String>(Arrays.asList("1", "2", "3"));
     protected final static String AUTH_PROVIDER = "digest";
     protected final static byte[] AUTH = "hello".getBytes();
     protected final static byte[] DATA = "Hint Water".getBytes();

--- a/src/java/test/org/apache/zookeeper/server/quorum/ReconfigFailureCasesTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/ReconfigFailureCasesTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NewConfigNoQuorum;
@@ -226,7 +227,7 @@ public class ReconfigFailureCasesTest extends QuorumPeerTestBase {
         int[][] ports = ReconfigRecoveryTest.generatePorts(SERVER_COUNT);
 
         // generate old config string
-        HashSet<Integer> observers = new HashSet<Integer>();
+        Set<Integer> observers = new HashSet<Integer>();
         observers.add(3);
         StringBuilder sb = ReconfigRecoveryTest.generateConfig(SERVER_COUNT, ports, observers);
         String currentQuorumCfgSection = sb.toString();

--- a/src/java/test/org/apache/zookeeper/server/quorum/ReconfigRecoveryTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/ReconfigRecoveryTest.java
@@ -22,6 +22,7 @@ import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZooKeeper;
@@ -399,7 +400,7 @@ public class ReconfigRecoveryTest extends QuorumPeerTestBase {
         String currentQuorumCfgSection, nextQuorumCfgSection;
 
         // generate old config string
-        HashSet<Integer> observers = new HashSet<Integer>();
+        Set<Integer> observers = new HashSet<Integer>();
         observers.add(2);
         StringBuilder sb = generateConfig(3, ports, observers);
         currentQuorumCfgSection = sb.toString();
@@ -473,7 +474,7 @@ public class ReconfigRecoveryTest extends QuorumPeerTestBase {
         String currentQuorumCfg, nextQuorumCfgSection;
 
         // generate old config string
-        HashSet<Integer> observers = new HashSet<Integer>();
+        Set<Integer> observers = new HashSet<Integer>();
         observers.add(2);
 
         StringBuilder sb = generateConfig(3, ports, observers);
@@ -570,7 +571,7 @@ public class ReconfigRecoveryTest extends QuorumPeerTestBase {
      * observerIds correspond to observers, other ids are for participants.
      */
     public static StringBuilder generateConfig(int numServers, int[][] ports,
-            HashSet<Integer> observerIds) {
+            Set<Integer> observerIds) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < numServers; i++) {
             String server = "server." + i + "=localhost:" + ports[i][0] + ":"

--- a/src/java/test/org/apache/zookeeper/test/ACLTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ACLTest.java
@@ -125,7 +125,7 @@ public class ACLTest extends ZKTestCase implements Watcher {
                 id.setId("1.1.1."+j);
                 id.setScheme("ip");
                 acl.setId(id);
-                ArrayList<ACL> list = new ArrayList<ACL>();
+                List<ACL> list = new ArrayList<ACL>();
                 list.add(acl);
                 zk.create(path, path.getBytes(), list, CreateMode.PERSISTENT);
             }

--- a/src/java/test/org/apache/zookeeper/test/AsyncTest.java
+++ b/src/java/test/org/apache/zookeeper/test/AsyncTest.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.test;
 
 
 import java.util.LinkedList;
+import java.util.List;
 
 import org.apache.zookeeper.AsyncCallback.DataCallback;
 import org.apache.zookeeper.AsyncCallback.StringCallback;
@@ -67,7 +68,8 @@ public class AsyncTest extends ZKTestCase
         return zk;
     }
 
-    LinkedList<Integer> results = new LinkedList<Integer>();
+    List<Integer> results = new LinkedList<Integer>();
+
     @Test
     public void testAsync() throws Exception
     {

--- a/src/java/test/org/apache/zookeeper/test/ClientBase.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientBase.java
@@ -211,7 +211,7 @@ public abstract class ClientBase extends ZKTestCase {
         return createClient(watcher, hostPort);
     }
 
-    private LinkedList<ZooKeeper> allClients;
+    private List<ZooKeeper> allClients;
     private boolean allClientsSetup = false;
 
     protected TestableZooKeeper createClient(CountdownWatcher watcher, String hp)

--- a/src/java/test/org/apache/zookeeper/test/CnxManagerTest.java
+++ b/src/java/test/org/apache/zookeeper/test/CnxManagerTest.java
@@ -29,6 +29,7 @@ import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.net.Socket;
@@ -54,7 +55,7 @@ public class CnxManagerTest extends ZKTestCase {
     protected static final int THRESHOLD = 4;
 
     int count;
-    HashMap<Long,QuorumServer> peers;
+    Map<Long,QuorumServer> peers;
     File peerTmpdir[];
     int peerQuorumPort[];
     int peerClientPort[];

--- a/src/java/test/org/apache/zookeeper/test/FLERestartTest.java
+++ b/src/java/test/org/apache/zookeeper/test/FLERestartTest.java
@@ -23,6 +23,8 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Semaphore;
 
 import org.slf4j.Logger;
@@ -43,8 +45,8 @@ public class FLERestartTest extends ZKTestCase {
     protected static final Logger LOG = LoggerFactory.getLogger(FLETest.class);
 
     private int count;
-    private HashMap<Long,QuorumServer> peers;
-    private ArrayList<FLERestartThread> restartThreads;
+    private Map<Long,QuorumServer> peers;
+    private List<FLERestartThread> restartThreads;
     private File tmpdir[];
     private int port[];
     private Semaphore finish;

--- a/src/java/test/org/apache/zookeeper/test/FLETest.java
+++ b/src/java/test/org/apache/zookeeper/test/FLETest.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,10 +65,10 @@ public class FLETest extends ZKTestCase {
     }
 
     int count;
-    HashMap<Long,QuorumServer> peers;
+    Map<Long,QuorumServer> peers;
     ArrayList<LEThread> threads;
-    HashMap<Integer, HashSet<TestVote> > voteMap;
-    HashMap<Long, LEThread> quora;
+    Map<Integer, HashSet<TestVote> > voteMap;
+    Map<Long, LEThread> quora;
     File tmpdir[];
     int port[];
     int successCount;

--- a/src/java/test/org/apache/zookeeper/test/FLEZeroWeightTest.java
+++ b/src/java/test/org/apache/zookeeper/test/FLEZeroWeightTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +45,7 @@ public class FLEZeroWeightTest extends ZKTestCase {
     Properties qp;
 
     int count;
-    HashMap<Long,QuorumServer> peers;
+    Map<Long,QuorumServer> peers;
     ArrayList<LEThread> threads;
     File tmpdir[];
     int port[];

--- a/src/java/test/org/apache/zookeeper/test/IntegrityCheck.java
+++ b/src/java/test/org/apache/zookeeper/test/IntegrityCheck.java
@@ -33,6 +33,7 @@ package org.apache.zookeeper.test;
  */
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +50,7 @@ public class IntegrityCheck implements StatCallback, DataCallback {
 
     ZooKeeper zk;
 
-    HashMap<String, byte[]> lastValue = new HashMap<String, byte[]>();
+    Map<String, byte[]> lastValue = new HashMap<String, byte[]>();
 
     int count;
 

--- a/src/java/test/org/apache/zookeeper/test/LocalSessionsOnlyTest.java
+++ b/src/java/test/org/apache/zookeeper/test/LocalSessionsOnlyTest.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.test;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.zookeeper.CreateMode;
@@ -107,7 +108,7 @@ public class LocalSessionsOnlyTest extends ZKTestCase {
         zk.close();
 
         // Validate data on both follower and leader
-        HashMap<String, Integer> peers = new HashMap<String, Integer>();
+        Map<String, Integer> peers = new HashMap<String, Integer>();
         peers.put("leader", leaderIdx);
         peers.put("follower", followerIdx);
         for (Entry<String, Integer> entry: peers.entrySet()) {

--- a/src/java/test/org/apache/zookeeper/test/OOMTest.java
+++ b/src/java/test/org/apache/zookeeper/test/OOMTest.java
@@ -23,6 +23,7 @@ import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -47,7 +48,7 @@ public class OOMTest extends ZKTestCase implements Watcher {
         File tmpDir = ClientBase.createTmpDir();
         // Grab some memory so that it is easier to cause an
         // OOM condition;
-        ArrayList<byte[]> hog = new ArrayList<byte[]>();
+        List<byte[]> hog = new ArrayList<byte[]>();
         while (true) {
             try {
                 hog.add(new byte[1024 * 1024 * 2]);

--- a/src/java/test/org/apache/zookeeper/test/QuorumBase.java
+++ b/src/java/test/org/apache/zookeeper/test/QuorumBase.java
@@ -24,6 +24,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -136,7 +137,7 @@ public class QuorumBase extends ClientBase {
         int tickTime = 2000;
         int initLimit = 3;
         int syncLimit = 3;
-        HashMap<Long,QuorumServer> peers = new HashMap<Long,QuorumServer>();
+        Map<Long,QuorumServer> peers = new HashMap<Long,QuorumServer>();
         peers.put(Long.valueOf(1), new QuorumServer(1, 
                 new InetSocketAddress(LOCALADDR, port1),
                 new InetSocketAddress(LOCALADDR, portLE1),
@@ -293,7 +294,7 @@ public class QuorumBase extends ClientBase {
         setupServer(5);
     }
 
-    HashMap<Long,QuorumServer> peers = null;
+    Map<Long,QuorumServer> peers = null;
     public void setupServer(int i) throws IOException {
         int tickTime = 2000;
         int initLimit = 3;

--- a/src/java/test/org/apache/zookeeper/test/ReconfigTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReconfigTest.java
@@ -479,7 +479,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         // lets remove someone who's not the leader
         leavingServers.add(getLeaderId(qu) == 5 ? "4": "5");
  
-        LinkedList<Integer> results = new LinkedList<Integer>();
+        List<Integer> results = new LinkedList<Integer>();
         
         zkAdminArr[1].reconfigure(null, leavingServers, null, -1, this, results);
         

--- a/src/java/test/org/apache/zookeeper/test/SessionTest.java
+++ b/src/java/test/org/apache/zookeeper/test/SessionTest.java
@@ -414,7 +414,7 @@ public class SessionTest extends ZKTestCase {
     }
 
     private class DupWatcher extends CountdownWatcher {
-        public LinkedList<WatchedEvent> states = new LinkedList<WatchedEvent>();
+        public List<WatchedEvent> states = new LinkedList<WatchedEvent>();
         public void process(WatchedEvent event) {
             super.process(event);
             if (event.getType() == EventType.None) {

--- a/src/java/test/org/apache/zookeeper/test/TruncateTest.java
+++ b/src/java/test/org/apache/zookeeper/test/TruncateTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.jute.Record;
 import org.apache.zookeeper.CreateMode;
@@ -189,7 +190,7 @@ public class TruncateTest extends ZKTestCase {
         int port3 = PortAssignment.unique();
         
         // Start up two of the quorum and add 10 txns
-        HashMap<Long,QuorumServer> peers = new HashMap<Long,QuorumServer>();
+        Map<Long,QuorumServer> peers = new HashMap<Long,QuorumServer>();
         peers.put(Long.valueOf(1), new QuorumServer(1,
                        new InetSocketAddress("127.0.0.1", PortAssignment.unique()),
                        new InetSocketAddress("127.0.0.1", PortAssignment.unique()),

--- a/src/recipes/queue/src/java/org/apache/zookeeper/recipes/queue/DistributedQueue.java
+++ b/src/recipes/queue/src/java/org/apache/zookeeper/recipes/queue/DistributedQueue.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.recipes.queue;
 
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
@@ -68,8 +69,8 @@ public class DistributedQueue {
      * @param watcher optional watcher on getChildren() operation.
      * @return map from id to child name for all children
      */
-    private TreeMap<Long,String> orderedChildren(Watcher watcher) throws KeeperException, InterruptedException {
-        TreeMap<Long,String> orderedChildren = new TreeMap<Long,String>();
+    private Map<Long,String> orderedChildren(Watcher watcher) throws KeeperException, InterruptedException {
+        Map<Long,String> orderedChildren = new TreeMap<Long,String>();
 
         List<String> childNames = null;
         try{
@@ -147,7 +148,7 @@ public class DistributedQueue {
      * @throws InterruptedException
      */
     public byte[] element() throws NoSuchElementException, KeeperException, InterruptedException {
-        TreeMap<Long,String> orderedChildren;
+        Map<Long,String> orderedChildren;
 
         // element, take, and remove follow the same pattern.
         // We want to return the child node with the smallest sequence number.
@@ -184,7 +185,7 @@ public class DistributedQueue {
      * @throws InterruptedException
      */
     public byte[] remove() throws NoSuchElementException, KeeperException, InterruptedException {
-        TreeMap<Long,String> orderedChildren;
+        Map<Long,String> orderedChildren;
         // Same as for element.  Should refactor this.
         while(true){
             try{
@@ -234,7 +235,7 @@ public class DistributedQueue {
      * @throws InterruptedException
      */
     public byte[] take() throws KeeperException, InterruptedException {
-        TreeMap<Long,String> orderedChildren;
+        Map<Long,String> orderedChildren;
         // Same as for element.  Should refactor this.
         while(true){
             LatchChildWatcher childWatcher = new LatchChildWatcher();


### PR DESCRIPTION
Use interface type instead of implementation type when appropriate.

There are a couple of places in code base where we declare a field / variable as implementation type (i.e. HashMap, HashSet) instead of interface type (i.e. Map, Set), while in other places we do the opposite by declaring as interface type. A quick check indicates that most if not all of these places could be updated so we have a consistent style over the code base (prefer using interface type), which is also a good coding style to stick per best practice.

Checked and fixed Set, Map and List interface usages.

Author: Tamas Penzes <tamaas@cloudera.com>

Reviewers: Abe Fine <afine@apache.org>, Michael Han <hanm@apache.org>

Closes #354 from tamaashu/ZOOKEEPER-2630

(cherry picked from commit 1165794be9587acccc02782dbff95bc482222528)