### PR TITLE
ZOOKEEPER-2997: CMake should not force static CRT linking

### DIFF
--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -39,11 +39,6 @@ add_definitions(-DUSE_STATIC_LIB)
 option(WANT_SYNCAPI "Enables Sync API support" ON)
 if(WANT_SYNCAPI)
   add_definitions(-DTHREADED)
-  if(WIN32)
-    # Note that the generator expression ensures that `/MTd` is used when Debug
-    # configurations are built.
-    add_compile_options(/MT$<$<CONFIG:Debug>:d>)
-  endif()
 endif()
 
 # CppUnit option


### PR DESCRIPTION
By removing this code, CMake will use its own defaults for the CRT
flags (e.g., `/MDd` for debug configurations). With it removed, the
user can override this behavior by setting the `CMAKE_CXX_FLAGS`
manually when configuring ZooKeeper.