### PR TITLE
ZOOKEEPER-2961: Fix testElectionFraud Flakyness

### DIFF
--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerMainTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerMainTest.java
@@ -34,6 +34,7 @@ import java.util.regex.Pattern;
 import org.apache.log4j.Layout;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
 import org.apache.log4j.WriterAppender;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -346,9 +347,9 @@ public class QuorumPeerMainTest extends QuorumPeerTestBase {
     @Test
     public void testElectionFraud() throws IOException, InterruptedException {
         // capture QuorumPeer logging
-        Layout layout = Logger.getRootLogger().getAppender("CONSOLE").getLayout();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        WriterAppender appender = new WriterAppender(layout, os);
+        String loggingPattern = ((PatternLayout) Logger.getRootLogger().getAppender("CONSOLE").getLayout()).getConversionPattern();
+        WriterAppender appender = new WriterAppender(new PatternLayout(loggingPattern), os);
         appender.setThreshold(Level.INFO);
         Logger qlogger = Logger.getLogger(QuorumPeer.class);
         qlogger.addAppender(appender);


### PR DESCRIPTION
This test relies on hooking into our logging system and creates a new appender using a PatternLayout object shared with the CONSOLE appender. PatternLayout has some synchronization issues (https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html) so we should create a new instance of it.