### PR TITLE
ZOOKEEPER-3123 MetricsProvider Lifecycle in ZooKeeper Server

### DIFF
--- a/src/java/main/org/apache/zookeeper/metrics/impl/MetricsProviderBootstrap.java
+++ b/src/java/main/org/apache/zookeeper/metrics/impl/MetricsProviderBootstrap.java
@@ -17,11 +17,9 @@
  */
 package org.apache.zookeeper.metrics.impl;
 
-import java.io.IOException;
 import java.util.Properties;
 import org.apache.zookeeper.metrics.MetricsProvider;
 import org.apache.zookeeper.metrics.MetricsProviderLifeCycleException;
-import org.apache.zookeeper.server.quorum.QuorumPeerMain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/java/main/org/apache/zookeeper/metrics/impl/MetricsProviderBootstrap.java
+++ b/src/java/main/org/apache/zookeeper/metrics/impl/MetricsProviderBootstrap.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.metrics.impl;
+
+import java.io.IOException;
+import java.util.Properties;
+import org.apache.zookeeper.metrics.MetricsProvider;
+import org.apache.zookeeper.metrics.MetricsProviderLifeCycleException;
+import org.apache.zookeeper.server.quorum.QuorumPeerMain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility for bootstrap process of MetricsProviders
+ */
+public abstract class MetricsProviderBootstrap {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetricsProviderBootstrap.class);
+
+    public static MetricsProvider startMetricsProvider(String metricsProviderClassName, Properties configuration)
+            throws MetricsProviderLifeCycleException {
+        try {
+            MetricsProvider metricsProvider = (MetricsProvider) Class.forName(metricsProviderClassName,
+                    true, Thread.currentThread().getContextClassLoader()).newInstance();
+            metricsProvider.configure(configuration);
+            metricsProvider.start();
+            return metricsProvider;
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException error) {
+            LOG.error("Cannot boot MetricsProvider {}", metricsProviderClassName, error);
+            throw new MetricsProviderLifeCycleException("Cannot boot MetricsProvider " + metricsProviderClassName,
+                    error);
+        } catch (MetricsProviderLifeCycleException error) {
+            LOG.error("Cannot boot MetricsProvider {}", metricsProviderClassName, error);
+            throw error;
+        }
+    }
+}

--- a/src/java/main/org/apache/zookeeper/metrics/impl/NullMetricsProvider.java
+++ b/src/java/main/org/apache/zookeeper/metrics/impl/NullMetricsProvider.java
@@ -68,7 +68,7 @@ public class NullMetricsProvider implements MetricsProvider {
 
         @Override
         public Summary getSummary(String name) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            return NullSummary.INSTANCE;
         }
 
     }

--- a/src/java/main/org/apache/zookeeper/metrics/impl/NullMetricsProvider.java
+++ b/src/java/main/org/apache/zookeeper/metrics/impl/NullMetricsProvider.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.metrics.impl;
+
+import java.util.Properties;
+import org.apache.zookeeper.metrics.Counter;
+import org.apache.zookeeper.metrics.Gauge;
+import org.apache.zookeeper.metrics.MetricsContext;
+import org.apache.zookeeper.metrics.MetricsProvider;
+import org.apache.zookeeper.metrics.MetricsProviderLifeCycleException;
+import org.apache.zookeeper.metrics.Summary;
+
+/**
+ * This is a dummy MetricsProvider which does nothing.
+ */
+public class NullMetricsProvider implements MetricsProvider {
+
+    @Override
+    public void configure(Properties configuration) throws MetricsProviderLifeCycleException {
+    }
+
+    @Override
+    public void start() throws MetricsProviderLifeCycleException {
+    }
+
+    @Override
+    public MetricsContext getRootContext() {
+        return NullMetricsContext.INSTANCE;
+    }
+
+    @Override
+    public void stop() {
+    }
+
+    public static final class NullMetricsContext implements MetricsContext {
+
+        public static final NullMetricsContext INSTANCE = new NullMetricsContext();
+
+        @Override
+        public MetricsContext getContext(String name) {
+            return INSTANCE;
+        }
+
+        @Override
+        public Counter getCounter(String name) {
+            return NullCounter.INSTANCE;
+        }
+
+        @Override
+        public boolean registerGauge(String name, Gauge gauge) {
+            return true;
+        }
+
+        @Override
+        public Summary getSummary(String name) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+    }
+
+    private static final class NullCounter implements Counter {
+
+        private static final NullCounter INSTANCE = new NullCounter();
+
+        @Override
+        public void inc(long delta) {
+        }
+
+        @Override
+        public long get() {
+            return 0;
+        }
+
+    }
+
+    private static final class NullSummary implements Summary {
+
+        private static final NullSummary INSTANCE = new NullSummary();
+
+        @Override
+        public void registerValue(long value) {
+        }
+
+    }
+}

