### PR TITLE
ZOOKEEPER-3038 Cleanup some nitpicks in TTL implementation

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/EphemeralType.java
+++ b/src/java/main/org/apache/zookeeper/server/EphemeralType.java
@@ -166,7 +166,7 @@ public enum EphemeralType {
     public static EphemeralType get(long ephemeralOwner) {
         if (extendedEphemeralTypesEnabled()) {
             if (Boolean.getBoolean(TTL_3_5_3_EMULATION_PROPERTY)) {
-                if (OldEphemeralType.get(ephemeralOwner) == OldEphemeralType.TTL) {
+                if (EphemeralTypeEmulate353.get(ephemeralOwner) == EphemeralTypeEmulate353.TTL) {
                     return TTL;
                 }
             }

--- a/src/java/main/org/apache/zookeeper/server/EphemeralTypeEmulate353.java
+++ b/src/java/main/org/apache/zookeeper/server/EphemeralTypeEmulate353.java
@@ -22,11 +22,11 @@ package org.apache.zookeeper.server;
  * See https://issues.apache.org/jira/browse/ZOOKEEPER-2901
  *
  * version 3.5.3 introduced bugs associated with how TTL nodes were implemented. version 3.5.4
- * fixes the problems but makes TTL nodes created in 3.5.3 invalid. OldEphemeralType is a copy
+ * fixes the problems but makes TTL nodes created in 3.5.3 invalid. EphemeralTypeEmulate353 is a copy
  * of the old - bad - implementation that is provided as a workaround. {@link EphemeralType#TTL_3_5_3_EMULATION_PROPERTY}
  * can be used to emulate support of the badly specified TTL nodes.
  */
-public enum OldEphemeralType {
+public enum EphemeralTypeEmulate353 {
     /**
      * Not ephemeral
      */
@@ -48,7 +48,7 @@ public enum OldEphemeralType {
     public static final long MAX_TTL = 0x0fffffffffffffffL;
     public static final long TTL_MASK = 0x8000000000000000L;
 
-    public static OldEphemeralType get(long ephemeralOwner) {
+    public static EphemeralTypeEmulate353 get(long ephemeralOwner) {
         if (ephemeralOwner == CONTAINER_EPHEMERAL_OWNER) {
             return CONTAINER;
         }
@@ -56,13 +56,6 @@ public enum OldEphemeralType {
             return TTL;
         }
         return (ephemeralOwner == 0) ? VOID : NORMAL;
-    }
-
-    public static long getTTL(long ephemeralOwner) {
-        if ((ephemeralOwner < 0) && (ephemeralOwner != CONTAINER_EPHEMERAL_OWNER)) {
-            return (ephemeralOwner & MAX_TTL);
-        }
-        return 0;
     }
 
     public static long ttlToEphemeralOwner(long ttl) {

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -50,7 +50,6 @@ import org.apache.zookeeper.common.AtomicFileWritingIdiom.WriterStatement;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.jmx.ZKMBeanInfo;
-import org.apache.zookeeper.server.EphemeralType;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;

--- a/src/java/test/org/apache/zookeeper/server/Emulate353TTLTest.java
+++ b/src/java/test/org/apache/zookeeper/server/Emulate353TTLTest.java
@@ -69,7 +69,7 @@ public class Emulate353TTLTest extends ClientBase {
     public void test353TTL()
             throws KeeperException, InterruptedException {
         DataTree dataTree = serverFactory.zkServer.getZKDatabase().dataTree;
-        long ephemeralOwner = OldEphemeralType.ttlToEphemeralOwner(100);
+        long ephemeralOwner = EphemeralTypeEmulate353.ttlToEphemeralOwner(100);
         dataTree.createNode("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, ephemeralOwner,
                 dataTree.getNode("/").stat.getCversion()+1, 1, 1);
 


### PR DESCRIPTION
A few nitpicks which needs to be cleaned up:

1. Rename OldEphemeralType --> EphemeralTypeEmulate353
2. Remove unused method: getTTL()
3. Remove unused import from QuorumPeer
