### PR TITLE
ZOOKEEPER-3067: Optionally disable client environment logging.

### DIFF
--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -216,7 +216,8 @@ set(test_sources
   tests/TestWatchers.cc
   tests/TestClient.cc
   tests/ZooKeeperQuorumServer.cc
-  tests/TestReadOnlyClient.cc)
+  tests/TestReadOnlyClient.cc
+  tests/TestLogClientEnv.cc)
 
 if(WANT_SYNCAPI)
   list(APPEND test_sources tests/PthreadMocks.cc)

--- a/src/c/Makefile.am
+++ b/src/c/Makefile.am
@@ -98,7 +98,7 @@ TEST_SOURCES = \
 	tests/TestZookeeperClose.cc \
 	tests/TestReconfig.cc \
 	tests/TestReconfigServer.cc \
-    tests/TestClientRetry.cc \
+	tests/TestClientRetry.cc \
 	tests/TestOperations.cc \
 	tests/TestMulti.cc \
 	tests/TestWatchers.cc \
@@ -106,6 +106,7 @@ TEST_SOURCES = \
 	tests/ZooKeeperQuorumServer.cc \
 	tests/ZooKeeperQuorumServer.h \
 	tests/TestReadOnlyClient.cc \
+	tests/TestLogClientEnv.cc \
 	$(NULL)
 
 if SOLARIS

--- a/src/c/include/zookeeper.h
+++ b/src/c/include/zookeeper.h
@@ -158,6 +158,9 @@ extern ZOOAPI const int ZOO_PERM_ALL;
 /* flags for zookeeper_init{,2} */
 #define ZOO_READONLY         1
 
+/** Disable logging of the client environment at initialization time. */
+#define ZOO_NO_LOG_CLIENTENV 2
+
 /** This Id represents anyone. */
 extern ZOOAPI struct Id ZOO_ANYONE_ID_UNSAFE;
 /** This Id is only usable to set ACLs. It will get substituted with the

--- a/src/c/src/zookeeper.c
+++ b/src/c/src/zookeeper.c
@@ -1139,7 +1139,10 @@ static zhandle_t *zookeeper_init_internal(const char *host, watcher_fn watcher,
 
     // Set log callback before calling into log_env
     zh->log_callback = log_callback;
-    log_env(zh);
+
+    if (!(flags & ZOO_NO_LOG_CLIENTENV)) {
+        log_env(zh);
+    }
 
 #ifdef _WIN32
     if (Win32WSAStartup()){

--- a/src/c/tests/TestLogClientEnv.cc
+++ b/src/c/tests/TestLogClientEnv.cc
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cppunit/extensions/HelperMacros.h>
+#include "CppAssertHelper.h"
+
+#include <string.h>
+#include <zookeeper.h>
+
+class Zookeeper_logClientEnv : public CPPUNIT_NS::TestFixture {
+    CPPUNIT_TEST_SUITE(Zookeeper_logClientEnv);
+    CPPUNIT_TEST(testLogClientEnv);
+    CPPUNIT_TEST_SUITE_END();
+
+    static void log_no_clientenv(const char *message) {
+      CPPUNIT_ASSERT(::strstr(message, "Client environment") == NULL);
+    }
+
+    static void log_clientenv(const char *message) {
+      static int first;
+
+      if (!first) {
+        CPPUNIT_ASSERT(::strstr(message, "Client environment") != NULL);
+        first = 1;
+      }
+    }
+
+public:
+
+    void testLogClientEnv() {
+      zhandle_t* zh;
+
+      zh = zookeeper_init2("localhost:22181", NULL, 0, NULL, NULL, 0, log_clientenv);
+      CPPUNIT_ASSERT(zh != 0);
+      zookeeper_close(zh);
+
+      zh = zookeeper_init2("localhost:22181", NULL, 0, NULL, NULL, ZOO_NO_LOG_CLIENTENV, log_no_clientenv);
+      CPPUNIT_ASSERT(zh != 0);
+      zookeeper_close(zh);
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(Zookeeper_logClientEnv);
+


### PR DESCRIPTION
Although logging the client environment at initialization can be
helpful for filing bug reports, it tends not to be that helpful
for internal applications. It also introduces a dependency on UID
lookups (via getlogin) that application otherwise may not desire.