### PR TITLE
ZOOKEEPER-2979 Use dropwizard library histogram for proposal-related metrics

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -29,6 +29,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="slf4j.version" value="1.7.25"/>
     <property name="commons-cli.version" value="1.2"/>
 
+    <property name="dropwizard.version" value="3.2.5" />
     <property name="wagon-http.version" value="2.4"/>
     <property name="maven-ant-tasks.version" value="2.1.3"/>
     <property name="log4j.version" value="1.2.17"/>
@@ -226,7 +227,6 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="tests-jar" value="${dist.maven.dir}/${final.name}-tests.jar"/>
     <property name="sources-jar" value="${dist.maven.dir}/${final.name}-sources.jar"/>
     <property name="javadoc-jar" value="${dist.maven.dir}/${final.name}-javadoc.jar"/>
-
 
     <!-- ====================================================== -->
     <!-- Macro definitions                                      -->

--- a/ivy.xml
+++ b/ivy.xml
@@ -139,6 +139,9 @@
     <dependency org="io.dropwizard.metrics" name="metrics-core"
                 rev="${dropwizard.version}" conf="default" />
 
+    <dependency org="org.hamcrest" name="hamcrest-all" rev="1.3"
+                conf="test->default" />
+
     <conflict manager="strict"/>
 
   </dependencies>

--- a/ivy.xml
+++ b/ivy.xml
@@ -136,6 +136,9 @@
 
     <dependency org="org.openclover" name="clover" rev="${clover.version}" conf="clover->default"/>
 
+    <dependency org="io.dropwizard.metrics" name="metrics-core"
+                rev="${dropwizard.version}" conf="default" />
+
     <conflict manager="strict"/>
 
   </dependencies>

--- a/ivy.xml
+++ b/ivy.xml
@@ -137,7 +137,9 @@
     <dependency org="org.openclover" name="clover" rev="${clover.version}" conf="clover->default"/>
 
     <dependency org="io.dropwizard.metrics" name="metrics-core"
-                rev="${dropwizard.version}" conf="default" />
+                rev="${dropwizard.version}" conf="default">
+      <exclude org="org.slf4j" module="slf4j-api"/>
+    </dependency>
 
     <dependency org="org.hamcrest" name="hamcrest-all" rev="1.3"
                 conf="test->default" />

