### PR TITLE
ZOOKEEPER-2955: Enable Clover code coverage report

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -23,6 +23,48 @@ xmlns:artifact="antlib:org.apache.maven.artifact.ant"
 xmlns:maven="antlib:org.apache.maven.artifact.ant"
 xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
 
+    <!-- ====================================================== -->
+    <!-- Dependency versions                                    -->
+    <!-- ====================================================== -->
+    <property name="slf4j.version" value="1.7.25"/>
+    <property name="commons-cli.version" value="1.2"/>
+
+    <property name="wagon-http.version" value="2.4"/>
+    <property name="maven-ant-tasks.version" value="2.1.3"/>
+    <property name="log4j.version" value="1.2.17"/>
+    <property name="jline.version" value="2.11"/>
+
+    <property name="audience-annotations.version" value="0.5.0" />
+
+    <property name="netty.version" value="3.10.6.Final"/>
+
+    <property name="junit.version" value="4.12"/>
+    <property name="mockito.version" value="1.8.2"/>
+    <property name="checkstyle.version" value="6.13"/>
+    <property name="commons-collections.version" value="3.2.2"/>
+
+    <property name="jdiff.version" value="1.0.9"/>
+    <property name="xerces.version" value="1.4.4"/>
+
+    <property name="apache-rat-tasks.version" value="0.10"/>
+    <property name="commons-lang.version" value="2.6"/>
+
+    <property name="javacc.version" value="5.0"/>
+
+    <property name="jetty.version" value="9.2.18.v20160721"/>
+    <property name="jackson-mapper-asl.version" value="1.9.11"/>
+    <property name="dependency-check-ant.version" value="2.1.0"/>
+
+    <property name="commons-io.version" value="2.4"/>
+    <property name="kerby.version" value="1.0.0-RC2"/>
+
+    <property name="clover.version" value="4.2.1" />
+
+
+    <!-- ====================================================== -->
+    <!-- Project properties                                     -->
+    <!-- ====================================================== -->
+
     <!-- read build.properties from the basedir if any -->
     <property file="${basedir}/build.properties" />
     <property name="Name" value="ZooKeeper" />
@@ -104,12 +146,6 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="dist.dir" value="${build.dir}/${final.name}"/>
     <property name="dist.maven.dir" value="${dist.dir}/dist-maven"/>
 
-    <property name="clover.home" location="${env.CLOVER_HOME}"/>
-    <property name="clover.jar" location="${clover.home}/lib/clover.jar" />
-    <property name="clover.db.dir" location="${test.java.build.dir}/clover/db"/>
-    <property name="clover.report.dir"
-              location="${test.java.build.dir}/clover/reports"/>
-
     <property name="contrib.dir" value="${src.dir}/contrib"/>
     <property name="recipes.dir" value="${src.dir}/recipes"/>
 
@@ -124,6 +160,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="ivy.javacc.lib" value="${build.dir}/javacc/lib"/>
     <property name="ivy.releaseaudit.lib" value="${build.dir}/releaseaudit/lib"/>
     <property name="ivy.owasp.lib" value="${build.dir}/owasp/lib"/>
+    <property name="ivy.clover.lib" value="${build.dir}/clover/lib"/>
     <property name="ivysettings.xml" value="${basedir}/ivysettings.xml"/>
 
     <property name="mvnrepo" value="https://repo1.maven.org/maven2"/>
@@ -132,21 +169,16 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="ant_task_repo_url"
         value="${mvnrepo}${tsk.org}${ant-task.version}/maven-ant-tasks-${ant-task.version}.jar"/>
     <property name="ant_task.jar" location="${ivy.lib}/maven-ant-tasks-${ant-task.version}.jar"/>
-    
-    <available property="clover.present"
-               classname="com.cenqua.clover.CloverInstr"
-               classpath="${clover.home}/lib/clover.jar"/>
+
+    <!-- clover property set -->
+    <property name="clover.home" location="${build.dir}/clover"/>
+    <property name="clover.jar" location="${clover.home}/lib/clover-${clover.version}.jar"/>
+    <property name="clover.dest" location="${build.dir}/clover"/>
+    <property name="clover.db.dir" location="${clover.dest}/db"/>
+    <property name="clover.report.dir" location="${clover.dest}/reports"/>
+    <property name="clover.db" location="${clover.db.dir}/zookeeper-coverage.db"/>
 
     <available file="${c.src.dir}/Makefile" property="Makefile.present"/>
-
-    <!-- check if clover reports should be generated -->
-    <condition property="clover.enabled">
-      <and>
-        <isset property="run.clover"/>
-        <isset property="clover.present"/>
-      </and>
-    </condition>
-
 
     <property name="test.cobertura.output.format" value="html" />
     <property name="coveragereport.dir" value="${build.dir}/cobertura" />
