### PR TITLE
ZOOKEEPER-2955: Enable Clover code coverage report

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -23,6 +23,46 @@ xmlns:artifact="antlib:org.apache.maven.artifact.ant"
 xmlns:maven="antlib:org.apache.maven.artifact.ant"
 xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
 
+    <!-- ====================================================== -->
+    <!-- Dependency versions                                    -->
+    <!-- ====================================================== -->
+    <property name="slf4j.version" value="1.7.25"/>
+
+    <property name="wagon-http.version" value="2.4"/>
+    <property name="maven-ant-tasks.version" value="2.1.3"/>
+    <property name="log4j.version" value="1.2.17"/>
+    <property name="jline.version" value="0.9.94"/>
+
+    <property name="jdeb.version" value="0.8"/>
+
+    <property name="audience-annotations.version" value="0.5.0" />
+
+    <property name="netty.version" value="3.10.6.Final"/>
+
+    <property name="junit.version" value="4.8.1"/>
+    <property name="mockito.version" value="1.8.5"/>
+    <property name="checkstyle.version" value="6.1.1"/>
+    <property name="commons-collections.version" value="3.2.2"/>
+    <property name="commons-io.version" value="2.4"/>
+
+    <property name="apache-directory-server.version" value="2.0.0-M15"/>
+    <property name="apache-directory-api.version" value="1.0.0-M20"/>
+
+    <property name="jdiff.version" value="1.0.9"/>
+    <property name="xerces.version" value="1.4.4"/>
+
+    <property name="apache-rat-tasks.version" value="0.6"/>
+    <property name="commons-lang.version" value="2.4"/>
+
+    <property name="dependency-check-ant.version" value="2.1.0"/>
+
+    <property name="clover.version" value="4.2.1" />
+
+
+    <!-- ====================================================== -->
+    <!-- Project properties                                     -->
+    <!-- ====================================================== -->
+
     <!-- read build.properties from the basedir if any -->
     <property file="${basedir}/build.properties" />
 
@@ -99,12 +139,6 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     <property name="dist.dir" value="${build.dir}/${final.name}"/>
     <property name="dist.maven.dir" value="${dist.dir}/dist-maven"/>
 
-    <property name="clover.home" location="${env.CLOVER_HOME}"/>
-    <property name="clover.jar" location="${clover.home}/lib/clover.jar" />
-    <property name="clover.db.dir" location="${test.java.build.dir}/clover/db"/>
-    <property name="clover.report.dir"
-              location="${test.java.build.dir}/clover/reports"/>
-
     <property name="contrib.dir" value="${src.dir}/contrib"/>
     <property name="recipes.dir" value="${src.dir}/recipes"/>
 
@@ -126,12 +160,19 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     <property name="ant_task_repo_url"
         value="${mvnrepo}${tsk.org}${ant-task.version}/maven-ant-tasks-${ant-task.version}.jar"/>
     <property name="ant_task.jar" location="${ivy.lib}/maven-ant-tasks-${ant-task.version}.jar"/>
-    
-    <available property="clover.present"
-               classname="com.cenqua.clover.CloverInstr"
-               classpath="${clover.home}/lib/clover.jar"/>
 
-    <available file="${c.src.dir}/Makefile" property="Makefile.present"/>
+    <!-- clover property set -->
+    <property name="clover.home" location="${env.CLOVER_HOME}"/>
+    <property name="clover.jar" location="${clover.home}/lib/clover-${clover.version}.jar"/>
+    <property name="clover.dest" location="${test.java.build.dir}/clover"/>
+    <property name="clover.db.dir" location="${clover.dest}/db"/>
+    <property name="clover.report.dir" location="${clover.dest}/reports"/>
+    <property name="clover.db" location="${clover.db.dir}/zookeeper-coverage.db"/>
+    <taskdef resource="cloverlib.xml" classpath="${clover.jar}"/>
+
+    <available property="clover.present"
+               classname="com.atlassian.clover.CloverInstr"
+               classpath="${clover.home}/lib/clover-${clover.version}.jar"/>
 
     <!-- check if clover reports should be generated -->
     <condition property="clover.enabled">
@@ -141,6 +182,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
       </and>
     </condition>
 
+    <available file="${c.src.dir}/Makefile" property="Makefile.present"/>
 
     <property name="test.cobertura.output.format" value="html" />
     <property name="coveragereport.dir" value="${build.dir}/cobertura" />
