### PR TITLE
 ZOOKEEPER-2968: Add C client code coverage tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -17,7 +17,7 @@
    limitations under the License.
 -->
 
-<project name="ZooKeeper" default="jar"
+<project name="ZooKeeper" default="jar" 
 xmlns:ivy="antlib:org.apache.ivy.ant"
 xmlns:artifact="antlib:org.apache.maven.artifact.ant"
 xmlns:maven="antlib:org.apache.maven.artifact.ant"
@@ -504,7 +504,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
       </exec>
       <mkdir dir="${build.dir}/c" />
       <condition property="enable.gcov.arg" value="--enable-gcov" else="">
-          <equals arg1="${enable.gcov}" arg2="true"/>
+        <equals arg1="${enable.gcov}" arg2="true"/>
       </condition>
       <exec executable="${c.src.dir}/configure" dir="${build.dir}/c"
             failonerror="yes">
@@ -1316,7 +1316,29 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
       </condition>
     </target>	
 
-    <target name="check-cppunit-makefile" depends="init" >
+    <target name="verify-cppunit-makefile-gcov">
+      <fileset id="fileset.makefile.gcov.enabled" dir="${test.cppunit.dir}" erroronmissingdir="false">
+        <include name="Makefile"/>
+        <containsregexp expression="^[^#]+-ftest-coverage.*$"/>
+      </fileset>
+      <condition property="makefile.gcov.enabled">
+        <resourcecount when="greater" count="0" refid="fileset.makefile.gcov.enabled"/>
+      </condition>
+      <echo message="makefile.gcov.enabled = ${makefile.gcov.enabled}"/>
+      <condition property="delete.cppunit.makefile">
+        <and>
+          <isset property="makefile.gcov.enabled"/>
+          <not><equals arg1="${enable.gcov}" arg2="true"/></not>
+        </and>
+      </condition>
+      <echo message="delete.cppunit.makefile = ${delete.cppunit.makefile}"/>
+    </target>
+    
+    <target name="delete-cppunit-makefile" if="delete.cppunit.makefile">
+      <delete file="${test.cppunit.dir}/Makefile"/>
+    </target>
+    
+    <target name="check-cppunit-makefile" depends="init,verify-cppunit-makefile-gcov,delete-cppunit-makefile" >
     	<condition property="need.cppunit.makefile">
        		<not> <available file="${test.cppunit.dir}/Makefile"/> </not>
     	</condition>
@@ -1347,7 +1369,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
       </antcall>
     	<mkdir dir="${test.cppunit.dir}"/>
         <condition property="enable.gcov.arg" value="--enable-gcov" else="">
-            <equals arg1="${enable.gcov}" arg2="true"/>
+          <equals arg1="${enable.gcov}" arg2="true"/>
         </condition>
     	<exec executable="${c.src.dir}/configure" dir="${test.cppunit.dir}"
           	failonerror="yes">
@@ -1465,25 +1487,26 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     </target>
 
     <target name="c_coverage_report" description="Runs coverage report for ZK C client code.">
-      <!-- delete configure file so that it gets regenerated with coverage enabled -->
+      <!-- delete configure and make files so that they get regenerated with coverage enabled -->
       <delete file="${c.src.dir}/configure"/>
+      <delete file="${test.cppunit.dir}/Makefile"/>
       <subant target="test-core-cppunit" failonerror="false">
         <property name="enable.gcov" value="true"/>
         <fileset dir="." file="build.xml"/>
       </subant>
       <mkdir dir="${build.dir}/c_coverage" />
-        <copy todir="${build.dir}/c" verbose="true" overwrite="true" failonerror="true">
-            <fileset dir="${build.dir}/test/test-cppunit/.libs">
-                <include name="*.gcno"/>
-                <include name="*.gcda"/>
-            </fileset>
-        </copy>
-        <exec dir="${build.dir}/c" executable="lcov">
-            <arg line="-t testname -o ZK_C_client.info -c -d ."/>
-        </exec>
-        <exec dir="${build.dir}/c_coverage" executable="genhtml">
-            <arg line="-o report ${build.dir}/c/ZK_C_client.info"/>
-        </exec>
+      <copy todir="${build.dir}/c" verbose="true" overwrite="true" failonerror="true">
+        <fileset dir="${build.dir}/test/test-cppunit/.libs">
+          <include name="*.gcno"/>
+          <include name="*.gcda"/>
+        </fileset>
+      </copy>
+      <exec dir="${build.dir}/c" executable="lcov">
+        <arg line="-t testname -o ZK_C_client.info -c -d ."/>
+      </exec>
+      <exec dir="${build.dir}/c_coverage" executable="genhtml">
+        <arg line="-o report ${build.dir}/c/ZK_C_client.info"/>
+      </exec>
     </target>
 
     <!-- Run with 'ant -Dfindbugs.home="path to Findbugs directory" findbugs -->

--- a/build.xml
+++ b/build.xml
@@ -17,7 +17,7 @@
    limitations under the License.
 -->
 
-<project name="ZooKeeper" default="jar" 
+<project name="ZooKeeper" default="jar"
 xmlns:ivy="antlib:org.apache.ivy.ant"
 xmlns:artifact="antlib:org.apache.maven.artifact.ant"
 xmlns:maven="antlib:org.apache.maven.artifact.ant"
@@ -503,11 +503,15 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
         <env key="ACLOCAL" value="aclocal -I ${cppunit.m4}"/>
       </exec>
       <mkdir dir="${build.dir}/c" />
