### PR TITLE
ZOOKEEPER-3058: Do length check first before actual byte check in compareBytes method of Utils class

### DIFF
--- a/src/java/main/org/apache/jute/Utils.java
+++ b/src/java/main/org/apache/jute/Utils.java
@@ -268,14 +268,13 @@ public class Utils {
         return stream.toByteArray();
     }
     public static int compareBytes(byte b1[], int off1, int len1, byte b2[], int off2, int len2) {
-        int i;
-        for(i=0; i < len1 && i < len2; i++) {
+        if (len1 != len2) {
+            return len1 < len2 ? -1 : 1;
+        }
+        for(int i=0; i < len1; i++) {
             if (b1[off1+i] != b2[off2+i]) {
                 return b1[off1+i] < b2[off2+i] ? -1 : 1;
             }
-        }
-        if (len1 != len2) {
-            return len1 < len2 ? -1 : 1;
         }
         return 0;
     }


### PR DESCRIPTION
In compareBytes method of org.apache.jute.Utils class, all the individual bytes of 2 byte arrays are compared first and then their lengths are compared. We can improve the performance by first having length check, since we can rule out that they aren't equal by a single if condition(O(1) operation) rather than looping through arrays(O( n ) operation).