### PR TITLE
ZOOKEEPER-2978: fix potential null pointer exception when deleting node

### DIFF
--- a/src/java/main/org/apache/zookeeper/ZooKeeper.java
+++ b/src/java/main/org/apache/zookeeper/ZooKeeper.java
@@ -515,7 +515,7 @@ public class ZooKeeper implements AutoCloseable {
                 synchronized (existWatches) {
                     Set<Watcher> list = existWatches.remove(clientPath);
                     if (list != null) {
-                        addTo(existWatches.remove(clientPath), result);
+                        addTo(list, result);
                         LOG.warn("We are triggering an exists watch for delete! Shouldn't happen!");
                     }
                 }


### PR DESCRIPTION
At line 518, 'existWatches.remove(clientPath)' is null because watches for clientPath is already removed.