+      <condition property="enable.gcov.arg" value="--enable-gcov" else="">
+          <equals arg1="${enable.gcov}" arg2="true"/>
+      </condition>
       <exec executable="${c.src.dir}/configure" dir="${build.dir}/c"
             failonerror="yes">
         <env key="base_dir" value="${basedir}"/>
         <env key="CALLER" value="ANT"/>
         <arg value="--prefix=${build.dir}/c/build/${package.prefix}"/>
+        <arg line="${enable.gcov.arg}"/>
       </exec>
       <property name="c.build" value="${build.dir}/c/build"/>
       <exec dir="${build.dir}/c" executable="make" failonerror="true">
@@ -1342,11 +1346,15 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
         <param name="cppunit" value="true"/>
       </antcall>
     	<mkdir dir="${test.cppunit.dir}"/>
+        <condition property="enable.gcov.arg" value="--enable-gcov" else="">
+            <equals arg1="${enable.gcov}" arg2="true"/>
+        </condition>
     	<exec executable="${c.src.dir}/configure" dir="${test.cppunit.dir}"
           	failonerror="yes">
                 <env key="base_dir" value="${basedir}"/>
                 <env key="CALLER" value="ANT"/>
       		<arg value="--prefix=${test.cppunit.dir}"/>
+            <arg line="${enable.gcov.arg}"/>
     	</exec>
     </target>
 
@@ -1454,6 +1462,28 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
           <format type="xml"/>
         </current>
       </clover-report>
+    </target>
+
+    <target name="c_coverage_report" description="Runs coverage report for ZK C client code.">
+      <!-- delete configure file so that it gets regenerated with coverage enabled -->
+      <delete file="${c.src.dir}/configure"/>
+      <subant target="test-core-cppunit" failonerror="false">
+        <property name="enable.gcov" value="true"/>
+        <fileset dir="." file="build.xml"/>
+      </subant>
+      <mkdir dir="${build.dir}/c_coverage" />
+        <copy todir="${build.dir}/c" verbose="true" overwrite="true" failonerror="true">
+            <fileset dir="${build.dir}/test/test-cppunit/.libs">
+                <include name="*.gcno"/>
+                <include name="*.gcda"/>
+            </fileset>
+        </copy>
+        <exec dir="${build.dir}/c" executable="lcov">
+            <arg line="-t testname -o ZK_C_client.info -c -d ."/>
+        </exec>
+        <exec dir="${build.dir}/c_coverage" executable="genhtml">
+            <arg line="-o report ${build.dir}/c/ZK_C_client.info"/>
+        </exec>
     </target>
 
     <!-- Run with 'ant -Dfindbugs.home="path to Findbugs directory" findbugs -->

--- a/src/c/Makefile.am
+++ b/src/c/Makefile.am
@@ -10,6 +10,12 @@ AM_CPPFLAGS = -I${srcdir}/include -I${srcdir}/tests -I${srcdir}/generated $(SOLA
 AM_CFLAGS = -Wall -Werror -Wdeclaration-after-statement
 AM_CXXFLAGS = -Wall $(USEIPV6)
 
+# Additional flags for coverage testing (if enabled)
+if ENABLEGCOV
+  AM_CFLAGS += -fprofile-arcs -ftest-coverage
+  AM_LDFLAGS = -lgcov
+endif
+
 LIB_LDFLAGS = -no-undefined -version-info 2 $(SOLARIS_LIB_LDFLAGS)
 
 pkginclude_HEADERS = include/zookeeper.h include/zookeeper_version.h include/zookeeper_log.h include/proto.h include/recordio.h generated/zookeeper.jute.h

--- a/src/c/configure.ac
+++ b/src/c/configure.ac
@@ -86,6 +86,12 @@ else
     fi
 fi
 
+# Check whether to enable gcov (coverage test)
+AC_ARG_ENABLE(gcov, [AS_HELP_STRING([--enable-gcov],[enable coverage test])])
+AC_MSG_CHECKING([whether to enable gcov])
+AS_IF([test "x${enable_gcov}" = "xyes"],AC_MSG_RESULT([yes]), AC_MSG_RESULT([no]))
+AM_CONDITIONAL([ENABLEGCOV],[test "x${enable_gcov}" = "xyes"])
+
 AC_ARG_WITH([syncapi],
  [AS_HELP_STRING([--with-syncapi],[build with support for SyncAPI [default=yes]])],
  [],[with_syncapi=yes])

--- a/src/c/configure.ac
+++ b/src/c/configure.ac
@@ -89,7 +89,7 @@ fi
 # Check whether to enable gcov (coverage test)
 AC_ARG_ENABLE(gcov, [AS_HELP_STRING([--enable-gcov],[enable coverage test])])
 AC_MSG_CHECKING([whether to enable gcov])
-AS_IF([test "x${enable_gcov}" = "xyes"],AC_MSG_RESULT([yes]), AC_MSG_RESULT([no]))
+AS_IF([test "x${enable_gcov}" = "xyes"],AC_MSG_RESULT([yes]),AC_MSG_RESULT([no]))
 AM_CONDITIONAL([ENABLEGCOV],[test "x${enable_gcov}" = "xyes"])
 
 AC_ARG_WITH([syncapi],


### PR DESCRIPTION
ZOOKEEPER-2968: Add C client code coverage tests

This PR adds a new ant target 'c_coverage_report' which generates coverage report for the ZK C client.
The report is generated to build/c_coverage/report in html format.
As a requirement, lcov has to be installed prior to running target 'c_coverage_report'.

An additional check was added to 'check-cppunit-makefile' to ensure that the Makefile gets deleted and regenerated without the coverage compiler flags when running targets without --enable-gcov.