@@ -195,40 +227,6 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="sources-jar" value="${dist.maven.dir}/${final.name}-sources.jar"/>
     <property name="javadoc-jar" value="${dist.maven.dir}/${final.name}-javadoc.jar"/>
 
-    <!-- ====================================================== -->
-    <!-- Dependency versions                                    -->
-    <!-- ====================================================== -->
-    <property name="slf4j.version" value="1.7.25"/>
-    <property name="commons-cli.version" value="1.2"/>
-
-    <property name="wagon-http.version" value="2.4"/>
-    <property name="maven-ant-tasks.version" value="2.1.3"/>
-    <property name="log4j.version" value="1.2.17"/>
-    <property name="jline.version" value="2.11"/>
-
-    <property name="audience-annotations.version" value="0.5.0" />
-
-    <property name="netty.version" value="3.10.6.Final"/>
-
-    <property name="junit.version" value="4.12"/>
-    <property name="mockito.version" value="1.8.2"/>
-    <property name="checkstyle.version" value="6.13"/>
-    <property name="commons-collections.version" value="3.2.2"/>
-
-    <property name="jdiff.version" value="1.0.9"/>
-    <property name="xerces.version" value="1.4.4"/>
-
-    <property name="apache-rat-tasks.version" value="0.10"/>
-    <property name="commons-lang.version" value="2.6"/>
-
-    <property name="javacc.version" value="5.0"/>
-
-    <property name="jetty.version" value="9.2.18.v20160721"/>
-    <property name="jackson-mapper-asl.version" value="1.9.11"/>
-    <property name="dependency-check-ant.version" value="2.1.0"/>
-
-    <property name="commons-io.version" value="2.4"/>
-    <property name="kerby.version" value="1.0.0-RC2"/>
 
     <!-- ====================================================== -->
     <!-- Macro definitions                                      -->
@@ -258,7 +256,9 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
       <fileset dir="${ant.home}/lib">
           <include name="ant.jar" />
       </fileset>
-      <pathelement path="${clover.jar}" />
+      <fileset dir="${clover.home}/lib" erroronmissingdir="false">
+          <include name="**/*.jar" if="run.clover" />
+      </fileset>
     </path>
 
     <!-- the normal classpath -->
@@ -445,6 +445,12 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
         <ivy:retrieve settingsRef="${ant.project.name}" conf="owasp"
                       pattern="${ivy.owasp.lib}/[artifact]-[revision].[ext]"/>
         <ivy:cachepath pathid="owasp-classpath" conf="owasp"/>
+    </target>
+
+    <target name="ivy-retrieve-clover" if="run.clover" depends="init,ivy-init">
+        <ivy:retrieve settingsRef="${ant.project.name}" conf="clover"
+                      pattern="${ivy.clover.lib}/[artifact]-[revision].[ext]"/>
+        <ivy:cachepath pathid="clover-classpath" conf="clover"/>
     </target>
 
     <target name="dependency-report" depends="init,ivy-init">
@@ -1410,46 +1416,55 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <!-- Run optional third-party tool targets                  -->
     <!-- ====================================================== -->
 
-    <!-- clover code coverage -->
-    <target name="clover" depends="clover.setup, clover.info" 
-            description="Instrument the Unit tests using Clover.  Requires a Clover license and CLOVER_HOME environment variable set appropriately.  To use, specify -Drun.clover=true on the command line."/>
+    <!-- Clover code coverage -->
+    <target name="test-coverage-clover-java"
+            description="Runs Java tests with Clover and generates coverage report in HTML and XML.">
+      <antcall target="test-core-java">
+        <param name="run.clover" value="true"/>
+      </antcall>
+      <antcall target="clover-report"/>
+    </target>
 
-    <target name="clover.setup" if="clover.enabled">
+    <target name="clover" if="run.clover" depends="ivy-retrieve-clover,clover.check,clover.setup"
+            description="Used in compile target to add source code instrumentation for Clover and sets up the Clover database."/>
+
+    <target name="clover.check">
+        <available property="clover.present"
+                   classname="com.atlassian.clover.CloverInstr"
+                   classpath="${clover.home}/lib/clover-${clover.version}.jar"/>
+        <fail if="run.clover" unless="clover.present">
+            Clover not found.
+            Please make sure clover-${clover.version}.jar is in ${clover.home}/lib, or made available
+            to Ant using other mechanisms like -lib or CLASSPATH.
+        </fail>
+    </target>
+
+    <target name="clover.setup" if="run.clover">
       <taskdef resource="cloverlib.xml" classpath="${clover.jar}"/>
       <mkdir dir="${clover.db.dir}"/>