--- a/src/java/main/org/apache/zookeeper/server/ServerConfig.java
+++ b/src/java/main/org/apache/zookeeper/server/ServerConfig.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.util.Arrays;
 
 import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.zookeeper.metrics.impl.NullMetricsProvider;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig.ConfigException;
 
@@ -48,6 +49,7 @@ public class ServerConfig {
     protected int minSessionTimeout = -1;
     /** defaults to -1 if not set explicitly */
     protected int maxSessionTimeout = -1;
+    protected String metricsProviderClassName = NullMetricsProvider.class.getName();
 
     /**
      * Parse arguments for server configuration
@@ -99,6 +101,7 @@ public class ServerConfig {
         maxClientCnxns = config.getMaxClientCnxns();
         minSessionTimeout = config.getMinSessionTimeout();
         maxSessionTimeout = config.getMaxSessionTimeout();
+        metricsProviderClassName = config.getMetricsProviderClassName();
     }
 
     public InetSocketAddress getClientPortAddress() {
@@ -115,4 +118,6 @@ public class ServerConfig {
     public int getMinSessionTimeout() { return minSessionTimeout; }
     /** maximum session timeout in milliseconds, -1 if unset */
     public int getMaxSessionTimeout() { return maxSessionTimeout; }
+    public String getMetricsProviderClassName() { return metricsProviderClassName;}
+
 }

--- a/src/java/main/org/apache/zookeeper/server/ServerConfig.java
+++ b/src/java/main/org/apache/zookeeper/server/ServerConfig.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.server;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
+import java.util.Properties;
 
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.metrics.impl.NullMetricsProvider;
@@ -50,6 +51,7 @@ public class ServerConfig {
     /** defaults to -1 if not set explicitly */
     protected int maxSessionTimeout = -1;
     protected String metricsProviderClassName = NullMetricsProvider.class.getName();
+    protected Properties metricsProviderConfiguration = new Properties();
 
     /**
      * Parse arguments for server configuration
@@ -102,6 +104,7 @@ public class ServerConfig {
         minSessionTimeout = config.getMinSessionTimeout();
         maxSessionTimeout = config.getMaxSessionTimeout();
         metricsProviderClassName = config.getMetricsProviderClassName();
+        metricsProviderConfiguration = config.getMetricsProviderConfiguration();
     }
 
     public InetSocketAddress getClientPortAddress() {
@@ -118,6 +121,7 @@ public class ServerConfig {
     public int getMinSessionTimeout() { return minSessionTimeout; }
     /** maximum session timeout in milliseconds, -1 if unset */
     public int getMaxSessionTimeout() { return maxSessionTimeout; }
-    public String getMetricsProviderClassName() { return metricsProviderClassName;}
+    public String getMetricsProviderClassName() { return metricsProviderClassName; }
+    public Properties getMetricsProviderConfiguration() { return metricsProviderConfiguration; }
 
 }

--- a/src/java/main/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/src/java/main/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -52,6 +52,8 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.data.StatPersisted;
 import org.apache.zookeeper.jmx.MBeanRegistry;
+import org.apache.zookeeper.metrics.MetricsContext;
+import org.apache.zookeeper.metrics.impl.NullMetricsProvider;
 import org.apache.zookeeper.proto.AuthPacket;
 import org.apache.zookeeper.proto.ConnectRequest;
 import org.apache.zookeeper.proto.ConnectResponse;
