### PR TITLE
ZOOKEEPER-3079: avoid unsafe use of sprintf(3)

### DIFF
--- a/src/c/src/zookeeper.c
+++ b/src/c/src/zookeeper.c
@@ -4357,7 +4357,7 @@ int zoo_add_auth(zhandle_t *zh,const char* scheme,const char* cert,
 static const char* format_endpoint_info(const struct sockaddr_storage* ep)
 {
     static char buf[128] = { 0 };
-    char addrstr[128] = { 0 };
+    char addrstr[INET6_ADDRSTRLEN] = { 0 };
     void *inaddr;
 #ifdef _WIN32
     char * addrstring;


### PR DESCRIPTION
The function format_endpoint_info declares both addrstr and buf as 128
element char arrays, however on non-Windows platforms it calls
sprintf(3) to write into buf the value of addrstr followed by ':'
followed by the the port number.  This causes a compiler error when
building with GCC 8 because this could potentially overflow buf if the
value of addrstr was ever 127 characters long (or a little less
depending on how many digits are in port).  Of course, this couldn't
actually happen because addrstr is initialized by inet_ntop(3) which
won't write more than INET6_ADDRSTRLEN bytes (defined in <netinet/in.h>
on POSIX-compliant systems).  Of course, GCC doesn't know that, so let's
just declare addrstr as a char array of only size INET6_ADDRSTRLEN
instead of 128.

Signed-off-by: Kent R. Spillner <kspillner@acm.org>