### PR TITLE
ZOOKEEPER-1990 - fix Random instances

### DIFF
--- a/src/java/main/org/apache/zookeeper/ClientCnxn.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxn.java
@@ -801,7 +801,7 @@ public class ClientCnxn {
     class SendThread extends ZooKeeperThread {
         private long lastPingSentNs;
         private final ClientCnxnSocket clientCnxnSocket;
-        private Random r = new Random(System.nanoTime());        
+        private Random r = new Random();
         private boolean isFirstConnect = true;
 
         void readResponse(ByteBuffer incomingBuffer) throws IOException {

--- a/src/java/main/org/apache/zookeeper/server/SyncRequestProcessor.java
+++ b/src/java/main/org/apache/zookeeper/server/SyncRequestProcessor.java
@@ -61,7 +61,7 @@ public class SyncRequestProcessor extends ZooKeeperCriticalThread implements
      * invoked after flush returns successfully.
      */
     private final LinkedList<Request> toFlush = new LinkedList<Request>();
-    private final Random r = new Random(System.nanoTime());
+    private final Random r = new Random();
     /**
      * The number of log entries to log before starting a snapshot
      */


### PR DESCRIPTION
See the jira for more info.

Basically we have multiple ways of creating Random instances in ZooKeeper. Since java 1.7, the default constructor is good enough even in multi-threaded environment, we get a good seed.
But in some places, we just create a random instance, where System.nanotime is the seed, which is not a good practice in multi-threaded environments. 

I only replaced those, and I also left the tests as is, because in some cases it is intentional in them.

I created the PR to bring more attention to the ticket, please feel free to share your ideas on the topic!