### PR TITLE
ZOOKEEPER-3006: Potential NPE in ZKDatabase#calculateTxnLogSizeLimit

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/ZKDatabase.java
+++ b/src/java/main/org/apache/zookeeper/server/ZKDatabase.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Collection;
@@ -302,7 +303,10 @@ public class ZKDatabase {
     public long calculateTxnLogSizeLimit() {
         long snapSize = 0;
         try {
-            snapSize = snapLog.findMostRecentSnapshot().length();
+            File snapFile = snapLog.findMostRecentSnapshot();
+            if (snapFile != null) {
+                snapSize = snapFile.length();
+            }
         } catch (IOException e) {
             LOG.error("Unable to get size of most recent snapshot");
         }

--- a/src/java/test/org/apache/zookeeper/test/ZkDatabaseCorruptionTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ZkDatabaseCorruptionTest.java
@@ -29,6 +29,7 @@ import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.server.SyncRequestProcessor;
+import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.server.quorum.QuorumPeer.ServerState;
@@ -38,6 +39,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
 
 public class ZkDatabaseCorruptionTest extends ZKTestCase {
     protected static final Logger LOG = LoggerFactory.getLogger(ZkDatabaseCorruptionTest.class);
@@ -153,5 +156,15 @@ public class ZkDatabaseCorruptionTest extends ZKTestCase {
         if (leaderSid != 5)QuorumBase.shutdown(qb.s5);
     }
 
+    @Test
+    public void testAbsentRecentSnapshot() throws IOException {
+        ZKDatabase zkDatabase = new ZKDatabase(new FileTxnSnapLog(new File("foo"), new File("bar")){
+            @Override
+            public File findMostRecentSnapshot() throws IOException {
+                return null;
+            }
+        });
+        assertEquals(0, zkDatabase.calculateTxnLogSizeLimit());
+    }
 
 }


### PR DESCRIPTION
@LJ1043041006 found a potential NPE in ZKDatabase#calculateTxnLogSizeLimit: https://issues.apache.org/jira/browse/ZOOKEEPER-3006

```
//ZKDatabase
public long calculateTxnLogSizeLimit() {
    long snapSize = 0;
    try {
        snapSize = snapLog.findMostRecentSnapshot().length();
     } catch (IOException e) {
        LOG.error("Unable to get size of most recent snapshot");
    }
    return (long) (snapSize * snapshotSizeFactor);
}
```

 in FileTxnSnapLog#findMostRecentSnapshot(), it will return the result of  FileSnap#findMostRecentSnapshot:

```
// called by FileTxnSnapLog#findMostRecentSnapshot()
public File findMostRecentSnapshot() throws IOException {
        List<File> files = findNValidSnapshots(1);
        if (files.size() == 0) {
            return null;
        }
        return files.get(0);
}
```

So it will return null when the files sizes is 0, but ZKDatabase#calculateTxnLogSizeLimit has no null checker.