### PR TITLE
ZOOKEEPER-2101: Transaction larger than max buffer of jute makes zookeeper unavailable

### DIFF
--- a/src/java/main/org/apache/jute/BinaryOutputArchive.java
+++ b/src/java/main/org/apache/jute/BinaryOutputArchive.java
@@ -115,6 +115,11 @@ public class BinaryOutputArchive implements OutputArchive {
     		out.writeInt(-1);
     		return;
     	}
+    	if (barr.length >= BinaryInputArchive.maxBuffer) {
+    	  throw new IOException("Len error " + barr.length
+    	      + ", larger than max buffer: "
+    	      + BinaryInputArchive.maxBuffer + " set by jute.maxbuffer");
+    	}
     	out.writeInt(barr.length);
         out.write(barr);
     }

--- a/src/java/main/org/apache/zookeeper/server/ZKDatabase.java
+++ b/src/java/main/org/apache/zookeeper/server/ZKDatabase.java
@@ -18,7 +18,6 @@
 
 package org.apache.zookeeper.server;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Collection;
@@ -32,7 +31,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
-import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
 import org.apache.jute.Record;
@@ -264,19 +262,14 @@ public class ZKDatabase {
                 maxCommittedLog = request.zxid;
             }
 
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            BinaryOutputArchive boa = BinaryOutputArchive.getArchive(baos);
-            try {
-                request.getHdr().serialize(boa, "hdr");
-                if (request.getTxn() != null) {
-                    request.getTxn().serialize(boa, "txn");
-                }
-                baos.close();
-            } catch (IOException e) {
-                LOG.error("This really should be impossible", e);
+            byte[] data = SerializeUtils.serializeRequest(request);
+            if (request.request != null) {
+                LOG.debug("Request type: {}, size: {}, zxid: {}," +
+                    " Proposal size: {}", request.type,
+                    request.request.capacity(), request.zxid, data.length);
             }
             QuorumPacket pp = new QuorumPacket(Leader.PROPOSAL, request.zxid,
-                    baos.toByteArray(), null);
+                    data, null);
             Proposal p = new Proposal();
             p.packet = pp;
             p.request = request;

--- a/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
@@ -48,6 +48,7 @@ import org.apache.zookeeper.server.RequestProcessor;
 import org.apache.zookeeper.server.ZooKeeperCriticalThread;
 import org.apache.zookeeper.server.quorum.QuorumPeer.LearnerType;
 import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
+import org.apache.zookeeper.server.util.SerializeUtils;
 import org.apache.zookeeper.server.util.ZxidUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1047,20 +1048,9 @@ public class Leader {
             throw new XidRolloverException(msg);
         }
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        BinaryOutputArchive boa = BinaryOutputArchive.getArchive(baos);
-        try {
-            request.getHdr().serialize(boa, "hdr");
-            if (request.getTxn() != null) {
-                request.getTxn().serialize(boa, "txn");
-            }
-            baos.close();
-        } catch (IOException e) {
-            LOG.warn("This really should be impossible", e);
-        }
+        byte[] data = SerializeUtils.serializeRequest(request);
         QuorumPacket pp = new QuorumPacket(Leader.PROPOSAL, request.zxid,
-                baos.toByteArray(), null);
-
+            data, null);
         Proposal p = new Proposal();
         p.packet = pp;
         p.request = request;                


### PR DESCRIPTION
This patch has been created to reanimate an ancient, unclosed Jira:
https://issues.apache.org/jira/browse/ZOOKEEPER-2101

Original patch was done by Liu Shaohui and applied to latest trunk
without any modification.

This one would be a nice kick off for implementing jute (max) buffer size
monitoring.