### PR TITLE
ZOOKEEPER-3101: add reminder to ZOO_ERRORS

### DIFF
--- a/zookeeper-client/zookeeper-client-c/include/zookeeper.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper.h
@@ -142,6 +142,8 @@ enum ZOO_ERRORS {
   ZRECONFIGDISABLED = -123, /*!< Attempts to perform a reconfiguration operation when reconfiguration feature is disabled */
   ZSESSIONCLOSEDREQUIRESASLAUTH = -124, /*!< The session has been closed by server because server requires client to do SASL authentication, but client is not configured with SASL authentication or configuted with SASL but failed (i.e. wrong credential used.). */
   ZTHROTTLEDOP = -127 /*!< Operation was throttled and not executed at all. please, retry! */
+
+  /* when adding/changing values here also update zerror(int) to return correct error message */
 };
 
 #ifdef __cplusplus

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -4958,8 +4958,10 @@ const char* zerror(int c)
       return "the watcher couldn't be found";
     case ZRECONFIGDISABLED:
       return "attempts to perform a reconfiguration operation when reconfiguration feature is disable";
-   case ZTHROTTLEDOP:
-     return "Operation was throttled due to high load";
+    case ZSESSIONCLOSEDREQUIRESASLAUTH:
+      return "session closed by server because client is required to do SASL authentication";
+    case ZTHROTTLEDOP:
+      return "Operation was throttled due to high load";
     }
     if (c > 0) {
       return strerror(c);


### PR DESCRIPTION
Add comment at bottom of ZOO_ERRORS reminding developers to also
update zerror(int) when adding or changing values.  Suggested by
@phunt in https://github.com/apache/zookeeper/pull/575#issuecomment-406356144.

Signed-off-by: Kent R. Spillner <kspillner@acm.org>