### PR TITLE
[ZOOKEEPER-3009] Potential NPE in NIOServerCnxnFactory

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/NIOServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/NIOServerCnxnFactory.java
@@ -815,9 +815,12 @@ public class NIOServerCnxnFactory extends ServerCnxnFactory {
         cnxnExpiryQueue.update(cnxn, cnxn.getSessionTimeout());
     }
 
-    private void addCnxn(NIOServerCnxn cnxn) {
+    private void addCnxn(NIOServerCnxn cnxn) throws IOException {
         InetAddress addr = cnxn.getSocketAddress();
-        Set<NIOServerCnxn> set = (addr == null ? null : ipMap.get(addr));
+        if (addr == null) {
+            throw new IOException("Scoket of " + cnxn + " has been closed");
+        }
+        Set<NIOServerCnxn> set = ipMap.get(addr);
         if (set == null) {
             // in general we will see 1 connection from each
             // host, setting the initial cap to 2 allows us

--- a/src/java/main/org/apache/zookeeper/server/NIOServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/NIOServerCnxnFactory.java
@@ -817,7 +817,7 @@ public class NIOServerCnxnFactory extends ServerCnxnFactory {
 
     private void addCnxn(NIOServerCnxn cnxn) {
         InetAddress addr = cnxn.getSocketAddress();
-        Set<NIOServerCnxn> set = ipMap.get(addr);
+        Set<NIOServerCnxn> set = (addr == null ? null : ipMap.get(addr));
         if (set == null) {
             // in general we will see 1 connection from each
             // host, setting the initial cap to 2 allows us

--- a/src/java/main/org/apache/zookeeper/server/NIOServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/NIOServerCnxnFactory.java
@@ -818,7 +818,7 @@ public class NIOServerCnxnFactory extends ServerCnxnFactory {
     private void addCnxn(NIOServerCnxn cnxn) throws IOException {
         InetAddress addr = cnxn.getSocketAddress();
         if (addr == null) {
-            throw new IOException("Scoket of " + cnxn + " has been closed");
+            throw new IOException("Socket of " + cnxn + " has been closed");
         }
         Set<NIOServerCnxn> set = ipMap.get(addr);
         if (set == null) {


### PR DESCRIPTION
We have developed a static analysis tool [NPEDetector](https://github.com/lujiefsi/NPEDetector) to find some potential NPE. Our analysis shows that NPE reason can be simple:some callees may return null directly in corner case(e.g. node crash , IO exception), some of their callers have  !=null check but some do not have. 
### Bug:
Callee getSocketAddress can return null, may caused by node crash, network exception.... 
<pre>
    public InetAddress getSocketAddress() {
        if (sock.isOpen() == false) {
            return null;
        }
        return sock.socket().getInetAddress();
    }
</pre>
getSocketAddress has two callers:  removeCnxn and removeCnxn 

caller removeCnxn has null check
<pre>
 public boolean removeCnxn(NIOServerCnxn cnxn) {
        //other code
        InetAddress addr = cnxn.getSocketAddress();
        if (addr != null) {
            Set<NIOServerCnxn> set = ipMap.get(addr);
            //other code
        }
     //other code
    }
</pre>

but caller addCnxn has the similar code, but don't have the null check:
<pre>
     private void addCnxn(NIOServerCnxn cnxn) {
         InetAddress addr = cnxn.getSocketAddress();
         Set<NIOServerCnxn> set = ipMap.get(addr);
        //other code
      }
</pre>
I commit a patch to fix it: adding an null checker in addCnxn, and throws a semantics IOException rather than the ugly NPE.  I think the IOException  is ok, because the caller of addCnxn has the handler code:
<pre>
  private void processAcceptedConnections() {
               //other code
               try {
                    addCnxn(cnxn);
               } catch (IOException e) {
                    // register, createConnection
                    cleanupSelectionKey(key);
                    fastCloseSock(accepted);
               }
             }
</pre>
Maybe i am wrong, please point out my error.