### PR TITLE
ZOOKEEPER-2932 Performance enhancement about purging task.

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/persistence/FileTxnLog.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FileTxnLog.java
@@ -255,30 +255,19 @@ public class FileTxnLog implements TxnLog {
      */
     public static File[] getLogFiles(File[] logDirList,long snapshotZxid) {
         List<File> files = Util.sortDataDir(logDirList, "log", true);
-        long logZxid = 0;
-        // Find the log file that starts before or at the same time as the
-        // zxid of the snapshot
-        for (File f : files) {
+        int lastIndex = files.size() - 1;
+        List<File> v = new ArrayList<File>(5);
+        for (int i = lastIndex; i >= 0; i--) {
+            File f = files.get(i);
             long fzxid = Util.getZxidFromName(f.getName(), "log");
             if (fzxid > snapshotZxid) {
-                continue;
+                v.add(0, f);
+            } else {
+                v.add(0, f);
+                break;
             }
-            // the files
-            // are sorted with zxid's
-            if (fzxid > logZxid) {
-                logZxid = fzxid;
-            }
-        }
-        List<File> v=new ArrayList<File>(5);
-        for (File f : files) {
-            long fzxid = Util.getZxidFromName(f.getName(), "log");
-            if (fzxid < logZxid) {
-                continue;
-            }
-            v.add(f);
         }
         return v.toArray(new File[0]);
-
     }
 
     /**


### PR DESCRIPTION
The method FileTxnLog.getLogFiles is used to find out the target log files to be retained base on the given zxid when purging task is running. The current implementation of this method is trivial to understand, and iterate the log files twice to achieve its purchase. It could be improved from both performance and readability.