### PR TITLE
ZOOKEEPER-3002 upgrade to jdk 8

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -40,8 +40,8 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="revision.properties" value="revision.properties" />
     <property file="${basedir}/src/java/${revision.properties}" />
     
-    <property name="javac.target" value="1.7" />
-    <property name="javac.source" value="1.7" />
+    <property name="javac.target" value="1.8" />
+    <property name="javac.source" value="1.8" />
     <property name="build.encoding" value="utf8" />
 
     <property name="src.dir" value="${basedir}/src" />

--- a/docs/zookeeperAdmin.html
+++ b/docs/zookeeperAdmin.html
@@ -504,8 +504,8 @@ document.write("Last Published: " + document.lastModified);
         is no full support.</p>
 <a name="sc_requiredSoftware"></a>
 <h4>Required Software </h4>
-<p>ZooKeeper runs in Java, release 1.7 or greater (JDK 7 or
-        greater, FreeBSD support requires openjdk7).  It runs as an
+<p>ZooKeeper runs in Java, release 1.8 or greater (JDK 8 or
+        greater, FreeBSD support requires openjdk8).  It runs as an
         <em>ensemble</em> of ZooKeeper servers. Three
         ZooKeeper servers is the minimum recommended size for an
         ensemble, and we also recommend that they run on separate

--- a/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
+++ b/src/docs/src/documentation/content/xdocs/zookeeperAdmin.xml
@@ -163,8 +163,8 @@
       <section id="sc_requiredSoftware">
         <title>Required Software </title>
 
-        <para>ZooKeeper runs in Java, release 1.7 or greater (JDK 7 or
-        greater, FreeBSD support requires openjdk7).  It runs as an
+        <para>ZooKeeper runs in Java, release 1.8 or greater (JDK 8 or
+        greater, FreeBSD support requires openjdk8).  It runs as an
         <emphasis>ensemble</emphasis> of ZooKeeper servers. Three
         ZooKeeper servers is the minimum recommended size for an
         ensemble, and we also recommend that they run on separate


### PR DESCRIPTION
Set minimum requirement to java 1.8
The code successfully compiled with 8.0.161-oracle and 8.0.163-zulu.

Checking the generated class file it reports 1.8 as version:
javap -verbose build/classes/org/apache/zookeeper/server/ServerStats.class | grep version
minor version: 0
major version: 52