### PR TITLE
ZOOKEEPER-2893. very poor choice of logging if client fails to connect to server

### DIFF
--- a/src/java/main/org/apache/zookeeper/ClientCnxn.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxn.java
@@ -1041,6 +1041,8 @@ public class ClientCnxn {
 
         private InetSocketAddress rwServerAddress = null;
 
+        private InetSocketAddress addr = null;
+
         private final static int minPingRwTimeout = 100;
 
         private final static int maxPingRwTimeout = 60000;
@@ -1063,7 +1065,6 @@ public class ClientCnxn {
             }
             state = States.CONNECTING;
 
-            InetSocketAddress addr;
             if (rwServerAddress != null) {
                 addr = rwServerAddress;
                 rwServerAddress = null;
@@ -1232,11 +1233,12 @@ public class ClientCnxn {
                         } else if (e instanceof RWServerFoundException) {
                             LOG.info(e.getMessage());
                         } else {
+                            SocketAddress remoteAddr = clientCnxnSocket.getRemoteSocketAddress();
                             LOG.warn(
                                     "Session 0x"
                                             + Long.toHexString(getSessionId())
                                             + " for server "
-                                            + clientCnxnSocket.getRemoteSocketAddress()
+                                            + (remoteAddr == null ? addr : remoteAddr)
                                             + ", unexpected error"
                                             + RETRY_CONN_MSG, e);
                         }

--- a/src/java/main/org/apache/zookeeper/ClientCnxn.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxn.java
@@ -1232,15 +1232,13 @@ public class ClientCnxn {
                         } else if (e instanceof RWServerFoundException) {
                             LOG.info(e.getMessage());
                         } else if (e instanceof SocketException) {
-                            LOG.info(String.format("Socket error occurred: %s: %s", serverAddress, e.getMessage()));
+                            LOG.info("Socket error occurred: {}: {}", serverAddress, e.getMessage());
                         } else {
-                            LOG.warn(
-                                    "Session 0x"
-                                            + Long.toHexString(getSessionId())
-                                            + " for server "
-                                            + serverAddress
-                                            + ", unexpected error"
-                                            + RETRY_CONN_MSG, e);
+                            LOG.warn("Session 0x{} for server {}, unexpected error{}",
+                                            Long.toHexString(getSessionId()),
+                                            serverAddress,
+                                            RETRY_CONN_MSG,
+                                            e);
                         }
                         // At this point, there might still be new packets appended to outgoingQueue.
                         // they will be handled in next connection or cleared up if closed.


### PR DESCRIPTION
'addr' variable is used to identify which server to connect to.
I've made this available for error handling code in order to let it fallback to this address if the remote socket hasn't been initialised yet. This will give us better error messages if the client is unable to connect to server for some reason.