### PR TITLE
ZOOKEEPER-2920: Upgrade OWASP Dependency Check to 3.2.1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -53,7 +53,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
 
     <property name="jetty.version" value="9.4.10.v20180503"/>
     <property name="jackson.version" value="2.9.5"/>
-    <property name="dependency-check-ant.version" value="2.1.0"/>
+    <property name="dependency-check-ant.version" value="3.2.1"/>
 
     <property name="commons-io.version" value="2.6"/>
     <property name="kerby.version" value="1.1.0"/>


### PR DESCRIPTION
Updated and verified on all the active branches.

Change-Id: I750d7e576e8c731aab4cef26f6863eac6b1b8dc2