@@ -127,6 +129,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
     private final ServerStats serverStats;
     private final ZooKeeperServerListener listener;
+    private MetricsContext rootMetricsContext = NullMetricsProvider.NullMetricsContext.INSTANCE;
     private ZooKeeperServerShutdownHandler zkShutdownHandler;
     private volatile int createSessionTrackerServerId = 1;
 
@@ -871,6 +874,14 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
     public void setSecureServerCnxnFactory(ServerCnxnFactory factory) {
         secureServerCnxnFactory = factory;
+    }
+
+    public MetricsContext getRootMetricsContext() {
+        return rootMetricsContext;
+    }
+
+    public void setRootMetricsContext(MetricsContext rootMetricsContext) {
+        this.rootMetricsContext = rootMetricsContext;
     }
 
     /**

--- a/src/java/main/org/apache/zookeeper/server/ZooKeeperServerMain.java
+++ b/src/java/main/org/apache/zookeeper/server/ZooKeeperServerMain.java
@@ -123,9 +123,10 @@ public class ZooKeeperServerMain {
         try {
             try {
                 metricsProvider = MetricsProviderBootstrap
-                        .startMetricsProvider(config.metricsProviderClassName, config.metricsProviderConfiguration);
+                        .startMetricsProvider(config.getMetricsProviderClassName(),
+                                              config.getMetricsProviderConfiguration());
             } catch (MetricsProviderLifeCycleException error) {
-                throw new IOException("Cannot boot MetricsProvider "+config.metricsProviderClassName,
+                throw new IOException("Cannot boot MetricsProvider "+config.getMetricsProviderClassName(),
                     error);
             }
 

--- a/src/java/main/org/apache/zookeeper/server/ZooKeeperServerMain.java
+++ b/src/java/main/org/apache/zookeeper/server/ZooKeeperServerMain.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server;
 
 import java.io.IOException;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -26,6 +27,9 @@ import javax.management.JMException;
 
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.jmx.ManagedUtil;
+import org.apache.zookeeper.metrics.MetricsProvider;
+import org.apache.zookeeper.metrics.MetricsProviderLifeCycleException;
+import org.apache.zookeeper.metrics.impl.MetricsProviderBootstrap;
 import org.apache.zookeeper.server.admin.AdminServer;
 import org.apache.zookeeper.server.admin.AdminServer.AdminServerException;
 import org.apache.zookeeper.server.admin.AdminServerFactory;
@@ -50,7 +54,7 @@ public class ZooKeeperServerMain {
     private ServerCnxnFactory cnxnFactory;
     private ServerCnxnFactory secureCnxnFactory;
     private ContainerManager containerManager;
-
+    private MetricsProvider metricsProvider;
     private AdminServer adminServer;
 
     /*
@@ -117,6 +121,15 @@ public class ZooKeeperServerMain {
         LOG.info("Starting server");
         FileTxnSnapLog txnLog = null;
         try {
+            try {
+                metricsProvider = MetricsProviderBootstrap
+                        .startMetricsProvider(config.metricsProviderClassName, new Properties());
+            } catch (MetricsProviderLifeCycleException error) {
+                LOG.error("Cannot boot MetricsProvider {}", config.metricsProviderClassName, error);
+                throw new IOException("Cannot boot MetricsProvider "+config.metricsProviderClassName,
+                    error);
+            }
+
             // Note that this thread isn't going to be doing anything else,
             // so rather than spawning another thread, we will just call
             // run() in this thread.
@@ -124,6 +137,7 @@ public class ZooKeeperServerMain {
             txnLog = new FileTxnSnapLog(config.dataLogDir, config.dataDir);
             final ZooKeeperServer zkServer = new ZooKeeperServer(txnLog,
                     config.tickTime, config.minSessionTimeout, config.maxSessionTimeout, null);
+            zkServer.setRootMetricsContext(metricsProvider.getRootContext());
             txnLog.setServerStats(zkServer.serverStats());
 
             // Registers shutdown handler which will be used to know the
@@ -178,6 +192,9 @@ public class ZooKeeperServerMain {
         } finally {
             if (txnLog != null) {
                 txnLog.close();
+            }
+            if (metricsProvider != null) {
+                metricsProvider.stop();
             }
         }
     }

--- a/src/java/main/org/apache/zookeeper/server/ZooKeeperServerMain.java
+++ b/src/java/main/org/apache/zookeeper/server/ZooKeeperServerMain.java
@@ -123,9 +123,8 @@ public class ZooKeeperServerMain {
         try {
             try {
                 metricsProvider = MetricsProviderBootstrap
-                        .startMetricsProvider(config.metricsProviderClassName, new Properties());
+                        .startMetricsProvider(config.metricsProviderClassName, config.metricsProviderConfiguration);
             } catch (MetricsProviderLifeCycleException error) {
-                LOG.error("Cannot boot MetricsProvider {}", config.metricsProviderClassName, error);
                 throw new IOException("Cannot boot MetricsProvider "+config.metricsProviderClassName,
                     error);
             }
@@ -194,7 +193,11 @@ public class ZooKeeperServerMain {
                 txnLog.close();
             }
             if (metricsProvider != null) {
-                metricsProvider.stop();
+                try {
+                    metricsProvider.stop();
+                } catch (Throwable error) {
+                    LOG.warn("Error while stopping metrics", error);
+                }
             }
         }
     }

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -74,6 +74,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.zookeeper.common.NetUtils.formatInetAddr;
+import org.apache.zookeeper.metrics.MetricsContext;
+import org.apache.zookeeper.metrics.impl.NullMetricsProvider;
 
 /**
  * This class manages the quorum protocol. There are three states this server
@@ -772,6 +774,8 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     private final QuorumStats quorumStats;
 
     AdminServer adminServer;
+
+    private MetricsContext rootMetricsContext = NullMetricsProvider.NullMetricsContext.INSTANCE;
 
     public static QuorumPeer testingQuorumPeer() throws SaslException {
         return new QuorumPeer();
@@ -1677,6 +1681,10 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
 
     public void setSecureCnxnFactory(ServerCnxnFactory secureCnxnFactory) {
         this.secureCnxnFactory = secureCnxnFactory;
+    }
+
+    public void setRootMetricsContext(MetricsContext rootMetricsContext) {
+        this.rootMetricsContext = rootMetricsContext;
     }
 
     private void startServerCnxnFactory() {

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -54,7 +54,6 @@ import org.apache.zookeeper.server.quorum.flexible.QuorumHierarchical;
 import org.apache.zookeeper.server.quorum.flexible.QuorumMaj;
 import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
 import org.apache.zookeeper.server.util.VerifyingFileFactory;
-import org.apache.zookeeper.server.util.ConfigUtils;
 
 import static org.apache.zookeeper.common.NetUtils.formatInetAddr;
 import org.apache.zookeeper.metrics.impl.NullMetricsProvider;
@@ -81,6 +80,7 @@ public class QuorumPeerConfig {
     /** defaults to -1 if not set explicitly */
     protected int maxSessionTimeout = -1;
     protected String metricsProviderClassName = NullMetricsProvider.class.getName();
