### PR TITLE
ZOOKEEPER-1823:zkTxnLogToolkit -dump should support printing transaction data as a string

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/LogFormatter.java
+++ b/src/java/main/org/apache/zookeeper/server/LogFormatter.java
@@ -26,6 +26,9 @@ import java.util.Date;
 import java.util.zip.Adler32;
 import java.util.zip.Checksum;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.PosixParser;
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.Record;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -34,6 +37,10 @@ import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.server.persistence.FileHeader;
 import org.apache.zookeeper.server.persistence.FileTxnLog;
 import org.apache.zookeeper.server.util.SerializeUtils;
+import org.apache.zookeeper.txn.CreateContainerTxn;
+import org.apache.zookeeper.txn.CreateTTLTxn;
+import org.apache.zookeeper.txn.CreateTxn;
+import org.apache.zookeeper.txn.SetDataTxn;
 import org.apache.zookeeper.txn.TxnHeader;
 
 @InterfaceAudience.Public
@@ -41,25 +48,69 @@ public class LogFormatter {
     private static final Logger LOG = LoggerFactory.getLogger(LogFormatter.class);
 
     /**
+     * get transaction log data string with node's data as a string
+     * @param txn
+     * @return
+     */
+    private static String getDataStrFromTxn(Record txn) {
+        StringBuilder txnData = new StringBuilder();
+        if (txn == null) {
+            return txnData.toString();
+        }
+        if (txn instanceof CreateTxn) {
+            CreateTxn createTxn = ((CreateTxn) txn);
+            txnData.append(createTxn.getPath() + "," + new String(createTxn.getData()))
+                   .append("," + createTxn.getAcl() + "," + createTxn.getEphemeral())
+                   .append("," + createTxn.getParentCVersion());
+        } else if (txn instanceof SetDataTxn) {
+            SetDataTxn setDataTxn = ((SetDataTxn) txn);
+            txnData.append(setDataTxn.getPath() + "," + new String(setDataTxn.getData()))
+                   .append("," + setDataTxn.getVersion());
+        } else if (txn instanceof CreateContainerTxn) {
+            CreateContainerTxn createContainerTxn = ((CreateContainerTxn) txn);
+            txnData.append(createContainerTxn.getPath() + "," + new String(createContainerTxn.getData()))
+                   .append("," + createContainerTxn.getAcl() + "," + createContainerTxn.getParentCVersion());
+        } else if (txn instanceof CreateTTLTxn) {
+            CreateTTLTxn createTTLTxn = ((CreateTTLTxn) txn);
+            txnData.append(createTTLTxn.getPath() + "," + new String(createTTLTxn.getData()))
+                   .append("," + createTTLTxn.getAcl() + "," + createTTLTxn.getParentCVersion())
+                   .append("," + createTTLTxn.getTtl());
+        } else {
+            txnData.append(txn.toString());
+        }
+
+        return txnData.toString();
+    }
+    /**
      * @param args
      */
     public static void main(String[] args) throws Exception {
-        if (args.length != 1) {
+        CommandLine cl;
+        Options options = new Options();
+        PosixParser parser = new PosixParser();
+        String[] cmdArgs;
+
+        options.addOption("s", false, "showdata");
+        cl = parser.parse(options, args);
+        cmdArgs = cl.getArgs();
+
+        if (cmdArgs.length != 1) {
             System.err.println("USAGE: LogFormatter log_file");
+            System.err.println("USAGE: LogFormatter [-s] log_file to print transaction data as a string");
             System.exit(ExitCode.INVALID_INVOCATION.getValue());
         }
-        FileInputStream fis = new FileInputStream(args[0]);
+        FileInputStream fis = new FileInputStream(cmdArgs[0]);
         BinaryInputArchive logStream = BinaryInputArchive.getArchive(fis);
         FileHeader fhdr = new FileHeader();
         fhdr.deserialize(logStream, "fileheader");
 
         if (fhdr.getMagic() != FileTxnLog.TXNLOG_MAGIC) {
-            System.err.println("Invalid magic number for " + args[0]);
+            System.err.println(String.format("Invalid magic number for %s", cmdArgs[0]));
             System.exit(ExitCode.INVALID_INVOCATION.getValue());
         }
-        System.out.println("ZooKeeper Transactional Log File with dbid "
-                + fhdr.getDbid() + " txnlog format version "
-                + fhdr.getVersion());
+        System.out.println(String.format("%s with dbid %d txnlog format version %d\n",
+                "ZooKeeper Transactional Log File", fhdr.getDbid(), fhdr.getVersion()));
+        DateFormat dataFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.LONG);
 
         int count = 0;
         while (true) {
@@ -70,32 +121,33 @@ public class LogFormatter {
 
                 bytes = logStream.readBuffer("txnEntry");
             } catch (EOFException e) {
-                System.out.println("EOF reached after " + count + " txns.");
+                System.out.println(String.format("EOF reached after %d txns.", count));
                 return;
             }
             if (bytes.length == 0) {
                 // Since we preallocate, we define EOF to be an
                 // empty transaction
-                System.out.println("EOF reached after " + count + " txns.");
+                System.out.println(String.format("EOF reached after %d txns.", count));
                 return;
             }
             Checksum crc = new Adler32();
             crc.update(bytes, 0, bytes.length);
             if (crcValue != crc.getValue()) {
-                throw new IOException("CRC doesn't match " + crcValue +
-                        " vs " + crc.getValue());
+                throw new IOException(String.format("CRC doesn't match %s vs %s", crcValue, crc.getValue()));
             }
             TxnHeader hdr = new TxnHeader();
             Record txn = SerializeUtils.deserializeTxn(bytes, hdr);
-            System.out.println(DateFormat.getDateTimeInstance(DateFormat.SHORT,
-                    DateFormat.LONG).format(new Date(hdr.getTime()))
-                    + " session 0x"
-                    + Long.toHexString(hdr.getClientId())
-                    + " cxid 0x"
-                    + Long.toHexString(hdr.getCxid())
-                    + " zxid 0x"
-                    + Long.toHexString(hdr.getZxid())
-                    + " " + TraceFormatter.op2String(hdr.getType()) + " " + txn);
+
+            String txnStr = (txn != null) ? txn.toString() : "";
+            if (cl.hasOption("s")) {
+                txnStr = getDataStrFromTxn(txn);
+            }
+
+            System.out.println(String.format("%s session 0x%s cxid 0x%s zxid 0x%s %s %s\n",
+                    dataFormat.format(new Date(hdr.getTime())), Long.toHexString(hdr.getClientId()),
+                    Long.toHexString(hdr.getCxid()), Long.toHexString(hdr.getZxid()),
+                    TraceFormatter.op2String(hdr.getType()), txnStr));
+
             if (logStream.readByte("EOR") != 'B') {
                 LOG.error("Last transaction was partial.");
                 throw new EOFException("Last transaction was partial.");

--- a/src/java/main/org/apache/zookeeper/server/LogFormatter.java
+++ b/src/java/main/org/apache/zookeeper/server/LogFormatter.java
@@ -26,9 +26,6 @@ import java.util.Date;
 import java.util.zip.Adler32;
 import java.util.zip.Checksum;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.PosixParser;
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.Record;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -37,10 +34,6 @@ import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.server.persistence.FileHeader;
 import org.apache.zookeeper.server.persistence.FileTxnLog;
 import org.apache.zookeeper.server.util.SerializeUtils;
-import org.apache.zookeeper.txn.CreateContainerTxn;
-import org.apache.zookeeper.txn.CreateTTLTxn;
-import org.apache.zookeeper.txn.CreateTxn;
-import org.apache.zookeeper.txn.SetDataTxn;
 import org.apache.zookeeper.txn.TxnHeader;
 
 @InterfaceAudience.Public
@@ -48,69 +41,25 @@ public class LogFormatter {
     private static final Logger LOG = LoggerFactory.getLogger(LogFormatter.class);
 
     /**
-     * get transaction log data string with node's data as a string
-     * @param txn
-     * @return
-     */
-    private static String getDataStrFromTxn(Record txn) {
-        StringBuilder txnData = new StringBuilder();
-        if (txn == null) {
-            return txnData.toString();
-        }
-        if (txn instanceof CreateTxn) {
-            CreateTxn createTxn = ((CreateTxn) txn);
-            txnData.append(createTxn.getPath() + "," + new String(createTxn.getData()))
-                   .append("," + createTxn.getAcl() + "," + createTxn.getEphemeral())
-                   .append("," + createTxn.getParentCVersion());
-        } else if (txn instanceof SetDataTxn) {
-            SetDataTxn setDataTxn = ((SetDataTxn) txn);
-            txnData.append(setDataTxn.getPath() + "," + new String(setDataTxn.getData()))
-                   .append("," + setDataTxn.getVersion());
-        } else if (txn instanceof CreateContainerTxn) {
-            CreateContainerTxn createContainerTxn = ((CreateContainerTxn) txn);
-            txnData.append(createContainerTxn.getPath() + "," + new String(createContainerTxn.getData()))
-                   .append("," + createContainerTxn.getAcl() + "," + createContainerTxn.getParentCVersion());
-        } else if (txn instanceof CreateTTLTxn) {
-            CreateTTLTxn createTTLTxn = ((CreateTTLTxn) txn);
-            txnData.append(createTTLTxn.getPath() + "," + new String(createTTLTxn.getData()))
-                   .append("," + createTTLTxn.getAcl() + "," + createTTLTxn.getParentCVersion())
-                   .append("," + createTTLTxn.getTtl());
-        } else {
-            txnData.append(txn.toString());
-        }
-
-        return txnData.toString();
-    }
-    /**
      * @param args
      */
     public static void main(String[] args) throws Exception {
-        CommandLine cl;
-        Options options = new Options();
-        PosixParser parser = new PosixParser();
-        String[] cmdArgs;
-
-        options.addOption("s", false, "showdata");
-        cl = parser.parse(options, args);
-        cmdArgs = cl.getArgs();
-
-        if (cmdArgs.length != 1) {
+        if (args.length != 1) {
             System.err.println("USAGE: LogFormatter log_file");
-            System.err.println("USAGE: LogFormatter [-s] log_file to print transaction data as a string");
             System.exit(ExitCode.INVALID_INVOCATION.getValue());
         }
-        FileInputStream fis = new FileInputStream(cmdArgs[0]);
+        FileInputStream fis = new FileInputStream(args[0]);
         BinaryInputArchive logStream = BinaryInputArchive.getArchive(fis);
         FileHeader fhdr = new FileHeader();
         fhdr.deserialize(logStream, "fileheader");
 
         if (fhdr.getMagic() != FileTxnLog.TXNLOG_MAGIC) {
-            System.err.println(String.format("Invalid magic number for %s", cmdArgs[0]));
+            System.err.println("Invalid magic number for " + args[0]);
             System.exit(ExitCode.INVALID_INVOCATION.getValue());
         }
-        System.out.println(String.format("%s with dbid %d txnlog format version %d\n",
-                "ZooKeeper Transactional Log File", fhdr.getDbid(), fhdr.getVersion()));
-        DateFormat dataFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.LONG);
+        System.out.println("ZooKeeper Transactional Log File with dbid "
+                + fhdr.getDbid() + " txnlog format version "
+                + fhdr.getVersion());
 
         int count = 0;
         while (true) {
@@ -121,33 +70,32 @@ public class LogFormatter {
 
                 bytes = logStream.readBuffer("txnEntry");
             } catch (EOFException e) {
-                System.out.println(String.format("EOF reached after %d txns.", count));
+                System.out.println("EOF reached after " + count + " txns.");
                 return;
             }
             if (bytes.length == 0) {
                 // Since we preallocate, we define EOF to be an
                 // empty transaction
-                System.out.println(String.format("EOF reached after %d txns.", count));
+                System.out.println("EOF reached after " + count + " txns.");
                 return;
             }
             Checksum crc = new Adler32();
             crc.update(bytes, 0, bytes.length);
             if (crcValue != crc.getValue()) {
-                throw new IOException(String.format("CRC doesn't match %s vs %s", crcValue, crc.getValue()));
+                throw new IOException("CRC doesn't match " + crcValue +
+                        " vs " + crc.getValue());
             }
             TxnHeader hdr = new TxnHeader();
             Record txn = SerializeUtils.deserializeTxn(bytes, hdr);
-
-            String txnStr = (txn != null) ? txn.toString() : "";
-            if (cl.hasOption("s")) {
-                txnStr = getDataStrFromTxn(txn);
-            }
-
-            System.out.println(String.format("%s session 0x%s cxid 0x%s zxid 0x%s %s %s\n",
-                    dataFormat.format(new Date(hdr.getTime())), Long.toHexString(hdr.getClientId()),
-                    Long.toHexString(hdr.getCxid()), Long.toHexString(hdr.getZxid()),
-                    TraceFormatter.op2String(hdr.getType()), txnStr));
-
+            System.out.println(DateFormat.getDateTimeInstance(DateFormat.SHORT,
+                    DateFormat.LONG).format(new Date(hdr.getTime()))
+                    + " session 0x"
+                    + Long.toHexString(hdr.getClientId())
+                    + " cxid 0x"
+                    + Long.toHexString(hdr.getCxid())
+                    + " zxid 0x"
+                    + Long.toHexString(hdr.getZxid())
+                    + " " + TraceFormatter.op2String(hdr.getType()) + " " + txn);
             if (logStream.readByte("EOR") != 'B') {
                 LOG.error("Last transaction was partial.");
                 throw new EOFException("Last transaction was partial.");

--- a/src/java/main/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
@@ -314,7 +314,7 @@ public class TxnLogToolkit implements Closeable {
         Option quietOpt = new Option("v", "verbose", false, "Be verbose in recovery mode: print all entries, not just fixed ones.");
         options.addOption(quietOpt);
 
-        Option dumpOpt = new Option("d", "dump", false, "Dump mode. Dump all entries of the log file. (this is the default)");
+        Option dumpOpt = new Option("d", "dump", false, "Dump mode. Dump all entries of the log file with printing the content of a nodepath (default)");
         options.addOption(dumpOpt);
 
         Option forceOpt = new Option("y", "yes", false, "Non-interactive mode: repair all CRC errors without asking");

--- a/src/java/main/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
+++ b/src/java/main/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
@@ -31,6 +31,10 @@ import org.apache.jute.Record;
 import org.apache.zookeeper.server.ExitCode;
 import org.apache.zookeeper.server.TraceFormatter;
 import org.apache.zookeeper.server.util.SerializeUtils;
+import org.apache.zookeeper.txn.CreateContainerTxn;
+import org.apache.zookeeper.txn.CreateTTLTxn;
+import org.apache.zookeeper.txn.CreateTxn;
+import org.apache.zookeeper.txn.SetDataTxn;
 import org.apache.zookeeper.txn.TxnHeader;
 
 import java.io.Closeable;
@@ -222,13 +226,14 @@ public class TxnLogToolkit implements Closeable {
     private void printTxn(byte[] bytes, String prefix) throws IOException {
         TxnHeader hdr = new TxnHeader();
         Record txn = SerializeUtils.deserializeTxn(bytes, hdr);
+        String txnStr = getDataStrFromTxn(txn);
         String txns = String.format("%s session 0x%s cxid 0x%s zxid 0x%s %s %s",
                 DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.LONG).format(new Date(hdr.getTime())),
                 Long.toHexString(hdr.getClientId()),
                 Long.toHexString(hdr.getCxid()),
                 Long.toHexString(hdr.getZxid()),
                 TraceFormatter.op2String(hdr.getType()),
-                txn);
+                txnStr);
         if (prefix != null && !"".equals(prefix.trim())) {
             System.out.print(prefix + " - ");
         }
@@ -239,6 +244,41 @@ public class TxnLogToolkit implements Closeable {
         }
     }
 
+    /**
+     * get transaction log data string with node's data as a string
+     * @param txn
+     * @return
+     */
+    private static String getDataStrFromTxn(Record txn) {
+        StringBuilder txnData = new StringBuilder();
+        if (txn == null) {
+            return txnData.toString();
+        }
+        if (txn instanceof CreateTxn) {
+            CreateTxn createTxn = ((CreateTxn) txn);
+            txnData.append(createTxn.getPath() + "," + new String(createTxn.getData()))
+                   .append("," + createTxn.getAcl() + "," + createTxn.getEphemeral())
+                   .append("," + createTxn.getParentCVersion());
+        } else if (txn instanceof SetDataTxn) {
+            SetDataTxn setDataTxn = ((SetDataTxn) txn);
+            txnData.append(setDataTxn.getPath() + "," + new String(setDataTxn.getData()))
+                   .append("," + setDataTxn.getVersion());
+        } else if (txn instanceof CreateContainerTxn) {
+            CreateContainerTxn createContainerTxn = ((CreateContainerTxn) txn);
+            txnData.append(createContainerTxn.getPath() + "," + new String(createContainerTxn.getData()))
+                   .append("," + createContainerTxn.getAcl() + "," + createContainerTxn.getParentCVersion());
+        } else if (txn instanceof CreateTTLTxn) {
+            CreateTTLTxn createTTLTxn = ((CreateTTLTxn) txn);
+            txnData.append(createTTLTxn.getPath() + "," + new String(createTTLTxn.getData()))
+                   .append("," + createTTLTxn.getAcl() + "," + createTTLTxn.getParentCVersion())
+                   .append("," + createTTLTxn.getTtl());
+        } else {
+            txnData.append(txn.toString());
+        }
+
+        return txnData.toString();
+    }
+    
     private void openTxnLogFile() throws FileNotFoundException {
         txnFis = new FileInputStream(txnLogFile);
         logStream = BinaryInputArchive.getArchive(txnFis);

--- a/zookeeper-docs/src/documentation/content/xdocs/zookeeperAdmin.xml
+++ b/zookeeper-docs/src/documentation/content/xdocs/zookeeperAdmin.xml
@@ -2273,7 +2273,7 @@ server.3=zoo3:2888:3888</programlisting>
           $ bin/zkTxnLogToolkit.sh
 
           usage: TxnLogToolkit [-dhrv] txn_log_file_name
-          -d,--dump      Dump mode. Dump all entries of the log file. (this is the default)
+          -d,--dump      Dump mode. Dump all entries of the log file with printing the content of a nodepath (default)
           -h,--help      Print help message
           -r,--recover   Recovery mode. Re-calculate CRC for broken entries.
           -v,--verbose   Be verbose in recovery mode: print all entries, not just fixed ones.


### PR DESCRIPTION
- It would be a useful addition for debuggling to show transaction data as strings with a option `-s `
- update the usage string to `USAGE: LogFormatter [-s] log_file` and add a short description for the `-s `
    option

- for the issue [michim](https://issues.apache.org/jira/secure/ViewProfile.jspa?name=michim) mentioned has been resolved,the test evidence has been included in the jira(Notice:we cannot `split(",")[1]` to replace the node data,because the node path can be like this `"/mao,ling"`)
- more details in [ZOOKEEPER-1823](https://issues.apache.org/jira/browse/ZOOKEEPER-1823).Thanks [rgs](https://issues.apache.org/jira/secure/ViewProfile.jspa?name=rgs) for the origin work
