### PR TITLE
ZOOKEEPER-2873 abort startup on invalid ports

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -259,6 +259,11 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
                 throw new ConfigException("Address unresolved: " + serverParts[0] + ":" + serverParts[2]);
             }
 
+            if(addr.getPort() == electionAddr.getPort()) {
+                throw new ConfigException(
+                        "Client and election port must be different! Please update the configuration file on server." + sid);
+            }
+
             if (serverParts.length == 4) {
                 setType(serverParts[3]);
             }

--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerConfigTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerConfigTest.java
@@ -106,18 +106,12 @@ public class QuorumPeerConfigTest {
     /**
      * Test case for https://issues.apache.org/jira/browse/ZOOKEEPER-2873
      */
-    @Test
-    public void testSamePortConfiguredForClientAndElection() throws IOException {
+    @Test(expected = ConfigException.class)
+    public void testSamePortConfiguredForClientAndElection() throws IOException, ConfigException {
         QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
-        try {
-            Properties zkProp = getDefaultZKProperties();
-            zkProp.setProperty("server.1", "localhost:2888:2888");
-            quorumPeerConfig.parseProperties(zkProp);
-            fail("ConfigException is expected");
-        } catch (ConfigException ce) {
-            String expectedMessage = "Client and election port must be different! Please update the configuration file on server.1";
-            assertEquals(expectedMessage, ce.getMessage());
-        }
+        Properties zkProp = getDefaultZKProperties();
+        zkProp.setProperty("server.1", "localhost:2888:2888");
+        quorumPeerConfig.parseProperties(zkProp);
     }
 
     private Properties getDefaultZKProperties() {

--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerConfigTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerConfigTest.java
@@ -107,7 +107,7 @@ public class QuorumPeerConfigTest {
      * Test case for https://issues.apache.org/jira/browse/ZOOKEEPER-2873
      */
     @Test
-    public void testSamePortConfiguredForClientAndElection() throws IOException, ConfigException {
+    public void testSamePortConfiguredForClientAndElection() throws IOException {
         QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
         try {
             Properties zkProp = getDefaultZKProperties();

--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerConfigTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerConfigTest.java
@@ -103,6 +103,23 @@ public class QuorumPeerConfigTest {
         }
     }
 
+    /**
+     * Test case for https://issues.apache.org/jira/browse/ZOOKEEPER-2873
+     */
+    @Test
+    public void testSamePortConfiguredForClientAndElection() throws IOException, ConfigException {
+        QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
+        try {
+            Properties zkProp = getDefaultZKProperties();
+            zkProp.setProperty("server.1", "localhost:2888:2888");
+            quorumPeerConfig.parseProperties(zkProp);
+            fail("ConfigException is expected");
+        } catch (ConfigException ce) {
+            String expectedMessage = "Client and election port must be different! Please update the configuration file on server.1";
+            assertEquals(expectedMessage, ce.getMessage());
+        }
+    }
+
     private Properties getDefaultZKProperties() {
         Properties zkProp = new Properties();
         zkProp.setProperty("dataDir", new File("myDataDir").getAbsolutePath());

--- a/src/java/test/org/apache/zookeeper/test/ReconfigTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ReconfigTest.java
@@ -801,10 +801,12 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
 
     @Test
     public void testUnspecifiedClientAddress() throws Exception {
-    	int[] ports = new int[3];
-    	for (int port : ports) {
-    		port = PortAssignment.unique();
-    	}
+    	int[] ports = {
+                PortAssignment.unique(),
+                PortAssignment.unique(),
+                PortAssignment.unique()
+    	};
+
     	String server = "server.0=localhost:" + ports[0] + ":" + ports[1] + ";" + ports[2];
     	QuorumServer qs = new QuorumServer(0, server);
     	Assert.assertEquals(qs.clientAddr.getHostString(), "0.0.0.0");


### PR DESCRIPTION
This change will check each server.x config if the client and election port are the same. Currently, ZK will startup and a race for the ports will take place. There will be an error, but ZK will keep running (without the ability to elect a leader). Now, ZK will fail on startup.