### PR TITLE
ZOOKEEPER-2960. The dataDir and dataLogDir are used opposingly

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
@@ -137,8 +137,8 @@ public class QuorumPeerMain {
 
           quorumPeer.setQuorumPeers(config.getServers());
           quorumPeer.setTxnFactory(new FileTxnSnapLog(
-                  new File(config.getDataDir()),
-                  new File(config.getDataLogDir())));
+                  new File(config.getDataLogDir()),
+                  new File(config.getDataDir())));
           quorumPeer.setElectionType(config.getElectionAlg());
           quorumPeer.setMyid(config.getServerId());
           quorumPeer.setTickTime(config.getTickTime());


### PR DESCRIPTION
Previously a small refactoring has swapped the usage of dataDir and dataLogDir when QuorumPeerMain instantiates FileTxnSnapLog class.

This PR fixes it + adds unit test for verification.