### PR TITLE
[zookeeper-2937] disallow client requests without completing authentication...

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/ServerCnxn.java
+++ b/src/java/main/org/apache/zookeeper/server/ServerCnxn.java
@@ -48,6 +48,7 @@ public abstract class ServerCnxn implements Stats, Watcher {
     private static final Logger LOG = LoggerFactory.getLogger(ServerCnxn.class);
     
     private Set<Id> authInfo = Collections.newSetFromMap(new ConcurrentHashMap<Id, Boolean>());
+    private boolean authCheckCompleted = false;
 
     /**
      * If the client is of old version, we don't send r-o mode info to it.
@@ -84,6 +85,14 @@ public abstract class ServerCnxn implements Stats, Watcher {
     public boolean removeAuthInfo(Id id) {
         return authInfo.remove(id);
     }
+
+    public boolean isAuthCheckComplete() {
+        return authCheckCompleted;
+    };
+
+    public void authCheckComplete() {
+        authCheckCompleted = true;
+    };
 
     abstract void sendBuffer(ByteBuffer closeConn);
 

--- a/src/java/main/org/apache/zookeeper/server/auth/AuthenticationProvider.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/AuthenticationProvider.java
@@ -79,4 +79,13 @@ public interface AuthenticationProvider {
      * @return true if id is well formed.
      */
     boolean isValid(String id);
+
+    /**
+     * This method is used to check and see if the provider has to
+     * authenticate the client before any requests from it can be processed.
+     *
+     * @return true if this provider needs to authenticate the client before
+     * it can honor any requests from it
+     */
+    boolean needAuthentication();
 }

--- a/src/java/main/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
@@ -126,6 +126,10 @@ public class DigestAuthenticationProvider implements AuthenticationProvider {
         return id.equals(aclExpr);
     }
 
+    public boolean needAuthentication() {
+        return false;
+    }
+
     /** Call with a single argument of user:pass to generate authdata.
      * Authdata output can be used when setting superDigest for example. 
      * @param args single argument of user:pass

--- a/src/java/main/org/apache/zookeeper/server/auth/IPAuthenticationProvider.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/IPAuthenticationProvider.java
@@ -129,4 +129,8 @@ public class IPAuthenticationProvider implements AuthenticationProvider {
         }
         return true;
     }
+
+    public boolean needAuthentication() {
+        return false;
+    }
 }

--- a/src/java/main/org/apache/zookeeper/server/auth/KeyAuthenticationProvider.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/KeyAuthenticationProvider.java
@@ -137,4 +137,9 @@ public class KeyAuthenticationProvider extends ServerAuthenticationProvider {
     public boolean isValid(String id) {
         return true;
     }
+
+    @Override
+    public boolean needAuthentication() {
+        return false;
+    }
 }

--- a/src/java/main/org/apache/zookeeper/server/auth/SASLAuthenticationProvider.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/SASLAuthenticationProvider.java
@@ -70,5 +70,8 @@ public class SASLAuthenticationProvider implements AuthenticationProvider {
         }
    }
 
+   public boolean needAuthentication() {
+        return false;
+   }
 
 }

--- a/src/java/main/org/apache/zookeeper/server/auth/WrappedAuthenticationProvider.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/WrappedAuthenticationProvider.java
@@ -74,4 +74,9 @@ class WrappedAuthenticationProvider extends ServerAuthenticationProvider {
     public boolean isValid(String id) {
         return implementation.isValid(id);
     }
+
+    @Override
+    public boolean needAuthentication() {
+        return implementation.needAuthentication();
+    }
 }

--- a/src/java/main/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -244,4 +244,9 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
         }
         return keyManager;
     }
+
+    @Override
+    public boolean needAuthentication() {
+        return false;
+    }
 }


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/ZOOKEEPER-2937
- do not process data packets, if authentication via providers that
  *requires* authentication aren't completed