@@ -204,38 +246,6 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     <property name="sources-jar" value="${dist.maven.dir}/${final.name}-sources.jar"/>
     <property name="javadoc-jar" value="${dist.maven.dir}/${final.name}-javadoc.jar"/>
 
-    <!-- ====================================================== -->
-    <!-- Dependency versions                                    -->
-    <!-- ====================================================== -->
-    <property name="slf4j.version" value="1.7.25"/>
-
-    <property name="wagon-http.version" value="2.4"/>
-    <property name="maven-ant-tasks.version" value="2.1.3"/>
-    <property name="log4j.version" value="1.2.17"/>
-    <property name="jline.version" value="0.9.94"/>
-
-    <property name="jdeb.version" value="0.8"/>
-
-    <property name="audience-annotations.version" value="0.5.0" />
-
-    <property name="netty.version" value="3.10.6.Final"/>
-
-    <property name="junit.version" value="4.8.1"/>
-    <property name="mockito.version" value="1.8.5"/>
-    <property name="checkstyle.version" value="6.1.1"/>
-    <property name="commons-collections.version" value="3.2.2"/>
-    <property name="commons-io.version" value="2.4"/>
-
-    <property name="apache-directory-server.version" value="2.0.0-M15"/>
-    <property name="apache-directory-api.version" value="1.0.0-M20"/>
-
-    <property name="jdiff.version" value="1.0.9"/>
-    <property name="xerces.version" value="1.4.4"/>
-
-    <property name="apache-rat-tasks.version" value="0.6"/>
-    <property name="commons-lang.version" value="2.4"/>
-
-    <property name="dependency-check-ant.version" value="2.1.0"/>
 
     <!-- ====================================================== -->
     <!-- Macro definitions                                      -->
@@ -949,7 +959,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         <replacetoken>/tmp/zookeeper</replacetoken>
         <replacevalue>${VAR_DIR}/data</replacevalue>
       </replace>
-  	  
+
       <chmod perm="ugo+x" type="file" parallel="false">
         <fileset dir="${dist.dir}/bin"/>
         <fileset dir="${dist.dir}/sbin"/>
@@ -1063,7 +1073,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         <property name="dist.dir" value="${dist.dir}"/>
         <fileset file="${contrib.dir}/build.xml"/>
         <fileset file="${recipes.dir}/build.xml"/>
-      </subant>  	
+      </subant>
       <path id="c.lib">
         <fileset dir="${build.dir}">
           <include name="${final.name}-lib.tar.gz"/>
@@ -1168,10 +1178,10 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         </tarfileset>
         <tarfileset dir="${build.dir}/c/build/${package.prefix}/include" prefix="${package.prefix}/include">
           <include name="**" />
-        </tarfileset> 
+        </tarfileset>
         <tarfileset dir="${build.dir}/c/build/${package.prefix}/lib" filemode="755" prefix="${package.prefix}/lib">
           <include name="**" />
-        </tarfileset> 
+        </tarfileset>
         <tarfileset dir="${build.dir}/${final.name}/conf" filemode="644" prefix="${package.conf.dir}">
           <include name="**" />
         </tarfileset>
@@ -1479,27 +1489,28 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
 	<!-- yet to implement -->
     </target>
     
-    <target name="test-core-java" depends="test-init, test-category, junit.run"/> 
+    <target name="test-core-java" depends="test-init, test-category, junit.run"/>
 
-    <target name="test-core-cppunit" depends="test-init, test-category, call-test-cppunit"/> 
+    <target name="test-core-cppunit" depends="test-init, test-category, call-test-cppunit"/>
 
-    <target name="test-core" depends="test-core-java, test-core-cppunit"/> 
+    <target name="test-core" depends="test-core-java, test-core-cppunit"/>
 
     <!-- ====================================================== -->
     <!-- Run optional third-party tool targets                  -->
     <!-- ====================================================== -->
 
     <!-- clover code coverage -->
-    <target name="clover" depends="clover.setup, clover.info" 
+    <target name="clover" depends="clover.setup, clover.info"
             description="Instrument the Unit tests using Clover.  Requires a Clover license and CLOVER_HOME environment variable set appropriately.  To use, specify -Drun.clover=true on the command line."/>
 
     <target name="clover.setup" if="clover.enabled">
-      <taskdef resource="cloverlib.xml" classpath="${clover.jar}"/>
       <mkdir dir="${clover.db.dir}"/>