-      <clover-setup initString="${clover.db.dir}/zookeeper_coverage.db">
+      <clover-setup initString="${clover.db}">
         <fileset dir="${java.src.dir}"
                  includes="org/apache/zookeeper/**/*"
-                 excludes="org/apache/zookeeper/version/**/*"/>
+                 excludes="org/apache/zookeeper/version/**/*">
+        </fileset>
+        <testsources dir="${test.src.dir}">
+          <testclass package="org.apache.zookeeper.*" name=".*Test">
+              <testmethod annotation="Test"/>
+          </testclass>
+        </testsources>
       </clover-setup>
     </target>
 
-    <target name="clover.info" if="run.clover" unless="clover.present">
-      <echo>
-        Clover not found. Code coverage reports disabled.
-      </echo>
-    </target>
-
-    <target name="clover.check">
-      <fail unless="clover.present">
-        ##################################################################
-        Clover not found.
-        Please make sure clover.jar is in ANT_HOME/lib, or made available
-        to Ant using other mechanisms like -lib or CLASSPATH.
-        ##################################################################
-      </fail>
-    </target>
-
-    <target name="generate-clover-reports" depends="clover.check, clover">
+    <target name="clover-report" depends="ivy-retrieve-clover"
+            description="Generates coverage report in HTML and XML. Run the tests first with 'ant -Drun.clover=true test-core-java' to generate coverage data.">
+      <taskdef resource="cloverlib.xml" classpath="${clover.jar}"/>
       <mkdir dir="${clover.report.dir}"/>
-      <taskdef resource="cloverlib.xml" classpath="${clover.jar}"/> 
-      
-      <clover-report initString="${clover.db.dir}/zookeeper_coverage.db">
+      <clover-report initString="${clover.db}">
         <current outfile="${clover.report.dir}" title="${final.name}">
           <format type="html"/>
         </current>
       </clover-report>
-      <clover-report initString="${clover.db.dir}/zookeeper_coverage.db">
+      <clover-report initString="${clover.db}">
         <current outfile="${clover.report.dir}/clover.xml" title="${final.name}">
           <format type="xml"/>
         </current>

--- a/ivy.xml
+++ b/ivy.xml
@@ -35,6 +35,7 @@
     <conf name="javacc" visibility="private"/>
     <conf name="releaseaudit" visibility="private" description="Artifacts required for releaseaudit target"/>
     <conf name="owasp" visibility="private" description="Artifacts required for owasp target"/>
+    <conf name="clover" visibility="private" description="Artifacts required for clover target"/>
   </configurations>
 
   <publications>
@@ -132,6 +133,8 @@
                   conf="optional->default"/>
     <dependency org="org.codehaus.jackson" name="jackson-mapper-asl"
                 rev="${jackson-mapper-asl.version}" conf="optional->default"/>
+
+    <dependency org="org.openclover" name="clover" rev="${clover.version}" conf="clover->default"/>
 
     <conflict manager="strict"/>
 


### PR DESCRIPTION
ZOOKEEPER-2955: Enable Clover code coverage report

This PR configures OpenClover to generate Java code coverage reports.

To generate Java code coverage report run:
ant test-coverage-clover-java

For quick testing of this PR run:
ant -Dtestcase=test_file_name test-coverage-clover-java

Clover can also be run step-by-step:
ant -Drun.clover=true test-core-java
ant clover-report

Note: run.clover must not be set when building ZK for production use.

The reports will be placed under the build/test/clover/reports directory in HTML and XML formats.

Author: Mark Fenes <mfenes@cloudera.com>

Reviewers: phunt@apache.org

Closes #443 from mfenes/ZOOKEEPER-2955 and squashes the following commits:

321fc0152 [Mark Fenes] ZOOKEEPER-2955: Enable Clover code coverage report
ca68181b2 [Mark Fenes] ZOOKEEPER-2955: Enable Clover code coverage report
4cd1a3170 [Mark Fenes] Trigger notification
09872a66b [Mark Fenes] ZOOKEEPER-2955: Enable Clover code coverage report
3e0f2543c [Mark Fenes] Trigger notification
0cdb44442 [Mark Fenes] ZOOKEEPER-2955: Enable Clover code coverage report
270c12efc [Mark Fenes] ZOOKEEPER-2955: Enable Clover code coverage report
f59dcf8ad [Mark Fenes] ZOOKEEPER-2955: Enable Clover code coverage report

Change-Id: I089ca39224fa6012a299a46e4a35333ecc87ef35