### PR TITLE
Potential NPE in Observer#observeLeader and Follower#followLeader

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
@@ -208,7 +208,7 @@ public class Learner {
         if (leaderServer == null) {
             LOG.warn("Couldn't find the leader with id = "
                     + current.getId());
-            throw New RuntimeException("Couldn't find the leader with id = " + current.getId());
+            throw new RuntimeException("Couldn't find the leader with id = " + current.getId());
         }
         return leaderServer;
     }


### PR DESCRIPTION
@lj1043041006 found a potential NPE in ZK
---
Bug description:

callee Learner#findLeader will return null and callee developer check it but just log:
```
// code placeholder
if (leaderServer == null) {
   LOG.warn("Couldn't find the leader with id = " + current.getId());
}
return leaderServer;
```

caller  Observer#observeLeader and Follower#followLeader will directly use return value w/o null check:
```
//Follower#followLeader
QuorumServer leaderServer = findLeader();
try {
    connectToLeader(leaderServer.addr, leaderServer.hostname);
    ..........
}
//Observer#observeLeader
QuorumServer leaderServer = findLeader();
LOG.info("Observing " + leaderServer.addr);
try {
    connectToLeader(leaderServer.addr, leaderServer.hostname);
}
```

https://issues.apache.org/jira/browse/ZOOKEEPER-3010