-      <clover-setup initString="${clover.db.dir}/zookeeper_coverage.db">
+      <clover-setup initString="${clover.db}">
         <fileset dir="${java.src.dir}"
                  includes="org/apache/zookeeper/**/*"
                  excludes="org/apache/zookeeper/version/**/*"/>
+        <fileset dir="${test.src.dir}"
+                 includes="org/apache/zookeeper/**/*"/>
       </clover-setup>
     </target>
 
@@ -1521,14 +1532,13 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
 
     <target name="generate-clover-reports" depends="clover.check, clover">
       <mkdir dir="${clover.report.dir}"/>
-      <taskdef resource="cloverlib.xml" classpath="${clover.jar}"/> 
-      
-      <clover-report initString="${clover.db.dir}/zookeeper_coverage.db">
+
+      <clover-report initString="${clover.db}">
         <current outfile="${clover.report.dir}" title="${final.name}">
           <format type="html"/>
         </current>
       </clover-report>
-      <clover-report initString="${clover.db.dir}/zookeeper_coverage.db">
+      <clover-report initString="${clover.db}">
         <current outfile="${clover.report.dir}/clover.xml" title="${final.name}">
           <format type="xml"/>
         </current>

--- a/build.xml
+++ b/build.xml
@@ -433,7 +433,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         <ivy:cachepath pathid="owasp-classpath" conf="owasp"/>
     </target>
 
-    <target name="ivy-retrieve-test-coverage-java" depends="init,ivy-init">
+    <target name="ivy-retrieve-test-coverage-java" if="run.clover" depends="init,ivy-init">
         <ivy:retrieve settingsRef="${ant.project.name}" conf="test-coverage-java"
                       pattern="${ivy.coverage.lib}/[artifact]-[revision].[ext]"/>
         <ivy:cachepath pathid="coverage-classpath" conf="test-coverage-java"/>
@@ -1501,7 +1501,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     <!-- ====================================================== -->
 
     <!-- clover code coverage -->
-    <target name="clover" depends="ivy-retrieve-test-coverage-java, clover.check, clover.setup"
+    <target name="clover" if="run.clover" depends="ivy-retrieve-test-coverage-java, clover.check, clover.setup"
             description="Instrument the Unit tests using Clover. To use, specify -Drun.clover=true on the command line."/>
 
     <target name="clover.check">

--- a/build.xml
+++ b/build.xml
@@ -452,7 +452,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         <ivy:report conf="*" todir="${build.dir}/dependency-report"/>
     </target>
 
-    <target name="compile" depends="ivy-retrieve,clover,build-generated">
+    <target name="compile" depends="ivy-retrieve,clover,build-generated,print_compile_classpath">
         <javac srcdir="${java.src.dir}" destdir="${build.classes}" includeantruntime="false"
                target="${javac.target}" source="${javac.source}" debug="on">
             <classpath refid="java.classpath"/>
@@ -1346,7 +1346,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
       </and>
     </condition>
 
-    <target name="junit.run">
+    <target name="junit.run" depends="print_test_classpath">
         <junit showoutput="${test.output}"
                printsummary="${test.junit.printsummary}"
                haltonfailure="${test.junit.haltonfailure}"
@@ -1940,11 +1940,11 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         <echo message="|   |-- ${echo.compile.classpath}"/>
     </target>
 
-    <target name="print_junit_classpath">
-        <pathconvert pathsep="${line.separator}|   |-- " property="echo.junit.classpath" refid="junit.classpath"/>
-        <echo message="|-- junit classpath"/>
+    <target name="print_test_classpath">
+        <pathconvert pathsep="${line.separator}|   |-- " property="echo.test.classpath" refid="test.java.classpath"/>
+        <echo message="|-- test classpath"/>
         <echo message="|   |"/>
-        <echo message="|   |-- ${echo.junit.classpath}"/>
+        <echo message="|   |-- ${echo.test.classpath}"/>
     </target>
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -263,7 +263,9 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
       <fileset dir="${ant.home}/lib">
           <include name="ant.jar" />
       </fileset>
-      <pathelement path="${clover.jar}" />
+      <fileset dir="${clover.home}/lib" erroronmissingdir="false">
+          <include name="**/*.jar" if="run.clover" />
+      </fileset>
     </path>
 
     <!-- the normal classpath -->
