### PR TITLE
WIP - ZOOKEEPER-2990: Implement probabilistic tracing

### DIFF
--- a/src/java/main/org/apache/zookeeper/ClientCnxn.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxn.java
@@ -1189,7 +1189,7 @@ public class ClientCnxn {
                 eventThread.queueEvent(new WatchedEvent(Event.EventType.None,
                         Event.KeeperState.Disconnected, null));
             }
-            ZooTrace.logTraceMessage(LOG, ZooTrace.getTextTraceLevel(),
+            ZooTrace.logTraceMessage(LOG, ZooTrace.SESSION_TRACE_MASK,
                     "SendThread exited loop for session: 0x"
                            + Long.toHexString(getSessionId()));
         }

--- a/src/java/main/org/apache/zookeeper/common/IOUtils.java
+++ b/src/java/main/org/apache/zookeeper/common/IOUtils.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.ByteBuffer;
 
 import org.slf4j.Logger;
 
@@ -118,6 +119,14 @@ public class IOUtils {
             }
             bytesRead = in.read(buf);
         }
+    }
+
+    public static short[] readShortArray(ByteBuffer buffer, int size) {
+        short[] result = new short[size];
+        for(int i = 0; i < size; i++) {
+            result[i] = buffer.getShort();
+        }
+        return result;
     }
 
 }

--- a/src/java/main/org/apache/zookeeper/server/SessionTrackerImpl.java
+++ b/src/java/main/org/apache/zookeeper/server/SessionTrackerImpl.java
@@ -227,7 +227,7 @@ public class SessionTrackerImpl extends ZooKeeperCriticalThread implements Sessi
 
         running = false;
         if (LOG.isTraceEnabled()) {
-            ZooTrace.logTraceMessage(LOG, ZooTrace.getTextTraceLevel(),
+            ZooTrace.logTraceMessage(LOG, ZooTrace.SESSION_TRACE_MASK,
                                      "Shutdown SessionTrackerImpl!");
         }
     }


### PR DESCRIPTION
- stmk can be called with extra list of 10 short numbers to set the rate for each mask bit. Max rate is 1000
example: perl -e "print 'stmk', pack('q>s>s>s>s>s>s>s>s>s>s>', 0b0011111010, 0, 100, 200, 300, 400, 500, 600, 7, 8, 9)"