### PR TITLE
ZOOKEEPER-3078: remove print_completion_queue

### DIFF
--- a/src/c/src/zookeeper.c
+++ b/src/c/src/zookeeper.c
@@ -253,8 +253,6 @@ static void cleanup_bufs(zhandle_t *zh,int callCompletion,int rc);
 static int disable_conn_permute=0; // permute enabled by default
 static struct sockaddr_storage *addr_rw_server = 0;
 
-static __attribute__((unused)) void print_completion_queue(zhandle_t *zh);
-
 static void *SYNCHRONOUS_MARKER = (void*)&SYNCHRONOUS_MARKER;
 static int isValidPath(const char* path, const int flags);
 
@@ -2528,26 +2526,6 @@ int api_epilog(zhandle_t *zh,int rc)
     if(inc_ref_counter(zh,-1)==0 && zh->close_requested!=0)
         zookeeper_close(zh);
     return rc;
-}
-
-static __attribute__((unused)) void print_completion_queue(zhandle_t *zh)
-{
-    completion_list_t* cptr;
-
-    if(logLevel<ZOO_LOG_LEVEL_DEBUG) return;
-
-    fprintf(LOGSTREAM,"Completion queue: ");
-    if (zh->sent_requests.head==0) {
-        fprintf(LOGSTREAM,"empty\n");
-        return;
-    }
-
-    cptr=zh->sent_requests.head;
-    while(cptr){
-        fprintf(LOGSTREAM,"%d,",cptr->xid);
-        cptr=cptr->next;
-    }
-    fprintf(LOGSTREAM,"end\n");
 }
 
 //#ifdef THREADED


### PR DESCRIPTION
The fprintf(LOGSTREAM, ...) calls cause compiler errors when building
with GCC 8: "error: null argument where non-null required".  This is
because since ZOOKEEPER-1400 (2013-05-19 commit 37973fab: Allow logging
via callback instead of raw FILE pointer) LOGSTREAM is defined as NULL.
However, the last use of print_completion_queue was removed 2008-01-10
in commit ffc4b0d4 (Changed zoo_get() signature, changed the watcher
callback signature, fixed zookeeper_close() resource leaks and race
conditions, fixed the race condition causing xid mismatch).  So we can
avoid the compiler errors by just removing print_completion_queue.

Signed-off-by: Kent R. Spillner <kspillner@acm.org>