### PR TITLE
ZOOKEEPER-3001: Incorrect log message when try to delete container node

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/ContainerManager.java
+++ b/src/java/main/org/apache/zookeeper/server/ContainerManager.java
@@ -116,8 +116,8 @@ public class ContainerManager {
             Request request = new Request(null, 0, 0,
                     ZooDefs.OpCode.deleteContainer, path, null);
             try {
-                LOG.info("Attempting to delete candidate container: %s",
-                        containerPath);
+                LOG.info(String.format("Attempting to delete candidate container: %s",
+                        containerPath));
                 requestProcessor.processRequest(request);
             } catch (Exception e) {
                 LOG.error(String.format("Could not delete container: %s" ,


### PR DESCRIPTION
Missing `String.format` when print the log.