### PR TITLE
ZOOKEEPER-2967: Add check to validate dataDir and dataLogDir parameters at startup

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/persistence/FileSnap.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FileSnap.java
@@ -37,7 +37,6 @@ import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
-import org.apache.zookeeper.common.AtomicFileOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.server.DataTree;

--- a/src/java/main/org/apache/zookeeper/server/persistence/FileSnap.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FileSnap.java
@@ -51,11 +51,11 @@ import org.apache.zookeeper.server.util.SerializeUtils;
 public class FileSnap implements SnapShot {
     File snapDir;
     private volatile boolean close = false;
-    private static final int VERSION = 2;
-    private static final long dbId = -1;
+    private static final int VERSION=2;
+    private static final long dbId=-1;
     private static final Logger LOG = LoggerFactory.getLogger(FileSnap.class);
     public final static int SNAP_MAGIC
-            = ByteBuffer.wrap("ZKSN".getBytes()).getInt();
+        = ByteBuffer.wrap("ZKSN".getBytes()).getInt();
 
     public static final String SNAPSHOT_FILE_PREFIX = "snapshot";
 
@@ -66,7 +66,7 @@ public class FileSnap implements SnapShot {
     /**
      * deserialize a data tree from the most recent snapshot
      * @return the zxid of the snapshot
-     */
+     */ 
     public long deserialize(DataTree dt, Map<Long, Integer> sessions)
             throws IOException {
         // we run through 100 snapshots (not all of them)
@@ -98,11 +98,11 @@ public class FileSnap implements SnapShot {
             } catch(IOException e) {
                 LOG.warn("problem reading snap file " + snap, e);
             } finally {
-                if (snapIS != null)
+                if (snapIS != null) 
                     snapIS.close();
-                if (crcIn != null)
+                if (crcIn != null) 
                     crcIn.close();
-            }
+            } 
         }
         if (!foundValid) {
             throw new IOException("Not able to find valid snapshots in " + snapDir);
@@ -124,7 +124,7 @@ public class FileSnap implements SnapShot {
         header.deserialize(ia, "fileheader");
         if (header.getMagic() != SNAP_MAGIC) {
             throw new IOException("mismatching magic headers "
-                    + header.getMagic() +
+                    + header.getMagic() + 
                     " !=  " + FileSnap.SNAP_MAGIC);
         }
         SerializeUtils.deserializeSnapshot(dt,ia,sessions);
@@ -141,7 +141,7 @@ public class FileSnap implements SnapShot {
         }
         return files.get(0);
     }
-
+    
     /**
      * find the last (maybe) valid n snapshots. this does some 
      * minor checks on the validity of the snapshots. It just

--- a/src/java/main/org/apache/zookeeper/server/persistence/FileSnap.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FileSnap.java
@@ -37,6 +37,7 @@ import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
+import org.apache.zookeeper.common.AtomicFileOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.server.DataTree;
@@ -51,11 +52,14 @@ import org.apache.zookeeper.server.util.SerializeUtils;
 public class FileSnap implements SnapShot {
     File snapDir;
     private volatile boolean close = false;
-    private static final int VERSION=2;
-    private static final long dbId=-1;
+    private static final int VERSION = 2;
+    private static final long dbId = -1;
     private static final Logger LOG = LoggerFactory.getLogger(FileSnap.class);
     public final static int SNAP_MAGIC
-        = ByteBuffer.wrap("ZKSN".getBytes()).getInt();
+            = ByteBuffer.wrap("ZKSN".getBytes()).getInt();
+
+    public static final String SNAPSHOT_FILE_PREFIX = "snapshot";
+
     public FileSnap(File snapDir) {
         this.snapDir = snapDir;
     }
@@ -63,7 +67,7 @@ public class FileSnap implements SnapShot {
     /**
      * deserialize a data tree from the most recent snapshot
      * @return the zxid of the snapshot
-     */ 
+     */
     public long deserialize(DataTree dt, Map<Long, Integer> sessions)
             throws IOException {
         // we run through 100 snapshots (not all of them)
@@ -95,16 +99,16 @@ public class FileSnap implements SnapShot {
             } catch(IOException e) {
                 LOG.warn("problem reading snap file " + snap, e);
             } finally {
-                if (snapIS != null) 
+                if (snapIS != null)
                     snapIS.close();
-                if (crcIn != null) 
+                if (crcIn != null)
                     crcIn.close();
-            } 
+            }
         }
         if (!foundValid) {
             throw new IOException("Not able to find valid snapshots in " + snapDir);
         }
-        dt.lastProcessedZxid = Util.getZxidFromName(snap.getName(), "snapshot");
+        dt.lastProcessedZxid = Util.getZxidFromName(snap.getName(), SNAPSHOT_FILE_PREFIX);
         return dt.lastProcessedZxid;
     }
 
@@ -121,7 +125,7 @@ public class FileSnap implements SnapShot {
         header.deserialize(ia, "fileheader");
         if (header.getMagic() != SNAP_MAGIC) {
             throw new IOException("mismatching magic headers "
-                    + header.getMagic() + 
+                    + header.getMagic() +
                     " !=  " + FileSnap.SNAP_MAGIC);
         }
         SerializeUtils.deserializeSnapshot(dt,ia,sessions);
@@ -138,7 +142,7 @@ public class FileSnap implements SnapShot {
         }
         return files.get(0);
     }
