### PR TITLE
ZOOKEEPER-2983: Print the classpath when running compile and test ant targets

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -446,7 +446,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         <ivy:report conf="*" todir="${build.dir}/dependency-report"/>
     </target>
 
-    <target name="compile" depends="ivy-retrieve,clover,build-generated">
+    <target name="compile" depends="ivy-retrieve,clover,build-generated,print_compile_classpath">
         <javac srcdir="${java.src.dir}" destdir="${build.classes}" includeantruntime="false"
                target="${javac.target}" source="${javac.source}" debug="on">
             <classpath refid="java.classpath"/>
@@ -1340,7 +1340,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
       </and>
     </condition>
 
-    <target name="junit.run">
+    <target name="junit.run" depends="print_test_classpath">
         <junit showoutput="${test.output}"
                printsummary="${test.junit.printsummary}"
                haltonfailure="${test.junit.haltonfailure}"
@@ -1917,5 +1917,19 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
        <delete dir=".settings" />
        <delete dir="${build.dir.eclipse}" />
      </target>
+
+    <target name="print_compile_classpath">
+        <pathconvert pathsep="${line.separator}|   |-- " property="echo.compile.classpath" refid="java.classpath"/>
+        <echo message="|-- compile classpath"/>
+        <echo message="|   |"/>
+        <echo message="|   |-- ${echo.compile.classpath}"/>
+    </target>
+
+    <target name="print_test_classpath">
+        <pathconvert pathsep="${line.separator}|   |-- " property="echo.test.classpath" refid="test.java.classpath"/>
+        <echo message="|-- test classpath"/>
+        <echo message="|   |"/>
+        <echo message="|   |-- ${echo.test.classpath}"/>
+    </target>
 
 </project>


### PR DESCRIPTION
ZOOKEEPER-2983: Print the classpath when running compile and test ant targets

I've added 2 new ant targets to print the compile and test classpath in a formatted way.
Printing the classpath helps to verify that we have only the intended classes, jars on the classpath, e.g. clover.jar is included only when running coverage tests.