### PR TITLE
[ZOOKEEPER-3095] Connect string fix for non-existent hosts

### DIFF
--- a/src/c/src/zookeeper.c
+++ b/src/c/src/zookeeper.c
@@ -810,7 +810,7 @@ static int resolve_hosts(const zhandle_t *zh, const char *hosts_in, addrvec_t *a
                 LOG_ERROR(LOGCALLBACK(zh), "getaddrinfo: %s\n", strerror(errno));
 #endif
                 rc=ZSYSTEMERROR;
-                goto fail;
+                goto next;
             }
         }
 
@@ -842,11 +842,16 @@ static int resolve_hosts(const zhandle_t *zh, const char *hosts_in, addrvec_t *a
         }
 
         freeaddrinfo(res0);
-
+next:
         host = strtok_r(0, ",", &strtok_last);
         }
 #endif
     }
+    if (avec->count == 0) {
+      rc = ZSYSTEMERROR; // not a single host resolved
+      goto fail;
+    }
+
     free(hosts);
 
     if(!disable_conn_permute){

--- a/src/c/tests/TestClient.cc
+++ b/src/c/tests/TestClient.cc
@@ -204,6 +204,7 @@ class Zookeeper_simpleSystem : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testAsyncWatcherAutoReset);
     CPPUNIT_TEST(testDeserializeString);
     CPPUNIT_TEST(testFirstServerDown);
+    CPPUNIT_TEST(testNonexistentHost);
 #ifdef THREADED
     CPPUNIT_TEST(testNullData);
 #ifdef ZOO_IPV6_ENABLED
@@ -325,7 +326,17 @@ public:
         CPPUNIT_ASSERT(zk != 0);
         CPPUNIT_ASSERT(ctx.waitForConnected(zk));
     }
-    
+
+    /* Checks that a non-existent host will not block the connection*/
+    void testNonexistentHost() {
+      char hosts[] = "jimmy:5555,127.0.0.1:22181";
+      watchctx_t ctx;
+      zoo_deterministic_conn_order(true /* disable permute */);
+      zhandle_t *zh = createClient(hosts, &ctx);
+      CPPUNIT_ASSERT(ctx.waitForConnected(zh));
+      zoo_deterministic_conn_order(false /* enable permute */);
+    }
+
     /** this checks for a deadlock in calling zookeeper_close and calls from a default watcher that might get triggered just when zookeeper_close() is in progress **/
     void testHangingClient() {
         int zrc = 0;

--- a/src/c/tests/zkServer.sh
+++ b/src/c/tests/zkServer.sh
@@ -77,7 +77,7 @@ fi
 
 if [ "x${base_dir}" == "x" ]
 then
-zk_base="../../"
+zk_base="../../../"
 else
 zk_base="${base_dir}"
 fi


### PR DESCRIPTION
ZKPatch: eda58d9970c76831046ddc45251c9b110856836e (extract)