### PR TITLE
ZOOKEEPER-3025: Make `hashtable` search `include`

### DIFF
--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -153,6 +153,7 @@ configure_file(cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/config.h)
 # hashtable library
 set(hashtable_sources src/hashtable/hashtable_itr.c src/hashtable/hashtable.c)
 add_library(hashtable STATIC ${hashtable_sources})
+target_include_directories(hashtable PUBLIC include)
 target_link_libraries(hashtable PUBLIC $<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:FreeBSD>>:m>)
 
 # zookeeper library


### PR DESCRIPTION
When ZOOKEEPER-2999 removed the directory side-effect of
`include_directories(include)`, and added it as a target-level include
to the `zookeeper` library, this broke the Windows build. It worked on
Linux (where the patch was tested) because `winconfig.h` and is not
included, but on Windows, the `hashtable` library included
`winconfig.h` (found in `include`) but no longer knew where to find
it. The fix is to add `include` to the `hashtable` library's list of
include directories.