### PR TITLE
ZOOKEEPER-2959: ignore accepted epoch and LEADERINFO ack from observers

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/LearnerHandler.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/LearnerHandler.java
@@ -533,7 +533,7 @@ public class LearnerHandler extends ZooKeeperThread {
                 return;
             }
             LOG.info("Received NEWLEADER-ACK message from " + getSid());
-            leader.waitForNewLeaderAck(getSid(), qp.getZxid(), getLearnerType());
+            leader.waitForNewLeaderAck(getSid(), qp.getZxid());
 
             syncLimitCheck.start();
             

--- a/src/java/main/org/apache/zookeeper/server/quorum/flexible/QuorumHierarchical.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/flexible/QuorumHierarchical.java
@@ -23,10 +23,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Properties;
 import java.util.Map.Entry;
+import java.util.Set;
 
 
 import org.slf4j.Logger;
@@ -232,7 +232,7 @@ public class QuorumHierarchical implements QuorumVerifier {
     /**
      * Verifies if a given set is a quorum.
      */
-    public boolean containsQuorum(HashSet<Long> set){
+    public boolean containsQuorum(Set<Long> set){
         HashMap<Long, Long> expansion = new HashMap<Long, Long>();
         
         /*

--- a/src/java/main/org/apache/zookeeper/server/quorum/flexible/QuorumMaj.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/flexible/QuorumMaj.java
@@ -18,7 +18,7 @@
 
 package org.apache.zookeeper.server.quorum.flexible;
 
-import java.util.HashSet;
+import java.util.Set;
 
 //import org.apache.zookeeper.server.quorum.QuorumCnxManager;
 
@@ -56,7 +56,7 @@ public class QuorumMaj implements QuorumVerifier {
     /**
      * Verifies if a set is a majority.
      */
-    public boolean containsQuorum(HashSet<Long> set){
+    public boolean containsQuorum(Set<Long> set){
         return (set.size() > half);
     }
     

--- a/src/java/main/org/apache/zookeeper/server/quorum/flexible/QuorumVerifier.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/flexible/QuorumVerifier.java
@@ -18,16 +18,16 @@
 
 package org.apache.zookeeper.server.quorum.flexible;
 
-import java.util.HashSet;
+import java.util.Set;
 
 /**
  * All quorum validators have to implement a method called
- * containsQuorum, which verifies if a HashSet of server 
+ * containsQuorum, which verifies if a Set of server 
  * identifiers constitutes a quorum.
  *
  */
 
 public interface QuorumVerifier {
     long getWeight(long id);
-    boolean containsQuorum(HashSet<Long> set);
+    boolean containsQuorum(Set<Long> set);
 }

--- a/src/java/test/org/apache/zookeeper/server/quorum/LeaderWithObserverTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/LeaderWithObserverTest.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.apache.zookeeper.server.quorum.ZabUtils.createLeader;
+import static org.apache.zookeeper.server.quorum.ZabUtils.createQuorumPeer;
+
+public class LeaderWithObserverTest {
+
+    QuorumPeer peer;
+    Leader leader;
+    File tmpDir;
+    long participantId;
+    long observerId;
+
+    @Before
+    public void setUp() throws Exception {
+        tmpDir = ClientBase.createTmpDir();
+        peer = createQuorumPeer(tmpDir);
+        participantId = 1;
+        observerId = peer.quorumPeers.size();
+        leader = createLeader(tmpDir, peer);
+        peer.leader = leader;
+        peer.quorumPeers.put(observerId, new QuorumPeer.QuorumServer(observerId, "127.0.0.1", PortAssignment.unique(),
+                0, QuorumPeer.LearnerType.OBSERVER));
+
+        // these tests are serial, we can speed up InterruptedException
+        peer.tickTime = 1;
+    }
+
+    @After
+    public void tearDown(){
+        leader.shutdown("end of test");
+        tmpDir.delete();
+    }
+
+    @Test
+    public void testGetEpochToPropose() throws Exception {
+        long lastAcceptedEpoch = 5;
+        peer.setAcceptedEpoch(5);
+
+        Assert.assertEquals("Unexpected vote in connectingFollowers", 0, leader.connectingFollowers.size());
+        Assert.assertTrue(leader.waitingForNewEpoch);
+        try {
+            // Leader asks for epoch (mocking Leader.lead behavior)
+            // First add to connectingFollowers
+            leader.getEpochToPropose(peer.getId(), lastAcceptedEpoch);
+        } catch (InterruptedException e) {
+            // ignore timeout
+        }
+
+        Assert.assertEquals("Unexpected vote in connectingFollowers", 1, leader.connectingFollowers.size());
+        Assert.assertEquals("Leader shouldn't set new epoch until quorum of participants is in connectingFollowers",
+                lastAcceptedEpoch, peer.getAcceptedEpoch());
+        Assert.assertTrue(leader.waitingForNewEpoch);
+        try {
+            // Observer asks for epoch (mocking LearnerHandler behavior)
+            leader.getEpochToPropose(observerId, lastAcceptedEpoch);
+        } catch (InterruptedException e) {
+            // ignore timeout
+        }
+
+        Assert.assertEquals("Unexpected vote in connectingFollowers", 1, leader.connectingFollowers.size());
+        Assert.assertEquals("Leader shouldn't set new epoch after observer asks for epoch",
+                lastAcceptedEpoch, peer.getAcceptedEpoch());
+        Assert.assertTrue(leader.waitingForNewEpoch);
+        try {
+            // Now participant asks for epoch (mocking LearnerHandler behavior). Second add to connectingFollowers.
+            // Triggers verifier.containsQuorum = true
+            leader.getEpochToPropose(participantId, lastAcceptedEpoch);
+        } catch (Exception e) {
+            Assert.fail("Timed out in getEpochToPropose");
+        }
+
+        Assert.assertEquals("Unexpected vote in connectingFollowers", 2, leader.connectingFollowers.size());
+        Assert.assertEquals("Leader should record next epoch", lastAcceptedEpoch + 1, peer.getAcceptedEpoch());
+        Assert.assertFalse(leader.waitingForNewEpoch);
+    }
+
+    @Test
+    public void testWaitForEpochAck() throws Exception {
+        // things needed for waitForEpochAck to run (usually in leader.lead(), but we're not running leader here)
+        leader.readyToStart = true;
+        leader.leaderStateSummary = new StateSummary(leader.self.getCurrentEpoch(), leader.zk.getLastProcessedZxid());
+
+        Assert.assertEquals("Unexpected vote in electingFollowers", 0, leader.electingFollowers.size());
+        Assert.assertFalse(leader.electionFinished);
+        try {
+            // leader calls waitForEpochAck, first add to electingFollowers
+            leader.waitForEpochAck(peer.getId(), new StateSummary(0, 0));
+        }  catch (InterruptedException e) {
+            // ignore timeout
+        }
+
+        Assert.assertEquals("Unexpected vote in electingFollowers", 1, leader.electingFollowers.size());
+        Assert.assertFalse(leader.electionFinished);
+        try {
+            // observer calls waitForEpochAck, should fail verifier.containsQuorum
+            leader.waitForEpochAck(observerId, new StateSummary(0, 0));
+        }  catch (InterruptedException e) {
+            // ignore timeout
+        }
+
+        Assert.assertEquals("Unexpected vote in electingFollowers", 1, leader.electingFollowers.size());
+        Assert.assertFalse(leader.electionFinished);
+        try {
+            // second add to electingFollowers, verifier.containsQuorum=true, waitForEpochAck returns without exceptions
+            leader.waitForEpochAck(participantId, new StateSummary(0, 0));
+            Assert.assertEquals("Unexpected vote in electingFollowers", 2, leader.electingFollowers.size());
+            Assert.assertTrue(leader.electionFinished);
+        } catch (Exception e) {
+            Assert.fail("Timed out in waitForEpochAck");
+        }
+    }
+
+    @Test
+    public void testWaitForNewLeaderAck() throws Exception {
+        long zxid = leader.zk.getZxid();
+
+        // things needed for waitForNewLeaderAck to run (usually in leader.lead(), but we're not running leader here)
+        leader.newLeaderProposal.packet = new QuorumPacket(0, zxid,null, null);
+
+        Assert.assertEquals("Unexpected vote in ackSet", 0, leader.newLeaderProposal.ackSet.size());
+        Assert.assertFalse(leader.quorumFormed);
+        try {
+            // leader calls waitForNewLeaderAck, first add to ackSet
+            leader.waitForNewLeaderAck(peer.getId(), zxid);
+        }  catch (InterruptedException e) {
+            // ignore timeout
+        }
+
+        Assert.assertEquals("Unexpected vote in ackSet", 1, leader.newLeaderProposal.ackSet.size());
+        Assert.assertFalse(leader.quorumFormed);
+        try {
+            // observer calls waitForNewLeaderAck, should fail verifier.containsQuorum
+            leader.waitForNewLeaderAck(observerId, zxid);
+        }  catch (InterruptedException e) {
+            // ignore timeout
+        }
+
+        Assert.assertEquals("Unexpected vote in ackSet", 1, leader.newLeaderProposal.ackSet.size());
+        Assert.assertFalse(leader.quorumFormed);
+        try {
+            // second add to ackSet, verifier.containsQuorum=true, waitForNewLeaderAck returns without exceptions
+            leader.waitForNewLeaderAck(participantId, zxid);
+            Assert.assertEquals("Unexpected vote in ackSet", 2, leader.newLeaderProposal.ackSet.size());
+            Assert.assertTrue(leader.quorumFormed);
+        } catch (Exception e) {
+            Assert.fail("Timed out in waitForEpochAck");
+        }
+    }
+}

--- a/src/java/test/org/apache/zookeeper/server/quorum/ZabUtils.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/ZabUtils.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.server.ServerCnxn;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ZKDatabase;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.server.quorum.flexible.QuorumMaj;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+
+public class ZabUtils {
+
+    private ZabUtils() {}
+
+    public static final int SYNC_LIMIT = 2;
+
+    public static QuorumPeer createQuorumPeer(File tmpDir) throws IOException{
+        QuorumPeer peer = new QuorumPeer();
+        peer.syncLimit = 2;
+        peer.initLimit = 2;
+        peer.tickTime = 2000;
+        peer.quorumPeers = new HashMap<Long, QuorumPeer.QuorumServer>();
+        peer.quorumPeers.put(0L, new QuorumPeer.QuorumServer(0, "127.0.0.1", PortAssignment.unique(), 0, null));
+        peer.quorumPeers.put(1L, new QuorumPeer.QuorumServer(1, "127.0.0.1", PortAssignment.unique(), 0, null));
+        peer.quorumPeers.put(2L, new QuorumPeer.QuorumServer(2, "127.0.0.1", PortAssignment.unique(), 0, null));
+        peer.setQuorumVerifier(new QuorumMaj(peer.quorumPeers.size()));
+        peer.setCnxnFactory(new NullServerCnxnFactory());
+        File version2 = new File(tmpDir, "version-2");
+        version2.mkdir();
+        FileOutputStream fos = new FileOutputStream(new File(version2, "currentEpoch"));
+        fos.write("0\n".getBytes());
+        fos.close();
+        fos = new FileOutputStream(new File(version2, "acceptedEpoch"));
+        fos.write("0\n".getBytes());
+        fos.close();
+        return peer;
+    }
+
+    public static Leader createLeader(File tmpDir, QuorumPeer peer)
+            throws IOException, NoSuchFieldException, IllegalAccessException{
+        LeaderZooKeeperServer zk = prepareLeader(tmpDir, peer);
+        return new Leader(peer, zk);
+    }
+
+    public static MockLeader createMockLeader(File tmpDir, QuorumPeer peer)
+            throws IOException, NoSuchFieldException, IllegalAccessException{
+        LeaderZooKeeperServer zk = prepareLeader(tmpDir, peer);
+        return new MockLeader(peer, zk);
+    }
+
+    private static LeaderZooKeeperServer prepareLeader(File tmpDir, QuorumPeer peer)
+            throws IOException, NoSuchFieldException, IllegalAccessException {
+        FileTxnSnapLog logFactory = new FileTxnSnapLog(tmpDir, tmpDir);
+        peer.setTxnFactory(logFactory);
+        Field addrField = peer.getClass().getDeclaredField("myQuorumAddr");
+        addrField.setAccessible(true);
+        addrField.set(peer, new InetSocketAddress(PortAssignment.unique()));
+        ZKDatabase zkDb = new ZKDatabase(logFactory);
+        return new LeaderZooKeeperServer(logFactory, peer, new ZooKeeperServer.BasicDataTreeBuilder(), zkDb);
+    }
+
+    private static final class NullServerCnxnFactory extends ServerCnxnFactory {
+        public void startup(ZooKeeperServer zkServer) throws IOException,
+                InterruptedException {
+        }
+        public void start() {
+        }
+        public void shutdown() {
+        }
+        public void setMaxClientCnxnsPerHost(int max) {
+        }
+        public void join() throws InterruptedException {
+        }
+        public int getMaxClientCnxnsPerHost() {
+            return 0;
+        }
+        public int getLocalPort() {
+            return 0;
+        }
+        public InetSocketAddress getLocalAddress() {
+            return null;
+        }
+        public Iterable<ServerCnxn> getConnections() {
+            return null;
+        }
+        public void configure(InetSocketAddress addr, int maxClientCnxns)
+                throws IOException {
+        }
+        public void closeSession(long sessionId) {
+        }
+        public void closeAll() {
+        }
+        @Override
+        public int getNumAliveConnections() {
+            return 0;
+        }
+    }
+
+    public static final class MockLeader extends Leader {
+
+        MockLeader(QuorumPeer qp, LeaderZooKeeperServer zk)
+                throws IOException {
+            super(qp, zk);
+        }
+
+        /**
+         * This method returns the value of the variable that holds the epoch
+         * to be proposed and that has been proposed, depending on the point
+         * of the execution in which it is called.
+         *
+         * @return epoch
+         */
+        public long getCurrentEpochToPropose() {
+            return epoch;
+        }
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZOOKEEPER-2959
- add getVotingView check for id in getEpochToPropose and waitForEpochAck
- refactor waitForNewLeaderAck to use getVotingView
- unit tests

credit: Xiang Yongqiang (https://github.com/xyq000) for original PR and reporting the issue