### PR TITLE
ZOOKEEPER-2982: Re-try DNS hostname -> IP resolution if node connection fails

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
@@ -201,6 +201,9 @@ public class Learner {
         Vote current = self.getCurrentVote();
         for (QuorumServer s : self.getView().values()) {
             if (s.id == current.getId()) {
+                // Ensure we have the leader's correct IP address before
+                // attempting to connect.
+                s.recreateSocketAddresses();
                 leaderServer = s;
                 break;
             }


### PR DESCRIPTION
This PR ports a fix from the 3.4 to the 3.5 branch, that was originally made in ZOOKEEPER-1506.