--- a/src/java/main/org/apache/zookeeper/server/command/MonitorCommand.java
+++ b/src/java/main/org/apache/zookeeper/server/command/MonitorCommand.java
@@ -75,14 +75,18 @@ public class MonitorCommand extends AbstractFourLetterCommand {
             print("synced_followers", leader.getForwardingFollowers().size());
             print("pending_syncs", leader.getNumPendingSyncs());
 
-            print("last_proposal_size", leader.getProposalStats().getLastProposalSize());
-            print("max_proposal_size", leader.getProposalStats().getMaxProposalSize());
-            print("min_proposal_size", leader.getProposalStats().getMinProposalSize());
+            print("avg_proposal", leader.getProposalStats().getAverage());
+            print("max_proposal", leader.getProposalStats().getMax());
+            print("min_proposal", leader.getProposalStats().getMin());
         }
     }
 
     private void print(String key, long number) {
         print(key, "" + number);
+    }
+
+    private void print(String key, double number) {
+        print(key, String.format("%s", number));
     }
 
     private void print(String key, String value) {

--- a/src/java/main/org/apache/zookeeper/server/command/MonitorCommand.java
+++ b/src/java/main/org/apache/zookeeper/server/command/MonitorCommand.java
@@ -30,7 +30,7 @@ import org.apache.zookeeper.server.util.OSMXBean;
 
 public class MonitorCommand extends AbstractFourLetterCommand {
 
-    MonitorCommand(PrintWriter pw, ServerCnxn serverCnxn) {
+    public MonitorCommand(PrintWriter pw, ServerCnxn serverCnxn) {
         super(pw, serverCnxn);
     }
 

--- a/src/java/main/org/apache/zookeeper/server/command/StatCommand.java
+++ b/src/java/main/org/apache/zookeeper/server/command/StatCommand.java
@@ -65,7 +65,7 @@ public class StatCommand extends AbstractFourLetterCommand {
             if (serverStats.getServerState().equals("leader")) {
                 Leader leader = ((LeaderZooKeeperServer)zkServer).getLeader();
                 ProposalStats proposalStats = leader.getProposalStats();
-                pw.printf("Proposal sizes last/min/max: %s%n", proposalStats.toString());
+                pw.printf("Proposal min/avg/max: %s%n", proposalStats.toString());
             }
         }
     }

--- a/src/java/main/org/apache/zookeeper/server/command/StatResetCommand.java
+++ b/src/java/main/org/apache/zookeeper/server/command/StatResetCommand.java
@@ -21,7 +21,6 @@ package org.apache.zookeeper.server.command;
 import java.io.PrintWriter;
 
 import org.apache.zookeeper.server.ServerCnxn;
-import org.apache.zookeeper.server.ServerStats;
 
 public class StatResetCommand extends AbstractFourLetterCommand {
     public StatResetCommand(PrintWriter pw, ServerCnxn serverCnxn) {
@@ -33,8 +32,7 @@ public class StatResetCommand extends AbstractFourLetterCommand {
         if (!isZKServerRunning()) {
             pw.println(ZK_NOT_SERVING);
         } else {
-            ServerStats serverStats = zkServer.serverStats();
-            serverStats.reset();
+            zkServer.serverStats().reset();
             pw.println("Server stats reset.");
         }
     }

--- a/src/java/main/org/apache/zookeeper/server/command/StatResetCommand.java
+++ b/src/java/main/org/apache/zookeeper/server/command/StatResetCommand.java
@@ -22,7 +22,6 @@ import java.io.PrintWriter;
 
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ServerStats;
-import org.apache.zookeeper.server.quorum.LeaderZooKeeperServer;
 
 public class StatResetCommand extends AbstractFourLetterCommand {
     public StatResetCommand(PrintWriter pw, ServerCnxn serverCnxn) {
@@ -36,9 +35,6 @@ public class StatResetCommand extends AbstractFourLetterCommand {
         } else {
             ServerStats serverStats = zkServer.serverStats();
             serverStats.reset();
-            if (serverStats.getServerState().equals("leader")) {
-                ((LeaderZooKeeperServer)zkServer).getLeader().getProposalStats().reset();
-            }
             pw.println("Server stats reset.");
         }
     }

--- a/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
@@ -1059,7 +1059,7 @@ public class Leader {
         }
 
         byte[] data = SerializeUtils.serializeRequest(request);
-        proposalStats.setLastProposalSize(data.length);
+        proposalStats.updateProposalSize(data.length);
         QuorumPacket pp = new QuorumPacket(Leader.PROPOSAL, request.zxid, data, null);
 
         Proposal p = new Proposal();

--- a/src/java/main/org/apache/zookeeper/server/quorum/LeaderBean.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/LeaderBean.java
@@ -52,24 +52,4 @@ public class LeaderBean extends ZooKeeperServerBean implements LeaderMXBean {
     public long getElectionTimeTaken() {
         return leader.self.getElectionTimeTaken();
     }
-
-    @Override
-    public int getLastProposalSize() {
-        return leader.getProposalStats().getLastProposalSize();
-    }
-
-    @Override
-    public int getMinProposalSize() {
-        return leader.getProposalStats().getMinProposalSize();
-    }
-
-    @Override
-    public int getMaxProposalSize() {
-        return leader.getProposalStats().getMaxProposalSize();
-    }
-
-    @Override
-    public void resetProposalStatistics() {
-        leader.getProposalStats().reset();
-    }
 }

--- a/src/java/main/org/apache/zookeeper/server/quorum/LeaderMXBean.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/LeaderMXBean.java
@@ -38,24 +38,4 @@ public interface LeaderMXBean extends ZooKeeperServerMXBean {
      * @return time taken for leader election in milliseconds.
      */
     public long getElectionTimeTaken();
-
-    /**
-     * @return size of latest generated proposal
-     */
-    public int getLastProposalSize();
-
-    /**
-     * @return size of smallest generated proposal
-     */
-    public int getMinProposalSize();
-
-    /**
-     * @return size of largest generated proposal
-     */
-    public int getMaxProposalSize();
-
-    /**
-     * Resets statistics of proposal size (min/max/last)
-     */
-    public void resetProposalStatistics();
 }

--- a/src/java/test/org/apache/zookeeper/server/quorum/CommandTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/CommandTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.ServerCnxn;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ServerStats;
+import org.apache.zookeeper.server.ZKDatabase;
+import org.junit.Before;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public abstract class CommandTest {
+    ServerCnxn serverCnxnMock;
+    StringWriter outputWriter;
+    ServerStats.Provider providerMock;
+    LeaderZooKeeperServer zks;
+    ServerCnxnFactory serverCnxnFactory;
+
+    @Before
+    public void setUp() {
+        outputWriter = new StringWriter();
+        serverCnxnMock = mock(ServerCnxn.class);
+
+        zks = mock(LeaderZooKeeperServer.class);
+        when(zks.isRunning()).thenReturn(true);
+        providerMock = mock(ServerStats.Provider.class);
+        when(zks.serverStats()).thenReturn(new ServerStats(providerMock));
+        ZKDatabase zkDatabaseMock = mock(ZKDatabase.class);
+        when(zks.getZKDatabase()).thenReturn(zkDatabaseMock);
+        DataTree dataTreeMock = mock(DataTree.class);
+        when(zkDatabaseMock.getDataTree()).thenReturn(dataTreeMock);
+        Leader leaderMock = mock(Leader.class);
+        when(leaderMock.getProposalStats()).thenReturn(new ProposalStats());
+        when(zks.getLeader()).thenReturn(leaderMock);
+
+        serverCnxnFactory = mock(ServerCnxnFactory.class);
+        ServerCnxn serverCnxn = mock(ServerCnxn.class);
+        List<ServerCnxn> connections = new ArrayList<>();
+        connections.add(serverCnxn);
+        when(serverCnxnFactory.getConnections()).thenReturn(connections);
+    }
+}

--- a/src/java/test/org/apache/zookeeper/server/quorum/CommandTestCase.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/CommandTestCase.java
@@ -32,7 +32,7 @@ import java.util.List;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public abstract class CommandTest {
+public abstract class CommandTestCase {
     ServerCnxn serverCnxnMock;
     StringWriter outputWriter;
     ServerStats.Provider providerMock;

--- a/src/java/test/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
@@ -18,29 +18,18 @@
 
 package org.apache.zookeeper.server.quorum;
 
-import org.apache.jute.OutputArchive;
-import org.apache.jute.Record;
-import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
-import org.apache.zookeeper.server.util.SerializeUtils;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.txn.TxnHeader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.io.File;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
 public class LeaderBeanTest {
@@ -91,29 +80,5 @@ public class LeaderBeanTest {
 
         // Assert
         assertEquals(1, leaderBean.getElectionTimeTaken());
-    }
-
-    private Request createMockRequest() throws IOException {
-        TxnHeader header = mock(TxnHeader.class);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                OutputArchive oa = (OutputArchive) args[0];
-                oa.writeString("header", "test");
-                return null;
-            }
-        }).when(header).serialize(any(OutputArchive.class), anyString());
-        Record txn = mock(Record.class);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                OutputArchive oa = (OutputArchive) args[0];
-                oa.writeString("record", "test");
-                return null;
-            }
-        }).when(txn).serialize(any(OutputArchive.class), anyString());
-        return new Request(1, 2, 3, header, txn, 4);
     }
 }

--- a/src/java/test/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
@@ -93,38 +93,6 @@ public class LeaderBeanTest {
         assertEquals(1, leaderBean.getElectionTimeTaken());
     }
 
-    @Test
-    public void testGetProposalSize() throws IOException, Leader.XidRolloverException {
-        // Arrange
-        Request req = createMockRequest();
-
-        // Act
-        leader.propose(req);
-
-        // Assert
-        byte[] data = SerializeUtils.serializeRequest(req);
-        assertEquals(data.length, leaderBean.getLastProposalSize());
-        assertEquals(data.length, leaderBean.getMinProposalSize());
-        assertEquals(data.length, leaderBean.getMaxProposalSize());
-    }
-
-    @Test
-    public void testResetProposalStats() throws IOException, Leader.XidRolloverException {
-        // Arrange
-        int initialProposalSize = leaderBean.getLastProposalSize();
-        Request req = createMockRequest();
-
-        // Act
-        leader.propose(req);
-
-        // Assert
-        assertNotEquals(initialProposalSize, leaderBean.getLastProposalSize());
-        leaderBean.resetProposalStatistics();
-        assertEquals(initialProposalSize, leaderBean.getLastProposalSize());
-        assertEquals(initialProposalSize, leaderBean.getMinProposalSize());
-        assertEquals(initialProposalSize, leaderBean.getMaxProposalSize());
-    }
-
     private Request createMockRequest() throws IOException {
         TxnHeader header = mock(TxnHeader.class);
         doAnswer(new Answer() {

--- a/src/java/test/org/apache/zookeeper/server/quorum/MonitorCommandTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/MonitorCommandTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
-public class MonitorCommandTest extends CommandTest {
+public class MonitorCommandTest extends CommandTestCase {
     private MonitorCommand monitorCommand;
 
     @Before

--- a/src/java/test/org/apache/zookeeper/server/quorum/ProposalStatsTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/ProposalStatsTest.java
@@ -26,33 +26,20 @@ public class ProposalStatsTest {
     @Test
     public void testSetProposalSizeSetMinMax() {
         ProposalStats stats = new ProposalStats();
-        assertEquals(-1, stats.getLastProposalSize());
-        assertEquals(-1, stats.getMinProposalSize());
-        assertEquals(-1, stats.getMaxProposalSize());
-        stats.setLastProposalSize(10);
-        assertEquals(10, stats.getLastProposalSize());
-        assertEquals(10, stats.getMinProposalSize());
-        assertEquals(10, stats.getMaxProposalSize());
-        stats.setLastProposalSize(20);
-        assertEquals(20, stats.getLastProposalSize());
-        assertEquals(10, stats.getMinProposalSize());
-        assertEquals(20, stats.getMaxProposalSize());
-        stats.setLastProposalSize(5);
-        assertEquals(5, stats.getLastProposalSize());
-        assertEquals(5, stats.getMinProposalSize());
-        assertEquals(20, stats.getMaxProposalSize());
-    }
-
-    @Test
-    public void testReset() {
-        ProposalStats stats = new ProposalStats();
-        stats.setLastProposalSize(10);
-        assertEquals(10, stats.getLastProposalSize());
-        assertEquals(10, stats.getMinProposalSize());
-        assertEquals(10, stats.getMaxProposalSize());
-        stats.reset();
-        assertEquals(-1, stats.getLastProposalSize());
-        assertEquals(-1, stats.getMinProposalSize());
-        assertEquals(-1, stats.getMaxProposalSize());
+        assertEquals(0, stats.getAverage(), 0);
+        assertEquals(0, stats.getMin());
+        assertEquals(0, stats.getMax());
+        stats.updateProposalSize(10);
+        assertEquals(10, stats.getAverage(), 0);
+        assertEquals(10, stats.getMin());
+        assertEquals(10, stats.getMax());
+        stats.updateProposalSize(20);
+        assertEquals(15, stats.getAverage(), 0);
+        assertEquals(10, stats.getMin());
+        assertEquals(20, stats.getMax());
+        stats.updateProposalSize(3);
+        assertEquals(11, stats.getAverage(), 0);
+        assertEquals(3, stats.getMin());
+        assertEquals(20, stats.getMax());
     }
 }

--- a/src/java/test/org/apache/zookeeper/server/quorum/StatCommandTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/StatCommandTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
-public class StatCommandTest extends CommandTest {
+public class StatCommandTest extends CommandTestCase {
     private StatCommand statCommand;
 
     @Before

--- a/src/java/test/org/apache/zookeeper/server/quorum/StatResetCommandTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/StatResetCommandTest.java
@@ -106,6 +106,5 @@ public class StatResetCommandTest {
         String output = outputWriter.toString();
         assertEquals("Server stats reset.\n", output);
         verify(serverStats, times(1)).reset();
-        verify(proposalStats, times(1)).reset();
     }
 }


### PR DESCRIPTION
This PR is intended to be the successor of https://github.com/apache/zookeeper/pull/415
Using dropwizard library's Histogram component we're able to provide more sophisticated statistics on Proposal sizes. 

From the docs:
"A histogram measures the statistical distribution of values in a stream of data. In addition to minimum, maximum, mean, etc., it also measures median, 75th, 90th, 95th, 98th, 99th, and 99.9th percentiles."

http://metrics.dropwizard.io/3.1.0/manual/core/#histograms
