### PR TITLE
ZOOKEEPER-2934: Updated usage of LOG_DEBUG in recipes to follow changes in ZK client

### DIFF
--- a/src/recipes/queue/src/c/include/zoo_queue.h
+++ b/src/recipes/queue/src/c/include/zoo_queue.h
@@ -100,7 +100,7 @@ ZOOAPI int zkr_queue_remove(zkr_queue_t *queue, char *buffer, int *buffer_len);
  * \param buffer_len a pointer to the length of the buffer
  * \return returns 0 (ZOK) and sets *buffer_len to the length of data written if successful. Otherwise it will set *buffer_len to -1 and return a zookeeper error code. 
  */
-ZOOAPI int zkr_queue_take(zkr_queue_t *queue, char *buffer, int *buffer_len);
+ZOOAPI int zkr_queue_take(zhandle_t *zh, zkr_queue_t *queue, char *buffer, int *buffer_len);
 
 /**
  * \brief destroys a zookeeper queue structure 


### PR DESCRIPTION
LOG_* macros have been changed recently in https://issues.apache.org/jira/browse/ZOOKEEPER-1400

This patch updates 'lock' and 'queue' recipes to follow the changes.