### PR TITLE
ZOOKEEPER-2944: Specify correct overflow value

### DIFF
--- a/src/docs/src/documentation/content/xdocs/zookeeperProgrammers.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperProgrammers.xml
@@ -241,7 +241,7 @@
         counter used to store the next sequence number is a signed int
         (4bytes) maintained by the parent node, the counter will
         overflow when incremented beyond 2147483647 (resulting in a
-        name "&lt;path&gt;-2147483647").</para>
+        name "&lt;path&gt;-2147483648").</para>
       </section>
 
       <section>


### PR DESCRIPTION
When a sequence counter exceeds 2147483647, the next value is -2147483648.