@@ -1930,5 +1932,19 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
        <delete dir=".settings" />
        <delete dir="${build.dir.eclipse}" />
      </target>
+
+    <target name="print_compile_classpath">
+        <pathconvert pathsep="${line.separator}|   |-- " property="echo.compile.classpath" refid="java.classpath"/>
+        <echo message="|-- compile classpath"/>
+        <echo message="|   |"/>
+        <echo message="|   |-- ${echo.compile.classpath}"/>
+    </target>
+
+    <target name="print_junit_classpath">
+        <pathconvert pathsep="${line.separator}|   |-- " property="echo.junit.classpath" refid="junit.classpath"/>
+        <echo message="|-- junit classpath"/>
+        <echo message="|   |"/>
+        <echo message="|   |-- ${echo.junit.classpath}"/>
+    </target>
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -152,7 +152,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     <property name="ivy.jdiff.lib" value="${build.dir}/jdiff/lib"/>
     <property name="ivy.releaseaudit.lib" value="${build.dir}/releaseaudit/lib"/>
     <property name="ivy.owasp.lib" value="${build.dir}/owasp/lib"/>
-    <property name="ivy.coverage.lib" value="${test.java.build.dir}/lib"/>
+    <property name="ivy.clover.lib" value="${build.dir}/clover/lib"/>
     <property name="ivysettings.xml" value="${basedir}/ivysettings.xml"/>
 
     <property name="mvnrepo" value="https://repo1.maven.org/maven2"/>
@@ -163,9 +163,9 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     <property name="ant_task.jar" location="${ivy.lib}/maven-ant-tasks-${ant-task.version}.jar"/>
 
     <!-- clover property set -->
-    <property name="clover.home" location="${test.java.build.dir}"/>
+    <property name="clover.home" location="${build.dir}/clover"/>
     <property name="clover.jar" location="${clover.home}/lib/clover-${clover.version}.jar"/>
-    <property name="clover.dest" location="${test.java.build.dir}/clover"/>
+    <property name="clover.dest" location="${build.dir}/clover"/>
     <property name="clover.db.dir" location="${clover.dest}/db"/>
     <property name="clover.report.dir" location="${clover.dest}/reports"/>
     <property name="clover.db" location="${clover.db.dir}/zookeeper-coverage.db"/>
@@ -433,10 +433,10 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         <ivy:cachepath pathid="owasp-classpath" conf="owasp"/>
     </target>
 
-    <target name="ivy-retrieve-test-coverage-java" if="run.clover" depends="init,ivy-init">
-        <ivy:retrieve settingsRef="${ant.project.name}" conf="test-coverage-java"
-                      pattern="${ivy.coverage.lib}/[artifact]-[revision].[ext]"/>
-        <ivy:cachepath pathid="coverage-classpath" conf="test-coverage-java"/>
+    <target name="ivy-retrieve-clover" if="run.clover" depends="init,ivy-init">
+        <ivy:retrieve settingsRef="${ant.project.name}" conf="clover"
+                      pattern="${ivy.clover.lib}/[artifact]-[revision].[ext]"/>
+        <ivy:cachepath pathid="clover-classpath" conf="clover"/>
     </target>
 
     <target name="ivy-retrieve-mvn-ant-task" depends="init,ivy-init">
@@ -1489,20 +1489,21 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
 
     <target name="test-core" depends="test-core-java, test-core-cppunit"/>
 
-    <target name="test-coverage-java">
-        <antcall target="test-core-java">
-            <param name="run.clover" value="true"/>
-        </antcall>
-        <antcall target="generate-clover-reports"/>
-    </target>
-
     <!-- ====================================================== -->
     <!-- Run optional third-party tool targets                  -->
     <!-- ====================================================== -->
 
-    <!-- clover code coverage -->
-    <target name="clover" if="run.clover" depends="ivy-retrieve-test-coverage-java, clover.check, clover.setup"
-            description="Instrument the Unit tests using Clover. To use, specify -Drun.clover=true on the command line."/>
+    <!-- Clover code coverage -->
+    <target name="test-coverage-clover-java"
+            description="Runs Java tests with Clover and generates coverage report in HTML and XML.">
+      <antcall target="test-core-java">
+        <param name="run.clover" value="true"/>
+      </antcall>
+      <antcall target="clover-report"/>
+    </target>
+
+    <target name="clover" if="run.clover" depends="ivy-retrieve-clover,clover.check,clover.setup"
+            description="Used in compile target to add source code instrumentation for Clover and sets up the Clover database."/>
 
     <target name="clover.check">
         <available property="clover.present"
