### PR TITLE
Zookeeper 3093

### DIFF
--- a/src/c/src/zookeeper.c
+++ b/src/c/src/zookeeper.c
@@ -4246,6 +4246,10 @@ const char* zerror(int c)
       return "bad arguments";
     case ZINVALIDSTATE:
       return "invalid zhandle state";
+    case ZNEWCONFIGNOQUORUM:
+      return "no quorum of new config is connected and up-to-date with the leader of last commmitted config - try invoking reconfiguration after new servers are connected and synced";
+    case ZRECONFIGINPROGRESS:
+      return "Another reconfiguration is in progress -- concurrent reconfigs not supported (yet)";
     case ZAPIERROR:
       return "api error";
     case ZNONODE:
@@ -4276,10 +4280,6 @@ const char* zerror(int c)
       return "session moved to another server, so operation is ignored";
     case ZNOTREADONLY:
       return "state-changing request is passed to read-only server";
-    case ZNEWCONFIGNOQUORUM:
-      return "no quorum of new config is connected and up-to-date with the leader of last commmitted config - try invoking reconfiguration after new servers are connected and synced";
-    case ZRECONFIGINPROGRESS:
-      return "Another reconfiguration is in progress -- concurrent reconfigs not supported (yet)";
     }
     if (c > 0) {
       return strerror(c);

--- a/src/c/src/zookeeper.c
+++ b/src/c/src/zookeeper.c
@@ -4280,6 +4280,12 @@ const char* zerror(int c)
       return "session moved to another server, so operation is ignored";
     case ZNOTREADONLY:
       return "state-changing request is passed to read-only server";
+    case ZEPHEMERALONLOCALSESSION:
+      return "attempt to create ephemeral node on a local session";
+    case ZNOWATCHER:
+      return "the watcher couldn't be found";
+    case ZRECONFIGDISABLED:
+      return "attempts to perform a reconfiguration operation when reconfiguration feature is disable";
     }
     if (c > 0) {
       return strerror(c);

--- a/src/c/src/zookeeper.c
+++ b/src/c/src/zookeeper.c
@@ -4276,10 +4276,10 @@ const char* zerror(int c)
       return "session moved to another server, so operation is ignored";
     case ZNOTREADONLY:
       return "state-changing request is passed to read-only server";
-   case ZNEWCONFIGNOQUORUM:
-       return "no quorum of new config is connected and up-to-date with the leader of last commmitted config - try invoking reconfiguration after new servers are connected and synced";
-   case ZRECONFIGINPROGRESS:
-     return "Another reconfiguration is in progress -- concurrent reconfigs not supported (yet)";
+    case ZNEWCONFIGNOQUORUM:
+      return "no quorum of new config is connected and up-to-date with the leader of last commmitted config - try invoking reconfiguration after new servers are connected and synced";
+    case ZRECONFIGINPROGRESS:
+      return "Another reconfiguration is in progress -- concurrent reconfigs not supported (yet)";
     }
     if (c > 0) {
       return strerror(c);


### PR DESCRIPTION
I noticed that zerror(ZNOWATCHER) returns "unknown error" and when I went to investigate why I realized that actually three new values were added to ZOO_ERRORS enum without corresponding cases in zerror.  While here, also take the opportunity to shuffle the ordering of cases in zerror to match ZOO_ERRORS in order to make it easier to visually compare the two in the future to see if any values are missing cases (e.g. the fact that ZNEWCONFIGNOQUORUM and ZRECONFIGINPROGRESS were added to the bottom of the switch made it harder to see which all cases were missing).