### PR TITLE
ZOOKEEPER-3007:Potential NPE in ReferenceCountedACLCache#deserialize

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/ReferenceCountedACLCache.java
+++ b/src/java/main/org/apache/zookeeper/server/ReferenceCountedACLCache.java
@@ -109,16 +109,18 @@ public class ReferenceCountedACLCache {
             }
             List<ACL> aclList = new ArrayList<ACL>();
             Index j = ia.startVector("acls");
-            while (!j.done()) {
-                ACL acl = new ACL();
-                acl.deserialize(ia, "acl");
-                aclList.add(acl);
-                j.incr();
+            if (j != null) {
+                while (!j.done()) {
+                    ACL acl = new ACL();
+                    acl.deserialize(ia, "acl");
+                    aclList.add(acl);
+                    j.incr();
+                }
+                longKeyMap.put(val, aclList);
+                aclKeyMap.put(aclList, val);
+                referenceCounter.put(val, new AtomicLongWithEquals(0));
+                i--;
             }
-            longKeyMap.put(val, aclList);
-            aclKeyMap.put(aclList, val);
-            referenceCounter.put(val, new AtomicLongWithEquals(0));
-            i--;
         }
     }
 

--- a/src/java/main/org/apache/zookeeper/server/ReferenceCountedACLCache.java
+++ b/src/java/main/org/apache/zookeeper/server/ReferenceCountedACLCache.java
@@ -109,18 +109,20 @@ public class ReferenceCountedACLCache {
             }
             List<ACL> aclList = new ArrayList<ACL>();
             Index j = ia.startVector("acls");
-            if (j != null) {
-                while (!j.done()) {
-                    ACL acl = new ACL();
-                    acl.deserialize(ia, "acl");
-                    aclList.add(acl);
-                    j.incr();
-                }
-                longKeyMap.put(val, aclList);
-                aclKeyMap.put(aclList, val);
-                referenceCounter.put(val, new AtomicLongWithEquals(0));
-                i--;
+            if (j == null) {
+                LOG.error("ERROR: incorrent format of InputArchive" + ia);
+                throw new RuntimeException("ERROR: incorrent format of InputArchive" + ia);
             }
+            while (!j.done()) {
+                ACL acl = new ACL();
+                acl.deserialize(ia, "acl");
+                aclList.add(acl);
+                j.incr();
+            }
+            longKeyMap.put(val, aclList);
+            aclKeyMap.put(aclList, val);
+            referenceCounter.put(val, new AtomicLongWithEquals(0));
+            i--;
         }
     }
 

--- a/src/java/test/org/apache/zookeeper/server/ReferenceCountedACLCacheTest.java
+++ b/src/java/test/org/apache/zookeeper/server/ReferenceCountedACLCacheTest.java
@@ -20,6 +20,8 @@ package org.apache.zookeeper.server;
 
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
+import org.apache.jute.InputArchive;
+import org.apache.jute.OutputArchive;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
@@ -188,8 +190,33 @@ public class ReferenceCountedACLCacheTest {
         callAddUsageNTimes(deserializedCache, aclId3, 3);
         callAddUsageNTimes(deserializedCache, aclId4, 4);
         callAddUsageNTimes(deserializedCache, aclId5, 5);
-
         assertCachesEqual(cache, deserializedCache);
+    }
+
+    @Test
+    public void testNPEInDeserialize() throws IOException {
+        ReferenceCountedACLCache serializeCache = new ReferenceCountedACLCache(){
+            @Override
+            public synchronized void serialize(OutputArchive oa) throws IOException {
+                oa.writeInt(1, "map");
+                oa.writeLong(1, "long");
+                oa.startVector(null, "acls");
+                oa.endVector(null, "acls");
+            }
+        };
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        BinaryOutputArchive archive = BinaryOutputArchive.getArchive(baos);
+        serializeCache.serialize(archive);
+
+        BinaryInputArchive inArchive = BinaryInputArchive.getArchive(new ByteArrayInputStream(baos.toByteArray()));
+        ReferenceCountedACLCache deserializedCache = new ReferenceCountedACLCache();
+        try{
+            deserializedCache.deserialize(inArchive);
+        }catch (NullPointerException e){
+            fail("should not throw NPE while do deserialized");
+        }catch (RuntimeException e) {
+            // do nothing.
+        }
     }
 
     private void assertCachesEqual(ReferenceCountedACLCache expected, ReferenceCountedACLCache actual){


### PR DESCRIPTION
@LJ1043041006 found a potential NPE in ZK
----
callee BinaryInputArchive#startVector will return null:
```
// code placeholder
public Index startVector(String tag) throws IOException {
    int len = readInt(tag);
     if (len == -1) {
     return null;
}
```

-----
and caller ReferenceCountedACLCache#deserialize  call it without null check
```
// code placeholder
Index j = ia.startVector("acls");
while (!j.done()) {
  ACL acl = new ACL();
  acl.deserialize(ia, "acl");
}
```
