### PR TITLE
ZOOKEEPER-3043: QuorumKerberosHostBasedAuthTest fails on Linux box: Unable to parse:includedir /etc/krb5.conf.d/   

### DIFF
--- a/src/java/test/org/apache/zookeeper/server/quorum/auth/KerberosTestUtils.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/auth/KerberosTestUtils.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 import org.apache.zookeeper.util.SecurityUtils;
 
 public class KerberosTestUtils {
-    private static String keytabFile = new File(System.getProperty("test.dir", "build"), UUID.randomUUID().toString())
+    private static String keytabFile = new File(System.getProperty("build.test.dir", "build"), UUID.randomUUID().toString())
             .getAbsolutePath();
 
     public static String getRealm() {


### PR DESCRIPTION
Change test directory for KerberosTestUtils from test.dir to build.test.dir