### PR TITLE
ZOOKEEPER-2847: Cannot bind to client port when reconfig based on old static config

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -698,6 +698,7 @@ public class QuorumPeerConfig {
                         " is different from client address found in dynamic file: " + qs.clientAddr);
         }
         if (qs != null && qs.clientAddr != null) clientPortAddress = qs.clientAddr;
+        if (qs != null && qs.clientAddr == null) qs.clientAddr = clientPortAddress;
     }
 
     private void setupPeerType() {


### PR DESCRIPTION
Fixed the issue where clientPortAddress in the static config is not correctly saved in QuorumVerifier. This can cause zookeeper attempting to re-bind to a port already in use during dynamic reconfiguration, failing to recognize that the new port and the current port are identical.