+    protected Properties metricsProviderConfiguration = new Properties();
     protected boolean localSessionsEnabled = false;
     protected boolean localSessionsUpgradingEnabled = false;
 
@@ -329,6 +329,9 @@ public class QuorumPeerConfig {
                 quorumCnxnThreadsSize = Integer.parseInt(value);
             } else if (key.equals("metricsProvider.className")) {
                 metricsProviderClassName = value;
+            } else if (key.startsWith("metricsProvider.")) {
+                String keyForMetricsProvider = key.substring(16);
+                metricsProviderConfiguration.put(keyForMetricsProvider, value);
             } else {
                 System.setProperty("zookeeper." + key, value);
             }
@@ -747,6 +750,7 @@ public class QuorumPeerConfig {
     public int getMinSessionTimeout() { return minSessionTimeout; }
     public int getMaxSessionTimeout() { return maxSessionTimeout; }
     public String getMetricsProviderClassName() { return metricsProviderClassName; }
+    public Properties getMetricsProviderConfiguration() { return metricsProviderConfiguration; }
     public boolean areLocalSessionsEnabled() { return localSessionsEnabled; }
     public boolean isLocalSessionsUpgradingEnabled() {
         return localSessionsUpgradingEnabled;

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -57,6 +57,7 @@ import org.apache.zookeeper.server.util.VerifyingFileFactory;
 import org.apache.zookeeper.server.util.ConfigUtils;
 
 import static org.apache.zookeeper.common.NetUtils.formatInetAddr;
+import org.apache.zookeeper.metrics.impl.NullMetricsProvider;
 
 @InterfaceAudience.Public
 public class QuorumPeerConfig {
@@ -79,6 +80,7 @@ public class QuorumPeerConfig {
     protected int minSessionTimeout = -1;
     /** defaults to -1 if not set explicitly */
     protected int maxSessionTimeout = -1;
+    protected String metricsProviderClassName = NullMetricsProvider.class.getName();
     protected boolean localSessionsEnabled = false;
     protected boolean localSessionsUpgradingEnabled = false;
 
@@ -325,6 +327,8 @@ public class QuorumPeerConfig {
                 quorumServicePrincipal = value;
             } else if (key.equals("quorum.cnxn.threads.size")) {
                 quorumCnxnThreadsSize = Integer.parseInt(value);
+            } else if (key.equals("metricsProvider.className")) {
+                metricsProviderClassName = value;
             } else {
                 System.setProperty("zookeeper." + key, value);
             }
@@ -409,7 +413,14 @@ public class QuorumPeerConfig {
         if (minSessionTimeout > maxSessionTimeout) {
             throw new IllegalArgumentException(
                     "minSessionTimeout must not be larger than maxSessionTimeout");
-        }          
+        }
+
+        LOG.info("metricsProvider.className is {}", metricsProviderClassName);
+        try {
+            Class.forName(metricsProviderClassName, false, Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException error) {
+            throw new IllegalArgumentException("metrics provider class was not found", error);
+        }
 
         // backward compatibility - dynamic configuration in the same file as
         // static configuration params see writeDynamicConfig()
@@ -735,6 +746,7 @@ public class QuorumPeerConfig {
     public int getMaxClientCnxns() { return maxClientCnxns; }
     public int getMinSessionTimeout() { return minSessionTimeout; }
     public int getMaxSessionTimeout() { return maxSessionTimeout; }
+    public String getMetricsProviderClassName() { return metricsProviderClassName; }
     public boolean areLocalSessionsEnabled() { return localSessionsEnabled; }
     public boolean isLocalSessionsUpgradingEnabled() {
         return localSessionsUpgradingEnabled;

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
@@ -147,9 +147,10 @@ public class QuorumPeerMain {
       MetricsProvider metricsProvider;
       try {
         metricsProvider = MetricsProviderBootstrap
-                      .startMetricsProvider(config.metricsProviderClassName, config.metricsProviderConfiguration);
+                      .startMetricsProvider(config.getMetricsProviderClassName(),
+                                            config.getMetricsProviderConfiguration());
       } catch (MetricsProviderLifeCycleException error) {
-        throw new IOException("Cannot boot MetricsProvider " + config.metricsProviderClassName,
+        throw new IOException("Cannot boot MetricsProvider " + config.getMetricsProviderClassName(),
                       error);
       }
       try {

--- a/src/java/test/org/apache/zookeeper/metrics/BaseTestMetricsProvider.java
+++ b/src/java/test/org/apache/zookeeper/metrics/BaseTestMetricsProvider.java
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.metrics;
+
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.zookeeper.metrics.impl.NullMetricsProvider;
+
+/**
+ * Simple MetricsProvider for tests.
+ */
+public abstract class BaseTestMetricsProvider implements MetricsProvider {
+
+    @Override
+    public void configure(Properties prprts) throws MetricsProviderLifeCycleException {
+    }
+
+    @Override
+    public void start() throws MetricsProviderLifeCycleException {
+    }
+
+    @Override
+    public MetricsContext getRootContext() {
+        return NullMetricsProvider.NullMetricsContext.INSTANCE;
+    }
+
+    @Override
+    public void stop() {
+    }
+
+    public static final class MetricsProviderCapturingLifecycle extends BaseTestMetricsProvider {
+
+        public static final AtomicBoolean configureCalled = new AtomicBoolean();
+        public static final AtomicBoolean startCalled = new AtomicBoolean();
+        public static final AtomicBoolean stopCalled = new AtomicBoolean();
+        public static final AtomicBoolean getRootContextCalled = new AtomicBoolean();
+
+        public static void reset() {
+            configureCalled.set(false);
+            startCalled.set(false);
+            stopCalled.set(false);
+            getRootContextCalled.set(false);
+        }
+        
+        @Override
+        public void configure(Properties prprts) throws MetricsProviderLifeCycleException {
+            if (!configureCalled.compareAndSet(false, true)) {
+                // called twice
+                throw new IllegalStateException();
+            }
+        }
+
+        @Override
+        public void start() throws MetricsProviderLifeCycleException {
+            if (!startCalled.compareAndSet(false, true)) {
+                // called twice
+                throw new IllegalStateException();
+            }
+        }
+
+        @Override
+        public MetricsContext getRootContext() {
+            if (!getRootContextCalled.compareAndSet(false, true)) {
+                // called twice
+                throw new IllegalStateException();
+            }
+            return NullMetricsProvider.NullMetricsContext.INSTANCE;
+        }
+
+        @Override
+        public void stop() {
+            if (!stopCalled.compareAndSet(false, true)) {
+                // called twice
+                throw new IllegalStateException();
+            }
+        }
+
+    }
+
+    public static final class MetricsProviderWithErrorInStart extends BaseTestMetricsProvider {
+
+        @Override
+        public void start() throws MetricsProviderLifeCycleException {
+            throw new MetricsProviderLifeCycleException();
+        }
+
+    }
+
+    public static final class MetricsProviderWithErrorInConfigure extends BaseTestMetricsProvider {
+
+        @Override
+        public void configure(Properties prprts) throws MetricsProviderLifeCycleException {
+            throw new MetricsProviderLifeCycleException();
+        }
+
+    }
+
+    public static final class MetricsProviderWithConfiguration extends BaseTestMetricsProvider {
+
+        public static final AtomicInteger httpPort = new AtomicInteger();
+
+        @Override
+        public void configure(Properties prprts) throws MetricsProviderLifeCycleException {
+            httpPort.set(Integer.parseInt(prprts.getProperty("httpPort")));
+        }
+
+    }
+
+    public static final class MetricsProviderWithErrorInStop extends BaseTestMetricsProvider {
+
+        public static final AtomicBoolean stopCalled = new AtomicBoolean();
+
+        @Override
+        public void stop() {
+            stopCalled.set(true);
+            throw new RuntimeException();
+        }
+
+    }
+
+}

--- a/src/java/test/org/apache/zookeeper/server/ZooKeeperServerMainTest.java
+++ b/src/java/test/org/apache/zookeeper/server/ZooKeeperServerMainTest.java
@@ -390,7 +390,7 @@ public class ZooKeeperServerMainTest extends ZKTestCase implements Watcher {
         args[0] = main.confFile.toString();
         try {
             main.main.initializeAndRun(args);
-            Assert.fail("Must throw exception as metrics provider is cannot boot");
+            Assert.fail("Must throw exception as metrics provider cannot boot");
         } catch (IOException iae) {
             // expected
         }

--- a/src/java/test/org/apache/zookeeper/server/ZooKeeperServerMainTest.java
+++ b/src/java/test/org/apache/zookeeper/server/ZooKeeperServerMainTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.zookeeper.server;
 
-import org.apache.zookeeper.metrics.BaseTestMetricsProvider;
 import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 import static org.junit.Assert.fail;
 
@@ -40,6 +39,7 @@ import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.common.PathUtils;
+import org.apache.zookeeper.metrics.BaseTestMetricsProvider;
 import org.apache.zookeeper.metrics.BaseTestMetricsProvider.MetricsProviderCapturingLifecycle;
 import org.apache.zookeeper.metrics.BaseTestMetricsProvider.MetricsProviderWithConfiguration;
 import org.apache.zookeeper.metrics.BaseTestMetricsProvider.MetricsProviderWithErrorInConfigure;

--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerMainTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerMainTest.java
@@ -59,6 +59,7 @@ import org.apache.zookeeper.ZooKeeper.States;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.metrics.BaseTestMetricsProvider;
+import org.apache.zookeeper.metrics.impl.NullMetricsProvider;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.quorum.Leader.Proposal;
 import org.apache.zookeeper.test.ClientBase;
@@ -1147,6 +1148,8 @@ public class QuorumPeerMainTest extends QuorumPeerTestBase {
             QuorumPeerConfig configMock = mock(QuorumPeerConfig.class);
             when(configMock.getDataDir()).thenReturn(dataDir);
             when(configMock.getDataLogDir()).thenReturn(dataLogDir);
+            when(configMock.getMetricsProviderClassName())
+                    .thenReturn(NullMetricsProvider.class.getName());
 
             QuorumPeer qpMock = mock(QuorumPeer.class);
 

--- a/src/java/test/org/apache/zookeeper/test/ClientBase.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientBase.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -57,7 +58,6 @@ import org.apache.zookeeper.server.ServerCnxnFactoryAccessor;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.persistence.FilePadding;
-import org.apache.zookeeper.server.persistence.FileTxnLog;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.server.util.OSMXBean;
 import org.junit.After;
@@ -287,6 +287,9 @@ public abstract class ClientBase extends ZKTestCase {
                         !result.contains("READ-ONLY")) {
                     return true;
                 }
+            } catch (ConnectException e) {
+                // ignore as this is expected, do not log stacktrace
+                LOG.info("server {} not up", hp);
             } catch (IOException e) {
                 // ignore as this is expected
                 LOG.info("server {} not up", hp, e);

--- a/src/java/test/org/apache/zookeeper/test/ClientBase.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientBase.java
@@ -25,7 +25,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -58,6 +57,7 @@ import org.apache.zookeeper.server.ServerCnxnFactoryAccessor;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.persistence.FilePadding;
+import org.apache.zookeeper.server.persistence.FileTxnLog;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.server.util.OSMXBean;
 import org.junit.After;
@@ -287,9 +287,6 @@ public abstract class ClientBase extends ZKTestCase {
                         !result.contains("READ-ONLY")) {
                     return true;
                 }
-            } catch (ConnectException e) {
-                // ignore as this is expected, do not log stacktrace
-                LOG.info("server {} not up", hp);
             } catch (IOException e) {
                 // ignore as this is expected
                 LOG.info("server {} not up", hp, e);


### PR DESCRIPTION
Manage the lifecycle of a MetricsProvider inside a ZooKeeper server.
- handle configuration
- start and configure the MetricsProvider
- notify shutdown to the MetricsProvider

This is an early preview, because there are some points to discuss:
- We have to throw an IOException in case of failure (in order not to change the current signature of main methods used to start the server)
- The patch only provides the lifecycle, it introduces some dead fields (root metrics context), this is expected as the real instrumentation will be done in a further step, is it okay ?
- Test cases cover only standalone mode, do we need to add a new suite for testing configuration and boot errors on QuorumPeer mode ? (the answer should be YES)
- MetricsProvider configuration is not subject to dynamic 'reconfig'

Configuration to the MetricsProvider is not yet handled, the idea is to let the user configure properties like
metricsProvider.className=o.a.z.metrics.prometheus.PrometheusMetricsProvider
metricsProvider.customParam1=value1
metricsProvider.customParam2=value2

in this case the MetricsProvider will receive {customParam1=value1, customParam2=value2} as parameter in configure()

is it okay ?