### PR TITLE
ZOOKEEPER-2930: Leader cannot be elected due to network timeout of some members.

### DIFF
--- a/zookeeper-common/src/test/java/org/apache/zookeeper/test/CnxManagerTest.java
+++ b/zookeeper-common/src/test/java/org/apache/zookeeper/test/CnxManagerTest.java
@@ -186,10 +186,8 @@ public class CnxManagerTest extends ZKTestCase {
 
     @Test
     public void testCnxManagerTimeout() throws Exception {
-        Random rand = new Random();
-        byte b = (byte) rand.nextInt();
         int deadPort = PortAssignment.unique();
-        String deadAddress = "10.1.1." + b;
+        String deadAddress = "10.1.1.255";
 
         LOG.info("This is the dead address I'm trying: " + deadAddress);
 
@@ -213,7 +211,7 @@ public class CnxManagerTest extends ZKTestCase {
         cnxManager.toSend(2L, createMsg(ServerState.LOOKING.ordinal(), 1, -1, 1));
         long end = Time.currentElapsedTime();
 
-        if((end - begin) > 6000) Assert.fail("Waited more than necessary");
+        if((end - begin) > 3000) Assert.fail("Waited more than necessary");
         cnxManager.halt();
         Assert.assertFalse(cnxManager.listener.isAlive());
     }


### PR DESCRIPTION
Move sock.connect() into the async connection worker thread.
Moved a load of connectOne(sid) into the async connection worker thread.
Use use the async connection worker for all connections.
This prevents connection delays blocking notifications to other nodes.