### PR TITLE
ZOOKEEPER-3103 Pluggable metrics system for ZooKeeper - MetricsProvider API definition

### DIFF
--- a/src/java/main/org/apache/zookeeper/metrics/Counter.java
+++ b/src/java/main/org/apache/zookeeper/metrics/Counter.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.metrics;
+
+/**
+ * A counter refers to a value which can only increase.
+ * Usually the value is reset when the process starts.
+ */
+public interface Counter {
+
+    /**
+     * Increment the value by one.
+     */
+    public default void inc() {
+        inc(1);
+    }
+
+    /**
+     * Increment the value by a given amount.
+     *
+     * @param delta
+     */
+    public void inc(long delta);
+
+    /**
+     * Get the current value held by the counter.
+     *
+     * @return the current value
+     */
+    public long get();
+}

--- a/src/java/main/org/apache/zookeeper/metrics/Counter.java
+++ b/src/java/main/org/apache/zookeeper/metrics/Counter.java
@@ -26,22 +26,24 @@ public interface Counter {
 
     /**
      * Increment the value by one.
+     * <p>This method is thread safe, The MetricsProvider will take care of synchronization.</p>
      */
-    public default void inc() {
+    default void inc() {
         inc(1);
     }
 
     /**
      * Increment the value by a given amount.
+     * <p>This method is thread safe, The MetricsProvider will take care of synchronization.<p>
      *
-     * @param delta
+     * @param delta amount to increment, this cannot be a negative number.
      */
-    public void inc(long delta);
+    void inc(long delta);
 
     /**
      * Get the current value held by the counter.
      *
      * @return the current value
      */
-    public long get();
+    long get();
 }

--- a/src/java/main/org/apache/zookeeper/metrics/Counter.java
+++ b/src/java/main/org/apache/zookeeper/metrics/Counter.java
@@ -42,6 +42,7 @@ public interface Counter {
 
     /**
      * Get the current value held by the counter.
+     * <p>This method is thread safe, The MetricsProvider will take care of synchronization.<p>
      *
      * @return the current value
      */

--- a/src/java/main/org/apache/zookeeper/metrics/Counter.java
+++ b/src/java/main/org/apache/zookeeper/metrics/Counter.java
@@ -34,7 +34,7 @@ public interface Counter {
 
     /**
      * Increment the value by a given amount.
-     * <p>This method is thread safe, The MetricsProvider will take care of synchronization.<p>
+     * <p>This method is thread safe, The MetricsProvider will take care of synchronization.</p>
      *
      * @param delta amount to increment, this cannot be a negative number.
      */
@@ -42,7 +42,7 @@ public interface Counter {
 
     /**
      * Get the current value held by the counter.
-     * <p>This method is thread safe, The MetricsProvider will take care of synchronization.<p>
+     * <p>This method is thread safe, The MetricsProvider will take care of synchronization.</p>
      *
      * @return the current value
      */

--- a/src/java/main/org/apache/zookeeper/metrics/Gauge.java
+++ b/src/java/main/org/apache/zookeeper/metrics/Gauge.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.metrics;
+
+/**
+ * A Gauge is an application provided object which will be called by the framework in order to sample the value
+ * of an integer value.
+ */
+public interface Gauge {
+
+    /**
+     * Returns the current value associated with this gauge.
+     * The MetricsProvider will call this callback without taking care of synchronization, it is up to the application
+     * to handle thread safety.
+     *
+     * @return the current value for the gauge
+     */
+    public long getCurrentValue();
+}

--- a/src/java/main/org/apache/zookeeper/metrics/Gauge.java
+++ b/src/java/main/org/apache/zookeeper/metrics/Gauge.java
@@ -31,5 +31,5 @@ public interface Gauge {
      *
      * @return the current value for the gauge
      */
-    public long getCurrentValue();
+    long get();
 }

--- a/src/java/main/org/apache/zookeeper/metrics/MetricsContext.java
+++ b/src/java/main/org/apache/zookeeper/metrics/MetricsContext.java
@@ -31,7 +31,7 @@ public interface MetricsContext {
      *
      * @return a new metrics context.
      */
-    public MetricsContext getContext(String name);
+    MetricsContext getContext(String name);
 
     /**
      * Returns a counter.
@@ -39,16 +39,18 @@ public interface MetricsContext {
      * @param name
      * @return the counter identified by name in this context.
      */
-    public Counter getCounter(String name);
+    Counter getCounter(String name);
 
     /**
      * Registers an user provided {@link Gauge} which will be called by the MetricsProvider in order to sample
      * an integer value.
      *
-     * @param name
-     * @param gauge
+     * @param name unique name of the Gauge in this context
+     * @param gauge the implementation of the Gauge
+     *
+     * @return true is the Gauge was successfully registered, false if the Gauge was already registered.
      */
-    public void registerGauge(String name, Gauge gauge);
+    boolean registerGauge(String name, Gauge gauge);
 
     /**
      * Returns a summary.
@@ -56,6 +58,6 @@ public interface MetricsContext {
      * @param name
      * @return the summary identified by name in this context.
      */
-    public Summary getSummary(String name);
+    Summary getSummary(String name);
 
 }

--- a/src/java/main/org/apache/zookeeper/metrics/MetricsContext.java
+++ b/src/java/main/org/apache/zookeeper/metrics/MetricsContext.java
@@ -19,8 +19,16 @@
 package org.apache.zookeeper.metrics;
 
 /**
- * Container of metrics.
+ * A MetricsContext is like a namespace for metrics.
+ * Each component/submodule will have its own MetricsContext.
+ * <p>In some cases it is possible to have a separate MetricsContext
+ * for each instance of a component, for instance on the server side
+ * a possible usecase it to gather metrics for every other peer.
+ * </p>
+ * <p>
  * Contexts are organized in a hierarchy.
+ * </p>
+ *
  */
 public interface MetricsContext {
 

--- a/src/java/main/org/apache/zookeeper/metrics/MetricsContext.java
+++ b/src/java/main/org/apache/zookeeper/metrics/MetricsContext.java
@@ -48,7 +48,7 @@ public interface MetricsContext {
      * @param name unique name of the Gauge in this context
      * @param gauge the implementation of the Gauge
      *
-     * @return true is the Gauge was successfully registered, false if the Gauge was already registered.
+     * @return true if the Gauge was successfully registered, false if the Gauge was already registered.
      */
     boolean registerGauge(String name, Gauge gauge);
 

--- a/src/java/main/org/apache/zookeeper/metrics/MetricsContext.java
+++ b/src/java/main/org/apache/zookeeper/metrics/MetricsContext.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.metrics;
+
+/**
+ * Container of metrics.
+ * Contexts are organized in a hierarchy.
+ */
+public interface MetricsContext {
+
+    /**
+     * Returns a sub context.
+     *
+     * @param name the name of the subcontext
+     *
+     * @return a new metrics context.
+     */
+    public MetricsContext getContext(String name);
+
+    /**
+     * Returns a counter.
+     *
+     * @param name
+     * @return the counter identified by name in this context.
+     */
+    public Counter getCounter(String name);
+
+    /**
+     * Registers an user provided {@link Gauge} which will be called by the MetricsProvider in order to sample
+     * an integer value.
+     *
+     * @param name
+     * @param gauge
+     */
+    public void registerGauge(String name, Gauge gauge);
+
+    /**
+     * Returns a summary.
+     *
+     * @param name
+     * @return the summary identified by name in this context.
+     */
+    public Summary getSummary(String name);
+
+}

--- a/src/java/main/org/apache/zookeeper/metrics/MetricsProvider.java
+++ b/src/java/main/org/apache/zookeeper/metrics/MetricsProvider.java
@@ -38,7 +38,7 @@ public interface MetricsProvider {
      *
      * @throws MetricsProviderLifeCycleException in case of invalid configuration.
      */
-    public void configure(Properties configuration) throws MetricsProviderLifeCycleException;
+    void configure(Properties configuration) throws MetricsProviderLifeCycleException;
 
     /**
      * Start the provider.
@@ -46,19 +46,19 @@ public interface MetricsProvider {
      *
      * @throws MetricsProviderLifeCycleException in case of failure
      */
-    public void start() throws MetricsProviderLifeCycleException;
+    void start() throws MetricsProviderLifeCycleException;
 
     /**
      * Provides access to the root context.
      *
      * @return the root context
      */
-    public MetricsContext getRootContext();
+    MetricsContext getRootContext();
 
     /**
      * Releases resources held by the provider.<br>
      * This method must not throw exceptions.<br>
      * This method can be called more than once.
      */
-    public void stop();
+    void stop();
 }

--- a/src/java/main/org/apache/zookeeper/metrics/MetricsProvider.java
+++ b/src/java/main/org/apache/zookeeper/metrics/MetricsProvider.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.metrics;
+
+import java.util.Properties;
+
+/**
+ * A MetricsProvider is a system which collects Metrics and publishes current values to external facilities.
+ *
+ * The system will create an instance of the configured class using the default constructor, which must be public.<br>
+ * After the instantiation of the provider, the system will call {@link #configure(java.util.Map) } in order to provide configuration,
+ * and then when the system is ready to work it will call {@link #start() }.
+ * <br>
+ * Providers can be used both on ZooKeeper servers and on ZooKeeper clients.
+ */
+public interface MetricsProvider {
+
+    /**
+     * Configure the provider.
+     *
+     * @param configuration the configuration.
+     *
+     * @throws MetricsProviderLifeCycleException in case of invalid configuration.
+     */
+    public void configure(Properties configuration) throws MetricsProviderLifeCycleException;
+
+    /**
+     * Start the provider.
+     * For instance such method will start a network endpoint.
+     *
+     * @throws MetricsProviderLifeCycleException in case of failure
+     */
+    public void start() throws MetricsProviderLifeCycleException;
+
+    /**
+     * Provides access to the root context.
+     *
+     * @return the root context
+     */
+    public MetricsContext getRootContext();
+
+    /**
+     * Releases resources held by the provider.<br>
+     * This method must not throw exceptions.<br>
+     * This method can be called more than once.
+     */
+    public void stop();
+}

--- a/src/java/main/org/apache/zookeeper/metrics/MetricsProviderLifeCycleException.java
+++ b/src/java/main/org/apache/zookeeper/metrics/MetricsProviderLifeCycleException.java
@@ -20,8 +20,12 @@ package org.apache.zookeeper.metrics;
 
 /**
  * A generic exception thrown during the licecycle of a MetricsProvider.
+ * <p>These exception will prevent the system from booting.</p>
+ * <p>Normally these exception will be ignored during shutdown.</p>
  */
 public class MetricsProviderLifeCycleException extends Exception {
+
+    private static final long serialVersionUID = 1L;
 
     public MetricsProviderLifeCycleException() {
     }

--- a/src/java/main/org/apache/zookeeper/metrics/MetricsProviderLifeCycleException.java
+++ b/src/java/main/org/apache/zookeeper/metrics/MetricsProviderLifeCycleException.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.metrics;
+
+/**
+ * A generic exception thrown during the licecycle of a MetricsProvider.
+ */
+public class MetricsProviderLifeCycleException extends Exception {
+
+    public MetricsProviderLifeCycleException() {
+    }
+
+    public MetricsProviderLifeCycleException(String message) {
+        super(message);
+    }
+
+    public MetricsProviderLifeCycleException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MetricsProviderLifeCycleException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/java/main/org/apache/zookeeper/metrics/Summary.java
+++ b/src/java/main/org/apache/zookeeper/metrics/Summary.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.metrics;
+
+/**
+ * Summaries track the size and number of events.
+ * They are able to publish minumum, maximum, average values, depending on the capabilities of the MetricsProvider.
+ */
+public interface Summary {
+
+     /**
+      * Register a value.
+      *
+      * @param value current value
+      */
+     public void registerValue(long value);
+
+}

--- a/src/java/main/org/apache/zookeeper/metrics/Summary.java
+++ b/src/java/main/org/apache/zookeeper/metrics/Summary.java
@@ -26,9 +26,10 @@ public interface Summary {
 
      /**
       * Register a value.
+      * <p>This method is thread safe, The MetricsProvider will take care of synchronization.</p>
       *
       * @param value current value
       */
-     public void registerValue(long value);
+     void registerValue(long value);
 
 }


### PR DESCRIPTION
Define the API which must be implemented by a Metrics Provider.

a MetricsProvider is a pluggable component which is able to gather metrics about the system and publish them to an external application for analysis.