@@ -1521,13 +1522,18 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
       <clover-setup initString="${clover.db}">
         <fileset dir="${java.src.dir}"
                  includes="org/apache/zookeeper/**/*"
-                 excludes="org/apache/zookeeper/version/**/*"/>
-        <fileset dir="${test.src.dir}"
-                 includes="org/apache/zookeeper/**/*"/>
+                 excludes="org/apache/zookeeper/version/**/*">
+        </fileset>
+        <testsources dir="${test.src.dir}">
+          <testclass package="org.apache.zookeeper.*" name=".*Test">
+              <testmethod annotation="Test"/>
+          </testclass>
+        </testsources>
       </clover-setup>
     </target>
 
-    <target name="generate-clover-reports" depends="clover">
+    <target name="clover-report" depends="ivy-retrieve-clover"
+            description="Generates coverage report in HTML and XML. Run the tests first with 'ant -Drun.clover=true test-core-java' to generate coverage data.">
       <taskdef resource="cloverlib.xml" classpath="${clover.jar}"/>
       <mkdir dir="${clover.report.dir}"/>
       <clover-report initString="${clover.db}">

--- a/build.xml
+++ b/build.xml
@@ -452,7 +452,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         <ivy:report conf="*" todir="${build.dir}/dependency-report"/>
     </target>
 
-    <target name="compile" depends="ivy-retrieve,clover,build-generated,print_compile_classpath">
+    <target name="compile" depends="ivy-retrieve,clover,build-generated">
         <javac srcdir="${java.src.dir}" destdir="${build.classes}" includeantruntime="false"
                target="${javac.target}" source="${javac.source}" debug="on">
             <classpath refid="java.classpath"/>
@@ -1346,7 +1346,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
       </and>
     </condition>
 
-    <target name="junit.run" depends="print_test_classpath">
+    <target name="junit.run">
         <junit showoutput="${test.output}"
                printsummary="${test.junit.printsummary}"
                haltonfailure="${test.junit.haltonfailure}"
@@ -1932,19 +1932,5 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
        <delete dir=".settings" />
        <delete dir="${build.dir.eclipse}" />
      </target>
-
-    <target name="print_compile_classpath">
-        <pathconvert pathsep="${line.separator}|   |-- " property="echo.compile.classpath" refid="java.classpath"/>
-        <echo message="|-- compile classpath"/>
-        <echo message="|   |"/>
-        <echo message="|   |-- ${echo.compile.classpath}"/>
-    </target>
-
-    <target name="print_test_classpath">
-        <pathconvert pathsep="${line.separator}|   |-- " property="echo.test.classpath" refid="test.java.classpath"/>
-        <echo message="|-- test classpath"/>
-        <echo message="|   |"/>
-        <echo message="|   |-- ${echo.test.classpath}"/>
-    </target>
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -152,6 +152,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     <property name="ivy.jdiff.lib" value="${build.dir}/jdiff/lib"/>
     <property name="ivy.releaseaudit.lib" value="${build.dir}/releaseaudit/lib"/>
     <property name="ivy.owasp.lib" value="${build.dir}/owasp/lib"/>
+    <property name="ivy.coverage.lib" value="${test.java.build.dir}/lib"/>
     <property name="ivysettings.xml" value="${basedir}/ivysettings.xml"/>
 
     <property name="mvnrepo" value="https://repo1.maven.org/maven2"/>
@@ -162,25 +163,12 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     <property name="ant_task.jar" location="${ivy.lib}/maven-ant-tasks-${ant-task.version}.jar"/>
 
     <!-- clover property set -->
-    <property name="clover.home" location="${env.CLOVER_HOME}"/>
+    <property name="clover.home" location="${test.java.build.dir}"/>
     <property name="clover.jar" location="${clover.home}/lib/clover-${clover.version}.jar"/>
     <property name="clover.dest" location="${test.java.build.dir}/clover"/>
     <property name="clover.db.dir" location="${clover.dest}/db"/>
     <property name="clover.report.dir" location="${clover.dest}/reports"/>
     <property name="clover.db" location="${clover.db.dir}/zookeeper-coverage.db"/>
