### PR TITLE
ZOOKEEPER-3027 Accidently removed public API of FileTxnLog.setPreallocSize()

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/persistence/FilePadding.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FilePadding.java
@@ -46,6 +46,13 @@ public class FilePadding {
     private long currentSize;
 
     /**
+     * Getter of preAllocSize has been added for testing
+     */
+    public static long getPreAllocSize() {
+        return preAllocSize;
+    }
+
+    /**
      * method to allow setting preallocate size
      * of log file to pad the file.
      *

--- a/src/java/main/org/apache/zookeeper/server/persistence/FileTxnLog.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/FileTxnLog.java
@@ -136,6 +136,15 @@ public class FileTxnLog implements TxnLog {
     }
 
     /**
+      * method to allow setting preallocate size
+      * of log file to pad the file.
+      * @param size the size to set to in bytes
+      */
+    public static void setPreallocSize(long size) {
+        FilePadding.setPreallocSize(size);
+    }
+
+    /**
      * creates a checksum algorithm to be used
      * @return the checksum used for this txnlog
      */

--- a/src/java/test/org/apache/zookeeper/server/persistence/FileTxnLogTest.java
+++ b/src/java/test/org/apache/zookeeper/server/persistence/FileTxnLogTest.java
@@ -31,6 +31,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
 public class FileTxnLogTest  extends ZKTestCase {
   protected static final Logger LOG = LoggerFactory.getLogger(FileTxnLogTest.class);
 
@@ -97,5 +100,12 @@ public class FileTxnLogTest  extends ZKTestCase {
     fileTxnIterator.next();
     createTxn = (CreateTxn) fileTxnIterator.getTxn();
     Assert.assertTrue(Arrays.equals(createTxn.getData(), new byte[]{}));
+  }
+
+  @Test
+  public void testSetPreallocSize() {
+    long customPreallocSize = 10101;
+    FileTxnLog.setPreallocSize(customPreallocSize);
+    Assert.assertThat(FilePadding.getPreAllocSize(), is(equalTo(customPreallocSize)));
   }
 }


### PR DESCRIPTION
In my latest commit regarding TxnLogToolkit there's a refactor to outsource file padding logic from FileTxnLog to a separate class:

https://github.com/apache/zookeeper/commit/126fb0f22d701cad58bf3123bf7d8f2219e60387#diff-89717124564925d61d29dd817bcdd915L147

Unfortunately public static method setPreallocSize(int) has also been moved to the new class, but it's being actively used by hadoop-common project too:

https://github.com/apache/hadoop/blob/trunk/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/ClientBaseWithFixes.java#L384

I'd like to submit a patch to revert the deleted method which is going to call the new one, but will keep backward compatibility with Hadoop.