### PR TITLE
[3094] Make BufferSizeTest reliable

### DIFF
--- a/src/java/test/org/apache/zookeeper/test/BufferSizeTest.java
+++ b/src/java/test/org/apache/zookeeper/test/BufferSizeTest.java
@@ -121,12 +121,15 @@ public class BufferSizeTest extends ClientBase {
     private void testStartupFailure(File testDir, String failureMsg) throws Exception {
         stopServer();
         // Point server at testDir
+        File oldTmpDir = tmpDir;
         tmpDir = testDir;
         try {
             startServer();
             fail(failureMsg);
         } catch (IOException e) {
             LOG.info("Successfully caught IOException: " + e);
+        } finally {
+            tmpDir = oldTmpDir;
         }
     }
 }


### PR DESCRIPTION
ZKPatch: d8b825d6533e9848565beff09e9a018136ca32bd (extract)

Changes made to the testStartupFailure test to remember the old directory and switch back to it after the test has completed.