-    <taskdef resource="cloverlib.xml" classpath="${clover.jar}"/>
-
-    <available property="clover.present"
-               classname="com.atlassian.clover.CloverInstr"
-               classpath="${clover.home}/lib/clover-${clover.version}.jar"/>
-
-    <!-- check if clover reports should be generated -->
-    <condition property="clover.enabled">
-      <and>
-        <isset property="run.clover"/>
-        <isset property="clover.present"/>
-      </and>
-    </condition>
 
     <available file="${c.src.dir}/Makefile" property="Makefile.present"/>
 
@@ -443,6 +431,12 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         <ivy:retrieve settingsRef="${ant.project.name}" conf="owasp"
                       pattern="${ivy.owasp.lib}/[artifact]-[revision].[ext]"/>
         <ivy:cachepath pathid="owasp-classpath" conf="owasp"/>
+    </target>
+
+    <target name="ivy-retrieve-test-coverage-java" depends="init,ivy-init">
+        <ivy:retrieve settingsRef="${ant.project.name}" conf="test-coverage-java"
+                      pattern="${ivy.coverage.lib}/[artifact]-[revision].[ext]"/>
+        <ivy:cachepath pathid="coverage-classpath" conf="test-coverage-java"/>
     </target>
 
     <target name="ivy-retrieve-mvn-ant-task" depends="init,ivy-init">
@@ -1495,15 +1489,34 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
 
     <target name="test-core" depends="test-core-java, test-core-cppunit"/>
 
+    <target name="test-coverage-java">
+        <antcall target="test-core-java">
+            <param name="run.clover" value="true"/>
+        </antcall>
+        <antcall target="generate-clover-reports"/>
+    </target>
+
     <!-- ====================================================== -->
     <!-- Run optional third-party tool targets                  -->
     <!-- ====================================================== -->
 
     <!-- clover code coverage -->
-    <target name="clover" depends="clover.setup, clover.info"
-            description="Instrument the Unit tests using Clover.  Requires a Clover license and CLOVER_HOME environment variable set appropriately.  To use, specify -Drun.clover=true on the command line."/>
+    <target name="clover" depends="ivy-retrieve-test-coverage-java, clover.check, clover.setup"
+            description="Instrument the Unit tests using Clover. To use, specify -Drun.clover=true on the command line."/>
 
-    <target name="clover.setup" if="clover.enabled">
+    <target name="clover.check">
+        <available property="clover.present"
+                   classname="com.atlassian.clover.CloverInstr"
+                   classpath="${clover.home}/lib/clover-${clover.version}.jar"/>
+        <fail if="run.clover" unless="clover.present">
+            Clover not found.
+            Please make sure clover-${clover.version}.jar is in ${clover.home}/lib, or made available
+            to Ant using other mechanisms like -lib or CLASSPATH.
+        </fail>
+    </target>
+
+    <target name="clover.setup" if="run.clover">
+      <taskdef resource="cloverlib.xml" classpath="${clover.jar}"/>
       <mkdir dir="${clover.db.dir}"/>
       <clover-setup initString="${clover.db}">
         <fileset dir="${java.src.dir}"
@@ -1514,25 +1527,9 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
       </clover-setup>
     </target>
 
-    <target name="clover.info" if="run.clover" unless="clover.present">
-      <echo>
-        Clover not found. Code coverage reports disabled.
-      </echo>
-    </target>
-
-    <target name="clover.check">
-      <fail unless="clover.present">
-        ##################################################################
-        Clover not found.
-        Please make sure clover.jar is in ANT_HOME/lib, or made available
-        to Ant using other mechanisms like -lib or CLASSPATH.
-        ##################################################################
-      </fail>
-    </target>
-
-    <target name="generate-clover-reports" depends="clover.check, clover">
+    <target name="generate-clover-reports" depends="clover">
+      <taskdef resource="cloverlib.xml" classpath="${clover.jar}"/>
       <mkdir dir="${clover.report.dir}"/>
-
       <clover-report initString="${clover.db}">
         <current outfile="${clover.report.dir}" title="${final.name}">
           <format type="html"/>

--- a/build.xml
+++ b/build.xml
@@ -955,7 +955,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         <replacetoken>/tmp/zookeeper</replacetoken>
         <replacevalue>${VAR_DIR}/data</replacevalue>
       </replace>
-
+  	  
       <chmod perm="ugo+x" type="file" parallel="false">
         <fileset dir="${dist.dir}/bin"/>
         <fileset dir="${dist.dir}/sbin"/>
