### PR TITLE
ZOOKEEPER-3077: build outside of source directory

### DIFF
--- a/src/c/configure.ac
+++ b/src/c/configure.ac
@@ -41,7 +41,7 @@ if test "$CALLER" = "ANT" ; then
 CPPUNIT_CFLAGS="$CPPUNIT_CFLAGS -DZKSERVER_CMD=\"\\\"${base_dir}/src/c/tests/zkServer.sh\\\"\""
 else
 CPPUNIT_CFLAGS="$CPPUNIT_CFLAGS -DZKSERVER_CMD=\"\\\"./tests/zkServer.sh\\\"\""
-AC_CHECK_FILES([generated/zookeeper.jute.c generated/zookeeper.jute.h],[],
+AC_CHECK_FILES([$srcdir/generated/zookeeper.jute.c $srcdir/generated/zookeeper.jute.h],[],
     [AC_MSG_ERROR([jute files are missing! Please run "ant compile_jute" while in the zookeeper top level directory.])
 ])
 fi


### PR DESCRIPTION
Allow building native C library outside of source directory by explicitly
looking for jute generated header and source files inside source directory.

Signed-off-by: Kent R. Spillner <kspillner@acm.org>