### PR TITLE
ZOOKEEPER-2849: Exponential back-off retry for Quorum port binding

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/BackoffStrategy.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/BackoffStrategy.java
@@ -1,0 +1,19 @@
+package org.apache.zookeeper.server.quorum;
+
+public interface BackoffStrategy {
+
+    long STOP = -1L;
+
+    /**
+     * Get the number of milliseconds to wait before retrying the operation,
+     * or {@code BackoffStrategy.STOP} if no more retries should be made.
+     * @return the number of milliseconds to wait before retrying the operation.
+     * @throws IllegalStateException
+     */
+    long nextWaitMillis() throws IllegalStateException;
+
+    /**
+     * Reset to it's initial state.
+     */
+    void reset();
+}

--- a/src/java/main/org/apache/zookeeper/server/quorum/ExponentialBackoffStrategy.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/ExponentialBackoffStrategy.java
@@ -1,0 +1,192 @@
+package org.apache.zookeeper.server.quorum;
+
+/**
+ * A {@link BackoffStrategy} that increases the wait time between each
+ * interval up to the configured maximum wait time.
+ */
+public class ExponentialBackoffStrategy implements BackoffStrategy {
+
+    // Sensible default values to use if not set by the user
+    private static final long DEFAULT_INITIAL_BACKOFF_MILLIS = 500L;  // 0.5s
+    private static final long DEFAULT_MAX_BACKOFF_MILLIS = 30_000L;  // 30s
+    private static final long DEFAULT_MAX_ELAPSED_MILLIS = 5 * 60_000L; // 10m
+    private static final double DEFAULT_BACKOFF_MULTIPLE = 1.5;
+
+    // internal values per instance
+    private final long initialBackoffMillis;
+    private final long maxBackoffMillis;
+    private final long maxElapsedMillis;
+    private final double backoffMultiple;
+
+    // internal state
+    private long nextWait;
+    private long totalElapsed;
+    private final boolean limitBackoffMillis;
+    private final boolean checkElapsedTime;
+
+    /**
+     * Construct a new instance.
+     * @param builder the Builder to use for configuring this BackoffStrategy
+     */
+    private ExponentialBackoffStrategy(Builder builder) {
+        this.initialBackoffMillis = builder.initialBackoffMillis;
+        this.maxBackoffMillis = builder.maxBackoffMillis;
+        this.maxElapsedMillis = builder.maxElapsedMillis;
+        this.backoffMultiple = builder.backoffMultiple;
+
+        if(maxBackoffMillis == -1) {
+            limitBackoffMillis = false;
+        } else {
+            limitBackoffMillis = true;
+        }
+
+        if(maxElapsedMillis == -1) {
+            checkElapsedTime = false;
+        } else {
+            checkElapsedTime = true;
+        }
+
+        reset();
+    }
+
+
+    @Override
+    public long nextWaitMillis() throws IllegalStateException {
+        // check if we have exceeded the allowed maximum elapsed time
+        if(checkElapsedTime && totalElapsed > maxElapsedMillis) {
+            return BackoffStrategy.STOP;
+        }
+
+        long waitMillis = nextWait;
+
+        // calculate the next wait milliseconds
+        nextWait = Math.round(nextWait * backoffMultiple);
+
+        // don't exceed the allowed maximum wait milliseconds
+        // if a maximum was configured
+        if(limitBackoffMillis && nextWait > maxBackoffMillis) {
+            nextWait = maxBackoffMillis;
+        }
+
+        // track total elapsed time, even if we don't wait we have to assume
+        // that some amount of time passed outside of the wait or we'll never
+        // hit the elapsed time limit
+        totalElapsed += waitMillis != 0 ? waitMillis : 1L;
+        return waitMillis;
+    }
+
+    @Override
+    public void reset() {
+        nextWait = this.initialBackoffMillis;
+        totalElapsed = 0;
+    }
+
+    /**
+     *
+     * @return a new {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for instances of {@link ExponentialBackoffStrategy}.
+     */
+    public static final class Builder {
+        private long initialBackoffMillis = DEFAULT_INITIAL_BACKOFF_MILLIS;
+        private long maxBackoffMillis = DEFAULT_MAX_BACKOFF_MILLIS;
+        private long maxElapsedMillis = DEFAULT_MAX_ELAPSED_MILLIS;
+        private double backoffMultiple = DEFAULT_BACKOFF_MULTIPLE;
+
+        /**
+         * Set the initial number of milliseconds to wait.  Valid values are
+         * 0 to Long.MAX_VALUE, 0 resulting in no wait time in the initial
+         * interval.
+         * @param milliseconds the initial number of milliseconds to wait
+         * @return this Builder
+         */
+        public Builder setInitialBackoff(long milliseconds) {
+            this.initialBackoffMillis = milliseconds;
+            return this;
+        }
+
+        /**
+         * Set the maximum number of wait milliseconds that can be generated.
+         * Valid values are -1 to Long.MAX_VALUE, 0 resulting in 0
+         * milliseconds in each wait interval (no wait) & -1 resulting in no
+         * limit to the number of milliseconds in each wait interval.
+         * @param milliseconds the maximum number of wait milliseconds
+         * @return this Builder
+         */
+        public Builder setMaxBackoff(long milliseconds) {
+            this.maxBackoffMillis = milliseconds;
+            return this;
+        }
+
+        /**
+         * Set the total number of milliseconds that can be provided to wait.
+         * Valid values are -1 to Long.MAX_VALUE.  0 would result in
+         * {@link BackoffStrategy#STOP} returned on the first call to
+         * {@link ExponentialBackoffStrategy#nextWaitMillis()}.  -1 would
+         * result in no maximum being applied to the BackoffStrategy.
+         * @param milliseconds the maximum elapsed milliseconds this BackoffStrategy
+         *                     can provide
+         * @return this Builder
+         */
+        public Builder setMaxElapsed(long milliseconds) {
+            this.maxElapsedMillis = milliseconds;
+            return this;
+        }
+
+        /**
+         * Set the multiple applied to the previous backoff milliseconds
+         * value to get to the next backoff milliseconds value.  Valid values
+         * must be greater than 0.0 and less than Double.MAX_VALUE.
+         * @param multiple the backoff multiple
+         * @return this Builder
+         */
+        public Builder setBackoffMultiplier(double multiple) {
+            this.backoffMultiple = multiple;
+            return this;
+        }
+
+        /**
+         * Construct a new {@link ExponentialBackoffStrategy} instance using this
+         * Builder's configuration.
+         * @return a new ExponentialBackoffStrategy instance
+         */
+        public ExponentialBackoffStrategy build() {
+            // Valid Range: 0 to Long.MAX_VALUE, 0 meaning no initial wait
+            validateInclusiveBetween(0L, Long.MAX_VALUE, initialBackoffMillis);
+            // Valid Range: 0 to Long.MAX_VALUE, 0 meaning no limit
+            validateInclusiveBetween(-1L, Long.MAX_VALUE, maxBackoffMillis);
+            // Valid Range: 0 to Long.MAX_VALUE, 0 meaning no limit
+            validateInclusiveBetween(-1L, Long.MAX_VALUE, maxElapsedMillis);
+            // Valid Range: 1.0001 to Double.MAX_VALUE
+            validateExclusiveBetween(0.0, Double.MAX_VALUE, backoffMultiple);
+
+            return new ExponentialBackoffStrategy(this);
+        }
+
+        private void validateInclusiveBetween(long min, long max, long value) {
+            if(value < min) {
+                throw new IllegalArgumentException();
+            }
+
+            if(value > max) {
+                throw new IllegalArgumentException();
+            }
+        }
+
+        private void validateExclusiveBetween(double min, double max, double
+            value) {
+            if(value <= min) {
+                throw new IllegalArgumentException();
+            }
+
+            if(value >= max) {
+                throw new IllegalArgumentException();
+            }
+        }
+    }
+}

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -946,7 +946,8 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
                 le = new AuthFastLeaderElection(this, true);
                 break;
             case 3:
-                qcm = new QuorumCnxManager(this);
+                qcm = new QuorumCnxManager(this,
+                    ExponentialBackoffStrategy.builder().build());
                 QuorumCnxManager.Listener listener = qcm.listener;
                 if(listener != null){
                     listener.start();

--- a/src/java/test/org/apache/zookeeper/server/quorum/ExponentialBackoffStrategyTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/ExponentialBackoffStrategyTest.java
@@ -1,0 +1,163 @@
+package org.apache.zookeeper.server.quorum;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ExponentialBackoffStrategy}.
+ */
+public class ExponentialBackoffStrategyTest {
+
+    // Input validation tests
+    @Test(expected = IllegalArgumentException.class)
+    public void initialBackoffRangeMin() {
+        ExponentialBackoffStrategy.builder()
+            .setInitialBackoff(-1L)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void initialBackoffRangeMax() {
+        ExponentialBackoffStrategy.builder()
+            .setInitialBackoff(Long.MAX_VALUE + 1L)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void maxBackoffRangeMin() {
+        ExponentialBackoffStrategy.builder()
+            .setMaxBackoff(-2L)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void maxBackoffRangeMax() {
+        ExponentialBackoffStrategy.builder()
+            .setMaxBackoff(Long.MAX_VALUE + 1L)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void maxElapsedRangeMin() {
+        ExponentialBackoffStrategy.builder()
+            .setMaxElapsed(-2L)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void maxElapsedRangeMax() {
+        ExponentialBackoffStrategy.builder()
+            .setMaxElapsed(Long.MIN_VALUE)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void multipleRangeMin() {
+        ExponentialBackoffStrategy.builder()
+            .setBackoffMultiplier(-0.00000000001)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void multipleRangeMax() {
+        ExponentialBackoffStrategy.builder()
+            .setBackoffMultiplier(Double.MAX_VALUE + 0.1)
+            .build();
+    }
+
+    // Test the generated intervals are what we expect
+    @Test
+    public void generateWaitIntervals() {
+        final ExponentialBackoffStrategy strategy = ExponentialBackoffStrategy
+            .builder()
+            .setInitialBackoff(10L)
+            .setMaxBackoff(50L)
+            .setMaxElapsed(80L)
+            .setBackoffMultiplier(1.5)
+            .build();
+
+        assertEquals(10L, strategy.nextWaitMillis());
+        assertEquals(15L, strategy.nextWaitMillis());
+        assertEquals(23L, strategy.nextWaitMillis());
+        assertEquals(35L, strategy.nextWaitMillis());
+        assertEquals(BackoffStrategy.STOP, strategy.nextWaitMillis());
+    }
+
+
+    @Test
+    public void exponentialDecreasingBackoff() {
+        final ExponentialBackoffStrategy strategy =
+            ExponentialBackoffStrategy.builder()
+                .setInitialBackoff(100L)
+                .setMaxBackoff(50L)
+                .setBackoffMultiplier(0.6)
+                .setMaxElapsed(1_000L)
+                .build();
+
+
+        assertEquals(100L, strategy.nextWaitMillis());
+        assertEquals(50L, strategy.nextWaitMillis());
+        assertEquals(30L, strategy.nextWaitMillis());
+        assertEquals(18L, strategy.nextWaitMillis());
+        assertEquals(11L, strategy.nextWaitMillis());
+        assertEquals(7L, strategy.nextWaitMillis());
+        assertEquals(4L, strategy.nextWaitMillis());
+        assertEquals(2L, strategy.nextWaitMillis());
+        assertEquals(1L, strategy.nextWaitMillis());
+        // total elapsed so far is 223, so check that we get 777 more
+        // intervals of 1ms then STOP
+        for (int i = 0; i <= 777; i++) {
+            assertEquals(1L, strategy.nextWaitMillis());
+        }
+        assertEquals(BackoffStrategy.STOP, strategy.nextWaitMillis());
+    }
+
+
+    @Test
+    public void generateWaitIntervalsNoWaits() {
+        final ExponentialBackoffStrategy strategy = ExponentialBackoffStrategy
+            .builder()
+            .setInitialBackoff(0L)
+            .setMaxBackoff(0L)
+            .setMaxElapsed(100L)
+            .setBackoffMultiplier(10.0)
+            .build();
+
+        for (int i = 0; i <= 100; i++) {
+            assertEquals(0L, strategy.nextWaitMillis());
+        }
+        assertEquals(BackoffStrategy.STOP, strategy.nextWaitMillis());
+    }
+
+    @Test
+    public void generateWaitIntervalsNoLimits() {
+        final ExponentialBackoffStrategy strategy = ExponentialBackoffStrategy
+            .builder()
+            .setInitialBackoff(1L)
+            .setMaxBackoff(-1L)
+            .setMaxElapsed(-1L)
+            .setBackoffMultiplier(2.5)
+            .build();
+
+        assertEquals(1L, strategy.nextWaitMillis());
+        assertEquals(3L, strategy.nextWaitMillis());
+        assertEquals(8L, strategy.nextWaitMillis());
+        assertEquals(20L, strategy.nextWaitMillis());
+        assertEquals(50L, strategy.nextWaitMillis());
+        assertEquals(125L, strategy.nextWaitMillis());
+        assertEquals(313L, strategy.nextWaitMillis());
+        assertEquals(783L, strategy.nextWaitMillis());
+
+        long previousWait = 783L;
+        for (int i = 0; i < 10_000; i++) {
+            long currentWait = strategy.nextWaitMillis();
+            assertNotEquals(BackoffStrategy.STOP, currentWait);
+            assertTrue("Expected " + previousWait + " to be greater than " +
+                currentWait, previousWait <= currentWait);
+            previousWait = currentWait;
+        }
+    }
+}

--- a/src/java/test/org/apache/zookeeper/server/quorum/FLEBackwardElectionRoundTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/FLEBackwardElectionRoundTest.java
@@ -114,7 +114,7 @@ public class FLEBackwardElectionRoundTest extends ZKTestCase {
          * Start mock server 1
          */
         QuorumPeer mockPeer = new QuorumPeer(peers, tmpdir[1], tmpdir[1], port[1], 3, 1, 1000, 2, 2);
-        cnxManagers[0] = new QuorumCnxManager(mockPeer);
+        cnxManagers[0] = new QuorumCnxManager(mockPeer, ExponentialBackoffStrategy.builder().build());
         cnxManagers[0].listener.start();
 
         cnxManagers[0].toSend(0l, initialMsg);
@@ -123,7 +123,7 @@ public class FLEBackwardElectionRoundTest extends ZKTestCase {
          * Start mock server 2
          */
         mockPeer = new QuorumPeer(peers, tmpdir[2], tmpdir[2], port[2], 3, 2, 1000, 2, 2);
-        cnxManagers[1] = new QuorumCnxManager(mockPeer);
+        cnxManagers[1] = new QuorumCnxManager(mockPeer, ExponentialBackoffStrategy.builder().build());
         cnxManagers[1].listener.start();
 
         cnxManagers[1].toSend(0l, initialMsg);

--- a/src/java/test/org/apache/zookeeper/server/quorum/FLELostMessageTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/FLELostMessageTest.java
@@ -95,7 +95,7 @@ public class FLELostMessageTest extends ZKTestCase {
 
     void mockServer() throws InterruptedException, IOException {
         QuorumPeer peer = new QuorumPeer(peers, tmpdir[0], tmpdir[0], port[0], 3, 0, 1000, 2, 2);
-        cnxManager = new QuorumCnxManager(peer);
+        cnxManager = new QuorumCnxManager(peer, ExponentialBackoffStrategy.builder().build());
         cnxManager.listener.start();
 
         cnxManager.toSend(1l, FLETestUtils.createMsg(ServerState.LOOKING.ordinal(), 0, 0, 0));

--- a/src/java/test/org/apache/zookeeper/test/CnxManagerTest.java
+++ b/src/java/test/org/apache/zookeeper/test/CnxManagerTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.net.Socket;
 
 import org.apache.zookeeper.common.Time;
+import org.apache.zookeeper.server.quorum.ExponentialBackoffStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
@@ -110,7 +111,7 @@ public class CnxManagerTest extends ZKTestCase {
         public void run(){
             try {
                 QuorumPeer peer = new QuorumPeer(peers, peerTmpdir[0], peerTmpdir[0], peerClientPort[0], 3, 0, 1000, 2, 2);
-                QuorumCnxManager cnxManager = new QuorumCnxManager(peer);
+                QuorumCnxManager cnxManager = new QuorumCnxManager(peer, ExponentialBackoffStrategy.builder().build());
                 QuorumCnxManager.Listener listener = cnxManager.listener;
                 if(listener != null){
                     listener.start();
@@ -154,7 +155,7 @@ public class CnxManagerTest extends ZKTestCase {
         thread.start();
 
         QuorumPeer peer = new QuorumPeer(peers, peerTmpdir[1], peerTmpdir[1], peerClientPort[1], 3, 1, 1000, 2, 2);
-        QuorumCnxManager cnxManager = new QuorumCnxManager(peer);
+        QuorumCnxManager cnxManager = new QuorumCnxManager(peer, ExponentialBackoffStrategy.builder().build());
         QuorumCnxManager.Listener listener = cnxManager.listener;
         if(listener != null){
             listener.start();
@@ -201,7 +202,7 @@ public class CnxManagerTest extends ZKTestCase {
         peerTmpdir[2] = ClientBase.createTmpDir();
 
         QuorumPeer peer = new QuorumPeer(peers, peerTmpdir[1], peerTmpdir[1], peerClientPort[1], 3, 1, 1000, 2, 2);
-        QuorumCnxManager cnxManager = new QuorumCnxManager(peer);
+        QuorumCnxManager cnxManager = new QuorumCnxManager(peer, ExponentialBackoffStrategy.builder().build());
         QuorumCnxManager.Listener listener = cnxManager.listener;
         if(listener != null){
             listener.start();
@@ -229,7 +230,7 @@ public class CnxManagerTest extends ZKTestCase {
     @Test
     public void testCnxManagerSpinLock() throws Exception {
         QuorumPeer peer = new QuorumPeer(peers, peerTmpdir[1], peerTmpdir[1], peerClientPort[1], 3, 1, 1000, 2, 2);
-        QuorumCnxManager cnxManager = new QuorumCnxManager(peer);
+        QuorumCnxManager cnxManager = new QuorumCnxManager(peer, ExponentialBackoffStrategy.builder().build());
         QuorumCnxManager.Listener listener = cnxManager.listener;
         if(listener != null){
             listener.start();
@@ -294,7 +295,7 @@ public class CnxManagerTest extends ZKTestCase {
         peers.get(2L).type = LearnerType.OBSERVER;
         QuorumPeer peer = new QuorumPeer(peers, peerTmpdir[1], peerTmpdir[1],
                 peerClientPort[1], 3, 1, 1000, 2, 2);
-        QuorumCnxManager cnxManager = new QuorumCnxManager(peer);
+        QuorumCnxManager cnxManager = new QuorumCnxManager(peer, ExponentialBackoffStrategy.builder().build());
         QuorumCnxManager.Listener listener = cnxManager.listener;
         if (listener != null) {
             listener.start();
@@ -341,7 +342,7 @@ public class CnxManagerTest extends ZKTestCase {
     @Test
     public void testSocketTimeout() throws Exception {
         QuorumPeer peer = new QuorumPeer(peers, peerTmpdir[1], peerTmpdir[1], peerClientPort[1], 3, 1, 2000, 2, 2);
-        QuorumCnxManager cnxManager = new QuorumCnxManager(peer);
+        QuorumCnxManager cnxManager = new QuorumCnxManager(peer, ExponentialBackoffStrategy.builder().build());
         QuorumCnxManager.Listener listener = cnxManager.listener;
         if(listener != null){
             listener.start();

--- a/src/java/test/org/apache/zookeeper/test/FLEPredicateTest.java
+++ b/src/java/test/org/apache/zookeeper/test/FLEPredicateTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 
+import org.apache.zookeeper.server.quorum.ExponentialBackoffStrategy;
 import org.apache.zookeeper.server.quorum.FastLeaderElection;
 import org.apache.zookeeper.server.quorum.QuorumCnxManager;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
@@ -41,7 +42,7 @@ public class FLEPredicateTest extends ZKTestCase {
     
     class MockFLE extends FastLeaderElection {
         MockFLE(QuorumPeer peer){
-            super(peer, new QuorumCnxManager(peer));
+            super(peer, new QuorumCnxManager(peer, ExponentialBackoffStrategy.builder().build()));
         }
         
         boolean predicate(long newId, long newZxid, long newEpoch, long curId, long curZxid, long curEpoch){


### PR DESCRIPTION
  Added BackoffStrategy interface with ExponentialBackoffStrategy as a concrete implementation. Enhanced
  QuorumCnxManager to utilize the provided BackoffStrategy to determine retry of port binding as opposed to
  a fixed interval/count.