### PR TITLE
[ZOOKEEPER-3060] Logging the server local port to stderr

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/NIOServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/NIOServerCnxnFactory.java
@@ -686,6 +686,8 @@ public class NIOServerCnxnFactory extends ServerCnxnFactory {
         LOG.info("binding to port " + addr);
         ss.socket().bind(addr);
         ss.configureBlocking(false);
+        int port = ss.socket().getLocalPort();
+        LOG.info("bound to port " + port);
         acceptThread = new AcceptThread(ss, addr, selectorThreads);
     }
 
@@ -706,6 +708,8 @@ public class NIOServerCnxnFactory extends ServerCnxnFactory {
             LOG.info("binding to port " + addr);
             ss.socket().bind(addr);
             ss.configureBlocking(false);
+            int port = ss.socket().getLocalPort();
+            LOG.info("bound to port " + port);
             acceptThread.setReconfiguring();
             tryClose(oldSS);
             acceptThread.wakeupSelector();


### PR DESCRIPTION
This simple straightforward patch adds logging of the server local port to stderr which aids in simplifying debugging if you want to have to look that up

ZKPatch: f478ca59e2d14d3a2d67321ad9086493d47c8661 (extract)