-    
+
     /**
      * find the last (maybe) valid n snapshots. this does some 
      * minor checks on the validity of the snapshots. It just
@@ -152,7 +156,7 @@ public class FileSnap implements SnapShot {
      * @throws IOException
      */
     private List<File> findNValidSnapshots(int n) throws IOException {
-        List<File> files = Util.sortDataDir(snapDir.listFiles(),"snapshot", false);
+        List<File> files = Util.sortDataDir(snapDir.listFiles(), SNAPSHOT_FILE_PREFIX, false);
         int count = 0;
         List<File> list = new ArrayList<File>();
         for (File f : files) {
@@ -182,13 +186,13 @@ public class FileSnap implements SnapShot {
      * @throws IOException
      */
     public List<File> findNRecentSnapshots(int n) throws IOException {
-        List<File> files = Util.sortDataDir(snapDir.listFiles(), "snapshot", false);
+        List<File> files = Util.sortDataDir(snapDir.listFiles(), SNAPSHOT_FILE_PREFIX, false);
         int count = 0;
         List<File> list = new ArrayList<File>();
         for (File f: files) {
             if (count == n)
                 break;
-            if (Util.getZxidFromName(f.getName(), "snapshot") != -1) {
+            if (Util.getZxidFromName(f.getName(), SNAPSHOT_FILE_PREFIX) != -1) {
                 count++;
                 list.add(f);
             }

--- a/src/java/main/org/apache/zookeeper/server/persistence/FileTxnLog.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FileTxnLog.java
@@ -54,25 +54,25 @@ import org.slf4j.LoggerFactory;
  * <blockquote><pre>
  * LogFile:
  *     FileHeader TxnList ZeroPad
- *
+ * 
  * FileHeader: {
  *     magic 4bytes (ZKLG)
  *     version 4bytes
  *     dbid 8bytes
  *   }
- *
+ * 
  * TxnList:
  *     Txn || Txn TxnList
- *
+ *     
  * Txn:
  *     checksum Txnlen TxnHeader Record 0x42
- *
+ * 
  * checksum: 8bytes Adler32 is currently used
  *   calculated across payload -- Txnlen, TxnHeader, Record and 0x42
- *
+ * 
  * Txnlen:
  *     len 4bytes
- *
+ * 
  * TxnHeader: {
  *     sessionid 8bytes
  *     cxid 4bytes
@@ -80,13 +80,13 @@ import org.slf4j.LoggerFactory;
  *     time 8bytes
  *     type 4bytes
  *   }
- *
+ *     
  * Record:
  *     See Jute definition file for details on the various record types
- *
+ *      
  * ZeroPad:
  *     0 padded to EOF (filled during preallocation stage)
- * </pre></blockquote>
+ * </pre></blockquote> 
  */
 public class FileTxnLog implements TxnLog {
     private static final Logger LOG;
@@ -186,12 +186,12 @@ public class FileTxnLog implements TxnLog {
             log.close();
         }
     }
-
+    
     /**
      * append an entry to the transaction log
      * @param hdr the header of the transaction
      * @param txn the transaction part of the entry
-     * returns true iff something appended, otw false
+     * returns true iff something appended, otw false 
      */
     public synchronized boolean append(TxnHeader hdr, Record txn)
         throws IOException
@@ -474,10 +474,10 @@ public class FileTxnLog implements TxnLog {
     }
 
     /**
-     * a class that keeps track of the position
+     * a class that keeps track of the position 
      * in the input stream. The position points to offset
-     * that has been consumed by the applications. It can
-     * wrap buffered input streams to provide the right offset
+     * that has been consumed by the applications. It can 
+     * wrap buffered input streams to provide the right offset 
      * for the application.
      */
     static class PositionInputStream extends FilterInputStream {
@@ -486,7 +486,7 @@ public class FileTxnLog implements TxnLog {
             super(in);
             position = 0;
         }
-
+        
         @Override
         public int read() throws IOException {
             int rc = super.read();
@@ -501,9 +501,9 @@ public class FileTxnLog implements TxnLog {
             if (rc > 0) {
                 position += rc;
             }
-            return rc;
+            return rc;            
         }
-
+        
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
             int rc = super.read(b, off, len);
@@ -512,7 +512,7 @@ public class FileTxnLog implements TxnLog {
             }
             return rc;
         }
-
+        
         @Override
         public long skip(long n) throws IOException {
             long rc = super.skip(n);
@@ -540,7 +540,7 @@ public class FileTxnLog implements TxnLog {
             throw new UnsupportedOperationException("reset");
         }
     }
-
+    
     /**
      * this class implements the txnlog iterator interface
      * which is used for reading the transaction logs
@@ -553,7 +553,7 @@ public class FileTxnLog implements TxnLog {
         File logFile;
         InputArchive ia;
         static final String CRC_ERROR="CRC check failed";
-
+       
         PositionInputStream inputStream=null;
         //stored files is the list of files greater than
         //the zxid we are looking for.
@@ -624,7 +624,7 @@ public class FileTxnLog implements TxnLog {
             FileHeader header= new FileHeader();
             header.deserialize(ia, "fileheader");
             if (header.getMagic() != FileTxnLog.TXNLOG_MAGIC) {
-                throw new IOException("Transaction log: " + this.logFile + " has invalid magic number "
+                throw new IOException("Transaction log: " + this.logFile + " has invalid magic number " 
                         + header.getMagic()
                         + " != " + FileTxnLog.TXNLOG_MAGIC);
             }

--- a/src/java/main/org/apache/zookeeper/server/persistence/FileTxnLog.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FileTxnLog.java
@@ -54,25 +54,25 @@ import org.slf4j.LoggerFactory;
  * <blockquote><pre>
  * LogFile:
  *     FileHeader TxnList ZeroPad
- * 
+ *
  * FileHeader: {
  *     magic 4bytes (ZKLG)
  *     version 4bytes
  *     dbid 8bytes
  *   }
- * 
+ *
  * TxnList:
  *     Txn || Txn TxnList
- *     
+ *
  * Txn:
  *     checksum Txnlen TxnHeader Record 0x42
- * 
+ *
  * checksum: 8bytes Adler32 is currently used
  *   calculated across payload -- Txnlen, TxnHeader, Record and 0x42
- * 
+ *
  * Txnlen:
  *     len 4bytes
- * 
+ *
  * TxnHeader: {
  *     sessionid 8bytes
  *     cxid 4bytes
@@ -80,13 +80,13 @@ import org.slf4j.LoggerFactory;
  *     time 8bytes
  *     type 4bytes
  *   }
- *     
+ *
  * Record:
  *     See Jute definition file for details on the various record types
- *      
+ *
  * ZeroPad:
  *     0 padded to EOF (filled during preallocation stage)
- * </pre></blockquote> 
+ * </pre></blockquote>
  */
 public class FileTxnLog implements TxnLog {
     private static final Logger LOG;
@@ -98,6 +98,8 @@ public class FileTxnLog implements TxnLog {
         ByteBuffer.wrap("ZKLG".getBytes()).getInt();
 
     public final static int VERSION = 2;
+
+    public static final String LOG_FILE_PREFIX = "log";
 
     /** Maximum time we allow for elapsed fsync before WARNing */
     private final static long fsyncWarningThresholdMS;
@@ -184,12 +186,12 @@ public class FileTxnLog implements TxnLog {
             log.close();
         }
     }
-    
+
     /**
      * append an entry to the transaction log
      * @param hdr the header of the transaction
      * @param txn the transaction part of the entry
-     * returns true iff something appended, otw false 
+     * returns true iff something appended, otw false
      */
     public synchronized boolean append(TxnHeader hdr, Record txn)
         throws IOException
@@ -207,13 +209,11 @@ public class FileTxnLog implements TxnLog {
         }
 
         if (logStream==null) {
-            if(LOG.isInfoEnabled()){
-                LOG.info("Creating new log file: log." +
-                        Long.toHexString(hdr.getZxid()));
-            }
+           if(LOG.isInfoEnabled()){
+                LOG.info("Creating new log file: " + Util.makeLogName(hdr.getZxid()));
+           }
 
-            logFileWrite = new File(logDir, ("log." +
-                    Long.toHexString(hdr.getZxid())));
+            logFileWrite = new File(logDir, Util.makeLogName(hdr.getZxid()));
             fos = new FileOutputStream(logFileWrite);
             logStream=new BufferedOutputStream(fos);
             oa = BinaryOutputArchive.getArchive(logStream);
@@ -290,12 +290,12 @@ public class FileTxnLog implements TxnLog {
      * @return
      */
     public static File[] getLogFiles(File[] logDirList,long snapshotZxid) {
-        List<File> files = Util.sortDataDir(logDirList, "log", true);
+        List<File> files = Util.sortDataDir(logDirList, LOG_FILE_PREFIX, true);
         long logZxid = 0;
         // Find the log file that starts before or at the same time as the
         // zxid of the snapshot
         for (File f : files) {
-            long fzxid = Util.getZxidFromName(f.getName(), "log");
+            long fzxid = Util.getZxidFromName(f.getName(), LOG_FILE_PREFIX);
             if (fzxid > snapshotZxid) {
                 continue;
             }
@@ -307,7 +307,7 @@ public class FileTxnLog implements TxnLog {
         }
         List<File> v=new ArrayList<File>(5);
         for (File f : files) {
-            long fzxid = Util.getZxidFromName(f.getName(), "log");
+            long fzxid = Util.getZxidFromName(f.getName(), LOG_FILE_PREFIX);
             if (fzxid < logZxid) {
                 continue;
             }
@@ -324,7 +324,7 @@ public class FileTxnLog implements TxnLog {
     public long getLastLoggedZxid() {
         File[] files = getLogFiles(logDir.listFiles(), 0);
         long maxLog=files.length>0?
-                Util.getZxidFromName(files[files.length-1].getName(),"log"):-1;
+                Util.getZxidFromName(files[files.length-1].getName(),LOG_FILE_PREFIX):-1;
 
         // if a log file is more recent we must scan it to find
         // the highest zxid
@@ -474,10 +474,10 @@ public class FileTxnLog implements TxnLog {
     }
 
     /**
-     * a class that keeps track of the position 
+     * a class that keeps track of the position
      * in the input stream. The position points to offset
-     * that has been consumed by the applications. It can 
-     * wrap buffered input streams to provide the right offset 
+     * that has been consumed by the applications. It can
+     * wrap buffered input streams to provide the right offset
      * for the application.
      */
     static class PositionInputStream extends FilterInputStream {
@@ -486,7 +486,7 @@ public class FileTxnLog implements TxnLog {
             super(in);
             position = 0;
         }
-        
+
         @Override
         public int read() throws IOException {
             int rc = super.read();
@@ -501,9 +501,9 @@ public class FileTxnLog implements TxnLog {
             if (rc > 0) {
                 position += rc;
             }
-            return rc;            
+            return rc;
         }
-        
+
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
             int rc = super.read(b, off, len);
@@ -512,7 +512,7 @@ public class FileTxnLog implements TxnLog {
             }
             return rc;
         }
-        
+
         @Override
         public long skip(long n) throws IOException {
             long rc = super.skip(n);
@@ -540,7 +540,7 @@ public class FileTxnLog implements TxnLog {
             throw new UnsupportedOperationException("reset");
         }
     }
-    
+
     /**
      * this class implements the txnlog iterator interface
      * which is used for reading the transaction logs
@@ -553,7 +553,7 @@ public class FileTxnLog implements TxnLog {
         File logFile;
         InputArchive ia;
         static final String CRC_ERROR="CRC check failed";
-       
+
         PositionInputStream inputStream=null;
         //stored files is the list of files greater than
         //the zxid we are looking for.
@@ -578,13 +578,13 @@ public class FileTxnLog implements TxnLog {
          */
         void init() throws IOException {
             storedFiles = new ArrayList<File>();
-            List<File> files = Util.sortDataDir(FileTxnLog.getLogFiles(logDir.listFiles(), 0), "log", false);
+            List<File> files = Util.sortDataDir(FileTxnLog.getLogFiles(logDir.listFiles(), 0), LOG_FILE_PREFIX, false);
             for (File f: files) {
-                if (Util.getZxidFromName(f.getName(), "log") >= zxid) {
+                if (Util.getZxidFromName(f.getName(), LOG_FILE_PREFIX) >= zxid) {
                     storedFiles.add(f);
                 }
                 // add the last logfile that is less than the zxid
-                else if (Util.getZxidFromName(f.getName(), "log") < zxid) {
+                else if (Util.getZxidFromName(f.getName(), LOG_FILE_PREFIX) < zxid) {
                     storedFiles.add(f);
                     break;
                 }
@@ -624,7 +624,7 @@ public class FileTxnLog implements TxnLog {
             FileHeader header= new FileHeader();
             header.deserialize(ia, "fileheader");
             if (header.getMagic() != FileTxnLog.TXNLOG_MAGIC) {
-                throw new IOException("Transaction log: " + this.logFile + " has invalid magic number " 
+                throw new IOException("Transaction log: " + this.logFile + " has invalid magic number "
                         + header.getMagic()
                         + " != " + FileTxnLog.TXNLOG_MAGIC);
             }

--- a/src/java/main/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server.persistence;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
@@ -112,34 +113,26 @@ public class FileTxnSnapLog {
     }
 
     private void checkLogDir() throws LogdirContentCheckException {
-        File[] files = this.dataDir.listFiles();
-        if(files != null) {
-            boolean hasSnapshotFiles = false;
-            for (File file : files) {
-                if(Util.isSnapshotFile(file)){
-                    hasSnapshotFiles = true;
-                    break;
-                }
+        File[] files = this.dataDir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return Util.isSnapshotFileName(name);
             }
-            if (hasSnapshotFiles) {
-                throw new LogdirContentCheckException("Log directory has snapshot files. Check if dataLogDir and dataDir configuration is correct.");
-            }
+        });
+        if (files.length > 0) {
+            throw new LogdirContentCheckException("Log directory has snapshot files. Check if dataLogDir and dataDir configuration is correct.");
         }
     }
 
     private void checkSnapDir() throws SnapdirContentCheckException {
-        File[] files = this.snapDir.listFiles();
-        if(files != null) {
-            boolean hasLogFiles = false;
-            for (File file : files) {
-                if(Util.isLogFile(file)){
-                    hasLogFiles = true;
-                    break;
-                }
+        File[] files = this.snapDir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return Util.isLogFileName(name);
             }
-            if (hasLogFiles) {
-                throw new SnapdirContentCheckException("Snapshot directory has log files. Check if dataLogDir and dataDir configuration is correct.");
-            }
+        });
+        if (files.length > 0) {
+            throw new SnapdirContentCheckException("Snapshot directory has log files. Check if dataLogDir and dataDir configuration is correct.");
         }
     }
 

--- a/src/java/main/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -115,11 +115,12 @@ public class FileTxnSnapLog {
         File[] files = this.dataDir.listFiles();
         if(files != null) {
             boolean hasSnapshotFiles = false;
-
             for (File file : files) {
-                hasSnapshotFiles |= Util.isSnapshotFile(file);
+                if(Util.isSnapshotFile(file)){
+                    hasSnapshotFiles = true;
+                    break;
+                }
             }
-
             if (hasSnapshotFiles) {
                 throw new LogdirContentCheckException("Log directory has snapshot files. Check if dataLogDir and dataDir configuration is correct.");
             }
@@ -130,11 +131,12 @@ public class FileTxnSnapLog {
         File[] files = this.snapDir.listFiles();
         if(files != null) {
             boolean hasLogFiles = false;
-
             for (File file : files) {
-                hasLogFiles |= Util.isLogFile(file);
+                if(Util.isLogFile(file)){
+                    hasLogFiles = true;
+                    break;
+                }
             }
-
             if (hasLogFiles) {
                 throw new SnapdirContentCheckException("Snapshot directory has log files. Check if dataLogDir and dataDir configuration is correct.");
             }

--- a/src/java/main/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -103,6 +103,7 @@ public class FileTxnSnapLog {
         }
 
         // check content of transaction log and snapshot dirs if they are two different directories
+        // See ZOOKEEPER-2967 for more details
         if(!this.dataDir.getPath().equals(this.snapDir.getPath())){
             checkLogDir();
             checkSnapDir();
@@ -112,7 +113,7 @@ public class FileTxnSnapLog {
         snapLog = new FileSnap(this.snapDir);
     }
 
-    private void checkLogDir() throws LogdirContentCheckException {
+    private void checkLogDir() throws LogDirContentCheckException {
         File[] files = this.dataDir.listFiles(new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {
@@ -120,11 +121,11 @@ public class FileTxnSnapLog {
             }
         });
         if (files.length > 0) {
-            throw new LogdirContentCheckException("Log directory has snapshot files. Check if dataLogDir and dataDir configuration is correct.");
+            throw new LogDirContentCheckException("Log directory has snapshot files. Check if dataLogDir and dataDir configuration is correct.");
         }
     }
 
-    private void checkSnapDir() throws SnapdirContentCheckException {
+    private void checkSnapDir() throws SnapDirContentCheckException {
         File[] files = this.snapDir.listFiles(new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {
@@ -132,7 +133,7 @@ public class FileTxnSnapLog {
             }
         });
         if (files.length > 0) {
-            throw new SnapdirContentCheckException("Snapshot directory has log files. Check if dataLogDir and dataDir configuration is correct.");
+            throw new SnapDirContentCheckException("Snapshot directory has log files. Check if dataLogDir and dataDir configuration is correct.");
         }
     }
 
@@ -392,15 +393,15 @@ public class FileTxnSnapLog {
     }
 
     @SuppressWarnings("serial")
-    public static class LogdirContentCheckException extends DatadirException {
-        public LogdirContentCheckException(String msg) {
+    public static class LogDirContentCheckException extends DatadirException {
+        public LogDirContentCheckException(String msg) {
             super(msg);
         }
     }
 
     @SuppressWarnings("serial")
-    public static class SnapdirContentCheckException extends DatadirException {
-        public SnapdirContentCheckException(String msg) {
+    public static class SnapDirContentCheckException extends DatadirException {
+        public SnapDirContentCheckException(String msg) {
             super(msg);
         }
     }

--- a/src/java/main/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -21,7 +21,6 @@ package org.apache.zookeeper.server.persistence;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,13 +40,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This is a helper class
- * above the implementations
- * of txnlog and snapshot
+ * This is a helper class 
+ * above the implementations 
+ * of txnlog and snapshot 
  * classes
  */
 public class FileTxnSnapLog {
-    //the direcotry containing the
+    //the direcotry containing the 
     //the transaction logs
     private final File dataDir;
     //the directory containing the
@@ -57,22 +56,22 @@ public class FileTxnSnapLog {
     private SnapShot snapLog;
     public final static int VERSION = 2;
     public final static String version = "version-";
-
+    
     private static final Logger LOG = LoggerFactory.getLogger(FileTxnSnapLog.class);
-
+    
     /**
      * This listener helps
      * the external apis calling
      * restore to gather information
-     * while the data is being
+     * while the data is being 
      * restored.
      */
     public interface PlayBackListener {
         void onTxnLoaded(TxnHeader hdr, Record rec);
     }
-
+    
     /**
-     * the constructor which takes the datadir and
+     * the constructor which takes the datadir and 
      * snapdir.
      * @param dataDir the trasaction directory
      * @param snapDir the snapshot directory
@@ -145,28 +144,28 @@ public class FileTxnSnapLog {
     public File getDataDir() {
         return this.dataDir;
     }
-
+    
     /**
-     * get the snap dir used by this
+     * get the snap dir used by this 
      * filetxn snap log
      * @return the snap dir
      */
     public File getSnapDir() {
         return this.snapDir;
     }
-
+    
     /**
-     * this function restores the server
-     * database after reading from the
+     * this function restores the server 
+     * database after reading from the 
      * snapshots and transaction logs
      * @param dt the datatree to be restored
      * @param sessions the sessions to be restored
-     * @param listener the playback listener to run on the
+     * @param listener the playback listener to run on the 
      * database restoration
      * @return the highest zxid restored
      * @throws IOException
      */
-    public long restore(DataTree dt, Map<Long, Integer> sessions,
+    public long restore(DataTree dt, Map<Long, Integer> sessions, 
             PlayBackListener listener) throws IOException {
         snapLog.deserialize(dt, sessions);
         FileTxnLog txnLog = new FileTxnLog(dataDir);
@@ -175,11 +174,11 @@ public class FileTxnSnapLog {
         TxnHeader hdr;
         try {
             while (true) {
-                // iterator points to
+                // iterator points to 
                 // the first valid txn when initialized
                 hdr = itr.getHeader();
                 if (hdr == null) {
-                    //empty logs
+                    //empty logs 
                     return dt.lastProcessedZxid;
                 }
                 if (hdr.getZxid() < highestZxid && highestZxid != 0) {
@@ -196,7 +195,7 @@ public class FileTxnSnapLog {
                          hdr.getType() + " error: " + e.getMessage(), e);
                 }
                 listener.onTxnLoaded(hdr, itr.getTxn());
-                if (!itr.next())
+                if (!itr.next()) 
                     break;
             }
         } finally {
@@ -281,7 +280,7 @@ public class FileTxnSnapLog {
         LOG.info("Snapshotting: 0x{} to {}", Long.toHexString(lastZxid),
                 snapshotFile);
         snapLog.serialize(dataTree, sessionsWithTimeouts, snapshotFile);
-
+        
     }
 
     /**
@@ -309,11 +308,11 @@ public class FileTxnSnapLog {
 
         return truncated;
     }
-
+    
     /**
      * the most recent snapshot in the snapshot
      * directory
-     * @return the file that contains the most
+     * @return the file that contains the most 
      * recent snapshot
      * @throws IOException
      */
@@ -321,7 +320,7 @@ public class FileTxnSnapLog {
         FileSnap snaplog = new FileSnap(snapDir);
         return snaplog.findMostRecentSnapshot();
     }
-
+    
     /**
      * the n most recent snapshots
      * @param n the number of recent snapshots
@@ -350,7 +349,7 @@ public class FileTxnSnapLog {
     /**
      * append the request to the transaction logs
      * @param si the request to be appended
-     * returns true iff something appended, otw false
+     * returns true iff something appended, otw false 
      * @throws IOException
      */
     public boolean append(Request si) throws IOException {
@@ -367,12 +366,12 @@ public class FileTxnSnapLog {
 
     /**
      * roll the transaction logs
-     * @throws IOException
+     * @throws IOException 
      */
     public void rollLog() throws IOException {
         txnLog.rollLog();
     }
-
+    
     /**
      * close the transaction log files
      * @throws IOException

--- a/src/java/main/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -120,7 +120,7 @@ public class FileTxnSnapLog {
                 return Util.isSnapshotFileName(name);
             }
         });
-        if (files.length > 0) {
+        if (files != null && files.length > 0) {
             throw new LogDirContentCheckException("Log directory has snapshot files. Check if dataLogDir and dataDir configuration is correct.");
         }
     }
@@ -132,7 +132,7 @@ public class FileTxnSnapLog {
                 return Util.isLogFileName(name);
             }
         });
-        if (files.length > 0) {
+        if (files != null && files.length > 0) {
             throw new SnapDirContentCheckException("Snapshot directory has log files. Check if dataLogDir and dataDir configuration is correct.");
         }
     }

--- a/src/java/main/org/apache/zookeeper/server/persistence/Util.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/Util.java
@@ -50,7 +50,7 @@ public class Util {
     private static final String SNAP_DIR="snapDir";
     private static final String LOG_DIR="logDir";
     private static final String DB_FORMAT_CONV="dbFormatConversion";
-
+    
     public static String makeURIString(String dataDir, String dataLogDir, 
             String convPolicy){
         String uri="file:"+SNAP_DIR+"="+dataDir+";"+LOG_DIR+"="+dataLogDir;

--- a/src/java/main/org/apache/zookeeper/server/persistence/Util.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/Util.java
@@ -50,6 +50,9 @@ public class Util {
     private static final String SNAP_DIR="snapDir";
     private static final String LOG_DIR="logDir";
     private static final String DB_FORMAT_CONV="dbFormatConversion";
+
+    private static final String LOG_FILE_PREFIX = "log";
+    private static final String SNAP_FILE_PREFIX = "snapshot";
     
     public static String makeURIString(String dataDir, String dataLogDir, 
             String convPolicy){
@@ -83,7 +86,7 @@ public class Util {
      * @return file name
      */
     public static String makeLogName(long zxid) {
-        return "log." + Long.toHexString(zxid);
+        return LOG_FILE_PREFIX + "." + Long.toHexString(zxid);
     }
 
     /**
@@ -93,7 +96,7 @@ public class Util {
      * @return file name
      */
     public static String makeSnapshotName(long zxid) {
-        return "snapshot." + Long.toHexString(zxid);
+        return SNAP_FILE_PREFIX + "." + Long.toHexString(zxid);
     }
     
     /**
@@ -296,6 +299,26 @@ public class Util {
         List<File> filelist = Arrays.asList(files);
         Collections.sort(filelist, new DataDirFileComparator(prefix, ascending));
         return filelist;
+    }
+
+    /**
+     * Returns true if file is a log file.
+     *
+     * @param file
+     * @return
+     */
+    public static boolean isLogFile(File file) {
+        return file.getName().startsWith(LOG_FILE_PREFIX);
+    }
+
+    /**
+     * Returns true if file is a snapshot file.
+     *
+     * @param file
+     * @return
+     */
+    public static boolean isSnapshotFile(File file) {
+        return file.getName().startsWith(SNAP_FILE_PREFIX);
     }
     
 }

--- a/src/java/main/org/apache/zookeeper/server/persistence/Util.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/Util.java
@@ -51,9 +51,6 @@ public class Util {
     private static final String LOG_DIR="logDir";
     private static final String DB_FORMAT_CONV="dbFormatConversion";
 
-    private static final String LOG_FILE_PREFIX = "log";
-    private static final String SNAP_FILE_PREFIX = "snapshot";
-    
     public static String makeURIString(String dataDir, String dataLogDir, 
             String convPolicy){
         String uri="file:"+SNAP_DIR+"="+dataDir+";"+LOG_DIR+"="+dataLogDir;
@@ -86,7 +83,7 @@ public class Util {
      * @return file name
      */
     public static String makeLogName(long zxid) {
-        return LOG_FILE_PREFIX + "." + Long.toHexString(zxid);
+        return FileTxnLog.LOG_FILE_PREFIX + "." + Long.toHexString(zxid);
     }
 
     /**
@@ -96,7 +93,7 @@ public class Util {
      * @return file name
      */
     public static String makeSnapshotName(long zxid) {
-        return SNAP_FILE_PREFIX + "." + Long.toHexString(zxid);
+        return FileSnap.SNAPSHOT_FILE_PREFIX + "." + Long.toHexString(zxid);
     }
     
     /**
@@ -160,7 +157,7 @@ public class Util {
      * @throws IOException
      */
     public static boolean isValidSnapshot(File f) throws IOException {
-        if (f==null || Util.getZxidFromName(f.getName(), "snapshot") == -1)
+        if (f==null || Util.getZxidFromName(f.getName(), FileSnap.SNAPSHOT_FILE_PREFIX) == -1)
             return false;
 
         // Check for a valid snapshot
@@ -308,7 +305,7 @@ public class Util {
      * @return
      */
     public static boolean isLogFileName(String fileName) {
-        return fileName.startsWith(LOG_FILE_PREFIX + ".");
+        return fileName.startsWith(FileTxnLog.LOG_FILE_PREFIX + ".");
     }
 
     /**
@@ -318,7 +315,7 @@ public class Util {
      * @return
      */
     public static boolean isSnapshotFileName(String fileName) {
-        return fileName.startsWith(SNAP_FILE_PREFIX + ".");
+        return fileName.startsWith(FileSnap.SNAPSHOT_FILE_PREFIX + ".");
     }
     
 }

--- a/src/java/main/org/apache/zookeeper/server/persistence/Util.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/Util.java
@@ -302,23 +302,23 @@ public class Util {
     }
 
     /**
-     * Returns true if file is a log file.
+     * Returns true if fileName is a log file name.
      *
-     * @param file
+     * @param fileName
      * @return
      */
-    public static boolean isLogFile(File file) {
-        return file.getName().startsWith(LOG_FILE_PREFIX);
+    public static boolean isLogFileName(String fileName) {
+        return fileName.startsWith(LOG_FILE_PREFIX + ".");
     }
 
     /**
-     * Returns true if file is a snapshot file.
+     * Returns true if fileName is a snapshot file name.
      *
-     * @param file
+     * @param fileName
      * @return
      */
-    public static boolean isSnapshotFile(File file) {
-        return file.getName().startsWith(SNAP_FILE_PREFIX);
+    public static boolean isSnapshotFileName(String fileName) {
+        return fileName.startsWith(SNAP_FILE_PREFIX + ".");
     }
     
 }

--- a/src/java/test/org/apache/zookeeper/server/persistence/FileTxnSnapLogTest.java
+++ b/src/java/test/org/apache/zookeeper/server/persistence/FileTxnSnapLogTest.java
@@ -1,0 +1,380 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import org.apache.jute.Record;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.Request;
+import org.apache.zookeeper.test.ClientBase;
+import org.apache.zookeeper.txn.SetDataTxn;
+import org.apache.zookeeper.txn.TxnHeader;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class FileTxnSnapLogTest {
+
+    /**
+     * Test verifies the auto creation of data dir and data log dir.
+     * Sets "zookeeper.datadir.autocreate" to true.
+     */
+    @Test
+    public void testWithAutoCreateDataLogDir() throws IOException {
+        File tmpDir = ClientBase.createEmptyTestDir();
+        File dataDir = new File(tmpDir, "data");
+        File snapDir = new File(tmpDir, "data_txnlog");
+        Assert.assertFalse("data directory already exists", dataDir.exists());
+        Assert.assertFalse("snapshot directory already exists", snapDir.exists());
+
+        String priorAutocreateDirValue = System.getProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
+        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, "true");
+        FileTxnSnapLog fileTxnSnapLog;
+        try {
+            fileTxnSnapLog = new FileTxnSnapLog(dataDir, snapDir);
+        } finally {
+            if (priorAutocreateDirValue == null) {
+                System.clearProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
+            } else {
+                System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, priorAutocreateDirValue);
+            }
+        }
+        Assert.assertTrue(dataDir.exists());
+        Assert.assertTrue(snapDir.exists());
+        Assert.assertTrue(fileTxnSnapLog.getDataDir().exists());
+        Assert.assertTrue(fileTxnSnapLog.getSnapDir().exists());
+    }
+
+    /**
+     * Test verifies server should fail when data dir or data log dir doesn't
+     * exists. Sets "zookeeper.datadir.autocreate" to false.
+     */
+    @Test
+    public void testWithoutAutoCreateDataLogDir() throws Exception {
+        File tmpDir = ClientBase.createEmptyTestDir();
+        File dataDir = new File(tmpDir, "data");
+        File snapDir = new File(tmpDir, "data_txnlog");
+        Assert.assertFalse("data directory already exists", dataDir.exists());
+        Assert.assertFalse("snapshot directory already exists", snapDir.exists());
+
+        String priorAutocreateDirValue = System.getProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
+        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, "false");
+        try {
+            FileTxnSnapLog fileTxnSnapLog = new FileTxnSnapLog(dataDir, snapDir);
+        } catch (FileTxnSnapLog.DatadirException e) {
+            Assert.assertFalse(dataDir.exists());
+            Assert.assertFalse(snapDir.exists());
+            return;
+        } finally {
+            if (priorAutocreateDirValue == null) {
+                System.clearProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
+            } else {
+                System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, priorAutocreateDirValue);
+            }
+        }
+        Assert.fail("Expected exception from FileTxnSnapLog");
+    }
+
+    @Test
+    public void testAutoCreateDb() throws IOException {
+        File tmpDir = ClientBase.createEmptyTestDir();
+        File dataDir = new File(tmpDir, "data");
+        File snapDir = new File(tmpDir, "data_txnlog");
+        Assert.assertTrue("cannot create data directory", dataDir.mkdir());
+        Assert.assertTrue("cannot create snapshot directory", snapDir.mkdir());
+        File initFile = new File(dataDir, "initialize");
+        Assert.assertFalse("initialize file already exists", initFile.exists());
+
+        String priorAutocreateDbValue = System.getProperty(FileTxnSnapLog.ZOOKEEPER_DB_AUTOCREATE);
+        Map<Long, Integer> sessions = new ConcurrentHashMap<>();
+
+        attemptAutoCreateDb(dataDir, snapDir, sessions, priorAutocreateDbValue, "false", -1L);
+
+        attemptAutoCreateDb(dataDir, snapDir, sessions, priorAutocreateDbValue, "true", 0L);
+
+        Assert.assertTrue("cannot create initialize file", initFile.createNewFile());
+        attemptAutoCreateDb(dataDir, snapDir, sessions, priorAutocreateDbValue, "false", 0L);
+    }
+
+    @Test
+    public void testGetTxnLogSyncElapsedTime() throws IOException {
+        File tmpDir = ClientBase.createEmptyTestDir();
+        FileTxnSnapLog fileTxnSnapLog = new FileTxnSnapLog(new File(tmpDir, "data"),
+                new File(tmpDir, "data_txnlog"));
+
+        TxnHeader hdr = new TxnHeader(1, 1, 1, 1, ZooDefs.OpCode.setData);
+        Record txn = new SetDataTxn("/foo", new byte[0], 1);
+        Request req = new Request(0, 0, 0, hdr, txn, 0);
+
+        try {
+            fileTxnSnapLog.append(req);
+            fileTxnSnapLog.commit();
+            long syncElapsedTime = fileTxnSnapLog.getTxnLogElapsedSyncTime();
+            Assert.assertNotEquals("Did not update syncElapsedTime!", -1L, syncElapsedTime);
+        } finally {
+            fileTxnSnapLog.close();
+        }
+    }
+
+    private void attemptAutoCreateDb(File dataDir, File snapDir, Map<Long, Integer> sessions,
+                                     String priorAutocreateDbValue, String autoCreateValue,
+                                     long expectedValue) throws IOException {
+        sessions.clear();
+        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DB_AUTOCREATE, autoCreateValue);
+        FileTxnSnapLog fileTxnSnapLog = new FileTxnSnapLog(dataDir, snapDir);
+
+        try {
+            long zxid = fileTxnSnapLog.restore(new DataTree(), sessions, new FileTxnSnapLog.PlayBackListener() {
+                @Override
+                public void onTxnLoaded(TxnHeader hdr, Record rec) {
+                    // empty by default
+                }
+            });
+            Assert.assertEquals("unexpected zxid", expectedValue, zxid);
+        } finally {
+            if (priorAutocreateDbValue == null) {
+                System.clearProperty(FileTxnSnapLog.ZOOKEEPER_DB_AUTOCREATE);
+            } else {
+                System.setProperty(FileTxnSnapLog.ZOOKEEPER_DB_AUTOCREATE, priorAutocreateDbValue);
+            }
+        }
+    }
+
+    @Test
+    public void testDirCheckWithCorrectFiles() throws IOException {
+        File tmpDir = ClientBase.createEmptyTestDir();
+        File logDir = new File(tmpDir, "logdir");
+        File snapDir = new File(tmpDir, "snapdir");
+        File logVersionDir = new File(logDir, FileTxnSnapLog.version +  FileTxnSnapLog.VERSION);
+        File snapVersionDir = new File(snapDir, FileTxnSnapLog.version +  FileTxnSnapLog.VERSION);
+
+        if (!logVersionDir.exists()) {
+            logVersionDir.mkdirs();
+        }
+        if (!snapVersionDir.exists()) {
+            snapVersionDir.mkdirs();
+        }
+
+        Assert.assertTrue(logVersionDir.exists());
+        Assert.assertTrue(snapVersionDir.exists());
+
+        // transaction log files in log dir - correct
+        File logFile1 = new File(logVersionDir.getPath() +File.separator + Util.makeLogName(1L));
+        logFile1.createNewFile();
+        File logFile2 = new File(logVersionDir.getPath() +File.separator + Util.makeLogName(2L));
+        logFile2.createNewFile();
+
+        // snapshot files in snap dir - correct
+        File snapFile1 = new File(snapVersionDir.getPath() +File.separator + Util.makeSnapshotName(1L));
+        snapFile1.createNewFile();
+        File snapFile2 = new File(snapVersionDir.getPath() +File.separator + Util.makeSnapshotName(2L));
+        snapFile2.createNewFile();
+
+        Assert.assertTrue(logFile1.exists());
+        Assert.assertTrue(logFile2.exists());
+        Assert.assertTrue(snapFile1.exists());
+        Assert.assertTrue(snapFile2.exists());
+
+        String priorAutocreateDirValue = System.getProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
+        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, "false");
+        FileTxnSnapLog fileTxnSnapLog;
+        try {
+            fileTxnSnapLog = new FileTxnSnapLog(logDir, snapDir);
+        } catch (FileTxnSnapLog.LogdirContentCheckException e) {
+            Assert.fail("Should not throw LogdirContentCheckException.");
+        } catch (FileTxnSnapLog.SnapdirContentCheckException e) {
+            Assert.fail("Should not throw SnapdirContentCheckException.");
+        } finally {
+            if (priorAutocreateDirValue == null) {
+                System.clearProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
+            } else {
+                System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, priorAutocreateDirValue);
+            }
+        }
+    }
+
+    @Test
+    public void testDirCheckWithSameLogAndSnapDirs() throws IOException {
+        File tmpDir = ClientBase.createEmptyTestDir();
+        File logDir = new File(tmpDir, "logdir");
+
+        File logVersionDir = new File(logDir, FileTxnSnapLog.version +  FileTxnSnapLog.VERSION);
+
+        if (!logVersionDir.exists()) {
+            logVersionDir.mkdirs();
+        }
+
+        Assert.assertTrue(logVersionDir.exists());
+
+        // transaction log and snapshot files in the same dir in case transaction log dir and snapshot dir are configured to be the same
+        File logFile1 = new File(logVersionDir.getPath() +File.separator + Util.makeLogName(1L));
+        logFile1.createNewFile();
+        File logFile2 = new File(logVersionDir.getPath() +File.separator + Util.makeLogName(2L));
+        logFile2.createNewFile();
+        File snapFile1 = new File(logVersionDir.getPath() +File.separator + Util.makeSnapshotName(1L));
+        snapFile1.createNewFile();
+        File snapFile2 = new File(logVersionDir.getPath() +File.separator + Util.makeSnapshotName(2L));
+        snapFile2.createNewFile();
+
+        Assert.assertTrue(logFile1.exists());
+        Assert.assertTrue(logFile2.exists());
+        Assert.assertTrue(snapFile1.exists());
+        Assert.assertTrue(snapFile2.exists());
+
+        String priorAutocreateDirValue = System.getProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
+        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, "false");
+        FileTxnSnapLog fileTxnSnapLog;
+        try {
+            fileTxnSnapLog = new FileTxnSnapLog(logDir, logDir);
+        } catch (FileTxnSnapLog.LogdirContentCheckException e) {
+            Assert.fail("Should not throw LogdirContentCheckException.");
+        } catch (FileTxnSnapLog.SnapdirContentCheckException e) {
+            Assert.fail("Should not throw SnapdirContentCheckException.");
+        } finally {
+            if (priorAutocreateDirValue == null) {
+                System.clearProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
+            } else {
+                System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, priorAutocreateDirValue);
+            }
+        }
+    }
+
+    @Test(expected = FileTxnSnapLog.LogdirContentCheckException.class)
+    public void testDirCheckWithSnapFilesInLogDir() throws IOException {
+        File tmpDir = ClientBase.createEmptyTestDir();
+        File logDir = new File(tmpDir, "logdir");
+        File snapDir = new File(tmpDir, "snapdir");
+        File logVersionDir = new File(logDir, FileTxnSnapLog.version +  FileTxnSnapLog.VERSION);
+        File snapVersionDir = new File(snapDir, FileTxnSnapLog.version +  FileTxnSnapLog.VERSION);
+
+        if (!logVersionDir.exists()) {
+            logVersionDir.mkdirs();
+        }
+        if (!snapVersionDir.exists()) {
+            snapVersionDir.mkdirs();
+        }
+
+        Assert.assertTrue(logVersionDir.exists());
+        Assert.assertTrue(snapVersionDir.exists());
+
+        // transaction log files in log dir - correct
+        File logFile1 = new File(logVersionDir.getPath() +File.separator + Util.makeLogName(1L));
+        logFile1.createNewFile();
+        File logFile2 = new File(logVersionDir.getPath() +File.separator + Util.makeLogName(2L));
+        logFile2.createNewFile();
+
+        // snapshot files in log dir - incorrect
+        File snapFile3 = new File(logVersionDir.getPath() +File.separator + Util.makeSnapshotName(3L));
+        snapFile3.createNewFile();
+        File snapFile4 = new File(logVersionDir.getPath() +File.separator + Util.makeSnapshotName(4L));
+        snapFile4.createNewFile();
+
+        // snapshot files in snap dir - correct
+        File snapFile1 = new File(snapVersionDir.getPath() +File.separator + Util.makeSnapshotName(1L));
+        snapFile1.createNewFile();
+        File snapFile2 = new File(snapVersionDir.getPath() +File.separator + Util.makeSnapshotName(2L));
+        snapFile2.createNewFile();
+
+        Assert.assertTrue(logFile1.exists());
+        Assert.assertTrue(logFile2.exists());
+
+        Assert.assertTrue(snapFile3.exists());
+        Assert.assertTrue(snapFile4.exists());
+
+        Assert.assertTrue(snapFile1.exists());
+        Assert.assertTrue(snapFile2.exists());
+
+        String priorAutocreateDirValue = System.getProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
+        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, "false");
+        FileTxnSnapLog fileTxnSnapLog;
+        try {
+            fileTxnSnapLog = new FileTxnSnapLog(logDir, snapDir);
+        } finally {
+            if (priorAutocreateDirValue == null) {
+                System.clearProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
+            } else {
+                System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, priorAutocreateDirValue);
+            }
+        }
+    }
+
+    @Test(expected = FileTxnSnapLog.SnapdirContentCheckException.class)
+    public void testDirCheckWithLogFilesInSnapDir() throws IOException {
+        File tmpDir = ClientBase.createEmptyTestDir();
+        File logDir = new File(tmpDir, "logdir");
+        File snapDir = new File(tmpDir, "snapdir");
+        File logVersionDir = new File(logDir, FileTxnSnapLog.version +  FileTxnSnapLog.VERSION);
+        File snapVersionDir = new File(snapDir, FileTxnSnapLog.version +  FileTxnSnapLog.VERSION);
+
+        if (!logVersionDir.exists()) {
+            logVersionDir.mkdirs();
+        }
+        if (!snapVersionDir.exists()) {
+            snapVersionDir.mkdirs();
+        }
+
+        Assert.assertTrue(logVersionDir.exists());
+        Assert.assertTrue(snapVersionDir.exists());
+
+        // transaction log files in log dir - correct
+        File logFile1 = new File(logVersionDir.getPath() +File.separator + Util.makeLogName(1L));
+        logFile1.createNewFile();
+        File logFile2 = new File(logVersionDir.getPath() +File.separator + Util.makeLogName(2L));
+        logFile2.createNewFile();
+
+        // snapshot files in snap dir - correct
+        File snapFile1 = new File(snapVersionDir.getPath() +File.separator + Util.makeSnapshotName(1L));
+        snapFile1.createNewFile();
+        File snapFile2 = new File(snapVersionDir.getPath() +File.separator + Util.makeSnapshotName(2L));
+        snapFile2.createNewFile();
+
+        // transaction log files in snap dir - incorrect
+        File logFile3 = new File(snapVersionDir.getPath() +File.separator + Util.makeLogName(3L));
+        logFile3.createNewFile();
+        File logFile4 = new File(snapVersionDir.getPath() +File.separator + Util.makeLogName(4L));
+        logFile4.createNewFile();
+
+        Assert.assertTrue(logFile1.exists());
+        Assert.assertTrue(logFile2.exists());
+
+        Assert.assertTrue(snapFile1.exists());
+        Assert.assertTrue(snapFile2.exists());
+
+        Assert.assertTrue(logFile3.exists());
+        Assert.assertTrue(logFile4.exists());
+
+        String priorAutocreateDirValue = System.getProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
+        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, "false");
+        FileTxnSnapLog fileTxnSnapLog;
+        try {
+            fileTxnSnapLog = new FileTxnSnapLog(logDir, snapDir);
+        } finally {
+            if (priorAutocreateDirValue == null) {
+                System.clearProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
+            } else {
+                System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, priorAutocreateDirValue);
+            }
+        }
+    }
+
+}

--- a/src/java/test/org/apache/zookeeper/server/persistence/FileTxnSnapLogTest.java
+++ b/src/java/test/org/apache/zookeeper/server/persistence/FileTxnSnapLogTest.java
@@ -40,9 +40,19 @@ public class FileTxnSnapLogTest {
 
     private File tmpDir;
 
+    private File logDir;
+
+    private File snapDir;
+
+    private File logVersionDir;
+
+    private File snapVersionDir;
+
     @Before
     public void setUp() throws Exception {
         tmpDir = ClientBase.createEmptyTestDir();
+        logDir = new File(tmpDir, "logdir");
+        snapDir = new File(tmpDir, "snapdir");
     }
 
     @After
@@ -50,127 +60,11 @@ public class FileTxnSnapLogTest {
         if(tmpDir != null){
             TestUtils.deleteFileRecursively(tmpDir);
         }
-    }
-
-    /**
-     * Test verifies the auto creation of data dir and data log dir.
-     * Sets "zookeeper.datadir.autocreate" to true.
-     */
-    @Test
-    public void testWithAutoCreateDataLogDir() throws IOException {
-        File dataDir = new File(tmpDir, "data");
-        File snapDir = new File(tmpDir, "data_txnlog");
-        Assert.assertFalse("data directory already exists", dataDir.exists());
-        Assert.assertFalse("snapshot directory already exists", snapDir.exists());
-
-        String priorAutocreateDirValue = System.getProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
-        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, "true");
-        FileTxnSnapLog fileTxnSnapLog;
-        try {
-            fileTxnSnapLog = new FileTxnSnapLog(dataDir, snapDir);
-        } finally {
-            if (priorAutocreateDirValue == null) {
-                System.clearProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
-            } else {
-                System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, priorAutocreateDirValue);
-            }
-        }
-        Assert.assertTrue(dataDir.exists());
-        Assert.assertTrue(snapDir.exists());
-        Assert.assertTrue(fileTxnSnapLog.getDataDir().exists());
-        Assert.assertTrue(fileTxnSnapLog.getSnapDir().exists());
-    }
-
-    /**
-     * Test verifies server should fail when data dir or data log dir doesn't
-     * exists. Sets "zookeeper.datadir.autocreate" to false.
-     */
-    @Test
-    public void testWithoutAutoCreateDataLogDir() throws Exception {
-        File dataDir = new File(tmpDir, "data");
-        File snapDir = new File(tmpDir, "data_txnlog");
-        Assert.assertFalse("data directory already exists", dataDir.exists());
-        Assert.assertFalse("snapshot directory already exists", snapDir.exists());
-
-        String priorAutocreateDirValue = System.getProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
-        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, "false");
-        try {
-            FileTxnSnapLog fileTxnSnapLog = new FileTxnSnapLog(dataDir, snapDir);
-        } catch (FileTxnSnapLog.DatadirException e) {
-            Assert.assertFalse(dataDir.exists());
-            Assert.assertFalse(snapDir.exists());
-            return;
-        } finally {
-            if (priorAutocreateDirValue == null) {
-                System.clearProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
-            } else {
-                System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, priorAutocreateDirValue);
-            }
-        }
-        Assert.fail("Expected exception from FileTxnSnapLog");
-    }
-
-    @Test
-    public void testAutoCreateDb() throws IOException {
-        File dataDir = new File(tmpDir, "data");
-        File snapDir = new File(tmpDir, "data_txnlog");
-        Assert.assertTrue("cannot create data directory", dataDir.mkdir());
-        Assert.assertTrue("cannot create snapshot directory", snapDir.mkdir());
-        File initFile = new File(dataDir, "initialize");
-        Assert.assertFalse("initialize file already exists", initFile.exists());
-
-        String priorAutocreateDbValue = System.getProperty(FileTxnSnapLog.ZOOKEEPER_DB_AUTOCREATE);
-        Map<Long, Integer> sessions = new ConcurrentHashMap<>();
-
-        attemptAutoCreateDb(dataDir, snapDir, sessions, priorAutocreateDbValue, "false", -1L);
-
-        attemptAutoCreateDb(dataDir, snapDir, sessions, priorAutocreateDbValue, "true", 0L);
-
-        Assert.assertTrue("cannot create initialize file", initFile.createNewFile());
-        attemptAutoCreateDb(dataDir, snapDir, sessions, priorAutocreateDbValue, "false", 0L);
-    }
-
-    @Test
-    public void testGetTxnLogSyncElapsedTime() throws IOException {
-        FileTxnSnapLog fileTxnSnapLog = new FileTxnSnapLog(new File(tmpDir, "data"),
-                new File(tmpDir, "data_txnlog"));
-
-        TxnHeader hdr = new TxnHeader(1, 1, 1, 1, ZooDefs.OpCode.setData);
-        Record txn = new SetDataTxn("/foo", new byte[0], 1);
-        Request req = new Request(0, 0, 0, hdr, txn, 0);
-
-        try {
-            fileTxnSnapLog.append(req);
-            fileTxnSnapLog.commit();
-            long syncElapsedTime = fileTxnSnapLog.getTxnLogElapsedSyncTime();
-            Assert.assertNotEquals("Did not update syncElapsedTime!", -1L, syncElapsedTime);
-        } finally {
-            fileTxnSnapLog.close();
-        }
-    }
-
-    private void attemptAutoCreateDb(File dataDir, File snapDir, Map<Long, Integer> sessions,
-                                     String priorAutocreateDbValue, String autoCreateValue,
-                                     long expectedValue) throws IOException {
-        sessions.clear();
-        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DB_AUTOCREATE, autoCreateValue);
-        FileTxnSnapLog fileTxnSnapLog = new FileTxnSnapLog(dataDir, snapDir);
-
-        try {
-            long zxid = fileTxnSnapLog.restore(new DataTree(), sessions, new FileTxnSnapLog.PlayBackListener() {
-                @Override
-                public void onTxnLoaded(TxnHeader hdr, Record rec) {
-                    // empty by default
-                }
-            });
-            Assert.assertEquals("unexpected zxid", expectedValue, zxid);
-        } finally {
-            if (priorAutocreateDbValue == null) {
-                System.clearProperty(FileTxnSnapLog.ZOOKEEPER_DB_AUTOCREATE);
-            } else {
-                System.setProperty(FileTxnSnapLog.ZOOKEEPER_DB_AUTOCREATE, priorAutocreateDbValue);
-            }
-        }
+        this.tmpDir = null;
+        this.logDir = null;
+        this.snapDir = null;
+        this.logVersionDir = null;
+        this.snapVersionDir = null;
     }
 
     private File createVersionDir(File parentDir) {
@@ -189,9 +83,36 @@ public class FileTxnSnapLogTest {
         file.createNewFile();
     }
 
-    private void createFileTxnSnapLogWithNoAutoCreate(File logDir, File snapDir) throws IOException {
+    private void twoDirSetupWithCorrectFiles() throws IOException {
+        logVersionDir = createVersionDir(logDir);
+        snapVersionDir = createVersionDir(snapDir);
+
+        // transaction log files in log dir
+        createLogFile(logVersionDir,1);
+        createLogFile(logVersionDir,2);
+
+        // snapshot files in snap dir
+        createSnapshotFile(snapVersionDir,1);
+        createSnapshotFile(snapVersionDir,2);
+    }
+
+    private void singleDirSetupWithCorrectFiles() throws IOException {
+        logVersionDir = createVersionDir(logDir);
+
+        // transaction log and snapshot files in the same dir
+        createLogFile(logVersionDir,1);
+        createLogFile(logVersionDir,2);
+        createSnapshotFile(logVersionDir,1);
+        createSnapshotFile(logVersionDir,2);
+    }
+
+    private FileTxnSnapLog createFileTxnSnapLogWithNoAutoCreateDataDir(File logDir, File snapDir) throws IOException {
+        return createFileTxnSnapLogWithAutoCreateDataDir(logDir, snapDir, "false");
+    }
+
+    private FileTxnSnapLog createFileTxnSnapLogWithAutoCreateDataDir(File logDir, File snapDir, String autoCreateValue) throws IOException {
         String priorAutocreateDirValue = System.getProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE);
-        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, "false");
+        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, autoCreateValue);
         FileTxnSnapLog fileTxnSnapLog;
         try {
             fileTxnSnapLog = new FileTxnSnapLog(logDir, snapDir);
@@ -202,93 +123,152 @@ public class FileTxnSnapLogTest {
                 System.setProperty(FileTxnSnapLog.ZOOKEEPER_DATADIR_AUTOCREATE, priorAutocreateDirValue);
             }
         }
+        return fileTxnSnapLog;
+    }
+
+    private FileTxnSnapLog createFileTxnSnapLogWithAutoCreateDB(File logDir, File snapDir, String autoCreateValue) throws IOException {
+        String priorAutocreateDBValue = System.getProperty(FileTxnSnapLog.ZOOKEEPER_DB_AUTOCREATE);
+        System.setProperty(FileTxnSnapLog.ZOOKEEPER_DB_AUTOCREATE, autoCreateValue);
+        FileTxnSnapLog fileTxnSnapLog;
+        try {
+            fileTxnSnapLog = new FileTxnSnapLog(logDir, snapDir);
+        } finally {
+            if (priorAutocreateDBValue == null) {
+                System.clearProperty(FileTxnSnapLog.ZOOKEEPER_DB_AUTOCREATE);
+            } else {
+                System.setProperty(FileTxnSnapLog.ZOOKEEPER_DB_AUTOCREATE, priorAutocreateDBValue);
+            }
+        }
+        return fileTxnSnapLog;
+    }
+
+    /**
+     * Test verifies the auto creation of log dir and snap dir.
+     * Sets "zookeeper.datadir.autocreate" to true.
+     */
+    @Test
+    public void testWithAutoCreateDataDir() throws IOException {
+        Assert.assertFalse("log directory already exists", logDir.exists());
+        Assert.assertFalse("snapshot directory already exists", snapDir.exists());
+
+        FileTxnSnapLog fileTxnSnapLog = createFileTxnSnapLogWithAutoCreateDataDir(logDir, snapDir, "true");
+
+        Assert.assertTrue(logDir.exists());
+        Assert.assertTrue(snapDir.exists());
+        Assert.assertTrue(fileTxnSnapLog.getDataDir().exists());
+        Assert.assertTrue(fileTxnSnapLog.getSnapDir().exists());
+    }
+
+    /**
+     * Test verifies server should fail when log dir or snap dir doesn't exist.
+     * Sets "zookeeper.datadir.autocreate" to false.
+     */
+    @Test(expected = FileTxnSnapLog.DatadirException.class)
+    public void testWithoutAutoCreateDataDir() throws Exception {
+        Assert.assertFalse("log directory already exists", logDir.exists());
+        Assert.assertFalse("snapshot directory already exists", snapDir.exists());
+
+        try {
+            createFileTxnSnapLogWithAutoCreateDataDir(logDir, snapDir, "false");
+        } catch (FileTxnSnapLog.DatadirException e) {
+            Assert.assertFalse(logDir.exists());
+            Assert.assertFalse(snapDir.exists());
+            // rethrow exception
+            throw e;
+        }
+        Assert.fail("Expected exception from FileTxnSnapLog");
+    }
+
+    private void attemptAutoCreateDB(File dataDir, File snapDir, Map<Long, Integer> sessions,
+                                     String autoCreateValue, long expectedValue) throws IOException {
+        sessions.clear();
+
+        FileTxnSnapLog fileTxnSnapLog = createFileTxnSnapLogWithAutoCreateDB(dataDir, snapDir, autoCreateValue);
+
+        long zxid = fileTxnSnapLog.restore(new DataTree(), sessions, new FileTxnSnapLog.PlayBackListener() {
+            @Override
+            public void onTxnLoaded(TxnHeader hdr, Record rec) {
+                // empty by default
+            }
+        });
+        Assert.assertEquals("unexpected zxid", expectedValue, zxid);
+    }
+
+    @Test
+    public void testAutoCreateDB() throws IOException {
+        Assert.assertTrue("cannot create log directory", logDir.mkdir());
+        Assert.assertTrue("cannot create snapshot directory", snapDir.mkdir());
+        File initFile = new File(logDir, "initialize");
+        Assert.assertFalse("initialize file already exists", initFile.exists());
+
+        Map<Long, Integer> sessions = new ConcurrentHashMap<>();
+
+        attemptAutoCreateDB(logDir, snapDir, sessions,"false", -1L);
+        attemptAutoCreateDB(logDir, snapDir, sessions,"true", 0L);
+
+        Assert.assertTrue("cannot create initialize file", initFile.createNewFile());
+        attemptAutoCreateDB(logDir, snapDir, sessions,"false", 0L);
+    }
+
+    @Test
+    public void testGetTxnLogSyncElapsedTime() throws IOException {
+        FileTxnSnapLog fileTxnSnapLog = createFileTxnSnapLogWithAutoCreateDataDir(logDir, snapDir, "true");
+
+        TxnHeader hdr = new TxnHeader(1, 1, 1, 1, ZooDefs.OpCode.setData);
+        Record txn = new SetDataTxn("/foo", new byte[0], 1);
+        Request req = new Request(0, 0, 0, hdr, txn, 0);
+
+        try {
+            fileTxnSnapLog.append(req);
+            fileTxnSnapLog.commit();
+            long syncElapsedTime = fileTxnSnapLog.getTxnLogElapsedSyncTime();
+            Assert.assertNotEquals("Did not update syncElapsedTime!", -1L, syncElapsedTime);
+        } finally {
+            fileTxnSnapLog.close();
+        }
     }
 
     @Test
     public void testDirCheckWithCorrectFiles() throws IOException {
-        File logDir = new File(tmpDir, "logdir");
-        File snapDir = new File(tmpDir, "snapdir");
-
-        File logVersionDir = createVersionDir(logDir);
-        File snapVersionDir = createVersionDir(snapDir);
-
-        // transaction log files in log dir - correct
-        createLogFile(logVersionDir,1);
-        createLogFile(logVersionDir,2);
-
-        // snapshot files in snap dir - correct
-        createSnapshotFile(snapVersionDir,1);
-        createSnapshotFile(snapVersionDir,2);
+        twoDirSetupWithCorrectFiles();
 
         try {
-            createFileTxnSnapLogWithNoAutoCreate(logDir, snapDir);
-        } catch (FileTxnSnapLog.LogdirContentCheckException | FileTxnSnapLog.SnapdirContentCheckException e) {
+            createFileTxnSnapLogWithNoAutoCreateDataDir(logDir, snapDir);
+        } catch (FileTxnSnapLog.LogDirContentCheckException | FileTxnSnapLog.SnapDirContentCheckException e) {
             Assert.fail("Should not throw ContentCheckException.");
         }
     }
 
     @Test
-    public void testDirCheckWithSameLogAndSnapDirs() throws IOException {
-        File logDir = new File(tmpDir, "logdir");
-        File logVersionDir = createVersionDir(logDir);
-
-        // transaction log and snapshot files in the same dir
-        createLogFile(logVersionDir,1);
-        createLogFile(logVersionDir,2);
-        createSnapshotFile(logVersionDir,1);
-        createSnapshotFile(logVersionDir,2);
+    public void testDirCheckWithSingleDirSetup() throws IOException {
+        singleDirSetupWithCorrectFiles();
 
         try {
-            createFileTxnSnapLogWithNoAutoCreate(logDir, logDir);
-        } catch (FileTxnSnapLog.LogdirContentCheckException | FileTxnSnapLog.SnapdirContentCheckException e) {
+            createFileTxnSnapLogWithNoAutoCreateDataDir(logDir, logDir);
+        } catch (FileTxnSnapLog.LogDirContentCheckException | FileTxnSnapLog.SnapDirContentCheckException e) {
             Assert.fail("Should not throw ContentCheckException.");
         }
     }
 
-    @Test(expected = FileTxnSnapLog.LogdirContentCheckException.class)
+    @Test(expected = FileTxnSnapLog.LogDirContentCheckException.class)
     public void testDirCheckWithSnapFilesInLogDir() throws IOException {
-        File logDir = new File(tmpDir, "logdir");
-        File snapDir = new File(tmpDir, "snapdir");
+        twoDirSetupWithCorrectFiles();
 
-        File logVersionDir = createVersionDir(logDir);
-        File snapVersionDir = createVersionDir(snapDir);
+        // add snapshot files to the log version dir
+        createSnapshotFile(logVersionDir,3);
+        createSnapshotFile(logVersionDir,4);
 
-        // transaction log files in log dir - correct
-        createLogFile(logVersionDir,1);
-        createLogFile(logVersionDir,2);
-
-        // snapshot files in log dir - incorrect
-        createSnapshotFile(logVersionDir,1);
-        createSnapshotFile(logVersionDir,2);
-
-        // snapshot files in snap dir - correct
-        createSnapshotFile(snapVersionDir,3);
-        createSnapshotFile(snapVersionDir,4);
-
-        createFileTxnSnapLogWithNoAutoCreate(logDir, snapDir);
+        createFileTxnSnapLogWithNoAutoCreateDataDir(logDir, snapDir);
     }
 
-    @Test(expected = FileTxnSnapLog.SnapdirContentCheckException.class)
+    @Test(expected = FileTxnSnapLog.SnapDirContentCheckException.class)
     public void testDirCheckWithLogFilesInSnapDir() throws IOException {
-        File logDir = new File(tmpDir, "logdir");
-        File snapDir = new File(tmpDir, "snapdir");
+        twoDirSetupWithCorrectFiles();
 
-        File logVersionDir = createVersionDir(logDir);
-        File snapVersionDir = createVersionDir(snapDir);
-
-        // transaction log files in log dir - correct
-        createLogFile(logVersionDir,1);
-        createLogFile(logVersionDir,2);
-
-        // snapshot files in snap dir - correct
-        createSnapshotFile(snapVersionDir,1);
-        createSnapshotFile(snapVersionDir,2);
-
-        // transaction log files in snap dir - incorrect
+        // add transaction log files to the snap version dir
         createLogFile(snapVersionDir,3);
         createLogFile(snapVersionDir,4);
 
-        createFileTxnSnapLogWithNoAutoCreate(logDir, snapDir);
+        createFileTxnSnapLogWithNoAutoCreateDataDir(logDir, snapDir);
     }
-
 }

--- a/src/java/test/org/apache/zookeeper/test/AtomicFileOutputStreamTest.java
+++ b/src/java/test/org/apache/zookeeper/test/AtomicFileOutputStreamTest.java
@@ -43,7 +43,7 @@ public class AtomicFileOutputStreamTest extends ZKTestCase {
 
     @Before
     public void setupTestDir() throws IOException {
-        testDir = ClientBase.createTmpDir();
+        testDir = ClientBase.createEmptyTestDir();
         dstFile = new File(testDir, "test.txt");
     }
     @After

--- a/src/java/test/org/apache/zookeeper/test/ClientBase.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientBase.java
@@ -366,7 +366,8 @@ public abstract class ClientBase extends ZKTestCase {
         File tmpDir = new File(tmpFile + ".dir");
         Assert.assertFalse(tmpDir.exists()); // never true if tmpfile does it's job
         Assert.assertTrue(tmpDir.mkdirs());
-        
+
+        // todo not every tmp directory needs this file
         if (createInitFile) {
             createInitializeFile(tmpDir);
         }

--- a/src/java/test/org/apache/zookeeper/test/ClientBase.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientBase.java
@@ -366,8 +366,7 @@ public abstract class ClientBase extends ZKTestCase {
         File tmpDir = new File(tmpFile + ".dir");
         Assert.assertFalse(tmpDir.exists()); // never true if tmpfile does it's job
         Assert.assertTrue(tmpDir.mkdirs());
-
-        // todo not every tmp directory needs this file
+        
         if (createInitFile) {
             createInitializeFile(tmpDir);
         }

--- a/src/java/test/org/apache/zookeeper/test/ClientBase.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientBase.java
@@ -351,11 +351,15 @@ public abstract class ClientBase extends ZKTestCase {
         }
     }
 
+    public static File createEmptyTestDir() throws IOException {
+        return createTmpDir(BASETEST, false);
+    }
 
     public static File createTmpDir() throws IOException {
-        return createTmpDir(BASETEST);
+        return createTmpDir(BASETEST, true);
     }
-    static File createTmpDir(File parentDir) throws IOException {
+
+    static File createTmpDir(File parentDir, boolean createInitFile) throws IOException {
         File tmpFile = File.createTempFile("test", ".junit", parentDir);
         // don't delete tmpFile - this ensures we don't attempt to create
         // a tmpDir with a duplicate name
@@ -363,8 +367,21 @@ public abstract class ClientBase extends ZKTestCase {
         Assert.assertFalse(tmpDir.exists()); // never true if tmpfile does it's job
         Assert.assertTrue(tmpDir.mkdirs());
 
+        // todo not every tmp directory needs this file
+        if (createInitFile) {
+            createInitializeFile(tmpDir);
+        }
+
         return tmpDir;
     }
+
+    public static void createInitializeFile(File dir) throws IOException {
+        File initFile = new File(dir, "initialize");
+        if (!initFile.exists()) {
+            Assert.assertTrue(initFile.createNewFile());
+        }
+    }
+
     private static int getPort(String hostPort) {
         String[] split = hostPort.split(":");
         String portstr = split[split.length-1];
@@ -478,7 +495,7 @@ public abstract class ClientBase extends ZKTestCase {
 
         setUpAll();
 
-        tmpDir = createTmpDir(BASETEST);
+        tmpDir = createTmpDir(BASETEST, true);
 
         startServer();
 

--- a/src/java/test/org/apache/zookeeper/test/TestUtils.java
+++ b/src/java/test/org/apache/zookeeper/test/TestUtils.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.test;
+
+import java.io.File;
+
+import org.junit.Assert;
+
+/**
+ * This class contains test utility methods
+ */
+public class TestUtils {
+
+    /**
+     * deletes a folder recursively
+     *
+     * @param file
+     *            folder to be deleted
+     * @param failOnError
+     *            if true file deletion success is ensured
+     */
+    public static boolean deleteFileRecursively(File file,
+            final boolean failOnError) {
+        if (file != null) {
+            if (file.isDirectory()) {
+                File[] files = file.listFiles();
+                int size = files.length;
+                for (int i = 0; i < size; i++) {
+                    File f = files[i];
+                    boolean deleted = deleteFileRecursively(files[i], failOnError);
+                    if(!deleted && failOnError)
+                    {
+                        Assert.fail("file '" + f.getAbsolutePath()+"' deletion failed");
+                    }
+                }
+            }
+            return file.delete();
+        }
+        return true;
+    }
+
+    public static boolean deleteFileRecursively(File file) {
+        return deleteFileRecursively(file, false);
+    }
+}


### PR DESCRIPTION
ZOOKEEPER-2967: Add check to validate dataDir and dataLogDir parameters at startup

This PR adds a check to protect ZK against configuring dataDir and dataLogDir opposingly.

When FileTxnSnapLog is created, it checks if transaction log directory contains snapshot files or vice versa, snapshot directory contains transaction log files. If so, the check throws LogdirContentCheckException or SnapdirContentCheckException, respectively, which translates to DatadirException at ZK startup in QuorumPeerMain and ZooKeeperServerMain.

If the two directories are the same, then no check is done.

For testing, I've added 4 new unit tests which cover the following cases:

transaction log and snapshot directories are different and they are used correctly (no Exception)
transaction log and snapshot directories are the same (in this case no check is done)
transaction log and snapshot directories are different and transaction log directory contains snapshot files (LogdirContentCheckException -> ZK quits)
transaction log and snapshot directories are different and snapshot directory contains transaction log files (SnapdirContentCheckException -> ZK quits)