### PR TITLE
ZOOKEEPER-2998: CMake declares incorrect ZooKeeper version

### DIFF
--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 cmake_minimum_required(VERSION 3.6)
 
-project(zookeeper VERSION 3.5.3)
+project(zookeeper VERSION 3.6.0)
 set(email user@zookeeper.apache.org)
 set(description "zookeeper C client")
 


### PR DESCRIPTION
This was not updated for the current development branch; it should be
3.6.0.