### PR TITLE
ZOOKEEPER-2184: Zookeeper Client should re-resolve hosts when connection attempts fail

### DIFF
--- a/src/java/main/org/apache/zookeeper/ClientCnxn.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxn.java
@@ -28,6 +28,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -1193,7 +1194,7 @@ public class ClientCnxn {
                            + Long.toHexString(getSessionId()));
         }
 
-        private void pingRwServer() throws RWServerFoundException {
+        private void pingRwServer() throws RWServerFoundException, UnknownHostException {
             String result = null;
             InetSocketAddress addr = hostProvider.next(0);
             LOG.info("Checking server " + addr + " for being r/w." +

--- a/src/java/main/org/apache/zookeeper/client/HostProvider.java
+++ b/src/java/main/org/apache/zookeeper/client/HostProvider.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.client;
 import org.apache.yetus.audience.InterfaceAudience;
 
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 
 /**
  * A set of hosts a ZooKeeper client should connect to.
@@ -53,7 +54,7 @@ public interface HostProvider {
      * @param spinDelay
      *            Milliseconds to wait if all hosts have been tried once.
      */
-    public InetSocketAddress next(long spinDelay);
+    public InetSocketAddress next(long spinDelay) throws UnknownHostException;
 
     /**
      * Notify the HostProvider of a successful connection.

--- a/src/java/main/org/apache/zookeeper/client/HostProvider.java
+++ b/src/java/main/org/apache/zookeeper/client/HostProvider.java
@@ -48,11 +48,12 @@ public interface HostProvider {
 
     /**
      * The next host to try to connect to.
-     * 
+     *
      * For a spinDelay of 0 there should be no wait.
-     * 
-     * @param spinDelay
-     *            Milliseconds to wait if all hosts have been tried once.
+     *
+     * @param spinDelay Milliseconds to wait if all hosts have been tried once.
+     * @return The next host to try to connect to.
+     * @throws UnknownHostException if next host in the list is unresolvable. Call again to advance pointer to next item in the list.
      */
     public InetSocketAddress next(long spinDelay) throws UnknownHostException;
 

--- a/src/java/main/org/apache/zookeeper/client/HostProvider.java
+++ b/src/java/main/org/apache/zookeeper/client/HostProvider.java
@@ -52,10 +52,10 @@ public interface HostProvider {
      * For a spinDelay of 0 there should be no wait.
      *
      * @param spinDelay Milliseconds to wait if all hosts have been tried once.
-     * @return The next host to try to connect to.
-     * @throws UnknownHostException if next host in the list is unresolvable. Call again to advance pointer to next item in the list.
+     * @return The next host to try to connect to with resolved address. If the host is not resolvable, the unresolved
+     * address will be returned.
      */
-    public InetSocketAddress next(long spinDelay) throws UnknownHostException;
+    public InetSocketAddress next(long spinDelay);
 
     /**
      * Notify the HostProvider of a successful connection.

--- a/src/java/main/org/apache/zookeeper/client/StaticHostProvider.java
+++ b/src/java/main/org/apache/zookeeper/client/StaticHostProvider.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,10 @@
 
 package org.apache.zookeeper.client;
 
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -25,17 +29,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
-import org.apache.yetus.audience.InterfaceAudience;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * Most simple HostProvider, resolves only on instantiation.
- * 
+ *
  */
 @InterfaceAudience.Public
 public final class StaticHostProvider implements HostProvider {
@@ -54,7 +52,7 @@ public final class StaticHostProvider implements HostProvider {
 
     /**
      * Constructs a SimpleHostSet.
-     * 
+     *
      * @param serverAddresses
      *            possibly unresolved ZooKeeper server addresses
      * @throws IllegalArgumentException
@@ -62,16 +60,16 @@ public final class StaticHostProvider implements HostProvider {
      */
     public StaticHostProvider(Collection<InetSocketAddress> serverAddresses) {
         for (InetSocketAddress address : serverAddresses) {
-			try {
-            	InetAddress resolvedAddresses[] =  InetAddress.getAllByName(getHostString(address));
-            	for (InetAddress resolvedAddress : resolvedAddresses) {
-                	this.serverAddresses.add(new InetSocketAddress(resolvedAddress, address.getPort()));
-            	}
-			} catch (UnknownHostException e) {
+            try {
+                InetAddress resolvedAddresses[] = InetAddress.getAllByName(getHostString(address));
+                for (InetAddress resolvedAddress : resolvedAddresses) {
+                    this.serverAddresses.add(new InetSocketAddress(resolvedAddress, address.getPort()));
+                }
+            } catch (UnknownHostException e) {
                 LOG.error("Unable to connect to server: {}", address, e);
             }
         }
-        
+
         if (this.serverAddresses.isEmpty()) {
             throw new IllegalArgumentException(
                     "A HostProvider may not be empty!");
@@ -126,11 +124,11 @@ public final class StaticHostProvider implements HostProvider {
     private int nextAdded = 0;
     private int nextRemoved = 0;
 
-    int getNextAdded() {
+    public int getNextAdded() {
         return nextAdded;
     }
 
-    int getNextRemoved() {
+    public int getNextRemoved() {
         return nextRemoved;
     }
 

--- a/src/java/main/org/apache/zookeeper/client/StaticHostProvider.java
+++ b/src/java/main/org/apache/zookeeper/client/StaticHostProvider.java
@@ -95,11 +95,6 @@ public final class StaticHostProvider implements HostProvider {
      * Resolve all unresolved server addresses, put them in a list and shuffle.
      */
     private void init(Collection<InetSocketAddress> serverAddresses) {
-        if (this.serverAddresses.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "A HostProvider may not be empty!");
-        }
-
         for (InetSocketAddress address : serverAddresses) {
             try {
                 InetAddress resolvedAddresses[] = this.resolver.getAllByName(getHostString(address));
@@ -109,6 +104,11 @@ public final class StaticHostProvider implements HostProvider {
             } catch (UnknownHostException e) {
                 LOG.error("Unable to connect to server: {}", address, e);
             }
+        }
+
+        if (this.serverAddresses.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "A HostProvider may not be empty!");
         }
 
         Collections.shuffle(this.serverAddresses);

--- a/src/java/test/org/apache/zookeeper/client/StaticHostProviderTest.java
+++ b/src/java/test/org/apache/zookeeper/client/StaticHostProviderTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.zookeeper.test;
+package org.apache.zookeeper.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -80,8 +80,7 @@ public class StaticHostProviderTest extends ZKTestCase {
     }
 
     @Test
-    public void testTwoConsequitiveCallsToNextReturnDifferentElement()
-            throws UnknownHostException {
+    public void testTwoConsequitiveCallsToNextReturnDifferentElement() {
         HostProvider hostProvider = getHostProvider((byte) 2);
         assertNotSame(hostProvider.next(0), hostProvider.next(0));
     }
@@ -103,7 +102,8 @@ public class StaticHostProviderTest extends ZKTestCase {
             InetSocketAddress next = hostProvider.next(0);
             assertTrue(next instanceof InetSocketAddress);
             assertTrue(!next.isUnresolved());
-            assertTrue("Did not match "+ next.toString(), !next.toString().startsWith("/"));
+            assertTrue("InetSocketAddress must not have hostname part " +
+                       next.toString(), next.toString().startsWith("/"));
             // Do NOT trigger the reverse name service lookup.
             String hostname = next.getHostName();
             // In this case, the hostname equals literal IP address.
@@ -117,8 +117,32 @@ public class StaticHostProviderTest extends ZKTestCase {
         list.add(new InetSocketAddress("a", 2181));
         list.add(new InetSocketAddress("b", 2181));
         new StaticHostProvider(list);
+	}
+
+    @Test
+    public void testReResolving() {
+        byte size = 1;
+        ArrayList<InetSocketAddress> list = new ArrayList<InetSocketAddress>(size);
+
+        // Test a hostname that resolves to multiple addresses
+        list.add(InetSocketAddress.createUnresolved("www.apache.org", 1234));
+        StaticHostProvider hostProvider = new StaticHostProvider(list);
+        InetSocketAddress next = hostProvider.next(0);
+        next = hostProvider.next(0);
+        assertTrue("No address was removed", hostProvider.getNextRemoved() > 0);
+        assertTrue("No address was added", hostProvider.getNextAdded() > 0);
+
+        // Test a hostname that resolves to a single address
+        list.clear();
+        list.add(InetSocketAddress.createUnresolved("issues.apache.org", 1234));
+        hostProvider = new StaticHostProvider(list);
+        next = hostProvider.next(0);
+        next = hostProvider.next(0);
+        assertTrue("No address was removed", hostProvider.getNextRemoved() > 0);
+        assertTrue("No address was added", hostProvider.getNextAdded() > 0);
     }
 
+	@Test
     public void testOneInvalidHostAddresses() {
         Collection<InetSocketAddress> addr = getUnresolvedServerAddresses((byte) 1);
         addr.add(new InetSocketAddress("a", 2181));
@@ -128,6 +152,22 @@ public class StaticHostProviderTest extends ZKTestCase {
         InetSocketAddress n2 = sp.next(0);
 
         assertEquals(n2, n1);
+	}
+
+    @Test
+    public void testReResolvingLocalhost() {
+        byte size = 2;
+        ArrayList<InetSocketAddress> list = new ArrayList<InetSocketAddress>(size);
+
+        // Test a hostname that resolves to multiple addresses
+        list.add(InetSocketAddress.createUnresolved("localhost", 1234));
+        list.add(InetSocketAddress.createUnresolved("localhost", 1235));
+        StaticHostProvider hostProvider = new StaticHostProvider(list);
+        int sizeBefore = hostProvider.size();
+        InetSocketAddress next = hostProvider.next(0);
+        next = hostProvider.next(0);
+        assertTrue("Different number of addresses in the list: " + hostProvider.size() +
+                " (after), " + sizeBefore + " (before)", hostProvider.size() == sizeBefore);
     }
 
     private StaticHostProvider getHostProviderUnresolved(byte size) {
@@ -137,7 +177,7 @@ public class StaticHostProviderTest extends ZKTestCase {
     private Collection<InetSocketAddress> getUnresolvedServerAddresses(byte size) {
         ArrayList<InetSocketAddress> list = new ArrayList<InetSocketAddress>(size);
         while (size > 0) {
-            list.add(InetSocketAddress.createUnresolved("10.10.10." + size, 1234 + size));
+            list.add(InetSocketAddress.createUnresolved("192.0.2." + size, 1234 + size));
             --size;
         }
         return list;
@@ -148,7 +188,7 @@ public class StaticHostProviderTest extends ZKTestCase {
                 size);
         while (size > 0) {
             try {
-                list.add(new InetSocketAddress(InetAddress.getByAddress(new byte[]{10, 10, 10, size}), 1234 + size));
+                list.add(new InetSocketAddress(InetAddress.getByAddress(new byte[]{-64, 0, 2, size}), 1234 + size));
             } catch (UnknownHostException e) {
                 LOG.error("Exception while resolving address", e);
                 fail("Failed to resolve address");

--- a/src/java/test/org/apache/zookeeper/test/ClientPortBindTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientPortBindTest.java
@@ -102,9 +102,9 @@ public class ClientPortBindTest extends ZKTestCase implements Watcher {
         startSignal = new CountDownLatch(1);
         ZooKeeper zk = new ZooKeeper(HOSTPORT, CONNECTION_TIMEOUT, this);
         try {
-            startSignal.await(CONNECTION_TIMEOUT,
+            boolean isZero = startSignal.await(CONNECTION_TIMEOUT,
                     TimeUnit.MILLISECONDS);
-            Assert.assertTrue("count == " + startSignal.getCount(), startSignal.getCount() == 0);
+            Assert.assertTrue("count == " + startSignal.getCount(), isZero);
             zk.close();
         } finally {
             f.shutdown();

--- a/src/java/test/org/apache/zookeeper/test/ClientPortBindTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientPortBindTest.java
@@ -104,7 +104,7 @@ public class ClientPortBindTest extends ZKTestCase implements Watcher {
         try {
             startSignal.await(CONNECTION_TIMEOUT,
                     TimeUnit.MILLISECONDS);
-            Assert.assertTrue("count == 0", startSignal.getCount() == 0);
+            Assert.assertTrue("count == " + startSignal.getCount(), startSignal.getCount() == 0);
             zk.close();
         } finally {
             f.shutdown();

--- a/src/java/test/org/apache/zookeeper/test/ReadOnlyModeTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReadOnlyModeTest.java
@@ -27,6 +27,7 @@ import junit.framework.Assert;
 
 import org.apache.log4j.Layout;
 import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.apache.log4j.WriterAppender;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -43,12 +44,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 public class ReadOnlyModeTest extends ZKTestCase {
-    private static final Logger LOG = LoggerFactory.getLogger(ReadOnlyModeTest.class);
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(ReadOnlyModeTest.class);
     private static int CONNECTION_TIMEOUT = QuorumBase.CONNECTION_TIMEOUT;
     private QuorumUtil qu = new QuorumUtil(1);
 
@@ -237,13 +237,13 @@ public class ReadOnlyModeTest extends ZKTestCase {
     public void testSeekForRwServer() throws Exception {
 
         // setup the logger to capture all logs
-        Layout layout = org.apache.log4j.Logger.getRootLogger().getAppender("CONSOLE")
+        Layout layout = Logger.getRootLogger().getAppender("CONSOLE")
                 .getLayout();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         WriterAppender appender = new WriterAppender(layout, os);
         appender.setImmediateFlush(true);
         appender.setThreshold(Level.INFO);
-        org.apache.log4j.Logger zlogger = org.apache.log4j.Logger.getLogger("org.apache.zookeeper");
+        Logger zlogger = Logger.getLogger("org.apache.zookeeper");
         zlogger.addAppender(appender);
 
         try {

--- a/src/java/test/org/apache/zookeeper/test/ReadOnlyModeTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReadOnlyModeTest.java
@@ -21,8 +21,6 @@ package org.apache.zookeeper.test;
 import java.io.ByteArrayOutputStream;
 import java.io.LineNumberReader;
 import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.regex.Pattern;
 
 import junit.framework.Assert;
@@ -34,15 +32,11 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NotReadOnlyException;
 import org.apache.zookeeper.Transaction;
-import org.apache.zookeeper.WatchedEvent;
-import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.ZooKeeper.States;
 import org.apache.zookeeper.common.Time;
-import org.apache.zookeeper.client.StaticHostProviderTest;
 import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
 
 import org.junit.After;

--- a/src/java/test/org/apache/zookeeper/test/ReadOnlyModeTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReadOnlyModeTest.java
@@ -29,7 +29,6 @@ import junit.framework.Assert;
 
 import org.apache.log4j.Layout;
 import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.apache.log4j.WriterAppender;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -43,15 +42,19 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.ZooKeeper.States;
 import org.apache.zookeeper.common.Time;
+import org.apache.zookeeper.client.StaticHostProviderTest;
 import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 public class ReadOnlyModeTest extends ZKTestCase {
-    private static final org.slf4j.Logger LOG = LoggerFactory
-            .getLogger(ReadOnlyModeTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ReadOnlyModeTest.class);
     private static int CONNECTION_TIMEOUT = QuorumBase.CONNECTION_TIMEOUT;
     private QuorumUtil qu = new QuorumUtil(1);
 
@@ -198,6 +201,7 @@ public class ReadOnlyModeTest extends ZKTestCase {
         qu.shutdown(2);
 
         CountdownWatcher watcher = new CountdownWatcher();
+        LOG.debug("Connection string: {}", qu.getConnString());
         ZooKeeper zk = new ZooKeeper(qu.getConnString(), CONNECTION_TIMEOUT,
                 watcher, true);
         watcher.waitForConnected(CONNECTION_TIMEOUT);
@@ -239,13 +243,13 @@ public class ReadOnlyModeTest extends ZKTestCase {
     public void testSeekForRwServer() throws Exception {
 
         // setup the logger to capture all logs
-        Layout layout = Logger.getRootLogger().getAppender("CONSOLE")
+        Layout layout = org.apache.log4j.Logger.getRootLogger().getAppender("CONSOLE")
                 .getLayout();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         WriterAppender appender = new WriterAppender(layout, os);
         appender.setImmediateFlush(true);
         appender.setThreshold(Level.INFO);
-        Logger zlogger = Logger.getLogger("org.apache.zookeeper");
+        org.apache.log4j.Logger zlogger = org.apache.log4j.Logger.getLogger("org.apache.zookeeper");
         zlogger.addAppender(appender);
 
         try {

--- a/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
+++ b/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
@@ -126,7 +126,6 @@ public class StaticHostProviderTest extends ZKTestCase {
         ArrayList<InetSocketAddress> list = new ArrayList<InetSocketAddress>(size);
 
         // Test a hostname that resolves to a single address
-        list.clear();
         list.add(InetSocketAddress.createUnresolved("issues.apache.org", 1234));
         final InetAddress issuesApacheOrg = mock(InetAddress.class);
         when(issuesApacheOrg.getHostAddress()).thenReturn("192.168.1.1");

--- a/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
+++ b/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
@@ -31,13 +31,22 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.matchers.JUnitMatchers.hasItems;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class StaticHostProviderTest extends ZKTestCase {
@@ -166,7 +175,7 @@ public class StaticHostProviderTest extends ZKTestCase {
         when(apacheOrg2.toString()).thenReturn("www.apache.org");
         when(apacheOrg2.getHostName()).thenReturn("www.apache.org");
 
-        final List<InetAddress> resolvedAddresses = new ArrayList<>();
+        final List<InetAddress> resolvedAddresses = new ArrayList<InetAddress>();
         resolvedAddresses.add(apacheOrg1);
         resolvedAddresses.add(apacheOrg2);
         StaticHostProvider.Resolver resolver = new StaticHostProvider.Resolver() {
@@ -182,6 +191,92 @@ public class StaticHostProviderTest extends ZKTestCase {
         assertEquals(2, hostProvider.size());
         assertEquals(apacheOrg1.getHostAddress(), hostProvider.getServerAddresses().get(0).getAddress().getHostAddress());
         assertEquals(apacheOrg2.getHostAddress(), hostProvider.getServerAddresses().get(1).getAddress().getHostAddress());
+    }
+
+    @Test
+    public void testReResolveMultipleOneFailing() throws UnknownHostException {
+        // Arrange
+        final List<InetSocketAddress> list = new ArrayList<InetSocketAddress>();
+        list.add(InetSocketAddress.createUnresolved("www.apache.org", 1234));
+        final List<String> ipList = new ArrayList<String>();
+        final List<InetAddress> resolvedAddresses = new ArrayList<InetAddress>();
+        for (int i = 0; i < 3; i++) {
+            ipList.add(String.format("192.168.1.%d", i+1));
+            final InetAddress apacheOrg = mock(InetAddress.class);
+            when(apacheOrg.getHostAddress()).thenReturn(String.format("192.168.1.%d", i+1));
+            when(apacheOrg.toString()).thenReturn("www.apache.org");
+            when(apacheOrg.getHostName()).thenReturn("www.apache.org");
+            resolvedAddresses.add(apacheOrg);
+        }
+
+        StaticHostProvider.Resolver resolver = new StaticHostProvider.Resolver() {
+            @Override
+            public InetAddress[] getAllByName(String name) {
+                return resolvedAddresses.toArray(new InetAddress[resolvedAddresses.size()]);
+            }
+        };
+        StaticHostProvider.Resolver spyResolver = spy(resolver);
+        StaticHostProvider hostProvider = new StaticHostProvider(list, spyResolver);
+
+        // Act & Assert
+        InetSocketAddress resolvedFirst = hostProvider.next(0);
+        verify(spyResolver, times(1)).getAllByName("www.apache.org"); // resolution occurred
+        assertFalse("HostProvider should return resolved addresses", resolvedFirst.isUnresolved());
+        assertThat("Bad IP address returned", ipList, hasItems(resolvedFirst.getAddress().getHostAddress()));
+
+        hostProvider.onConnected(); // first address works
+        InetSocketAddress resolvedSecond = hostProvider.next(0);
+        verify(spyResolver, times(1)).getAllByName("www.apache.org"); // resolution didn't occur
+        assertFalse("HostProvider should return resolved addresses", resolvedSecond.isUnresolved());
+        assertThat("Bad IP address returned", ipList, hasItems(resolvedSecond.getAddress().getHostAddress()));
+        assertThat("HostProvider should return the next IP address", resolvedSecond, is(not(resolvedFirst)));
+
+        // Second address doesn't work, so we don't call onConnected() this time
+        // StaticHostProvider should try to re-resolve the address in this case
+        InetSocketAddress resolvedThird = hostProvider.next(0);
+        verify(spyResolver, times(2)).getAllByName("www.apache.org"); // resolution occurred
+        assertFalse("HostProvider should return resolved addresses", resolvedThird.isUnresolved());
+        assertThat("Bad IP address returned", ipList, hasItems(resolvedThird.getAddress().getHostAddress()));
+    }
+
+    @Test
+    public void testEmptyResolution() throws UnknownHostException {
+        // Arrange
+        final List<InetSocketAddress> list = new ArrayList<InetSocketAddress>();
+        list.add(InetSocketAddress.createUnresolved("www.apache.org", 1234));
+        list.add(InetSocketAddress.createUnresolved("www.google.com", 1234));
+        final List<InetAddress> resolvedAddresses = new ArrayList<InetAddress>();
+
+        final InetAddress apacheOrg1 = mock(InetAddress.class);
+        when(apacheOrg1.getHostAddress()).thenReturn("192.168.1.1");
+        when(apacheOrg1.toString()).thenReturn("www.apache.org");
+        when(apacheOrg1.getHostName()).thenReturn("www.apache.org");
+
+        resolvedAddresses.add(apacheOrg1);
+
+        StaticHostProvider.Resolver resolver = new StaticHostProvider.Resolver() {
+            @Override
+            public InetAddress[] getAllByName(String name) {
+                if ("www.apache.org".equalsIgnoreCase(name)) {
+                    return resolvedAddresses.toArray(new InetAddress[resolvedAddresses.size()]);
+                } else {
+                    return new InetAddress[0];
+                }
+            }
+        };
+        StaticHostProvider.Resolver spyResolver = spy(resolver);
+        StaticHostProvider hostProvider = new StaticHostProvider(list, spyResolver);
+
+        // Act & Assert
+        for (int i = 0; i < 10; i++) {
+            InetSocketAddress resolved = hostProvider.next(0);
+            hostProvider.onConnected();
+            assertFalse("HostProvider should return resolved addresses", resolved.isUnresolved());
+            assertEquals("192.168.1.1", resolved.getAddress().getHostAddress());
+        }
+
+        verify(spyResolver, times(1)).getAllByName("www.apache.org");
+        verify(spyResolver, times(1)).getAllByName("www.google.com");
     }
 
     @Test

--- a/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
+++ b/src/java/test/org/apache/zookeeper/test/StaticHostProviderTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.zookeeper.client;
+package org.apache.zookeeper.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -37,7 +37,6 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Random;
 
 public class StaticHostProviderTest extends ZKTestCase {
     private static final Logger LOG = LoggerFactory.getLogger(StaticHostProviderTest.class);


### PR DESCRIPTION
This one is the pick-up of @fpj 's original PR: #150 
Targeting and rebased on the 3.4 branch.