### PR TITLE
ZOOKEEPER-3039 TxnLogToolkit uses Scanner badly

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
@@ -98,7 +98,7 @@ public class TxnLogToolkit implements Closeable {
      */
     public static void main(String[] args) throws Exception {
         try (final TxnLogToolkit lt = parseCommandLine(args)) {
-            lt.dump(new InputStreamReader(System.in));
+            lt.dump(new Scanner(System.in));
             lt.printStat();
         } catch (TxnLogToolkitParseException e) {
             System.err.println(e.getMessage() + "\n");
@@ -131,7 +131,7 @@ public class TxnLogToolkit implements Closeable {
         }
     }
 
-    public void dump(Reader input) throws Exception {
+    public void dump(Scanner scanner) throws Exception {
         crcFixed = 0;
 
         FileHeader fhdr = new FileHeader();
@@ -172,7 +172,7 @@ public class TxnLogToolkit implements Closeable {
                 if (recoveryMode) {
                     if (!force) {
                         printTxn(bytes, "CRC ERROR");
-                        if (askForFix(input)) {
+                        if (askForFix(scanner)) {
                             crcValue = crc.getValue();
                             ++crcFixed;
                         }
@@ -201,19 +201,17 @@ public class TxnLogToolkit implements Closeable {
         }
     }
 
-    private boolean askForFix(Reader input) throws TxnLogToolkitException {
-        try (Scanner scanner = new Scanner(input)) {
-            while (true) {
-                System.out.print("Would you like to fix it (Yes/No/Abort) ? ");
-                char answer = Character.toUpperCase(scanner.next().charAt(0));
-                switch (answer) {
-                    case 'Y':
-                        return true;
-                    case 'N':
-                        return false;
-                    case 'A':
-                        throw new TxnLogToolkitException(0, "Recovery aborted.");
-                }
+    private boolean askForFix(Scanner scanner) throws TxnLogToolkitException {
+        while (true) {
+            System.out.print("Would you like to fix it (Yes/No/Abort) ? ");
+            char answer = Character.toUpperCase(scanner.next().charAt(0));
+            switch (answer) {
+                case 'Y':
+                    return true;
+                case 'N':
+                    return false;
+                case 'A':
+                    throw new TxnLogToolkitException(0, "Recovery aborted.");
             }
         }
     }

--- a/src/java/main/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
@@ -39,8 +39,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.Scanner;

--- a/src/java/test/org/apache/zookeeper/server/persistence/TxnLogToolkitTest.java
+++ b/src/java/test/org/apache/zookeeper/server/persistence/TxnLogToolkitTest.java
@@ -30,6 +30,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.StringReader;
+import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -138,7 +139,7 @@ public class TxnLogToolkitTest {
         TxnLogToolkit lt = new TxnLogToolkit(true, false, logfile.toString(), false);
 
         // Act
-        lt.dump(new StringReader("y\n"));
+        lt.dump(new Scanner("y\n"));
 
         // Assert
         String output = outContent.toString();

--- a/src/java/test/org/apache/zookeeper/server/persistence/TxnLogToolkitTest.java
+++ b/src/java/test/org/apache/zookeeper/server/persistence/TxnLogToolkitTest.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.StringReader;
 import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;


### PR DESCRIPTION
Fixed by creating a single Scanner for all queries in the main() method.