### PR TITLE
Fixed PurgeTxnLog params order in the zkCleanup.sh

### DIFF
--- a/bin/zkCleanup.sh
+++ b/bin/zkCleanup.sh
@@ -49,5 +49,5 @@ then
 else
 "$JAVA" "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" "-Dzookeeper.log.file=${ZOO_LOG_FILE}" \
      -cp "$CLASSPATH" $JVMFLAGS \
-     org.apache.zookeeper.server.PurgeTxnLog "$ZOODATALOGDIR" "$ZOODATADIR" $*
+     org.apache.zookeeper.server.PurgeTxnLog "$ZOODATADIR" "$ZOODATALOGDIR" $*
 fi


### PR DESCRIPTION
Fixed params order in the zkCleanup.sh script. Without that it did nothing. After the fix the files are removed.