### PR TITLE
ZOOKEEPER-2930: Leader cannot be elected due to network timeout of some members.

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -357,7 +357,7 @@ public class QuorumCnxManager {
                 return;
             }
             try {
-                if (!initiateConnection(sid, view.get(sid).electionAddr)) {
+                if (!initiateConnection(sid, electionAddr)) {
                     if (view.containsKey(sid)) {
                         view.get(sid).recreateSocketAddresses();
                     }

--- a/src/java/test/org/apache/zookeeper/server/quorum/CnxManagerTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/CnxManagerTest.java
@@ -162,11 +162,8 @@ public class CnxManagerTest extends ZKTestCase {
 
     @Test
     public void testCnxManagerTimeout() throws Exception {
-        Random rand = new Random();
-        byte b = (byte) rand.nextInt();
-        int finalOctet = b & 0xFF;
         int deadPort = PortAssignment.unique();
-        String deadAddress = new String("192.0.2." + finalOctet);
+        String deadAddress = "10.1.1.255";
             
         LOG.info("This is the dead address I'm trying: " + deadAddress);
             
@@ -187,7 +184,7 @@ public class CnxManagerTest extends ZKTestCase {
         cnxManager.toSend(new Long(2), createMsg(ServerState.LOOKING.ordinal(), 1, -1, 1));
         long end = System.currentTimeMillis();
             
-        if((end - begin) > 6000) Assert.fail("Waited more than necessary");
+        if((end - begin) > 3000) Assert.fail("Waited more than necessary");
         
     }       
     


### PR DESCRIPTION
Backported to 3.4 from the ZOOKEEPER-2930 branch (https://github.com/apache/zookeeper/pull/456)

Move sock.connect() into the async connection worker thread.
Moved a load of connectOne(sid) into the async connection worker thread.
Use use the async connection worker for all connections.
This prevents connection delays blocking notifications to other nodes.