### PR TITLE
ZOOKEEPER-3043: QuorumKerberosHostBasedAuthTest fails on Linux box: Unable to parse:includedir /etc/krb5.conf.d/

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -55,8 +55,8 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="jackson-mapper-asl.version" value="1.9.11"/>
     <property name="dependency-check-ant.version" value="2.1.0"/>
 
-    <property name="commons-io.version" value="2.5"/>
-    <property name="kerby.version" value="1.0.0"/>
+    <property name="commons-io.version" value="2.6"/>
+    <property name="kerby.version" value="1.1.0"/>
 
     <property name="clover.version" value="4.2.1" />
 

--- a/build.xml
+++ b/build.xml
@@ -55,8 +55,8 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="jackson-mapper-asl.version" value="1.9.11"/>
     <property name="dependency-check-ant.version" value="2.1.0"/>
 
-    <property name="commons-io.version" value="2.4"/>
-    <property name="kerby.version" value="1.0.0-RC2"/>
+    <property name="commons-io.version" value="2.5"/>
+    <property name="kerby.version" value="1.0.0"/>
 
     <property name="clover.version" value="4.2.1" />
 

--- a/src/java/test/org/apache/zookeeper/server/quorum/auth/KerberosTestUtils.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/auth/KerberosTestUtils.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 import org.apache.zookeeper.util.SecurityUtils;
 
 public class KerberosTestUtils {
-    private static String keytabFile = new File(System.getProperty("test.dir", "build"), UUID.randomUUID().toString())
+    private static String keytabFile = new File(System.getProperty("build.test.dir", "build"), UUID.randomUUID().toString())
             .getAbsolutePath();
 
     public static String getRealm() {


### PR DESCRIPTION
Fixes QuorumKerberosHostBasedAuthTest, see ZOOKEEPER-3043

 - upgrade Kerby to 1.0.0
 - upgrade commons-io to 2.5, needed by Kerby
 - fix test dir in KerberosTestUtils

This should be also cherry-picked to 3.5 branch