### PR TITLE
ZOOKEEPER-1580:QuorumPeer.setRunning is not used

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -479,7 +479,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
         currentVote = v;
     }
 
-    volatile boolean running = true;
+    private volatile boolean running = true;
 
     /**
      * The number of milliseconds of each tick
@@ -1260,7 +1260,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     }
     
     public void shutdown() {
-        running = false;
+        setRunning(false);
         if (leader != null) {
             leader.shutdown("quorum Peer shutdown");
         }
@@ -1751,7 +1751,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
         if (zkDb != null) zkDb.initConfigInZKDatabase(getQuorumVerifier());
     }
     
-    public void setRunning(boolean running) {
+    private void setRunning(boolean running) {
         this.running = running;
     }
 

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -1260,7 +1260,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     }
     
     public void shutdown() {
-        setRunning(false);
+        running = false;
         if (leader != null) {
             leader.shutdown("quorum Peer shutdown");
         }
@@ -1749,10 +1749,6 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
 
     public synchronized void initConfigInZKDatabase() {   
         if (zkDb != null) zkDb.initConfigInZKDatabase(getQuorumVerifier());
-    }
-    
-    private void setRunning(boolean running) {
-        this.running = running;
     }
 
     public boolean isRunning() {


### PR DESCRIPTION
- more details in [JIRA:ZOOKEEPER-1580](https://issues.apache.org/jira/browse/ZOOKEEPER-1580)
- I forget fetching the upstream codes, make a mistake in the origin [PR-446] (https://github.com/apache/zookeeper/pull/446) which includes some review history,so I close it and open a new one