@@ -1069,7 +1069,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         <property name="dist.dir" value="${dist.dir}"/>
         <fileset file="${contrib.dir}/build.xml"/>
         <fileset file="${recipes.dir}/build.xml"/>
-      </subant>
+      </subant>  	
       <path id="c.lib">
         <fileset dir="${build.dir}">
           <include name="${final.name}-lib.tar.gz"/>
@@ -1174,10 +1174,10 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         </tarfileset>
         <tarfileset dir="${build.dir}/c/build/${package.prefix}/include" prefix="${package.prefix}/include">
           <include name="**" />
-        </tarfileset>
+        </tarfileset> 
         <tarfileset dir="${build.dir}/c/build/${package.prefix}/lib" filemode="755" prefix="${package.prefix}/lib">
           <include name="**" />
-        </tarfileset>
+        </tarfileset> 
         <tarfileset dir="${build.dir}/${final.name}/conf" filemode="644" prefix="${package.conf.dir}">
           <include name="**" />
         </tarfileset>
@@ -1485,11 +1485,11 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
 	<!-- yet to implement -->
     </target>
     
-    <target name="test-core-java" depends="test-init, test-category, junit.run"/>
+    <target name="test-core-java" depends="test-init, test-category, junit.run"/> 
 
-    <target name="test-core-cppunit" depends="test-init, test-category, call-test-cppunit"/>
+    <target name="test-core-cppunit" depends="test-init, test-category, call-test-cppunit"/> 
 
-    <target name="test-core" depends="test-core-java, test-core-cppunit"/>
+    <target name="test-core" depends="test-core-java, test-core-cppunit"/> 
 
     <!-- ====================================================== -->
     <!-- Run optional third-party tool targets                  -->

--- a/ivy.xml
+++ b/ivy.xml
@@ -143,6 +143,8 @@
         <exclude org="org.slf4j" module="slf4j-api"/>
     </dependency>
 
+    <dependency org="org.openclover" name="clover" rev="${clover.version}"/>
+
     <conflict manager="strict"/>
 
   </dependencies>

--- a/ivy.xml
+++ b/ivy.xml
@@ -34,7 +34,7 @@
     <conf name="jdiff" visibility="private"/>
     <conf name="releaseaudit" visibility="private" description="Artifacts required for releaseaudit target"/>
     <conf name="owasp" visibility="private" description="Artifacts required for owasp target"/>
-    <conf name="test-coverage-java" visibility="private" description="Artifacts required for test-coverage-java target"/>
+    <conf name="clover" visibility="private" description="Artifacts required for clover target"/>
   </configurations>
 
   <publications>
@@ -144,7 +144,7 @@
         <exclude org="org.slf4j" module="slf4j-api"/>
     </dependency>
 
-    <dependency org="org.openclover" name="clover" rev="${clover.version}" conf="test-coverage-java->default"/>
+    <dependency org="org.openclover" name="clover" rev="${clover.version}" conf="clover->default"/>
 
     <conflict manager="strict"/>
 

--- a/ivy.xml
+++ b/ivy.xml
@@ -34,6 +34,7 @@
     <conf name="jdiff" visibility="private"/>
     <conf name="releaseaudit" visibility="private" description="Artifacts required for releaseaudit target"/>
     <conf name="owasp" visibility="private" description="Artifacts required for owasp target"/>
+    <conf name="test-coverage-java" visibility="private" description="Artifacts required for test-coverage-java target"/>
   </configurations>
 
   <publications>
@@ -143,7 +144,7 @@
         <exclude org="org.slf4j" module="slf4j-api"/>
     </dependency>
 
-    <dependency org="org.openclover" name="clover" rev="${clover.version}"/>
+    <dependency org="org.openclover" name="clover" rev="${clover.version}" conf="test-coverage-java->default"/>
 
     <conflict manager="strict"/>
 


### PR DESCRIPTION
ZOOKEEPER-2955: Enable Clover code coverage report

This PR configures OpenClover to generate Java code coverage reports.

To generate Java code coverage report run:
ant test-coverage-clover-java

For quick testing of this PR run:
ant -Dtestcase=test_file_name test-coverage-clover-java

Clover can also be run step-by-step:
ant -Drun.clover=true test-core-java
ant clover-report

Note: run.clover must not be set when building ZK for production use.

The reports will be placed under the build/test/clover/reports directory in HTML and XML formats.