### PR TITLE
ZOOKEEPER-2920: Upgrade OWASP Dependency Check to 3.2.1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -54,7 +54,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     <property name="apache-rat-tasks.version" value="0.6"/>
     <property name="commons-lang.version" value="2.4"/>
 
-    <property name="dependency-check-ant.version" value="2.1.0"/>
+    <property name="dependency-check-ant.version" value="3.2.1"/>
 
     <property name="clover.version" value="4.2.1" />
 


### PR DESCRIPTION
Updated and verified on all the active branches.

Change-Id: I750d7e576e8c731aab4cef26f6863eac6b1b8dc2
(cherry picked from commit d065898f77c9162faaffb9fa0dad543eb07771db)