### PR TITLE
 ZOOKEEPER-236: SSL Support for Atomic Broadcast protocol [part 2]

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -38,8 +38,6 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
 
     <property name="netty.version" value="3.10.6.Final"/>
 
-    <property name="httpcomponents.version" value="4.5.3"/>
-
     <property name="junit.version" value="4.12"/>
     <property name="mockito.version" value="1.8.5"/>
     <property name="checkstyle.version" value="7.1.2"/>

--- a/build.xml
+++ b/build.xml
@@ -38,10 +38,14 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
 
     <property name="netty.version" value="3.10.6.Final"/>
 
+    <property name="httpcomponents.version" value="4.5.3"/>
+
     <property name="junit.version" value="4.12"/>
     <property name="mockito.version" value="1.8.5"/>
-    <property name="checkstyle.version" value="6.13"/>
+    <property name="checkstyle.version" value="7.1.2"/>
     <property name="commons-collections.version" value="3.2.2"/>
+
+    <property name="bouncycastle.version" value="1.56"/>
 
     <property name="jdiff.version" value="1.0.9"/>
     <property name="xerces.version" value="1.4.4"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -63,6 +63,10 @@
       <artifact name="netty" type="jar" conf="default"/>
     </dependency>
 
+    <dependency org="org.apache.httpcomponents" name="httpclient" rev="${httpcomponents.version}">
+      <artifact name="httpclient" type="jar" conf="default" />
+    </dependency>
+
     <dependency org="junit" name="junit" rev="${junit.version}" conf="test->default"/>
 	<dependency org="org.mockito" name="mockito-all" rev="${mockito.version}"
                conf="test->default"/>
@@ -74,6 +78,9 @@
     <!-- force the tests to pull the latest commons-collections jar -->
     <dependency org="commons-collections" name="commons-collections" 
                 rev="${commons-collections.version}" conf="test->default"/>
+
+    <dependency org="org.bouncycastle" name="bcprov-jdk15on" rev="${bouncycastle.version}" conf="test->default"/>
+    <dependency org="org.bouncycastle" name="bcpkix-jdk15on" rev="${bouncycastle.version}" conf="test->default"/>
 
     <dependency org="jdiff" name="jdiff" rev="${jdiff.version}"
                 conf="jdiff->default"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -63,10 +63,6 @@
       <artifact name="netty" type="jar" conf="default"/>
     </dependency>
 
-    <dependency org="org.apache.httpcomponents" name="httpclient" rev="${httpcomponents.version}">
-      <artifact name="httpclient" type="jar" conf="default" />
-    </dependency>
-
     <dependency org="junit" name="junit" rev="${junit.version}" conf="test->default"/>
 	<dependency org="org.mockito" name="mockito-all" rev="${mockito.version}"
                conf="test->default"/>

--- a/src/java/main/org/apache/zookeeper/ClientCnxnSocketNetty.java
+++ b/src/java/main/org/apache/zookeeper/ClientCnxnSocketNetty.java
@@ -21,7 +21,7 @@ package org.apache.zookeeper;
 import org.apache.zookeeper.ClientCnxn.EndOfStreamException;
 import org.apache.zookeeper.ClientCnxn.Packet;
 import org.apache.zookeeper.client.ZKClientConfig;
-import org.apache.zookeeper.common.X509Util;
+import org.apache.zookeeper.common.ClientX509Util;
 import org.jboss.netty.bootstrap.ClientBootstrap;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -370,7 +370,7 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
         // Basically we only need to create it once.
         private synchronized void initSSL(ChannelPipeline pipeline) throws SSLContextException {
             if (sslContext == null || sslEngine == null) {
-                sslContext = X509Util.createSSLContext(clientConfig);
+                sslContext = new ClientX509Util().createSSLContext(clientConfig);
                 sslEngine = sslContext.createSSLEngine(host,port);
                 sslEngine.setUseClientMode(true);
             }

--- a/src/java/main/org/apache/zookeeper/client/FourLetterWordMain.java
+++ b/src/java/main/org/apache/zookeeper/client/FourLetterWordMain.java
@@ -31,9 +31,9 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
+import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.common.X509Exception.SSLContextException;
-import org.apache.zookeeper.common.X509Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,7 +90,7 @@ public class FourLetterWordMain {
             new InetSocketAddress(InetAddress.getByName(null), port);
         if (secure) {
             LOG.info("using secure socket");
-            SSLContext sslContext = X509Util.createSSLContext();
+            SSLContext sslContext = new ClientX509Util().getDefaultSSLContext();
             SSLSocketFactory socketFactory = sslContext.getSocketFactory();
             SSLSocket sslSock = (SSLSocket) socketFactory.createSocket();
             sslSock.connect(hostaddress, timeout);

--- a/src/java/main/org/apache/zookeeper/common/ClientX509Util.java
+++ b/src/java/main/org/apache/zookeeper/common/ClientX509Util.java
@@ -20,7 +20,7 @@ package org.apache.zookeeper.common;
 
 public class ClientX509Util extends X509Util {
 
-    private String sslAuthProviderProperty = getConfigPrefix() + "authProvider";
+    private final String sslAuthProviderProperty = getConfigPrefix() + "authProvider";
 
     @Override
     protected String getConfigPrefix() {

--- a/src/java/main/org/apache/zookeeper/common/ClientX509Util.java
+++ b/src/java/main/org/apache/zookeeper/common/ClientX509Util.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.common;
+
+public class ClientX509Util extends X509Util {
+
+    private String sslAuthProviderProperty = getConfigPrefix() + "authProvider";
+
+    @Override
+    protected String getConfigPrefix() {
+        return "zookeeper.ssl.";
+    }
+
+    @Override
+    protected boolean shouldVerifyClientHostname() {
+        return false;
+    }
+
+    public String getSslAuthProviderProperty() {
+        return sslAuthProviderProperty;
+    }
+}

--- a/src/java/main/org/apache/zookeeper/common/FileChangeWatcher.java
+++ b/src/java/main/org/apache/zookeeper/common/FileChangeWatcher.java
@@ -1,0 +1,162 @@
+package org.apache.zookeeper.common;
+
+import com.sun.nio.file.SensitivityWatchEventModifier;
+import org.apache.zookeeper.server.ZooKeeperThread;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.function.Consumer;
+
+/**
+ * Instances of this class can be used to watch a directory for file changes. When a file is added to, deleted from,
+ * or is modified in the given directory, the callback provided by the user will be called from a background thread.
+ * Some things to keep in mind:
+ * <ul>
+ * <li>The callback should be thread-safe.</li>
+ * <li>Changes that happen around the time the thread is started may be missed.</li>
+ * <li>There is a delay between a file changing and the callback firing.</li>
+ * <li>The watch is not recursive - changes to subdirectories will not trigger a callback.</li>
+ * </ul>
+ */
+public final class FileChangeWatcher {
+    private static final Logger LOG = LoggerFactory.getLogger(FileChangeWatcher.class);
+
+    private final WatcherThread watcherThread;
+
+    /**
+     * Creates a watcher that watches <code>dirPath</code> and invokes <code>callback</code> on changes.
+     *
+     * @param dirPath the directory to watch.
+     * @param callback the callback to invoke with events. <code>event.kind()</code> will return the type of event,
+     *                 and <code>event.context()</code> will return the filename relative to <code>dirPath</code>.
+     * @throws IOException if there is an error creating the WatchService.
+     */
+    public FileChangeWatcher(Path dirPath, Consumer<WatchEvent<?>> callback) throws IOException {
+        FileSystem fs = dirPath.getFileSystem();
+        WatchService watchService = fs.newWatchService();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Registering with watch service: " + dirPath);
+        }
+        dirPath.register(
+                watchService,
+                new WatchEvent.Kind<?>[]{
+                        StandardWatchEventKinds.ENTRY_CREATE,
+                        StandardWatchEventKinds.ENTRY_DELETE,
+                        StandardWatchEventKinds.ENTRY_MODIFY,
+                        StandardWatchEventKinds.OVERFLOW},
+                SensitivityWatchEventModifier.HIGH);
+        this.watcherThread = new WatcherThread(watchService, callback);
+        this.watcherThread.setDaemon(true);
+        this.watcherThread.start();
+    }
+
+    /**
+     * Waits for the background thread to enter the main loop before returning. This method exists mostly to make
+     * the unit tests simpler, which is why it is package private.
+     *
+     * @throws InterruptedException if this thread is interrupted while waiting for the background thread to start.
+     */
+    void waitForBackgroundThreadToStart() throws InterruptedException {
+        synchronized (watcherThread) {
+            while (!watcherThread.started) {
+                watcherThread.wait();
+            }
+        }
+    }
+
+    /**
+     * Tells the background thread to stop. Does not wait for it to exit.
+     */
+    public void stop() {
+        watcherThread.shouldStop = true;
+        watcherThread.interrupt();
+    }
+
+    /**
+     * Tells the background thread to stop and waits for it to exit. Only used by unit tests, which is why it is package
+     * private.
+     */
+    void stopAndJoinBackgroundThread() throws InterruptedException {
+        stop();
+        watcherThread.join();
+    }
+
+    /**
+     * Inner class that implements the watcher thread logic.
+     */
+    private static class WatcherThread extends ZooKeeperThread {
+        private static final String THREAD_NAME = "FileChangeWatcher";
+
+        volatile boolean shouldStop;
+        volatile boolean started;
+        final WatchService watchService;
+        final Consumer<WatchEvent<?>> callback;
+
+        WatcherThread(WatchService watchService, Consumer<WatchEvent<?>> callback) {
+            super(THREAD_NAME);
+            this.shouldStop = this.started = false;
+            this.watchService = watchService;
+            this.callback = callback;
+        }
+
+        @Override
+        public void run() {
+            LOG.info(getName() + " thread started");
+            synchronized (this) {
+                started = true;
+                this.notifyAll();
+            }
+            try {
+                runLoop();
+            } finally {
+                try {
+                    watchService.close();
+                } catch (IOException e) {
+                    LOG.warn("Error closing watch service", e);
+                }
+                LOG.info(getName() + " thread finished");
+            }
+        }
+
+        private void runLoop() {
+            while (!shouldStop) {
+                WatchKey key;
+                try {
+                    key = watchService.take();
+                } catch (InterruptedException|ClosedWatchServiceException e) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(getName() + " was interrupted and is shutting down ...");
+                    }
+                    break;
+                }
+                for (WatchEvent<?> event : key.pollEvents()) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Got file changed event: " + event.kind() + " with context: " + event.context());
+                    }
+                    try {
+                        callback.accept(event);
+                    } catch (Throwable e) {
+                        LOG.error("Error from callback", e);
+                    }
+                }
+                boolean isKeyValid = key.reset();
+                if (!isKeyValid) {
+                    // This is likely a problem, it means that file reloading is broken, probably because the
+                    // directory we are watching was deleted or otherwise became inaccessible (unmounted, permissions
+                    // changed, ???).
+                    // For now, we log an error and exit the watcher thread.
+                    LOG.error("Watch key no longer valid, maybe the directory is inaccessible?");
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/java/main/org/apache/zookeeper/common/QuorumX509Util.java
+++ b/src/java/main/org/apache/zookeeper/common/QuorumX509Util.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.common;
+
+public class QuorumX509Util extends X509Util {
+
+    @Override
+    protected String getConfigPrefix() {
+        return "zookeeper.ssl.quorum.";
+    }
+
+    @Override
+    protected boolean shouldVerifyClientHostname() {
+        return true;
+    }
+}

--- a/src/java/main/org/apache/zookeeper/common/X509Util.java
+++ b/src/java/main/org/apache/zookeeper/common/X509Util.java
@@ -80,6 +80,48 @@ public abstract class X509Util {
             "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
     };
 
+    /**
+     * This enum represents the file type of a KeyStore or TrustStore. Currently, only JKS (java keystore) type is
+     * supported, but PEM support will be added in a future diff.
+     */
+    public enum StoreFileType {
+        JKS(".jks");
+
+        private final String defaultFileExtension;
+
+        StoreFileType(String defaultFileExtension) {
+            this.defaultFileExtension = defaultFileExtension;
+        }
+
+        /**
+         * The property string that specifies that a key store or trust store should use this store file type.
+         */
+        public String getPropertyValue() {
+            return this.name();
+        }
+
+        /**
+         * The file extension that is associated with this file type.
+         */
+        public String getDefaultFileExtension() {
+            return defaultFileExtension;
+        }
+
+        /**
+         * Converts a property value to a StoreFileType enum. If the property value is not set or is empty, returns
+         * null.
+         * @param prop the property value.
+         * @return the StoreFileType.
+         * @throws IllegalArgumentException if the property value is not "JKS", "PEM", or empty/null.
+         */
+        public static StoreFileType fromPropertyValue(String prop) {
+            if (prop == null || prop.length() == 0) {
+                return null;
+            }
+            return StoreFileType.valueOf(prop.toUpperCase());
+        }
+    }
+
     private String sslProtocolProperty = getConfigPrefix() + "protocol";
     private String cipherSuitesProperty = getConfigPrefix() + "ciphersuites";
     private String sslKeystoreLocationProperty = getConfigPrefix() + "keyStore.location";

--- a/src/java/main/org/apache/zookeeper/common/X509Util.java
+++ b/src/java/main/org/apache/zookeeper/common/X509Util.java
@@ -33,6 +33,7 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedTrustManager;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -315,8 +316,15 @@ public abstract class X509Util {
         return sslSocket;
     }
 
-    public SSLSocket createSSLSocket(Socket socket) throws X509Exception, IOException {
-        SSLSocket sslSocket = (SSLSocket) getDefaultSSLContext().getSocketFactory().createSocket(socket, null, socket.getPort(), true);
+    public SSLSocket createSSLSocket(Socket socket, byte[] pushbackBytes) throws X509Exception, IOException {
+        SSLSocket sslSocket = null;
+        if (pushbackBytes != null && pushbackBytes.length > 0) {
+            sslSocket = (SSLSocket) getDefaultSSLContext().getSocketFactory().createSocket(
+                    socket, new ByteArrayInputStream(pushbackBytes), true);
+        } else {
+            sslSocket = (SSLSocket) getDefaultSSLContext().getSocketFactory().createSocket(
+                    socket, null, socket.getPort(), true);
+        }
         configureSSLSocket(sslSocket);
 
         return sslSocket;

--- a/src/java/main/org/apache/zookeeper/common/X509Util.java
+++ b/src/java/main/org/apache/zookeeper/common/X509Util.java
@@ -18,6 +18,10 @@
 package org.apache.zookeeper.common;
 
 
+import org.apache.zookeeper.common.X509Exception.KeyManagerException;
+import org.apache.zookeeper.common.X509Exception.SSLContextException;
+import org.apache.zookeeper.common.X509Exception.TrustManagerException;
+import org.apache.zookeeper.util.PemReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,22 +42,16 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.Socket;
-import java.security.InvalidAlgorithmParameterException;
+import java.security.GeneralSecurityException;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Security;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
 import java.security.cert.PKIXBuilderParameters;
 import java.security.cert.X509CertSelector;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-
-import org.apache.zookeeper.common.X509Exception.KeyManagerException;
-import org.apache.zookeeper.common.X509Exception.SSLContextException;
-import org.apache.zookeeper.common.X509Exception.TrustManagerException;
 
 /**
  * Utility code for X509 handling
@@ -81,11 +79,11 @@ public abstract class X509Util {
     };
 
     /**
-     * This enum represents the file type of a KeyStore or TrustStore. Currently, only JKS (java keystore) type is
-     * supported, but PEM support will be added in a future diff.
+     * This enum represents the file type of a KeyStore or TrustStore. Currently, JKS (java keystore) and PEM types
+     * are supported.
      */
     public enum StoreFileType {
-        JKS(".jks");
+        JKS(".jks"), PEM(".pem");
 
         private final String defaultFileExtension;
 
@@ -126,8 +124,10 @@ public abstract class X509Util {
     private String cipherSuitesProperty = getConfigPrefix() + "ciphersuites";
     private String sslKeystoreLocationProperty = getConfigPrefix() + "keyStore.location";
     private String sslKeystorePasswdProperty = getConfigPrefix() + "keyStore.password";
+    private String sslKeystoreTypeProperty = getConfigPrefix() + "keyStore.type";
     private String sslTruststoreLocationProperty = getConfigPrefix() + "trustStore.location";
     private String sslTruststorePasswdProperty = getConfigPrefix() + "trustStore.password";
+    private String sslTruststoreTypeProperty = getConfigPrefix() + "trustStore.type";
     private String sslHostnameVerificationEnabledProperty = getConfigPrefix() + "hostnameVerification";
     private String sslCrlEnabledProperty = getConfigPrefix() + "crl";
     private String sslOcspEnabledProperty = getConfigPrefix() + "ocsp";
@@ -164,12 +164,20 @@ public abstract class X509Util {
         return sslKeystorePasswdProperty;
     }
 
+    public String getSslKeystoreTypeProperty() {
+        return sslKeystoreTypeProperty;
+    }
+
     public String getSslTruststoreLocationProperty() {
         return sslTruststoreLocationProperty;
     }
 
     public String getSslTruststorePasswdProperty() {
         return sslTruststorePasswdProperty;
+    }
+
+    public String getSslTruststoreTypeProperty() {
+        return sslTruststoreTypeProperty;
     }
 
     public String getSslHostnameVerificationEnabledProperty() {
@@ -212,6 +220,7 @@ public abstract class X509Util {
 
         String keyStoreLocationProp = config.getProperty(sslKeystoreLocationProperty);
         String keyStorePasswordProp = config.getProperty(sslKeystorePasswdProperty);
+        String keyStoreTypeProp = config.getProperty(sslKeystoreTypeProperty);
 
         // There are legal states in some use cases for null KeyManager or TrustManager.
         // But if a user wanna specify one, location and password are required.
@@ -226,15 +235,19 @@ public abstract class X509Util {
                 throw new SSLContextException(getSslKeystorePasswdProperty() + " not specified");
             }
             try {
+                StoreFileType keyStoreType = StoreFileType.fromPropertyValue(keyStoreTypeProp);
                 keyManagers = new KeyManager[]{
-                        createKeyManager(keyStoreLocationProp, keyStorePasswordProp)};
+                        createKeyManager(keyStoreLocationProp, keyStorePasswordProp, keyStoreType)};
             } catch (KeyManagerException keyManagerException) {
                 throw new SSLContextException("Failed to create KeyManager", keyManagerException);
+            } catch (IllegalArgumentException e) {
+                throw new SSLContextException("Bad value for " + sslKeystoreTypeProperty + ": " + keyStoreTypeProp, e);
             }
         }
 
         String trustStoreLocationProp = config.getProperty(sslTruststoreLocationProperty);
         String trustStorePasswordProp = config.getProperty(sslTruststorePasswdProperty);
+        String trustStoreTypeProp = config.getProperty(sslTruststoreTypeProperty);
 
         boolean sslCrlEnabled = config.getBoolean(this.sslCrlEnabledProperty);
         boolean sslOcspEnabled = config.getBoolean(this.sslOcspEnabledProperty);
@@ -245,11 +258,14 @@ public abstract class X509Util {
             LOG.warn(getSslTruststoreLocationProperty() + " not specified");
         } else {
             try {
+                StoreFileType trustStoreType = StoreFileType.fromPropertyValue(trustStoreTypeProp);
                 trustManagers = new TrustManager[]{
-                        createTrustManager(trustStoreLocationProp, trustStorePasswordProp, sslCrlEnabled, sslOcspEnabled,
+                        createTrustManager(trustStoreLocationProp, trustStorePasswordProp, trustStoreType, sslCrlEnabled, sslOcspEnabled,
                                 sslServerHostnameVerificationEnabled, sslClientHostnameVerificationEnabled)};
             } catch (TrustManagerException trustManagerException) {
                 throw new SSLContextException("Failed to create TrustManager", trustManagerException);
+            } catch (IllegalArgumentException e) {
+                throw new SSLContextException("Bad value for " + sslTruststoreTypeProperty + ": " + trustStoreTypeProp, e);
             }
         }
 
@@ -258,20 +274,47 @@ public abstract class X509Util {
             SSLContext sslContext = SSLContext.getInstance(protocol);
             sslContext.init(keyManagers, trustManagers, null);
             return sslContext;
-        } catch (NoSuchAlgorithmException|KeyManagementException sslContextInitException) {
+        } catch (NoSuchAlgorithmException |KeyManagementException sslContextInitException) {
             throw new SSLContextException(sslContextInitException);
         }
     }
 
-    public static X509KeyManager createKeyManager(String keyStoreLocation, String keyStorePassword)
+    /**
+     * Creates a key manager by loading the key store from the given file of the given type, optionally decrypting it
+     * using the given password.
+     * @param keyStoreLocation the location of the key store file.
+     * @param keyStorePassword optional password to decrypt the key store. If empty, assumes the key store is not
+     *                         encrypted.
+     * @param keyStoreType must be JKS, PEM, or null. If null, attempts to autodetect the key store type from the file
+     *                     extension (.jks / .pem).
+     * @return the key manager.
+     * @throws KeyManagerException if something goes wrong.
+     */
+    public static X509KeyManager createKeyManager(String keyStoreLocation, String keyStorePassword, StoreFileType keyStoreType)
             throws KeyManagerException {
         FileInputStream inputStream = null;
         try {
             char[] keyStorePasswordChars = keyStorePassword.toCharArray();
             File keyStoreFile = new File(keyStoreLocation);
-            KeyStore ks = KeyStore.getInstance("JKS");
-            inputStream = new FileInputStream(keyStoreFile);
-            ks.load(inputStream, keyStorePasswordChars);
+            if (keyStoreType == null) {
+                keyStoreType = detectStoreFileTypeFromFileExtension(keyStoreFile);
+            }
+            KeyStore ks;
+            switch (keyStoreType) {
+                case JKS:
+                    ks = KeyStore.getInstance("JKS");
+                    inputStream = new FileInputStream(keyStoreFile);
+                    ks.load(inputStream, keyStorePasswordChars);
+                    break;
+                case PEM:
+                    Optional<String> passwordOption =
+                            keyStorePassword.length() > 0 ? Optional.of(keyStorePassword) : Optional.empty();
+                    ks = PemReader.loadKeyStore(keyStoreFile, keyStoreFile, passwordOption);
+                    break;
+                default:
+                    throw new KeyManagerException("Invalid key store type: " + keyStoreType + ", must be one of: " +
+                            Arrays.toString(StoreFileType.values()));
+            }
             KeyManagerFactory kmf = KeyManagerFactory.getInstance("PKIX");
             kmf.init(ks, keyStorePasswordChars);
 
@@ -281,9 +324,7 @@ public abstract class X509Util {
                 }
             }
             throw new KeyManagerException("Couldn't find X509KeyManager");
-
-        } catch (IOException|CertificateException|UnrecoverableKeyException|NoSuchAlgorithmException|KeyStoreException
-                keyManagerCreationException) {
+        } catch (IOException|GeneralSecurityException keyManagerCreationException) {
             throw new KeyManagerException(keyManagerCreationException);
         } finally {
             if (inputStream != null) {
@@ -296,7 +337,25 @@ public abstract class X509Util {
         }
     }
 
+    /**
+     * Creates a trust manager by loading the trust store from the given file of the given type, optionally decrypting
+     * it using the given password.
+     * @param trustStoreLocation the location of the trust store file.
+     * @param trustStorePassword optional password to decrypt the trust store (only applies to JKS trust stores). If
+     *                           empty, assumes the trust store is not encrypted.
+     * @param trustStoreType must be JKS, PEM, or null. If null, attempts to autodetect the trust store type from the
+     *                       file extension (.jks / .pem).
+     * @param crlEnabled enable CRL (certificate revocation list) checks.
+     * @param ocspEnabled enable OCSP (online certificate status protocol) checks.
+     * @param serverHostnameVerificationEnabled if true, verify hostnames of remote servers that client sockets created
+     *                                          by this X509Util connect to.
+     * @param clientHostnameVerificationEnabled if true, verify hostnames of remote clients that server sockets created
+     *                                          by this X509Util accept connections from.
+     * @return the trust manager.
+     * @throws TrustManagerException if something goes wrong.
+     */
     public static X509TrustManager createTrustManager(String trustStoreLocation, String trustStorePassword,
+                                                      StoreFileType trustStoreType,
                                                       boolean crlEnabled, boolean ocspEnabled,
                                                       final boolean serverHostnameVerificationEnabled,
                                                       final boolean clientHostnameVerificationEnabled)
@@ -304,13 +363,27 @@ public abstract class X509Util {
         FileInputStream inputStream = null;
         try {
             File trustStoreFile = new File(trustStoreLocation);
-            KeyStore ts = KeyStore.getInstance("JKS");
-            inputStream = new FileInputStream(trustStoreFile);
-            if (trustStorePassword != null) {
-                char[] trustStorePasswordChars = trustStorePassword.toCharArray();
-                ts.load(inputStream, trustStorePasswordChars);
-            } else {
-                ts.load(inputStream, null);
+            if (trustStoreType == null) {
+                trustStoreType = detectStoreFileTypeFromFileExtension(trustStoreFile);
+            }
+            KeyStore ts;
+            switch (trustStoreType) {
+                case JKS:
+                    ts = KeyStore.getInstance("JKS");
+                    inputStream = new FileInputStream(trustStoreFile);
+                    if (trustStorePassword != null) {
+                        char[] trustStorePasswordChars = trustStorePassword.toCharArray();
+                        ts.load(inputStream, trustStorePasswordChars);
+                    } else {
+                        ts.load(inputStream, null);
+                    }
+                    break;
+                case PEM:
+                    ts = PemReader.loadTrustStore(trustStoreFile);
+                    break;
+                default:
+                    throw new TrustManagerException("Invalid trust store type: " + trustStoreType + ", must be one of: " +
+                            Arrays.toString(StoreFileType.values()));
             }
 
             PKIXBuilderParameters pbParams = new PKIXBuilderParameters(ts, new X509CertSelector());
@@ -337,8 +410,7 @@ public abstract class X509Util {
                 }
             }
             throw new TrustManagerException("Couldn't find X509TrustManager");
-        } catch (IOException|CertificateException|NoSuchAlgorithmException|InvalidAlgorithmParameterException|KeyStoreException
-                 trustManagerCreationException) {
+        } catch (IOException|GeneralSecurityException trustManagerCreationException) {
             throw new TrustManagerException(trustManagerCreationException);
         } finally {
             if (inputStream != null) {
@@ -414,5 +486,27 @@ public abstract class X509Util {
         }
         LOG.debug("Using Java8-optimized cipher suites for Java version {}", javaVersion);
         return DEFAULT_CIPHERS_JAVA8;
+    }
+
+    /**
+     * Detects the type of KeyStore / TrustStore file from the file extension. If the file name ends with
+     * ".jks", returns <code>StoreFileType.JKS</code>. If the file name ends with ".pem", returns
+     * <code>StoreFileType.PEM</code>. Otherwise, throws an IOException.
+     * @param filename the filename of the key store or trust store file.
+     * @return a StoreFileType.
+     * @throws IOException if the filename does not end with ".jks" or ".pem".
+     */
+    public static StoreFileType detectStoreFileTypeFromFileExtension(File filename) throws IOException {
+        String name = filename.getName();
+        int i = name.lastIndexOf('.');
+        if (i >= 0) {
+            String extension = name.substring(i);
+            for (StoreFileType storeFileType : StoreFileType.values()) {
+                if (storeFileType.getDefaultFileExtension().equals(extension)) {
+                    return storeFileType;
+                }
+            }
+        }
+        throw new IOException("Unable to auto-detect store file type from file name: " + filename);
     }
 }

--- a/src/java/main/org/apache/zookeeper/common/X509Util.java
+++ b/src/java/main/org/apache/zookeeper/common/X509Util.java
@@ -211,7 +211,7 @@ public abstract class X509Util {
             }
         }
 
-        String protocol = System.getProperty(sslProtocolProperty, DEFAULT_PROTOCOL);
+        String protocol = config.getProperty(sslProtocolProperty, DEFAULT_PROTOCOL);
         try {
             SSLContext sslContext = SSLContext.getInstance(protocol);
             sslContext.init(keyManagers, trustManagers, null);

--- a/src/java/main/org/apache/zookeeper/common/X509Util.java
+++ b/src/java/main/org/apache/zookeeper/common/X509Util.java
@@ -69,7 +69,6 @@ public abstract class X509Util {
     private String sslTruststoreLocationProperty = getConfigPrefix() + "trustStore.location";
     private String sslTruststorePasswdProperty = getConfigPrefix() + "trustStore.password";
     private String sslHostnameVerificationEnabledProperty = getConfigPrefix() + "hostnameVerification";
-    private String sslClientHostnameVerificationEnabledProperty = getConfigPrefix() + "clientHostnameVerification";
     private String sslCrlEnabledProperty = getConfigPrefix() + "crl";
     private String sslOcspEnabledProperty = getConfigPrefix() + "ocsp";
 
@@ -115,10 +114,6 @@ public abstract class X509Util {
 
     public String getSslHostnameVerificationEnabledProperty() {
         return sslHostnameVerificationEnabledProperty;
-    }
-
-    public String getSslClientHostnameVerificationEnabledProperty() {
-        return sslClientHostnameVerificationEnabledProperty;
     }
 
     public String getSslCrlEnabledProperty() {
@@ -184,8 +179,7 @@ public abstract class X509Util {
         boolean sslCrlEnabled = config.getBoolean(this.sslCrlEnabledProperty);
         boolean sslOcspEnabled = config.getBoolean(this.sslOcspEnabledProperty);
         boolean sslServerHostnameVerificationEnabled = config.getBoolean(this.getSslHostnameVerificationEnabledProperty(), true);
-        boolean sslClientHostnameVerificationEnabled =
-                config.getBoolean(this.getSslClientHostnameVerificationEnabledProperty(), shouldVerifyClientHostname());
+        boolean sslClientHostnameVerificationEnabled = sslServerHostnameVerificationEnabled && shouldVerifyClientHostname();
 
         if (trustStoreLocationProp == null) {
             LOG.warn(getSslTruststoreLocationProperty() + " not specified");

--- a/src/java/main/org/apache/zookeeper/common/X509Util.java
+++ b/src/java/main/org/apache/zookeeper/common/X509Util.java
@@ -59,7 +59,7 @@ import org.apache.zookeeper.common.X509Exception.TrustManagerException;
 public abstract class X509Util {
     private static final Logger LOG = LoggerFactory.getLogger(X509Util.class);
 
-    static final String DEFAULT_PROTOCOL = "TLSv1";
+    static final String DEFAULT_PROTOCOL = "TLSv1.2";
 
     private String sslProtocolProperty = getConfigPrefix() + "protocol";
     private String cipherSuitesProperty = getConfigPrefix() + "ciphersuites";

--- a/src/java/main/org/apache/zookeeper/common/X509Util.java
+++ b/src/java/main/org/apache/zookeeper/common/X509Util.java
@@ -47,6 +47,7 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.PKIXBuilderParameters;
 import java.security.cert.X509CertSelector;
+import java.util.Arrays;
 
 import org.apache.zookeeper.common.X509Exception.KeyManagerException;
 import org.apache.zookeeper.common.X509Exception.SSLContextException;
@@ -298,6 +299,7 @@ public abstract class X509Util {
     private void configureSSLSocket(SSLSocket sslSocket) {
         if (cipherSuites != null) {
             SSLParameters sslParameters = sslSocket.getSSLParameters();
+            LOG.debug("Setup cipher suites for client socket: {}", Arrays.toString(cipherSuites));
             sslParameters.setCipherSuites(cipherSuites);
             sslSocket.setSSLParameters(sslParameters);
         }
@@ -322,6 +324,7 @@ public abstract class X509Util {
         SSLParameters sslParameters = sslServerSocket.getSSLParameters();
         sslParameters.setNeedClientAuth(true);
         if (cipherSuites != null) {
+            LOG.debug("Setup cipher suites for server socket: {}", Arrays.toString(cipherSuites));
             sslParameters.setCipherSuites(cipherSuites);
         }
 

--- a/src/java/main/org/apache/zookeeper/common/X509Util.java
+++ b/src/java/main/org/apache/zookeeper/common/X509Util.java
@@ -56,6 +56,11 @@ import org.apache.zookeeper.common.X509Exception.TrustManagerException;
 
 /**
  * Utility code for X509 handling
+ *
+ * Default cipher suites:
+ *
+ *   Performance testing done by Facebook engineers shows that on Intel x86_64 machines, Java9 performs better with
+ *   GCM and Java8 performs better with CBC, so these seem like reasonable defaults.
  */
 public abstract class X509Util {
     private static final Logger LOG = LoggerFactory.getLogger(X509Util.class);
@@ -326,7 +331,6 @@ public abstract class X509Util {
         }
     }
 
-
     public SSLServerSocket createSSLServerSocket() throws X509Exception, IOException {
         SSLServerSocket sslServerSocket = (SSLServerSocket) getDefaultSSLContext().getServerSocketFactory().createServerSocket();
         configureSSLServerSocket(sslServerSocket);
@@ -353,14 +357,8 @@ public abstract class X509Util {
     }
 
     private String[] getDefaultCipherSuites() {
-        String javaVersion = System.getProperty("java.version");
-        String[] versionParts = javaVersion.split("\\.");
-        if (versionParts.length == 0) {
-            LOG.warn("Unable to parse Java version properly. Using Java8-optimized cipher suites for Java version {}", javaVersion);
-            return DEFAULT_CIPHERS_JAVA8;
-        }
-        int majorVersion = Integer.parseInt(versionParts[0]);
-        if (majorVersion >= 9) {
+        String javaVersion = System.getProperty("java.specification.version");
+        if ("9".equals(javaVersion)) {
             LOG.debug("Using Java9-optimized cipher suites for Java version {}", javaVersion);
             return DEFAULT_CIPHERS_JAVA9;
         }

--- a/src/java/main/org/apache/zookeeper/common/ZKConfig.java
+++ b/src/java/main/org/apache/zookeeper/common/ZKConfig.java
@@ -112,6 +112,8 @@ public class ZKConfig {
     }
     
     private void putSSLProperties(X509Util x509Util) {
+        properties.put(x509Util.getSslProtocolProperty(),
+                System.getProperty(x509Util.getSslProtocolProperty()));
         properties.put(x509Util.getSslKeystoreLocationProperty(),
                 System.getProperty(x509Util.getSslKeystoreLocationProperty()));
         properties.put(x509Util.getSslKeystorePasswdProperty(),

--- a/src/java/main/org/apache/zookeeper/common/ZKConfig.java
+++ b/src/java/main/org/apache/zookeeper/common/ZKConfig.java
@@ -114,6 +114,10 @@ public class ZKConfig {
     private void putSSLProperties(X509Util x509Util) {
         properties.put(x509Util.getSslProtocolProperty(),
                 System.getProperty(x509Util.getSslProtocolProperty()));
+        properties.put(x509Util.getSslEnabledProtocolsProperty(),
+                System.getProperty(x509Util.getSslEnabledProtocolsProperty()));
+        properties.put(x509Util.getSslCipherSuitesProperty(),
+                System.getProperty(x509Util.getSslCipherSuitesProperty()));
         properties.put(x509Util.getSslKeystoreLocationProperty(),
                 System.getProperty(x509Util.getSslKeystoreLocationProperty()));
         properties.put(x509Util.getSslKeystorePasswdProperty(),
@@ -132,6 +136,8 @@ public class ZKConfig {
                 System.getProperty(x509Util.getSslCrlEnabledProperty()));
         properties.put(x509Util.getSslOcspEnabledProperty(),
                 System.getProperty(x509Util.getSslOcspEnabledProperty()));
+        properties.put(x509Util.getSslClientAuthProperty(),
+                System.getProperty(x509Util.getSslClientAuthProperty()));
     }
 
     /**

--- a/src/java/main/org/apache/zookeeper/common/ZKConfig.java
+++ b/src/java/main/org/apache/zookeeper/common/ZKConfig.java
@@ -138,6 +138,8 @@ public class ZKConfig {
                 System.getProperty(x509Util.getSslOcspEnabledProperty()));
         properties.put(x509Util.getSslClientAuthProperty(),
                 System.getProperty(x509Util.getSslClientAuthProperty()));
+        properties.put(x509Util.getSslHandshakeDetectionTimeoutMillisProperty(),
+                System.getProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty()));
     }
 
     /**

--- a/src/java/main/org/apache/zookeeper/common/ZKConfig.java
+++ b/src/java/main/org/apache/zookeeper/common/ZKConfig.java
@@ -118,10 +118,14 @@ public class ZKConfig {
                 System.getProperty(x509Util.getSslKeystoreLocationProperty()));
         properties.put(x509Util.getSslKeystorePasswdProperty(),
                 System.getProperty(x509Util.getSslKeystorePasswdProperty()));
+        properties.put(x509Util.getSslKeystoreTypeProperty(),
+                System.getProperty(x509Util.getSslKeystoreTypeProperty()));
         properties.put(x509Util.getSslTruststoreLocationProperty(),
                 System.getProperty(x509Util.getSslTruststoreLocationProperty()));
         properties.put(x509Util.getSslTruststorePasswdProperty(),
                 System.getProperty(x509Util.getSslTruststorePasswdProperty()));
+        properties.put(x509Util.getSslTruststoreTypeProperty(),
+                System.getProperty(x509Util.getSslTruststoreTypeProperty()));
         properties.put(x509Util.getSslHostnameVerificationEnabledProperty(),
                 System.getProperty(x509Util.getSslHostnameVerificationEnabledProperty()));
         properties.put(x509Util.getSslCrlEnabledProperty(),

--- a/src/java/main/org/apache/zookeeper/common/ZKConfig.java
+++ b/src/java/main/org/apache/zookeeper/common/ZKConfig.java
@@ -122,6 +122,8 @@ public class ZKConfig {
                 System.getProperty(x509Util.getSslTruststorePasswdProperty()));
         properties.put(x509Util.getSslHostnameVerificationEnabledProperty(),
                 System.getProperty(x509Util.getSslHostnameVerificationEnabledProperty()));
+        properties.put(x509Util.getSslClientHostnameVerificationEnabledProperty(),
+                System.getProperty(x509Util.getSslClientHostnameVerificationEnabledProperty()));
         properties.put(x509Util.getSslCrlEnabledProperty(),
                 System.getProperty(x509Util.getSslCrlEnabledProperty()));
         properties.put(x509Util.getSslOcspEnabledProperty(),

--- a/src/java/main/org/apache/zookeeper/common/ZKConfig.java
+++ b/src/java/main/org/apache/zookeeper/common/ZKConfig.java
@@ -122,8 +122,6 @@ public class ZKConfig {
                 System.getProperty(x509Util.getSslTruststorePasswdProperty()));
         properties.put(x509Util.getSslHostnameVerificationEnabledProperty(),
                 System.getProperty(x509Util.getSslHostnameVerificationEnabledProperty()));
-        properties.put(x509Util.getSslClientHostnameVerificationEnabledProperty(),
-                System.getProperty(x509Util.getSslClientHostnameVerificationEnabledProperty()));
         properties.put(x509Util.getSslCrlEnabledProperty(),
                 System.getProperty(x509Util.getSslCrlEnabledProperty()));
         properties.put(x509Util.getSslOcspEnabledProperty(),

--- a/src/java/main/org/apache/zookeeper/common/ZKTrustManager.java
+++ b/src/java/main/org/apache/zookeeper/common/ZKTrustManager.java
@@ -17,18 +17,37 @@
  */
 package org.apache.zookeeper.common;
 
-import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.naming.InvalidNameException;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.X509ExtendedTrustManager;
+import javax.security.auth.x500.X500Principal;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * A custom TrustManager that supports hostname verification via org.apache.http.conn.ssl.DefaultHostnameVerifier.
@@ -44,7 +63,7 @@ public class ZKTrustManager extends X509ExtendedTrustManager {
     private boolean serverHostnameVerificationEnabled;
     private boolean clientHostnameVerificationEnabled;
 
-    private DefaultHostnameVerifier hostnameVerifier;
+    private ZKHostnameVerifier hostnameVerifier;
 
     /**
      * Instantiate a new ZKTrustManager.
@@ -63,7 +82,7 @@ public class ZKTrustManager extends X509ExtendedTrustManager {
         this.x509ExtendedTrustManager = x509ExtendedTrustManager;
         this.serverHostnameVerificationEnabled = serverHostnameVerificationEnabled;
         this.clientHostnameVerificationEnabled = clientHostnameVerificationEnabled;
-        hostnameVerifier = new DefaultHostnameVerifier();
+        hostnameVerifier = new ZKHostnameVerifier();
     }
 
     @Override
@@ -145,6 +164,323 @@ public class ZKTrustManager extends X509ExtendedTrustManager {
                 LOG.error("Failed to verify host address: " + hostAddress, addressVerificationException);
                 LOG.error("Failed to verify hostname: " + hostName, hostnameVerificationException);
                 throw new CertificateException("Failed to verify both host address and host name", hostnameVerificationException);
+            }
+        }
+    }
+
+    /**
+     * Note: copied from Apache httpclient with some minor modifications. We want host verification, but depending
+     * on the httpclient jar caused unexplained performance regressions (even when the code was not used).
+     */
+    private static final class SubjectName {
+        static final int DNS = 2;
+        static final int IP = 7;
+
+        private final String value;
+        private final int type;
+
+        static SubjectName IP(final String value) {
+            return new SubjectName(value, IP);
+        }
+
+        static SubjectName DNS(final String value) {
+            return new SubjectName(value, DNS);
+        }
+
+        SubjectName(final String value, final int type) {
+            if (type != DNS && type != IP) {
+                throw new IllegalArgumentException("Invalid type: " + type);
+            }
+            this.value = Objects.requireNonNull(value);
+            this.type = type;
+        }
+
+        public int getType() {
+            return type;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
+    /**
+     * Note: copied from Apache httpclient. We want host verification, but depending on the
+     * httpclient jar caused unexplained performance regressions (even when the code was not used).
+     */
+    private static class InetAddressUtils {
+        private InetAddressUtils() {}
+
+        private static final Pattern IPV4_PATTERN = Pattern.compile(
+                "^(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}$");
+
+        private static final Pattern IPV6_STD_PATTERN = Pattern.compile(
+                "^(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$");
+
+        private static final Pattern IPV6_HEX_COMPRESSED_PATTERN = Pattern.compile(
+                "^((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)::((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)$");
+
+        public static boolean isIPv4Address(final String input) {
+            return IPV4_PATTERN.matcher(input).matches();
+        }
+
+        public static boolean isIPv6StdAddress(final String input) {
+            return IPV6_STD_PATTERN.matcher(input).matches();
+        }
+
+        public static boolean isIPv6HexCompressedAddress(final String input) {
+            return IPV6_HEX_COMPRESSED_PATTERN.matcher(input).matches();
+        }
+
+        public static boolean isIPv6Address(final String input) {
+            return isIPv6StdAddress(input) || isIPv6HexCompressedAddress(input);
+        }
+    }
+
+    /**
+     * Note: copied from Apache httpclient with some modifications. We want host verification, but depending
+     * on the httpclient jar caused unexplained performance regressions (even when the code was not used).
+     */
+    private static final class ZKHostnameVerifier implements HostnameVerifier {
+
+        enum HostNameType {
+
+            IPv4(7), IPv6(7), DNS(2);
+
+            final int subjectType;
+
+            HostNameType(final int subjectType) {
+                this.subjectType = subjectType;
+            }
+
+        }
+
+        private final Logger log = LoggerFactory.getLogger(ZKHostnameVerifier.class);
+
+        public ZKHostnameVerifier() {}
+
+        @Override
+        public boolean verify(final String host, final SSLSession session) {
+            try {
+                final Certificate[] certs = session.getPeerCertificates();
+                final X509Certificate x509 = (X509Certificate) certs[0];
+                verify(host, x509);
+                return true;
+            } catch (final SSLException ex) {
+                if (log.isDebugEnabled()) {
+                    log.debug(ex.getMessage(), ex);
+                }
+                return false;
+            }
+        }
+
+        public void verify(
+                final String host, final X509Certificate cert) throws SSLException {
+            final HostNameType hostType = determineHostFormat(host);
+            final List<SubjectName> subjectAlts = getSubjectAltNames(cert);
+            if (subjectAlts != null && !subjectAlts.isEmpty()) {
+                switch (hostType) {
+                    case IPv4:
+                        matchIPAddress(host, subjectAlts);
+                        break;
+                    case IPv6:
+                        matchIPv6Address(host, subjectAlts);
+                        break;
+                    default:
+                        matchDNSName(host, subjectAlts);
+                }
+            } else {
+                // CN matching has been deprecated by rfc2818 and can be used
+                // as fallback only when no subjectAlts are available
+                final X500Principal subjectPrincipal = cert.getSubjectX500Principal();
+                final String cn = extractCN(subjectPrincipal.getName(X500Principal.RFC2253));
+                if (cn == null) {
+                    throw new SSLException("Certificate subject for <" + host + "> doesn't contain " +
+                            "a common name and does not have alternative names");
+                }
+                matchCN(host, cn);
+            }
+        }
+
+        static void matchIPAddress(final String host, final List<SubjectName> subjectAlts) throws SSLException {
+            for (int i = 0; i < subjectAlts.size(); i++) {
+                final SubjectName subjectAlt = subjectAlts.get(i);
+                if (subjectAlt.getType() == SubjectName.IP) {
+                    if (host.equals(subjectAlt.getValue())) {
+                        return;
+                    }
+                }
+            }
+            throw new SSLPeerUnverifiedException("Certificate for <" + host + "> doesn't match any " +
+                    "of the subject alternative names: " + subjectAlts);
+        }
+
+        static void matchIPv6Address(final String host, final List<SubjectName> subjectAlts) throws SSLException {
+            final String normalisedHost = normaliseAddress(host);
+            for (int i = 0; i < subjectAlts.size(); i++) {
+                final SubjectName subjectAlt = subjectAlts.get(i);
+                if (subjectAlt.getType() == SubjectName.IP) {
+                    final String normalizedSubjectAlt = normaliseAddress(subjectAlt.getValue());
+                    if (normalisedHost.equals(normalizedSubjectAlt)) {
+                        return;
+                    }
+                }
+            }
+            throw new SSLPeerUnverifiedException("Certificate for <" + host + "> doesn't match any " +
+                    "of the subject alternative names: " + subjectAlts);
+        }
+
+        static void matchDNSName(final String host, final List<SubjectName> subjectAlts) throws SSLException {
+            final String normalizedHost = host.toLowerCase(Locale.ROOT);
+            for (int i = 0; i < subjectAlts.size(); i++) {
+                final SubjectName subjectAlt = subjectAlts.get(i);
+                if (subjectAlt.getType() == SubjectName.DNS) {
+                    final String normalizedSubjectAlt = subjectAlt.getValue().toLowerCase(Locale.ROOT);
+                    if (matchIdentityStrict(normalizedHost, normalizedSubjectAlt)) {
+                        return;
+                    }
+                }
+            }
+            throw new SSLPeerUnverifiedException("Certificate for <" + host + "> doesn't match any " +
+                    "of the subject alternative names: " + subjectAlts);
+        }
+
+        static void matchCN(final String host, final String cn) throws SSLException {
+            final String normalizedHost = host.toLowerCase(Locale.ROOT);
+            final String normalizedCn = cn.toLowerCase(Locale.ROOT);
+            if (!matchIdentityStrict(normalizedHost, normalizedCn)) {
+                throw new SSLPeerUnverifiedException("Certificate for <" + host + "> doesn't match " +
+                        "common name of the certificate subject: " + cn);
+            }
+        }
+
+        static boolean matchDomainRoot(final String host, final String domainRoot) {
+            if (domainRoot == null) {
+                return false;
+            }
+            return host.endsWith(domainRoot) && (host.length() == domainRoot.length()
+                    || host.charAt(host.length() - domainRoot.length() - 1) == '.');
+        }
+
+        private static boolean matchIdentity(final String host, final String identity,
+                                             final boolean strict) {
+            // RFC 2818, 3.1. Server Identity
+            // "...Names may contain the wildcard
+            // character * which is considered to match any single domain name
+            // component or component fragment..."
+            // Based on this statement presuming only singular wildcard is legal
+            final int asteriskIdx = identity.indexOf('*');
+            if (asteriskIdx != -1) {
+                final String prefix = identity.substring(0, asteriskIdx);
+                final String suffix = identity.substring(asteriskIdx + 1);
+                if (!prefix.isEmpty() && !host.startsWith(prefix)) {
+                    return false;
+                }
+                if (!suffix.isEmpty() && !host.endsWith(suffix)) {
+                    return false;
+                }
+                // Additional sanity checks on content selected by wildcard can be done here
+                if (strict) {
+                    final String remainder = host.substring(
+                            prefix.length(), host.length() - suffix.length());
+                    if (remainder.contains(".")) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return host.equalsIgnoreCase(identity);
+        }
+
+        static boolean matchIdentity(final String host, final String identity) {
+            return matchIdentity(host, identity, false);
+        }
+
+        static boolean matchIdentityStrict(final String host, final String identity) {
+            return matchIdentity(host, identity, true);
+        }
+
+        static String extractCN(final String subjectPrincipal) throws SSLException {
+            if (subjectPrincipal == null) {
+                return null;
+            }
+            try {
+                final LdapName subjectDN = new LdapName(subjectPrincipal);
+                final List<Rdn> rdns = subjectDN.getRdns();
+                for (int i = rdns.size() - 1; i >= 0; i--) {
+                    final Rdn rds = rdns.get(i);
+                    final Attributes attributes = rds.toAttributes();
+                    final Attribute cn = attributes.get("cn");
+                    if (cn != null) {
+                        try {
+                            final Object value = cn.get();
+                            if (value != null) {
+                                return value.toString();
+                            }
+                        } catch (final NoSuchElementException ignore) {
+                            // ignore exception
+                        } catch (final NamingException ignore) {
+                            // ignore exception
+                        }
+                    }
+                }
+                return null;
+            } catch (final InvalidNameException e) {
+                throw new SSLException(subjectPrincipal + " is not a valid X500 distinguished name");
+            }
+        }
+
+        static HostNameType determineHostFormat(final String host) {
+            if (InetAddressUtils.isIPv4Address(host)) {
+                return HostNameType.IPv4;
+            }
+            String s = host;
+            if (s.startsWith("[") && s.endsWith("]")) {
+                s = host.substring(1, host.length() - 1);
+            }
+            if (InetAddressUtils.isIPv6Address(s)) {
+                return HostNameType.IPv6;
+            }
+            return HostNameType.DNS;
+        }
+
+        static List<SubjectName> getSubjectAltNames(final X509Certificate cert) {
+            try {
+                final Collection<List<?>> entries = cert.getSubjectAlternativeNames();
+                if (entries == null) {
+                    return Collections.emptyList();
+                }
+                final List<SubjectName> result = new ArrayList<SubjectName>();
+                for (List<?> entry: entries) {
+                    final Integer type = entry.size() >= 2 ? (Integer) entry.get(0) : null;
+                    if (type != null) {
+                        final String s = (String) entry.get(1);
+                        result.add(new SubjectName(s, type));
+                    }
+                }
+                return result;
+            } catch (final CertificateParsingException ignore) {
+                return Collections.emptyList();
+            }
+        }
+
+        /*
+         * Normalize IPv6 or DNS name.
+         */
+        static String normaliseAddress(final String hostname) {
+            if (hostname == null) {
+                return hostname;
+            }
+            try {
+                final InetAddress inetAddress = InetAddress.getByName(hostname);
+                return inetAddress.getHostAddress();
+            } catch (final UnknownHostException unexpected) { // Should not happen, because we check for IPv6 address above
+                return hostname;
             }
         }
     }

--- a/src/java/main/org/apache/zookeeper/common/ZKTrustManager.java
+++ b/src/java/main/org/apache/zookeeper/common/ZKTrustManager.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.common;
+
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.X509ExtendedTrustManager;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+/**
+ * A custom TrustManager that supports hostname verification via org.apache.http.conn.ssl.DefaultHostnameVerifier.
+ *
+ * We attempt to perform verification using just the IP address first and if that fails will attempt to perform a
+ * reverse DNS lookup and verify using the hostname.
+ */
+public class ZKTrustManager extends X509ExtendedTrustManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ZKTrustManager.class);
+
+    private X509ExtendedTrustManager x509ExtendedTrustManager;
+    private boolean hostnameVerificationEnabled;
+    private boolean shouldVerifyClientHostname;
+
+    private DefaultHostnameVerifier hostnameVerifier;
+
+    /**
+     * Instantiate a new ZKTrustManager.
+     *
+     * @param x509ExtendedTrustManager The trustmanager to use for checkClientTrusted/checkServerTrusted logic
+     * @param verifySSLServerHostname  If true, this TrustManager should verify hostnames of servers that this
+     *                                 instance connects to.
+     * @param verifySSLClientHostname  If true, and verifySSLServerHostname is true, the hostname of a client
+     *                                 connecting to this machine will be verified in addition to the servers that this
+     *                                 instance connects to. If false, and verifySSLServerHostname is true, only
+     *                                 the hostnames of servers that this instance connects to will be verified. If
+     *                                 verifySSLServerHostname is false, this argument is ignored.
+     */
+    public ZKTrustManager(X509ExtendedTrustManager x509ExtendedTrustManager, boolean verifySSLServerHostname,
+                          boolean verifySSLClientHostname) {
+        this.x509ExtendedTrustManager = x509ExtendedTrustManager;
+        this.hostnameVerificationEnabled = verifySSLServerHostname;
+        this.shouldVerifyClientHostname = verifySSLClientHostname;
+
+        hostnameVerifier = new DefaultHostnameVerifier();
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return x509ExtendedTrustManager.getAcceptedIssuers();
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
+        if (hostnameVerificationEnabled && shouldVerifyClientHostname) {
+            performHostVerification(socket.getInetAddress(), chain[0]);
+        }
+        x509ExtendedTrustManager.checkClientTrusted(chain, authType, socket);
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
+        if (hostnameVerificationEnabled) {
+            performHostVerification(socket.getInetAddress(), chain[0]);
+        }
+        x509ExtendedTrustManager.checkServerTrusted(chain, authType, socket);
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
+        if (hostnameVerificationEnabled && shouldVerifyClientHostname) {
+            try {
+                performHostVerification(InetAddress.getByName(engine.getPeerHost()), chain[0]);
+            } catch (UnknownHostException e) {
+                throw new CertificateException("failed to verify host", e);
+            }
+        }
+        x509ExtendedTrustManager.checkServerTrusted(chain, authType, engine);
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
+        if (hostnameVerificationEnabled) {
+            try {
+                performHostVerification(InetAddress.getByName(engine.getPeerHost()), chain[0]);
+            } catch (UnknownHostException e) {
+                throw new CertificateException("failed to verify host", e);
+            }
+        }
+        x509ExtendedTrustManager.checkServerTrusted(chain, authType, engine);
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        x509ExtendedTrustManager.checkClientTrusted(chain, authType);
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        x509ExtendedTrustManager.checkServerTrusted(chain, authType);
+    }
+
+    private void performHostVerification(InetAddress inetAddress, X509Certificate certificate) throws CertificateException {
+        String hostAddress = "";
+        String hostName = "";
+        try {
+            hostAddress = inetAddress.getHostAddress();
+            hostnameVerifier.verify(hostAddress, certificate);
+        } catch (SSLException addressVerificationException) {
+            try {
+                LOG.debug("Failed to verify host address: " + hostAddress +
+                        ", attempting to verify host name with reverse dns lookup", addressVerificationException);
+                hostName = inetAddress.getHostName();
+                hostnameVerifier.verify(hostName, certificate);
+            } catch (SSLException hostnameVerificationException) {
+                LOG.error("Failed to verify host address: " + hostAddress, addressVerificationException);
+                LOG.error("Failed to verify hostname: " + hostName, hostnameVerificationException);
+                throw new CertificateException("Failed to verify both host address and host name", hostnameVerificationException);
+            }
+        }
+    }
+}

--- a/src/java/main/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/src/java/main/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -18,31 +18,10 @@
 
 package org.apache.zookeeper.server;
 
-import static org.jboss.netty.buffer.ChannelBuffers.dynamicBuffer;
-
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Executors;
-
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.X509KeyManager;
-import javax.net.ssl.X509TrustManager;
-
 import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.common.ZKConfig;
+import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.common.X509Exception.SSLContextException;
-import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.server.auth.ProviderRegistry;
 import org.apache.zookeeper.server.auth.X509AuthenticationProvider;
 import org.jboss.netty.bootstrap.ServerBootstrap;
@@ -68,6 +47,25 @@ import org.jboss.netty.handler.ssl.SslHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+
+import static org.jboss.netty.buffer.ChannelBuffers.dynamicBuffer;
+
 public class NettyServerCnxnFactory extends ServerCnxnFactory {
     private static final Logger LOG = LoggerFactory.getLogger(NettyServerCnxnFactory.class);
 
@@ -78,6 +76,7 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
         new HashMap<InetAddress, Set<NettyServerCnxn>>( );
     InetSocketAddress localAddress;
     int maxClientCnxns = 60;
+    ClientX509Util x509Util;
 
     /**
      * This is an inner class since we need to extend SimpleChannelHandler, but
@@ -292,7 +291,7 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
                     cnxn.setClientCertificateChain(session.getPeerCertificates());
 
                     String authProviderProp
-                            = System.getProperty(ZKConfig.SSL_AUTHPROVIDER, "x509");
+                            = System.getProperty(x509Util.getSslAuthProviderProperty(), "x509");
 
                     X509AuthenticationProvider authProvider =
                             (X509AuthenticationProvider)
@@ -348,20 +347,20 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
                 return p;
             }
         });
+        x509Util = new ClientX509Util();
     }
 
     private synchronized void initSSL(ChannelPipeline p)
             throws X509Exception, KeyManagementException, NoSuchAlgorithmException {
-        String authProviderProp = System.getProperty(ZKConfig.SSL_AUTHPROVIDER);
+        String authProviderProp = System.getProperty(x509Util.getSslAuthProviderProperty());
         SSLContext sslContext;
         if (authProviderProp == null) {
-            sslContext = X509Util.createSSLContext();
+            sslContext = x509Util.getDefaultSSLContext();
         } else {
             sslContext = SSLContext.getInstance("TLSv1");
             X509AuthenticationProvider authProvider =
                     (X509AuthenticationProvider)ProviderRegistry.getProvider(
-                            System.getProperty(ZKConfig.SSL_AUTHPROVIDER,
-                                    "x509"));
+                            System.getProperty(x509Util.getSslAuthProviderProperty(), "x509"));
 
             if (authProvider == null)
             {

--- a/src/java/main/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -109,7 +109,8 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
             }
             try {
                 tm = X509Util.createTrustManager(
-                        trustStoreLocation, trustStorePassword, crlEnabled, ocspEnabled, hostnameVerificationEnabled, false);
+                        trustStoreLocation, trustStorePassword, crlEnabled, ocspEnabled,
+                        hostnameVerificationEnabled, false);
             } catch (TrustManagerException e) {
                 LOG.error("Failed to create trust manager", e);
             }

--- a/src/java/main/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/src/java/main/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -70,25 +70,20 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
         ZKConfig config = new ZKConfig();
         X509Util x509Util = new ClientX509Util();
 
-        String keyStoreLocation = config.getProperty(x509Util.getSslKeystoreLocationProperty());
-        String keyStorePassword = config.getProperty(x509Util.getSslKeystorePasswdProperty());
+        String keyStoreLocation = config.getProperty(x509Util.getSslKeystoreLocationProperty(), "");
+        String keyStorePassword = config.getProperty(x509Util.getSslKeystorePasswdProperty(), "");
         String keyStoreTypeProp = config.getProperty(x509Util.getSslKeystoreTypeProperty());
 
-        boolean crlEnabled = Boolean.parseBoolean(System.getProperty(x509Util.getSslCrlEnabledProperty()));
-        boolean ocspEnabled = Boolean.parseBoolean(System.getProperty(x509Util.getSslOcspEnabledProperty()));
-        boolean hostnameVerificationEnabled = Boolean.parseBoolean(System.getProperty(x509Util.getSslHostnameVerificationEnabledProperty()));
+        boolean crlEnabled = Boolean.parseBoolean(config.getProperty(x509Util.getSslCrlEnabledProperty()));
+        boolean ocspEnabled = Boolean.parseBoolean(config.getProperty(x509Util.getSslOcspEnabledProperty()));
+        boolean hostnameVerificationEnabled = Boolean.parseBoolean(
+                config.getProperty(x509Util.getSslHostnameVerificationEnabledProperty()));
 
         X509KeyManager km = null;
         X509TrustManager tm = null;
-        if (keyStoreLocation == null && keyStorePassword == null) {
+        if (keyStoreLocation.isEmpty()) {
             LOG.warn("keystore not specified for client connection");
         } else {
-            if (keyStoreLocation == null) {
-                throw new X509Exception("keystore location not specified for client connection");
-            }
-            if (keyStorePassword == null) {
-                throw new X509Exception("keystore password not specified for client connection");
-            }
             X509Util.StoreFileType keyStoreType;
             try {
                 keyStoreType = X509Util.StoreFileType.fromPropertyValue(keyStoreTypeProp);
@@ -103,19 +98,13 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
             }
         }
         
-        String trustStoreLocation = config.getProperty(x509Util.getSslTruststoreLocationProperty());
-        String trustStorePassword = config.getProperty(x509Util.getSslTruststorePasswdProperty());
+        String trustStoreLocation = config.getProperty(x509Util.getSslTruststoreLocationProperty(), "");
+        String trustStorePassword = config.getProperty(x509Util.getSslTruststorePasswdProperty(), "");
         String trustStoreTypeProp = config.getProperty(x509Util.getSslTruststoreTypeProperty());
 
-        if (trustStoreLocation == null && trustStorePassword == null) {
+        if (trustStoreLocation.isEmpty()) {
             LOG.warn("Truststore not specified for client connection");
         } else {
-            if (trustStoreLocation == null) {
-                throw new X509Exception("Truststore location not specified for client connection");
-            }
-            if (trustStorePassword == null) {
-                throw new X509Exception("Truststore password not specified for client connection");
-            }
             X509Util.StoreFileType trustStoreType;
             try {
                 trustStoreType = X509Util.StoreFileType.fromPropertyValue(trustStoreTypeProp);

--- a/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
@@ -231,19 +231,17 @@ public class Leader {
         this.self = self;
         this.proposalStats = new BufferStats();
         try {
-            if (self.isSslQuorum()) {
-                if (self.shouldUsePortUnification()) {
-                    if (self.getQuorumListenOnAllIPs()) {
-                        ss = new UnifiedServerSocket(new QuorumX509Util(), self.getQuorumAddress().getPort());
-                    } else {
-                        ss = new UnifiedServerSocket(new QuorumX509Util());
-                    }
+            if (self.shouldUsePortUnification()) {
+                if (self.getQuorumListenOnAllIPs()) {
+                    ss = new UnifiedServerSocket(new QuorumX509Util(), self.getQuorumAddress().getPort());
                 } else {
-                    if (self.getQuorumListenOnAllIPs()) {
-                        ss = new QuorumX509Util().createSSLServerSocket(self.getQuorumAddress().getPort());
-                    } else {
-                        ss = new QuorumX509Util().createSSLServerSocket();
-                    }
+                    ss = new UnifiedServerSocket(new QuorumX509Util());
+                }
+            } else if (self.isSslQuorum()) {
+                if (self.getQuorumListenOnAllIPs()) {
+                    ss = new QuorumX509Util().createSSLServerSocket(self.getQuorumAddress().getPort());
+                } else {
+                    ss = new QuorumX509Util().createSSLServerSocket();
                 }
             } else {
                 if (self.getQuorumListenOnAllIPs()) {

--- a/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
@@ -41,7 +41,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.security.sasl.SaslException;
 
 import org.apache.zookeeper.ZooDefs.OpCode;
+import org.apache.zookeeper.common.QuorumX509Util;
 import org.apache.zookeeper.common.Time;
+import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.server.FinalRequestProcessor;
 import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.RequestProcessor;
@@ -225,19 +227,36 @@ public class Leader {
     
     private final ServerSocket ss;
 
-    Leader(QuorumPeer self,LeaderZooKeeperServer zk) throws IOException {
+    Leader(QuorumPeer self,LeaderZooKeeperServer zk) throws IOException, X509Exception {
         this.self = self;
         this.proposalStats = new BufferStats();
         try {
-            if (self.getQuorumListenOnAllIPs()) {
-                ss = new ServerSocket(self.getQuorumAddress().getPort());
+            if (self.shouldUsePortUnification()) {
+                if (self.getQuorumListenOnAllIPs()) {
+                    ss = new UnifiedServerSocket(new QuorumX509Util(), self.getQuorumAddress().getPort());
+                } else {
+                    ss = new UnifiedServerSocket(new QuorumX509Util());
+                }
+            } else if (self.isSslQuorum()) {
+                if (self.getQuorumListenOnAllIPs()) {
+                    ss = new QuorumX509Util().createSSLServerSocket(self.getQuorumAddress().getPort());
+                } else {
+                    ss = new QuorumX509Util().createSSLServerSocket();
+                }
             } else {
-                ss = new ServerSocket();
+                if (self.getQuorumListenOnAllIPs()) {
+                    ss = new ServerSocket(self.getQuorumAddress().getPort());
+                } else {
+                    ss = new ServerSocket();
+                }
             }
             ss.setReuseAddress(true);
             if (!self.getQuorumListenOnAllIPs()) {
                 ss.bind(self.getQuorumAddress());
             }
+        } catch (X509Exception e) {
+            LOG.error("failed to setup ssl server socket", e);
+            throw e;
         } catch (BindException e) {
             if (self.getQuorumListenOnAllIPs()) {
                 LOG.error("Couldn't bind to port " + self.getQuorumAddress().getPort(), e);
@@ -373,6 +392,7 @@ public class Leader {
                 while (!stop) {
                     try{
                         Socket s = ss.accept();
+
                         // start with the initLimit, once the ack is processed
                         // in LearnerHandler switch to the syncLimit
                         s.setSoTimeout(self.tickTime * self.initLimit);

--- a/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
@@ -391,8 +391,6 @@ public class Leader {
                         s.setSoTimeout(self.tickTime * self.initLimit);
                         s.setTcpNoDelay(nodelay);
 
-                        // Note: the call to s.getInputStream() will block the accepting thread if ss is a
-                        // UnifiedServerSocket.
                         BufferedInputStream is = new BufferedInputStream(
                                 s.getInputStream());
                         LearnerHandler fh = new LearnerHandler(s, is, Leader.this);

--- a/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
@@ -231,17 +231,19 @@ public class Leader {
         this.self = self;
         this.proposalStats = new BufferStats();
         try {
-            if (self.shouldUsePortUnification()) {
-                if (self.getQuorumListenOnAllIPs()) {
-                    ss = new UnifiedServerSocket(new QuorumX509Util(), self.getQuorumAddress().getPort());
+            if (self.isSslQuorum()) {
+                if (self.shouldUsePortUnification()) {
+                    if (self.getQuorumListenOnAllIPs()) {
+                        ss = new UnifiedServerSocket(new QuorumX509Util(), self.getQuorumAddress().getPort());
+                    } else {
+                        ss = new UnifiedServerSocket(new QuorumX509Util());
+                    }
                 } else {
-                    ss = new UnifiedServerSocket(new QuorumX509Util());
-                }
-            } else if (self.isSslQuorum()) {
-                if (self.getQuorumListenOnAllIPs()) {
-                    ss = new QuorumX509Util().createSSLServerSocket(self.getQuorumAddress().getPort());
-                } else {
-                    ss = new QuorumX509Util().createSSLServerSocket();
+                    if (self.getQuorumListenOnAllIPs()) {
+                        ss = new QuorumX509Util().createSSLServerSocket(self.getQuorumAddress().getPort());
+                    } else {
+                        ss = new QuorumX509Util().createSSLServerSocket();
+                    }
                 }
             } else {
                 if (self.getQuorumListenOnAllIPs()) {

--- a/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Leader.java
@@ -41,7 +41,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.security.sasl.SaslException;
 
 import org.apache.zookeeper.ZooDefs.OpCode;
-import org.apache.zookeeper.common.QuorumX509Util;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.server.FinalRequestProcessor;
@@ -233,15 +232,15 @@ public class Leader {
         try {
             if (self.shouldUsePortUnification()) {
                 if (self.getQuorumListenOnAllIPs()) {
-                    ss = new UnifiedServerSocket(new QuorumX509Util(), self.getQuorumAddress().getPort());
+                    ss = new UnifiedServerSocket(self.getX509Util(), self.getQuorumAddress().getPort());
                 } else {
-                    ss = new UnifiedServerSocket(new QuorumX509Util());
+                    ss = new UnifiedServerSocket(self.getX509Util());
                 }
             } else if (self.isSslQuorum()) {
                 if (self.getQuorumListenOnAllIPs()) {
-                    ss = new QuorumX509Util().createSSLServerSocket(self.getQuorumAddress().getPort());
+                    ss = self.getX509Util().createSSLServerSocket(self.getQuorumAddress().getPort());
                 } else {
-                    ss = new QuorumX509Util().createSSLServerSocket();
+                    ss = self.getX509Util().createSSLServerSocket();
                 }
             } else {
                 if (self.getQuorumListenOnAllIPs()) {

--- a/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
@@ -248,7 +248,7 @@ public class Learner {
      */
     protected void connectToLeader(InetSocketAddress addr, String hostname)
     throws IOException, InterruptedException, X509Exception {
-        createSocket();
+        this.sock = createSocket();
 
         int initLimitTime = self.tickTime * self.initLimit;
         int remainingInitLimitTime = initLimitTime;
@@ -286,7 +286,7 @@ public class Learner {
                     LOG.warn("Unexpected exception, tries=" + tries +
                             ", remaining init limit=" + remainingInitLimitTime +
                             ", connecting to " + addr,e);
-                    createSocket();
+                    this.sock = createSocket();
                 }
             }
             Thread.sleep(1000);
@@ -300,7 +300,8 @@ public class Learner {
         leaderOs = BinaryOutputArchive.getArchive(bufferedOutput);
     }
 
-    private void createSocket() throws X509Exception, IOException {
+    private Socket createSocket() throws X509Exception, IOException {
+        Socket sock;
         if (self.isSslQuorum()) {
             if (x509Util == null) {
                 x509Util = new QuorumX509Util();
@@ -310,6 +311,7 @@ public class Learner {
             sock = new Socket();
         }
         sock.setSoTimeout(self.tickTime * self.initLimit);
+        return sock;
     }
 
     /**

--- a/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
@@ -38,9 +38,7 @@ import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
 import org.apache.jute.Record;
-import org.apache.zookeeper.common.QuorumX509Util;
 import org.apache.zookeeper.common.X509Exception;
-import org.apache.zookeeper.common.X509Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.ZooDefs.OpCode;
@@ -73,8 +71,6 @@ public class Learner {
     
     protected Socket sock;
 
-    protected X509Util x509Util;
-    
     /**
      * Socket getter
      * @return 
@@ -303,10 +299,7 @@ public class Learner {
     private Socket createSocket() throws X509Exception, IOException {
         Socket sock;
         if (self.isSslQuorum()) {
-            if (x509Util == null) {
-                x509Util = new QuorumX509Util();
-            }
-            sock = x509Util.createSSLSocket();
+            sock = self.getX509Util().createSSLSocket();
         } else {
             sock = new Socket();
         }

--- a/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/Learner.java
@@ -38,6 +38,9 @@ import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
 import org.apache.jute.Record;
+import org.apache.zookeeper.common.QuorumX509Util;
+import org.apache.zookeeper.common.X509Exception;
+import org.apache.zookeeper.common.X509Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.ZooDefs.OpCode;
@@ -50,8 +53,8 @@ import org.apache.zookeeper.server.util.SerializeUtils;
 import org.apache.zookeeper.server.util.ZxidUtils;
 import org.apache.zookeeper.txn.SetDataTxn;
 import org.apache.zookeeper.txn.TxnHeader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLSocket;
 
 /**
  * This class is the superclass of two of the three main actors in a ZK
@@ -69,6 +72,8 @@ public class Learner {
     protected BufferedOutputStream bufferedOutput;
     
     protected Socket sock;
+
+    protected X509Util x509Util;
     
     /**
      * Socket getter
@@ -242,9 +247,8 @@ public class Learner {
      * @throws InterruptedException
      */
     protected void connectToLeader(InetSocketAddress addr, String hostname)
-    throws IOException, ConnectException, InterruptedException {
-        sock = new Socket();        
-        sock.setSoTimeout(self.tickTime * self.initLimit);
+    throws IOException, InterruptedException, X509Exception {
+        createSocket();
 
         int initLimitTime = self.tickTime * self.initLimit;
         int remainingInitLimitTime = initLimitTime;
@@ -260,6 +264,9 @@ public class Learner {
                 }
 
                 sockConnect(sock, addr, Math.min(self.tickTime * self.syncLimit, remainingInitLimitTime));
+                if (self.isSslQuorum())  {
+                    ((SSLSocket) sock).startHandshake();
+                }
                 sock.setTcpNoDelay(nodelay);
                 break;
             } catch (IOException e) {
@@ -279,8 +286,7 @@ public class Learner {
                     LOG.warn("Unexpected exception, tries=" + tries +
                             ", remaining init limit=" + remainingInitLimitTime +
                             ", connecting to " + addr,e);
-                    sock = new Socket();
-                    sock.setSoTimeout(self.tickTime * self.initLimit);
+                    createSocket();
                 }
             }
             Thread.sleep(1000);
@@ -292,8 +298,20 @@ public class Learner {
                 sock.getInputStream()));
         bufferedOutput = new BufferedOutputStream(sock.getOutputStream());
         leaderOs = BinaryOutputArchive.getArchive(bufferedOutput);
-    }   
-    
+    }
+
+    private void createSocket() throws X509Exception, IOException {
+        if (self.isSslQuorum()) {
+            if (x509Util == null) {
+                x509Util = new QuorumX509Util();
+            }
+            sock = x509Util.createSSLSocket();
+        } else {
+            sock = new Socket();
+        }
+        sock.setSoTimeout(self.tickTime * self.initLimit);
+    }
+
     /**
      * Once connected to the leader, perform the handshake protocol to
      * establish a following / observing connection. 

--- a/src/java/main/org/apache/zookeeper/server/quorum/PrependableSocket.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/PrependableSocket.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.quorum;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.net.Socket;
+import java.net.SocketImpl;
+
+public class PrependableSocket extends Socket {
+
+  private SequenceInputStream sequenceInputStream;
+
+  public PrependableSocket(SocketImpl base) throws IOException {
+    super(base);
+  }
+
+  @Override
+  public InputStream getInputStream() throws IOException {
+    if (sequenceInputStream == null) {
+      return super.getInputStream();
+    }
+
+    return sequenceInputStream;
+  }
+
+  public void prependToInputStream(byte[] bytes) throws IOException {
+    sequenceInputStream = new SequenceInputStream(new ByteArrayInputStream(bytes), getInputStream());
+  }
+
+}

--- a/src/java/main/org/apache/zookeeper/server/quorum/PrependableSocket.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/PrependableSocket.java
@@ -43,16 +43,21 @@ public class PrependableSocket extends Socket {
 
   /**
    * Prepend some bytes that have already been read back to the socket's input stream. Note that this method can be
-   * called at most once per socket instance.
+   * called at most once with a non-0 length per socket instance.
    * @param bytes the bytes to prepend.
+   * @param offset offset in the byte array to start at.
+   * @param length number of bytes to prepend.
    * @throws IOException if this method was already called on the socket instance, or if super.getInputStream() throws.
    */
-  public void prependToInputStream(byte[] bytes) throws IOException {
+  public void prependToInputStream(byte[] bytes, int offset, int length) throws IOException {
+    if (length == 0) {
+      return; // nothing to prepend
+    }
     if (pushbackInputStream != null) {
       throw new IOException("prependToInputStream() called more than once");
     }
-    PushbackInputStream pushbackInputStream = new PushbackInputStream(getInputStream(), bytes.length);
-    pushbackInputStream.unread(bytes);
+    PushbackInputStream pushbackInputStream = new PushbackInputStream(getInputStream(), length);
+    pushbackInputStream.unread(bytes, offset, length);
     this.pushbackInputStream = pushbackInputStream;
   }
 

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumBean.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumBean.java
@@ -29,16 +29,29 @@ public class QuorumBean implements QuorumMXBean, ZKMBeanInfo {
         this.peer = peer;
         name = "ReplicatedServer_id" + peer.getId();
     }
-    
+
+    @Override
     public String getName() {
         return name;
     }
-    
+
+    @Override
     public boolean isHidden() {
         return false;
     }
-    
+
+    @Override
     public int getQuorumSize() {
         return peer.getQuorumSize();
+    }
+
+    @Override
+    public boolean isSslQuorum() {
+        return peer.isSslQuorum();
+    }
+
+    @Override
+    public boolean isPortUnification() {
+        return peer.shouldUsePortUnification();
     }
 }

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -543,8 +543,8 @@ public class QuorumCnxManager {
                 LOG.info("Setting arbitrary identifier to observer: " + sid);
             }
         } catch (IOException e) {
+            LOG.warn("Exception reading or writing challenge: {}", e);
             closeSocket(sock);
-            LOG.warn("Exception reading or writing challenge: {}", e.toString());
             return;
         }
         // do authenticating learner

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -853,9 +853,9 @@ public class QuorumCnxManager {
             while((!shutdown) && (numRetries < 3)){
                 try {
                     if (self.shouldUsePortUnification()) {
-                        ss = new UnifiedServerSocket(self.getX509Util());
+                        ss = new UnifiedServerSocket(self.getX509Util(), true);
                     } else if (self.isSslQuorum()) {
-                        ss = self.getX509Util().createSSLServerSocket();
+                        ss = new UnifiedServerSocket(self.getX509Util(), false);
                     } else {
                         ss = new ServerSocket();
                     }
@@ -892,7 +892,7 @@ public class QuorumCnxManager {
                         }
                         numRetries = 0;
                     }
-                } catch (IOException|X509Exception e) {
+                } catch (IOException e) {
                     if (shutdown) {
                         break;
                     }

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -45,12 +45,17 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.zookeeper.common.QuorumX509Util;
+import org.apache.zookeeper.common.X509Exception;
+import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.server.ZooKeeperThread;
 import org.apache.zookeeper.server.quorum.auth.QuorumAuthLearner;
 import org.apache.zookeeper.server.quorum.auth.QuorumAuthServer;
 import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLSocket;
 
 /**
  * This class implements a connection manager for leader election using TCP. It
@@ -165,6 +170,8 @@ public class QuorumCnxManager {
     private final boolean tcpKeepAlive = Boolean.getBoolean("zookeeper.tcpKeepAlive");
 
 
+    private X509Util x509Util;
+
     static public class Message {
         Message(ByteBuffer buffer, long sid) {
             this.buffer = buffer;
@@ -270,9 +277,11 @@ public class QuorumCnxManager {
         initializeAuth(mySid, authServer, authLearner, quorumCnxnThreadsSize,
                 quorumSaslAuthEnabled);
 
-        // Starts listener thread that waits for connection requests 
+        // Starts listener thread that waits for connection requests
         listener = new Listener();
         listener.setName("QuorumPeerListener");
+
+        x509Util = new QuorumX509Util();
     }
 
     private void initializeAuth(final long mySid,
@@ -538,10 +547,8 @@ public class QuorumCnxManager {
             LOG.warn("Exception reading or writing challenge: {}", e.toString());
             return;
         }
-
         // do authenticating learner
         authServer.authenticate(sock, din);
-
         //If wins the challenge, then close the new connection.
         if (sid < self.getId()) {
             /*
@@ -632,37 +639,46 @@ public class QuorumCnxManager {
 
         Socket sock = null;
         try {
-            LOG.debug("Opening channel to server " + sid);
-            sock = new Socket();
-            setSockOpts(sock);
-            sock.connect(electionAddr, cnxTO);
-            LOG.debug("Connected to server " + sid);
+             LOG.debug("Opening channel to server " + sid);
+             if (self.isSslQuorum()) {
+                 SSLSocket sslSock = x509Util.createSSLSocket();
+                 setSockOpts(sslSock);
+                 sslSock.connect(electionAddr, cnxTO);
+                 sslSock.startHandshake();
+                 sock = sslSock;
+             } else {sock = new Socket();
+             setSockOpts(sock);
+             sock.connect(electionAddr, cnxTO);
+             }LOG.debug("Connected to server " + sid);
             // Sends connection request asynchronously if the quorum
             // sasl authentication is enabled. This is required because
             // sasl server authentication process may take few seconds to
             // finish, this may delay next peer connection requests.
             if (quorumSaslAuthEnabled) {
                 initiateConnectionAsync(sock, sid);
-            } else {
-                initiateConnection(sock, sid);
-            }
-            return true;
-        } catch (UnresolvedAddressException e) {
-            // Sun doesn't include the address that causes this
-            // exception to be thrown, also UAE cannot be wrapped cleanly
-            // so we log the exception in order to capture this critical
-            // detail.
-            LOG.warn("Cannot open channel to " + sid
-                    + " at election address " + electionAddr, e);
-            closeSocket(sock);
-            throw e;
-        } catch (IOException e) {
-            LOG.warn("Cannot open channel to " + sid
-                            + " at election address " + electionAddr,
-                    e);
+            } else { initiateConnection(sock, sid);
+            } return true;
+         } catch (UnresolvedAddressException e) {
+             // Sun doesn't include the address that causes this
+             // exception to be thrown, also UAE cannot be wrapped cleanly
+             // so we log the exception in order to capture this critical
+             // detail.
+             LOG.warn("Cannot open channel to " + sid
+                     + " at election address " + electionAddr, e);
+             closeSocket(sock);
+             throw e;} catch (X509Exception e) {
+            LOG.warn("Cannot open secure channel to " + sid
+              + " at election address " + electionAddr, e);
             closeSocket(sock);
             return false;
-        }
+         } catch (IOException e) {
+             LOG.warn("Cannot open channel to " + sid
+                     + " at election address " + electionAddr,
+                     e);
+             closeSocket(sock);
+             return false;
+         }
+   
     }
     
     /**
@@ -840,8 +856,16 @@ public class QuorumCnxManager {
             Socket client = null;
             while((!shutdown) && (numRetries < 3)){
                 try {
-                    ss = new ServerSocket();
+                    if (self.shouldUsePortUnification()) {
+                        ss = new UnifiedServerSocket(x509Util);
+                    } else if (self.isSslQuorum()) {
+                        ss = x509Util.createSSLServerSocket();
+                    } else {
+                        ss = new ServerSocket();
+                    }
+
                     ss.setReuseAddress(true);
+
                     if (self.getQuorumListenOnAllIPs()) {
                         int port = self.getElectionAddress().getPort();
                         addr = new InetSocketAddress(port);
@@ -856,6 +880,7 @@ public class QuorumCnxManager {
                     ss.bind(addr);
                     while (!shutdown) {
                         client = ss.accept();
+
                         setSockOpts(client);
                         LOG.info("Received connection request "
                                 + client.getRemoteSocketAddress());
@@ -871,7 +896,7 @@ public class QuorumCnxManager {
                         }
                         numRetries = 0;
                     }
-                } catch (IOException e) {
+                } catch (IOException|X509Exception e) {
                     if (shutdown) {
                         break;
                     }

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -45,9 +45,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.zookeeper.common.QuorumX509Util;
 import org.apache.zookeeper.common.X509Exception;
-import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.server.ZooKeeperThread;
 import org.apache.zookeeper.server.quorum.auth.QuorumAuthLearner;
 import org.apache.zookeeper.server.quorum.auth.QuorumAuthServer;
@@ -169,9 +167,6 @@ public class QuorumCnxManager {
      */
     private final boolean tcpKeepAlive = Boolean.getBoolean("zookeeper.tcpKeepAlive");
 
-
-    private X509Util x509Util;
-
     static public class Message {
         Message(ByteBuffer buffer, long sid) {
             this.buffer = buffer;
@@ -280,8 +275,6 @@ public class QuorumCnxManager {
         // Starts listener thread that waits for connection requests
         listener = new Listener();
         listener.setName("QuorumPeerListener");
-
-        x509Util = new QuorumX509Util();
     }
 
     private void initializeAuth(final long mySid,
@@ -639,9 +632,9 @@ public class QuorumCnxManager {
 
         Socket sock = null;
         try {
-             LOG.debug("Opening channel to server " + sid);
-             if (self.isSslQuorum()) {
-                 SSLSocket sslSock = x509Util.createSSLSocket();
+            LOG.debug("Opening channel to server " + sid);
+            if (self.isSslQuorum()) {
+                 SSLSocket sslSock = self.getX509Util().createSSLSocket();
                  setSockOpts(sslSock);
                  sslSock.connect(electionAddr, cnxTO);
                  sslSock.startHandshake();
@@ -860,9 +853,9 @@ public class QuorumCnxManager {
             while((!shutdown) && (numRetries < 3)){
                 try {
                     if (self.shouldUsePortUnification()) {
-                        ss = new UnifiedServerSocket(x509Util);
+                        ss = new UnifiedServerSocket(self.getX509Util());
                     } else if (self.isSslQuorum()) {
-                        ss = x509Util.createSSLServerSocket();
+                        ss = self.getX509Util().createSSLServerSocket();
                     } else {
                         ss = new ServerSocket();
                     }

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -646,10 +646,13 @@ public class QuorumCnxManager {
                  sslSock.connect(electionAddr, cnxTO);
                  sslSock.startHandshake();
                  sock = sslSock;
-             } else {sock = new Socket();
-             setSockOpts(sock);
-             sock.connect(electionAddr, cnxTO);
-             }LOG.debug("Connected to server " + sid);
+             } else {
+                 sock = new Socket();
+                 setSockOpts(sock);
+                 sock.connect(electionAddr, cnxTO);
+
+             }
+             LOG.debug("Connected to server " + sid);
             // Sends connection request asynchronously if the quorum
             // sasl authentication is enabled. This is required because
             // sasl server authentication process may take few seconds to

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumMXBean.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumMXBean.java
@@ -31,4 +31,14 @@ public interface QuorumMXBean {
      * @return configured number of peers in the quorum
      */
     public int getQuorumSize();
+
+    /**
+     * @return SSL communication between quorum members required
+     */
+    public boolean isSslQuorum();
+
+    /**
+     * @return SSL communication between quorum members enabled
+     */
+    public boolean isPortUnification();
 }

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -48,6 +48,7 @@ import javax.security.sasl.SaslException;
 import org.apache.zookeeper.KeeperException.BadArgumentsException;
 import org.apache.zookeeper.common.AtomicFileWritingIdiom;
 import org.apache.zookeeper.common.AtomicFileWritingIdiom.WriterStatement;
+import org.apache.zookeeper.common.QuorumX509Util;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.jmx.MBeanRegistry;
@@ -493,6 +494,12 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
         return shouldUsePortUnification;
     }
 
+    private final QuorumX509Util x509Util;
+
+    QuorumX509Util getX509Util() {
+        return x509Util;
+    }
+
     /**
      * This is who I think the leader currently is.
      */
@@ -813,6 +820,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
         quorumStats = new QuorumStats(this);
         jmxRemotePeerBean = new HashMap<Long, RemotePeerBean>();
         adminServer = AdminServerFactory.createAdminServer();
+        x509Util = new QuorumX509Util();
         initialize();
     }
 

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -49,6 +49,7 @@ import org.apache.zookeeper.KeeperException.BadArgumentsException;
 import org.apache.zookeeper.common.AtomicFileWritingIdiom;
 import org.apache.zookeeper.common.AtomicFileWritingIdiom.WriterStatement;
 import org.apache.zookeeper.common.Time;
+import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.jmx.ZKMBeanInfo;
 import org.apache.zookeeper.server.ServerCnxnFactory;
@@ -254,7 +255,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
                 throw new ConfigException("Address unresolved: " + serverParts[0] + ":" + serverParts[1]);
             }
             try {
-                electionAddr = new InetSocketAddress(serverParts[0], 
+                electionAddr = new InetSocketAddress(serverParts[0],
                         Integer.parseInt(serverParts[2]));
             } catch (NumberFormatException e) {
                 throw new ConfigException("Address unresolved: " + serverParts[0] + ":" + serverParts[2]);
@@ -479,6 +480,17 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     // VisibleForTesting
     void setId(long id) {
         this.myid = id;
+    }
+
+    private boolean sslQuorum;
+    private boolean shouldUsePortUnification;
+
+    public boolean isSslQuorum() {
+        return sslQuorum;
+    }
+
+    public boolean shouldUsePortUnification() {
+        return shouldUsePortUnification;
     }
 
     /**
@@ -1033,7 +1045,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
         return new Follower(this, new FollowerZooKeeperServer(logFactory, this, this.zkDb));
     }
 
-    protected Leader makeLeader(FileTxnSnapLog logFactory) throws IOException {
+    protected Leader makeLeader(FileTxnSnapLog logFactory) throws IOException, X509Exception {
         return new Leader(this, new LeaderZooKeeperServer(logFactory, this, this.zkDb));
     }
 
@@ -1714,6 +1726,14 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
 
     public void setSecureCnxnFactory(ServerCnxnFactory secureCnxnFactory) {
         this.secureCnxnFactory = secureCnxnFactory;
+    }
+
+    public void setSslQuorum(boolean sslQuorum) {
+        this.sslQuorum = sslQuorum;
+    }
+
+    public void setUsePortUnification(boolean shouldUsePortUnification) {
+        this.shouldUsePortUnification = shouldUsePortUnification;
     }
 
     private void startServerCnxnFactory() {

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -68,6 +68,7 @@ public class QuorumPeerConfig {
     protected InetSocketAddress secureClientPortAddress;
     protected boolean sslQuorum = false;
     protected boolean shouldUsePortUnification = false;
+    protected boolean sslQuorumReloadCertFiles = false;
     protected File dataDir;
     protected File dataLogDir;
     protected String dynamicConfigFileStr = null;
@@ -307,8 +308,10 @@ public class QuorumPeerConfig {
                 }
             } else if (key.equals("sslQuorum")){
                 sslQuorum = Boolean.parseBoolean(value);
-            } else if (key.equals("portUnification")){
+            } else if (key.equals("portUnification")) {
                 shouldUsePortUnification = Boolean.parseBoolean(value);
+            } else if (key.equals("sslQuorumReloadCertFiles")) {
+                sslQuorumReloadCertFiles = Boolean.parseBoolean(value);
             } else if ((key.startsWith("server.") || key.startsWith("group") || key.startsWith("weight")) && zkProp.containsKey("dynamicConfigFile")) {
                 throw new ConfigException("parameter: " + key + " must be in a separate dynamic config file");
             } else if (key.equals(QuorumAuth.QUORUM_SASL_AUTH_ENABLED)) {

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -37,8 +37,8 @@ import java.util.Properties;
 import java.util.Map.Entry;
 
 import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.common.StringUtils;
-import org.apache.zookeeper.common.ZKConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -66,6 +66,8 @@ public class QuorumPeerConfig {
 
     protected InetSocketAddress clientPortAddress;
     protected InetSocketAddress secureClientPortAddress;
+    protected boolean sslQuorum = false;
+    protected boolean shouldUsePortUnification = false;
     protected File dataDir;
     protected File dataLogDir;
     protected String dynamicConfigFileStr = null;
@@ -303,6 +305,10 @@ public class QuorumPeerConfig {
                 } else {
                     throw new ConfigException("Invalid option " + value + " for reconfigEnabled flag. Choose 'true' or 'false.'");
                 }
+            } else if (key.equals("sslQuorum")){
+                sslQuorum = Boolean.parseBoolean(value);
+            } else if (key.equals("portUnification")){
+                shouldUsePortUnification = Boolean.parseBoolean(value);
             } else if ((key.startsWith("server.") || key.startsWith("group") || key.startsWith("weight")) && zkProp.containsKey("dynamicConfigFile")) {
                 throw new ConfigException("parameter: " + key + " must be in a separate dynamic config file");
             } else if (key.equals(QuorumAuth.QUORUM_SASL_AUTH_ENABLED)) {
@@ -425,14 +431,15 @@ public class QuorumPeerConfig {
      *             provider is not configured.
      */
     private void configureSSLAuth() throws ConfigException {
-        String sslAuthProp = "zookeeper.authProvider." + System.getProperty(ZKConfig.SSL_AUTHPROVIDER, "x509");
+        ClientX509Util clientX509Util = new ClientX509Util();
+        String sslAuthProp = "zookeeper.authProvider." + System.getProperty(clientX509Util.getSslAuthProviderProperty(), "x509");
         if (System.getProperty(sslAuthProp) == null) {
             if ("zookeeper.authProvider.x509".equals(sslAuthProp)) {
                 System.setProperty("zookeeper.authProvider.x509",
                         "org.apache.zookeeper.server.auth.X509AuthenticationProvider");
             } else {
                 throw new ConfigException("No auth provider configured for the SSL authentication scheme '"
-                        + System.getProperty(ZKConfig.SSL_AUTHPROVIDER) + "'.");
+                        + System.getProperty(clientX509Util.getSslAuthProviderProperty()) + "'.");
             }
         }
     }
@@ -736,6 +743,13 @@ public class QuorumPeerConfig {
     public boolean areLocalSessionsEnabled() { return localSessionsEnabled; }
     public boolean isLocalSessionsUpgradingEnabled() {
         return localSessionsUpgradingEnabled;
+    }
+    public boolean isSslQuorum() {
+        return sslQuorum;
+    }
+
+    public boolean shouldUsePortUnification() {
+        return shouldUsePortUnification;
     }
 
     public int getInitLimit() { return initLimit; }

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
@@ -181,6 +181,8 @@ public class QuorumPeerMain {
           quorumPeer.initConfigInZKDatabase();
           quorumPeer.setCnxnFactory(cnxnFactory);
           quorumPeer.setSecureCnxnFactory(secureCnxnFactory);
+          quorumPeer.setSslQuorum(config.isSslQuorum());
+          quorumPeer.setUsePortUnification(config.shouldUsePortUnification());
           quorumPeer.setLearnerType(config.getPeerType());
           quorumPeer.setSyncEnabled(config.getSyncEnabled());
           quorumPeer.setQuorumListenOnAllIPs(config.getQuorumListenOnAllIPs());

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
@@ -186,6 +186,9 @@ public class QuorumPeerMain {
           quorumPeer.setLearnerType(config.getPeerType());
           quorumPeer.setSyncEnabled(config.getSyncEnabled());
           quorumPeer.setQuorumListenOnAllIPs(config.getQuorumListenOnAllIPs());
+          if (config.sslQuorumReloadCertFiles) {
+              quorumPeer.getX509Util().enableCertFileReloading();
+          }
 
           // sets quorum sasl authentication configurations
           quorumPeer.setQuorumSaslEnabled(config.quorumEnableSasl);

--- a/src/java/main/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.common.X509Exception;
+import org.apache.zookeeper.common.X509Util;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.handler.ssl.SslHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLSocket;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+
+public class UnifiedServerSocket extends ServerSocket {
+    private static final Logger LOG = LoggerFactory.getLogger(UnifiedServerSocket.class);
+
+    private X509Util x509Util;
+
+    public UnifiedServerSocket(X509Util x509Util) throws IOException {
+        super();
+        this.x509Util = x509Util;
+    }
+
+    public UnifiedServerSocket(X509Util x509Util, int port) throws IOException {
+        super(port);
+        this.x509Util = x509Util;
+    }
+
+    @Override
+    public Socket accept() throws IOException {
+        if (isClosed()) {
+            throw new SocketException("Socket is closed");
+        }
+        if (!isBound()) {
+            throw new SocketException("Socket is not bound yet");
+        }
+        final PrependableSocket prependableSocket = new PrependableSocket(null);
+        implAccept(prependableSocket);
+
+        byte[] litmus = new byte[5];
+        int bytesRead = prependableSocket.getInputStream().read(litmus, 0, 5);
+        prependableSocket.prependToInputStream(litmus);
+
+        if (bytesRead == 5 && SslHandler.isEncrypted(ChannelBuffers.wrappedBuffer(litmus))) {
+            LOG.info(getInetAddress() + " attempting to connect over ssl");
+            SSLSocket sslSocket;
+            try {
+                sslSocket = x509Util.createSSLSocket(prependableSocket);
+            } catch (X509Exception e) {
+                throw new IOException("failed to create SSL context", e);
+            }
+            sslSocket.setUseClientMode(false);
+            return sslSocket;
+        } else {
+            LOG.info(getInetAddress() + " attempting to connect without ssl");
+            return prependableSocket;
+        }
+    }
+}

--- a/src/java/main/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
@@ -27,23 +27,106 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLSocket;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
 
+/**
+ * A ServerSocket that can act either as a regular ServerSocket, as a SSLServerSocket, or as both, depending on
+ * the constructor parameters and on the type of client (TLS or plaintext) that connects to it.
+ * The constructors have the same signature as constructors of ServerSocket, with the addition of two parameters
+ * at the beginning:
+ * <ul>
+ *     <li>X509Util - provides the SSL context to construct a secure socket when a client connects with TLS.</li>
+ *     <li>boolean allowInsecureConnection - when true, acts as a hybrid server socket (plaintext / TLS). When
+ *         false, acts as a SSLServerSocket (rejects plaintext connections).</li>
+ * </ul>
+ * The <code>!allowInsecureConnection</code> mode is needed so we can update the SSLContext (in particular, the
+ * key store and/or trust store) without having to re-create the server socket. By starting with a plaintext socket
+ * and delaying the upgrade to TLS until after a client has connected and begins a handshake, we can keep the same
+ * UnifiedServerSocket instance around, and replace the default SSLContext in the provided X509Util when the key store
+ * and/or trust store file changes on disk.
+ */
 public class UnifiedServerSocket extends ServerSocket {
     private static final Logger LOG = LoggerFactory.getLogger(UnifiedServerSocket.class);
 
     private X509Util x509Util;
+    private final boolean allowInsecureConnection;
 
-    public UnifiedServerSocket(X509Util x509Util) throws IOException {
+    /**
+     * Creates an unbound unified server socket by calling {@link ServerSocket#ServerSocket()}.
+     * Secure client connections will be upgraded to TLS once this socket detects the ClientHello message (start of a
+     * TLS handshake). Plaintext client connections will either be accepted or rejected depending on the value of
+     * the <code>allowInsecureConnection</code> parameter.
+     * @param x509Util the X509Util that provides the SSLContext to use for secure connections.
+     * @param allowInsecureConnection if true, accept plaintext connections, otherwise close them.
+     * @throws IOException if {@link ServerSocket#ServerSocket()} throws.
+     */
+    public UnifiedServerSocket(X509Util x509Util, boolean allowInsecureConnection) throws IOException {
         super();
         this.x509Util = x509Util;
+        this.allowInsecureConnection = allowInsecureConnection;
     }
 
-    public UnifiedServerSocket(X509Util x509Util, int port) throws IOException {
+    /**
+     * Creates a unified server socket bound to the specified port by calling {@link ServerSocket#ServerSocket(int)}.
+     * Secure client connections will be upgraded to TLS once this socket detects the ClientHello message (start of a
+     * TLS handshake). Plaintext client connections will either be accepted or rejected depending on the value of
+     * the <code>allowInsecureConnection</code> parameter.
+     * @param x509Util the X509Util that provides the SSLContext to use for secure connections.
+     * @param allowInsecureConnection if true, accept plaintext connections, otherwise close them.
+     * @param port the port number, or {@code 0} to use a port number that is automatically allocated.
+     * @throws IOException if {@link ServerSocket#ServerSocket(int)} throws.
+     */
+    public UnifiedServerSocket(X509Util x509Util, boolean allowInsecureConnection, int port) throws IOException {
         super(port);
         this.x509Util = x509Util;
+        this.allowInsecureConnection = allowInsecureConnection;
+    }
+
+    /**
+     * Creates a unified server socket bound to the specified port, with the specified backlog, by calling
+     * {@link ServerSocket#ServerSocket(int, int)}.
+     * Secure client connections will be upgraded to TLS once this socket detects the ClientHello message (start of a
+     * TLS handshake). Plaintext client connections will either be accepted or rejected depending on the value of
+     * the <code>allowInsecureConnection</code> parameter.
+     * @param x509Util the X509Util that provides the SSLContext to use for secure connections.
+     * @param allowInsecureConnection if true, accept plaintext connections, otherwise close them.
+     * @param port the port number, or {@code 0} to use a port number that is automatically allocated.
+     * @param backlog requested maximum length of the queue of incoming connections.
+     * @throws IOException if {@link ServerSocket#ServerSocket(int, int)} throws.
+     */
+    public UnifiedServerSocket(X509Util x509Util,
+                               boolean allowInsecureConnection,
+                               int port,
+                               int backlog) throws IOException {
+        super(port, backlog);
+        this.x509Util = x509Util;
+        this.allowInsecureConnection = allowInsecureConnection;
+    }
+
+    /**
+     * Creates a unified server socket bound to the specified port, with the specified backlog, and local IP address
+     * to bind to, by calling {@link ServerSocket#ServerSocket(int, int, InetAddress)}.
+     * Secure client connections will be upgraded to TLS once this socket detects the ClientHello message (start of a
+     * TLS handshake). Plaintext client connections will either be accepted or rejected depending on the value of
+     * the <code>allowInsecureConnection</code> parameter.
+     * @param x509Util the X509Util that provides the SSLContext to use for secure connections.
+     * @param allowInsecureConnection if true, accept plaintext connections, otherwise close them.
+     * @param port the port number, or {@code 0} to use a port number that is automatically allocated.
+     * @param backlog requested maximum length of the queue of incoming connections.
+     * @param bindAddr the local InetAddress the server will bind to.
+     * @throws IOException if {@link ServerSocket#ServerSocket(int, int, InetAddress)} throws.
+     */
+    public UnifiedServerSocket(X509Util x509Util,
+                               boolean allowInsecureConnection,
+                               int port,
+                               int backlog,
+                               InetAddress bindAddr) throws IOException {
+        super(port, backlog, bindAddr);
+        this.x509Util = x509Util;
+        this.allowInsecureConnection = allowInsecureConnection;
     }
 
     @Override
@@ -72,9 +155,16 @@ public class UnifiedServerSocket extends ServerSocket {
             sslSocket.setNeedClientAuth(true); // TODO: probably need to add a property for this in X509Util
             return sslSocket;
         } else {
-            LOG.info(getInetAddress() + " attempting to connect without ssl");
-            prependableSocket.prependToInputStream(litmus);
-            return prependableSocket;
+            if (allowInsecureConnection) {
+                LOG.info(getInetAddress() + " attempting to connect without ssl");
+                prependableSocket.prependToInputStream(litmus);
+                return prependableSocket;
+            } else {
+                LOG.info(getInetAddress() + " attempted to connect without ssl but allowInsecureConnection is false, " +
+                    "closing socket");
+                prependableSocket.close();
+                throw new IOException("Blocked insecure connection attempt");
+            }
         }
     }
 }

--- a/src/java/main/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
@@ -243,8 +243,6 @@ public class UnifiedServerSocket extends ServerSocket {
                 } catch (X509Exception e) {
                     throw new IOException("failed to create SSL context", e);
                 }
-                sslSocket.setUseClientMode(false);
-                sslSocket.setNeedClientAuth(true);  // TODO: probably need to add a property for this in X509Util
                 prependableSocket = null;
                 mode = Mode.TLS;
             } else if (allowInsecureConnection) {

--- a/src/java/main/org/apache/zookeeper/util/PemReader.java
+++ b/src/java/main/org/apache/zookeeper/util/PemReader.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.util;
+
+import javax.crypto.Cipher;
+import javax.crypto.EncryptedPrivateKeyInfo;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.security.auth.x500.X500Principal;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Base64.getMimeDecoder;
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static javax.crypto.Cipher.DECRYPT_MODE;
+
+/**
+ * Note: this class is copied from io.airlift.security.pem.PemReader (see
+ * https://github.com/airlift/airlift/blob/master/security/src/main/java/io/airlift/security/pem/PemReader.java) with
+ * permission of the authors, to avoid adding an extra library dependency to Zookeeper.
+ */
+public final class PemReader
+{
+    private static final Pattern CERT_PATTERN = Pattern.compile(
+            "-+BEGIN\\s+.*CERTIFICATE[^-]*-+(?:\\s|\\r|\\n)+" + // Header
+                    "([a-z0-9+/=\\r\\n]+)" +                    // Base64 text
+                    "-+END\\s+.*CERTIFICATE[^-]*-+",            // Footer
+            CASE_INSENSITIVE);
+
+    private static final Pattern PRIVATE_KEY_PATTERN = Pattern.compile(
+            "-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" + // Header
+                    "([a-z0-9+/=\\r\\n]+)" +                       // Base64 text
+                    "-+END\\s+.*PRIVATE\\s+KEY[^-]*-+",            // Footer
+            CASE_INSENSITIVE);
+
+    private static final Pattern PUBLIC_KEY_PATTERN = Pattern.compile(
+            "-+BEGIN\\s+.*PUBLIC\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" + // Header
+                    "([a-z0-9+/=\\r\\n]+)" +                      // Base64 text
+                    "-+END\\s+.*PUBLIC\\s+KEY[^-]*-+",            // Footer
+            CASE_INSENSITIVE);
+
+    private PemReader() {}
+
+    public static KeyStore loadTrustStore(File certificateChainFile)
+            throws IOException, GeneralSecurityException
+    {
+        KeyStore keyStore = KeyStore.getInstance("JKS");
+        keyStore.load(null, null);
+
+        List<X509Certificate> certificateChain = readCertificateChain(certificateChainFile);
+        for (X509Certificate certificate : certificateChain) {
+            X500Principal principal = certificate.getSubjectX500Principal();
+            keyStore.setCertificateEntry(principal.getName("RFC2253"), certificate);
+        }
+        return keyStore;
+    }
+
+    public static KeyStore loadKeyStore(File certificateChainFile, File privateKeyFile, Optional<String> keyPassword)
+            throws IOException, GeneralSecurityException
+    {
+        PrivateKey key = loadPrivateKey(privateKeyFile, keyPassword);
+
+        List<X509Certificate> certificateChain = readCertificateChain(certificateChainFile);
+        if (certificateChain.isEmpty()) {
+            throw new CertificateException("Certificate file does not contain any certificates: " + certificateChainFile);
+        }
+
+        KeyStore keyStore = KeyStore.getInstance("JKS");
+        keyStore.load(null, null);
+        keyStore.setKeyEntry("key", key, keyPassword.orElse("").toCharArray(), certificateChain.toArray(new Certificate[0]));
+        return keyStore;
+    }
+
+    public static List<X509Certificate> readCertificateChain(File certificateChainFile)
+            throws IOException, GeneralSecurityException
+    {
+        String contents = new String(Files.readAllBytes(certificateChainFile.toPath()), StandardCharsets.US_ASCII);
+        return readCertificateChain(contents);
+    }
+
+    public static List<X509Certificate> readCertificateChain(String certificateChain)
+            throws CertificateException
+    {
+        Matcher matcher = CERT_PATTERN.matcher(certificateChain);
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+        List<X509Certificate> certificates = new ArrayList<>();
+
+        int start = 0;
+        while (matcher.find(start)) {
+            byte[] buffer = base64Decode(matcher.group(1));
+            certificates.add((X509Certificate) certificateFactory.generateCertificate(new ByteArrayInputStream(buffer)));
+            start = matcher.end();
+        }
+
+        return certificates;
+    }
+
+    public static PrivateKey loadPrivateKey(File privateKeyFile, Optional<String> keyPassword)
+            throws IOException, GeneralSecurityException
+    {
+        String privateKey = new String(Files.readAllBytes(privateKeyFile.toPath()), StandardCharsets.US_ASCII);
+        return loadPrivateKey(privateKey, keyPassword);
+    }
+
+    public static PrivateKey loadPrivateKey(String privateKey, Optional<String> keyPassword)
+            throws IOException, GeneralSecurityException
+    {
+        Matcher matcher = PRIVATE_KEY_PATTERN.matcher(privateKey);
+        if (!matcher.find()) {
+            throw new KeyStoreException("did not find a private key");
+        }
+        byte[] encodedKey = base64Decode(matcher.group(1));
+
+        PKCS8EncodedKeySpec encodedKeySpec;
+        if (keyPassword.isPresent()) {
+            EncryptedPrivateKeyInfo encryptedPrivateKeyInfo = new EncryptedPrivateKeyInfo(encodedKey);
+            SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(encryptedPrivateKeyInfo.getAlgName());
+            SecretKey secretKey = keyFactory.generateSecret(new PBEKeySpec(keyPassword.get().toCharArray()));
+
+            Cipher cipher = Cipher.getInstance(encryptedPrivateKeyInfo.getAlgName());
+            cipher.init(DECRYPT_MODE, secretKey, encryptedPrivateKeyInfo.getAlgParameters());
+
+            encodedKeySpec = encryptedPrivateKeyInfo.getKeySpec(cipher);
+        }
+        else {
+            encodedKeySpec = new PKCS8EncodedKeySpec(encodedKey);
+        }
+
+        // this code requires a key in PKCS8 format which is not the default openssl format
+        // to convert to the PKCS8 format you use : openssl pkcs8 -topk8 ...
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            return keyFactory.generatePrivate(encodedKeySpec);
+        }
+        catch (InvalidKeySpecException ignore) {
+        }
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return keyFactory.generatePrivate(encodedKeySpec);
+        }
+        catch (InvalidKeySpecException ignore) {
+        }
+
+        KeyFactory keyFactory = KeyFactory.getInstance("DSA");
+        return keyFactory.generatePrivate(encodedKeySpec);
+    }
+
+    public static PublicKey loadPublicKey(File publicKeyFile)
+            throws IOException, GeneralSecurityException
+    {
+        String publicKey = new String(Files.readAllBytes(publicKeyFile.toPath()), StandardCharsets.US_ASCII);
+        return loadPublicKey(publicKey);
+    }
+
+    public static PublicKey loadPublicKey(String publicKey)
+            throws GeneralSecurityException
+    {
+        Matcher matcher = PUBLIC_KEY_PATTERN.matcher(publicKey);
+        if (!matcher.find()) {
+            throw new KeyStoreException("did not find a public key");
+        }
+        String data = matcher.group(1);
+        byte[] encodedKey = base64Decode(data);
+
+        X509EncodedKeySpec encodedKeySpec = new X509EncodedKeySpec(encodedKey);
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            return keyFactory.generatePublic(encodedKeySpec);
+        }
+        catch (InvalidKeySpecException ignore) {
+        }
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return keyFactory.generatePublic(encodedKeySpec);
+        }
+        catch (InvalidKeySpecException ignore) {
+        }
+
+        KeyFactory keyFactory = KeyFactory.getInstance("DSA");
+        return keyFactory.generatePublic(encodedKeySpec);
+    }
+
+    private static byte[] base64Decode(String base64)
+    {
+        return getMimeDecoder().decode(base64.getBytes(StandardCharsets.US_ASCII));
+    }
+}

--- a/src/java/test/org/apache/zookeeper/common/FileChangeWatcherTest.java
+++ b/src/java/test/org/apache/zookeeper/common/FileChangeWatcherTest.java
@@ -1,0 +1,238 @@
+package org.apache.zookeeper.common;
+
+import org.apache.commons.codec.Charsets;
+import org.apache.commons.io.FileUtils;
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class FileChangeWatcherTest extends ZKTestCase {
+    private static File tempDir;
+    private static File tempFile;
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileChangeWatcherTest.class);
+
+    @BeforeClass
+    public static void createTempFile() throws IOException {
+        tempDir = ClientBase.createEmptyTestDir();
+        tempFile = File.createTempFile("zk_test_", "", tempDir);
+        tempFile.deleteOnExit();
+    }
+
+    @Test
+    public void testCallbackWorksOnFileChanges() throws IOException, InterruptedException {
+        FileChangeWatcher watcher = null;
+        try {
+            final List<WatchEvent<?>> events = new ArrayList<>();
+            watcher = new FileChangeWatcher(
+                    tempDir.toPath(),
+                    new Consumer<WatchEvent<?>>() {
+                        @Override
+                        public void accept(WatchEvent<?> event) {
+                            LOG.info("Got an update: " + event.kind() + " " + event.context());
+                            synchronized (events) {
+                                events.add(event);
+                                events.notifyAll();
+                            }
+                        }
+                    });
+            watcher.waitForBackgroundThreadToStart();
+            Thread.sleep(1000L); // XXX hack
+            for (int i = 0; i < 3; i++) {
+                LOG.info("Modifying file, attempt " + (i + 1));
+                FileUtils.writeStringToFile(tempFile, "Hello world " + i + "\n", Charsets.UTF_8, true);
+                synchronized (events) {
+                    if (events.size() < i + 1) {
+                        events.wait(3000L);
+                    }
+                    assertEquals("Wrong number of events", i + 1, events.size());
+                    WatchEvent<?> event = events.get(i);
+                    assertEquals(StandardWatchEventKinds.ENTRY_MODIFY, event.kind());
+                    assertEquals(tempFile.getName(), event.context().toString());
+                }
+            }
+        } finally {
+            if (watcher != null) {
+                watcher.stopAndJoinBackgroundThread();
+            }
+        }
+    }
+
+    @Test
+    public void testCallbackWorksOnFileTouched() throws IOException, InterruptedException {
+        FileChangeWatcher watcher = null;
+        try {
+            final List<WatchEvent<?>> events = new ArrayList<>();
+            watcher = new FileChangeWatcher(
+                    tempDir.toPath(),
+                    new Consumer<WatchEvent<?>>() {
+                        @Override
+                        public void accept(WatchEvent<?> event) {
+                            LOG.info("Got an update: " + event.kind() + " " + event.context());
+                            synchronized (events) {
+                                events.add(event);
+                                events.notifyAll();
+                            }
+                        }
+                    });
+            watcher.waitForBackgroundThreadToStart();
+            Thread.sleep(1000L); // XXX hack
+            LOG.info("Touching file");
+            FileUtils.touch(tempFile);
+            synchronized (events) {
+                if (events.isEmpty()) {
+                    events.wait(3000L);
+                }
+                assertFalse(events.isEmpty());
+                WatchEvent<?> event = events.get(0);
+                assertEquals(StandardWatchEventKinds.ENTRY_MODIFY, event.kind());
+                assertEquals(tempFile.getName(), event.context().toString());
+            }
+        } finally {
+            if (watcher != null) {
+                watcher.stopAndJoinBackgroundThread();
+            }
+        }
+    }
+
+    @Test
+    public void testCallbackWorksOnFileAdded() throws IOException, InterruptedException {
+        FileChangeWatcher watcher = null;
+        try {
+            final List<WatchEvent<?>> events = new ArrayList<>();
+            watcher = new FileChangeWatcher(
+                    tempDir.toPath(),
+                    new Consumer<WatchEvent<?>>() {
+                        @Override
+                        public void accept(WatchEvent<?> event) {
+                            LOG.info("Got an update: " + event.kind() + " " + event.context());
+                            synchronized (events) {
+                                events.add(event);
+                                events.notifyAll();
+                            }
+                        }
+                    });
+            watcher.waitForBackgroundThreadToStart();
+            Thread.sleep(1000L); // XXX hack
+            File tempFile2 = File.createTempFile("zk_test_", "", tempDir);
+            tempFile2.deleteOnExit();
+            synchronized (events) {
+                if (events.isEmpty()) {
+                    events.wait(3000L);
+                }
+                assertFalse(events.isEmpty());
+                WatchEvent<?> event = events.get(0);
+                assertEquals(StandardWatchEventKinds.ENTRY_CREATE, event.kind());
+                assertEquals(tempFile2.getName(), event.context().toString());
+            }
+        } finally {
+            if (watcher != null) {
+                watcher.stopAndJoinBackgroundThread();
+            }
+        }
+    }
+
+    @Test
+    public void testCallbackWorksOnFileDeleted() throws IOException, InterruptedException {
+        FileChangeWatcher watcher = null;
+        try {
+            final List<WatchEvent<?>> events = new ArrayList<>();
+            watcher = new FileChangeWatcher(
+                    tempDir.toPath(),
+                    new Consumer<WatchEvent<?>>() {
+                        @Override
+                        public void accept(WatchEvent<?> event) {
+                            LOG.info("Got an update: " + event.kind() + " " + event.context());
+                            synchronized (events) {
+                                events.add(event);
+                                events.notifyAll();
+                            }
+                        }
+                    });
+            watcher.waitForBackgroundThreadToStart();
+            Thread.sleep(1000L); // XXX hack
+            tempFile.delete();
+            synchronized (events) {
+                if (events.isEmpty()) {
+                    events.wait(3000L);
+                }
+                assertFalse(events.isEmpty());
+                WatchEvent<?> event = events.get(0);
+                assertEquals(StandardWatchEventKinds.ENTRY_DELETE, event.kind());
+                assertEquals(tempFile.getName(), event.context().toString());
+            }
+        } finally {
+            if (watcher != null) {
+                watcher.stopAndJoinBackgroundThread();
+            }
+        }
+    }
+
+    @Test
+    public void testCallbackErrorDoesNotCrashWatcherThread() throws IOException, InterruptedException {
+        FileChangeWatcher watcher = null;
+        try {
+            final List<WatchEvent<?>> events = new ArrayList<>();
+            final AtomicInteger callCount = new AtomicInteger(0);
+            watcher = new FileChangeWatcher(
+                    tempDir.toPath(),
+                    new Consumer<WatchEvent<?>>() {
+                        @Override
+                        public void accept(WatchEvent<?> event) {
+                            LOG.info("Got an update: " + event.kind() + " " + event.context());
+                            synchronized (callCount) {
+                                if (callCount.getAndIncrement() == 0) {
+                                    callCount.notifyAll();
+                                    throw new RuntimeException("This error should not crash the watcher thread");
+                                }
+                            }
+                            synchronized (events) {
+                                events.add(event);
+                                events.notifyAll();
+                            }
+                        }
+                    });
+            watcher.waitForBackgroundThreadToStart();
+            Thread.sleep(1000L); // XXX hack
+            LOG.info("Modifying file");
+            FileUtils.writeStringToFile(tempFile, "Hello world\n", Charsets.UTF_8, true);
+            synchronized (callCount) {
+                while (callCount.get() == 0) {
+                    callCount.wait(3000L);
+                }
+            }
+            LOG.info("Modifying file again");
+            FileUtils.writeStringToFile(tempFile, "Hello world again\n", Charsets.UTF_8, true);
+            synchronized (events) {
+                if (events.isEmpty()) {
+                    events.wait(3000L);
+                }
+                assertEquals(2, callCount.get());
+                assertFalse(events.isEmpty());
+                WatchEvent<?> event = events.get(0);
+                assertEquals(StandardWatchEventKinds.ENTRY_MODIFY, event.kind());
+                assertEquals(tempFile.getName(), event.context().toString());
+            }
+        } finally {
+            if (watcher != null) {
+                watcher.stopAndJoinBackgroundThread();
+            }
+        }
+
+    }
+}

--- a/src/java/test/org/apache/zookeeper/common/FileChangeWatcherTest.java
+++ b/src/java/test/org/apache/zookeeper/common/FileChangeWatcherTest.java
@@ -1,6 +1,5 @@
 package org.apache.zookeeper.common;
 
-import org.apache.commons.codec.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.test.ClientBase;
@@ -11,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.util.ArrayList;
@@ -55,7 +55,7 @@ public class FileChangeWatcherTest extends ZKTestCase {
             Thread.sleep(1000L); // XXX hack
             for (int i = 0; i < 3; i++) {
                 LOG.info("Modifying file, attempt " + (i + 1));
-                FileUtils.writeStringToFile(tempFile, "Hello world " + i + "\n", Charsets.UTF_8, true);
+                FileUtils.writeStringToFile(tempFile, "Hello world " + i + "\n", StandardCharsets.UTF_8, true);
                 synchronized (events) {
                     if (events.size() < i + 1) {
                         events.wait(3000L);
@@ -210,14 +210,14 @@ public class FileChangeWatcherTest extends ZKTestCase {
             watcher.waitForBackgroundThreadToStart();
             Thread.sleep(1000L); // XXX hack
             LOG.info("Modifying file");
-            FileUtils.writeStringToFile(tempFile, "Hello world\n", Charsets.UTF_8, true);
+            FileUtils.writeStringToFile(tempFile, "Hello world\n", StandardCharsets.UTF_8, true);
             synchronized (callCount) {
                 while (callCount.get() == 0) {
                     callCount.wait(3000L);
                 }
             }
             LOG.info("Modifying file again");
-            FileUtils.writeStringToFile(tempFile, "Hello world again\n", Charsets.UTF_8, true);
+            FileUtils.writeStringToFile(tempFile, "Hello world again\n", StandardCharsets.UTF_8, true);
             synchronized (events) {
                 if (events.isEmpty()) {
                     events.wait(3000L);

--- a/src/java/test/org/apache/zookeeper/common/X509KeyType.java
+++ b/src/java/test/org/apache/zookeeper/common/X509KeyType.java
@@ -1,0 +1,8 @@
+package org.apache.zookeeper.common;
+
+/**
+ * Represents a type of key pair used for X509 certs in tests. The two options are RSA or EC (elliptic curve).
+ */
+public enum X509KeyType {
+    RSA, EC;
+}

--- a/src/java/test/org/apache/zookeeper/common/X509TestContext.java
+++ b/src/java/test/org/apache/zookeeper/common/X509TestContext.java
@@ -1,0 +1,416 @@
+package org.apache.zookeeper.common;
+
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.OperatorCreationException;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class simplifies the creation of certificates and private keys for SSL/TLS connections.
+ */
+public class X509TestContext {
+    private static final String TRUST_STORE_PREFIX = "zk_test_ca";
+    private static final String KEY_STORE_PREFIX = "zk_test_key";
+
+    private final File tempDir;
+
+    private final X509KeyType trustStoreKeyType;
+    private final KeyPair trustStoreKeyPair;
+    private final long trustStoreCertExpirationMillis;
+    private final X509Certificate trustStoreCertificate;
+    private final String trustStorePassword;
+    private File trustStoreJksFile;
+
+    private final X509KeyType keyStoreKeyType;
+    private final KeyPair keyStoreKeyPair;
+    private final long keyStoreCertExpirationMillis;
+    private final X509Certificate keyStoreCertificate;
+    private final String keyStorePassword;
+    private File keyStoreJksFile;
+
+    private final Boolean hostnameVerification;
+
+    /**
+     * Constructor is intentionally private, use the Builder class instead.
+     * @param tempDir the directory in which key store and trust store temp files will be written.
+     * @param trustStoreKeyPair the key pair for the trust store.
+     * @param trustStoreCertExpirationMillis the expiration of the trust store cert, in milliseconds from now.
+     * @param trustStorePassword the password to protect a JKS trust store (ignored for PEM trust stores).
+     * @param keyStoreKeyPair the key pair for the key store.
+     * @param keyStoreCertExpirationMillis the expiration of the key store cert, in milliseconds from now.
+     * @param keyStorePassword the password to protect the key store private key.
+     * @throws IOException
+     * @throws GeneralSecurityException
+     * @throws OperatorCreationException
+     */
+    private X509TestContext(File tempDir,
+                            KeyPair trustStoreKeyPair,
+                            long trustStoreCertExpirationMillis,
+                            String trustStorePassword,
+                            KeyPair keyStoreKeyPair,
+                            long keyStoreCertExpirationMillis,
+                            String keyStorePassword,
+                            Boolean hostnameVerification) throws IOException, GeneralSecurityException, OperatorCreationException {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            throw new IllegalStateException("BC Security provider was not found");
+        }
+        this.tempDir = requireNonNull(tempDir);
+        if (!tempDir.isDirectory()) {
+            throw new IllegalArgumentException("Not a directory: " + tempDir);
+        }
+        this.trustStoreKeyPair = requireNonNull(trustStoreKeyPair);
+        this.trustStoreKeyType = keyPairToType(trustStoreKeyPair);
+        this.trustStoreCertExpirationMillis = trustStoreCertExpirationMillis;
+        this.trustStorePassword = requireNonNull(trustStorePassword);
+        this.keyStoreKeyPair = requireNonNull(keyStoreKeyPair);
+        this.keyStoreKeyType = keyPairToType(keyStoreKeyPair);
+        this.keyStoreCertExpirationMillis = keyStoreCertExpirationMillis;
+        this.keyStorePassword = requireNonNull(keyStorePassword);
+
+        X500NameBuilder caNameBuilder = new X500NameBuilder(BCStyle.INSTANCE);
+        caNameBuilder.addRDN(BCStyle.CN, MethodHandles.lookup().lookupClass().getCanonicalName() + " Root CA");
+        trustStoreCertificate = X509TestHelpers.newSelfSignedCACert(
+                caNameBuilder.build(),
+                trustStoreKeyPair,
+                trustStoreCertExpirationMillis);
+
+        X500NameBuilder nameBuilder = new X500NameBuilder(BCStyle.INSTANCE);
+        nameBuilder.addRDN(BCStyle.CN, MethodHandles.lookup().lookupClass().getCanonicalName() + " Zookeeper Test");
+        keyStoreCertificate = X509TestHelpers.newCert(
+                trustStoreCertificate,
+                trustStoreKeyPair,
+                nameBuilder.build(),
+                keyStoreKeyPair.getPublic(),
+                keyStoreCertExpirationMillis);
+        trustStoreJksFile = keyStoreJksFile = null;
+
+        this.hostnameVerification = hostnameVerification;
+    }
+
+    /**
+     * Returns the X509KeyType of the given key pair.
+     * @param keyPair the key pair.
+     * @return <code>X509KeyType.RSA</code> if given an RSA key pair, and <code>X509KeyType.EC</code> otherwise.
+     */
+    private X509KeyType keyPairToType(KeyPair keyPair) {
+        if (keyPair.getPrivate().getAlgorithm().contains("RSA")) {
+            return X509KeyType.RSA;
+        } else {
+            return X509KeyType.EC;
+        }
+    }
+
+    public File getTempDir() {
+        return tempDir;
+    }
+
+    public X509KeyType getTrustStoreKeyType() {
+        return trustStoreKeyType;
+    }
+
+    public KeyPair getTrustStoreKeyPair() {
+        return trustStoreKeyPair;
+    }
+
+    public long getTrustStoreCertExpirationMillis() {
+        return trustStoreCertExpirationMillis;
+    }
+
+    public X509Certificate getTrustStoreCertificate() {
+        return trustStoreCertificate;
+    }
+
+    public String getTrustStorePassword() {
+        return trustStorePassword;
+    }
+
+    /**
+     * Returns the path to the trust store file in the given format. Currently only JKS is supported. Note that the
+     * file is created lazily, the first time this method is called. The trust store file is temporary and will be
+     * deleted on exit.
+     * @param storeFileType the store file type.
+     * @return the path to the trust store file.
+     * @throws IOException if there is an error creating the trust store file.
+     */
+    public File getTrustStoreFile(X509Util.StoreFileType storeFileType) throws IOException {
+        switch (storeFileType) {
+            case JKS:
+                return getTrustStoreJksFile();
+            default:
+                throw new IllegalArgumentException("Invalid trust store type: " + storeFileType + ", must be one of: " +
+                        Arrays.toString(X509Util.StoreFileType.values()));
+        }
+    }
+
+    private File getTrustStoreJksFile() throws IOException {
+        if (trustStoreJksFile == null) {
+            try {
+                File trustStoreJksFile = File.createTempFile(
+                        TRUST_STORE_PREFIX, X509Util.StoreFileType.JKS.getDefaultFileExtension(), tempDir);
+                trustStoreJksFile.deleteOnExit();
+                final FileOutputStream trustStoreOutputStream = new FileOutputStream(trustStoreJksFile);
+                try {
+                    byte[] bytes = X509TestHelpers.certToJavaTrustStoreBytes(trustStoreCertificate, trustStorePassword);
+                    trustStoreOutputStream.write(bytes);
+                    trustStoreOutputStream.flush();
+                } finally {
+                    trustStoreOutputStream.close();
+                }
+                this.trustStoreJksFile = trustStoreJksFile;
+            } catch (GeneralSecurityException e) {
+                throw new IOException(e);
+            }
+        }
+        return trustStoreJksFile;
+    }
+
+    public X509KeyType getKeyStoreKeyType() {
+        return keyStoreKeyType;
+    }
+
+    public KeyPair getKeyStoreKeyPair() {
+        return keyStoreKeyPair;
+    }
+
+    public long getKeyStoreCertExpirationMillis() {
+        return keyStoreCertExpirationMillis;
+    }
+
+    public X509Certificate getKeyStoreCertificate() {
+        return keyStoreCertificate;
+    }
+
+    public String getKeyStorePassword() {
+        return keyStorePassword;
+    }
+
+    public boolean isKeyStoreEncrypted() {
+        return keyStorePassword.length() > 0;
+    }
+
+    /**
+     * Returns the path to the key store file in the given format. Currently only JKS is supported. Note that the
+     * file is created lazily, the first time this method is called. The key store file is temporary and will be
+     * deleted on exit.
+     * @param storeFileType the store file type.
+     * @return the path to the key store file.
+     * @throws IOException if there is an error creating the key store file.
+     */
+    public File getKeyStoreFile(X509Util.StoreFileType storeFileType) throws IOException {
+        switch (storeFileType) {
+            case JKS:
+                return getKeyStoreJksFile();
+            default:
+                throw new IllegalArgumentException("Invalid key store type: " + storeFileType + ", must be one of: " +
+                        Arrays.toString(X509Util.StoreFileType.values()));
+        }
+    }
+
+    private File getKeyStoreJksFile() throws IOException {
+        if (keyStoreJksFile == null) {
+            try {
+                File keyStoreJksFile = File.createTempFile(
+                        KEY_STORE_PREFIX, X509Util.StoreFileType.JKS.getDefaultFileExtension(), tempDir);
+                keyStoreJksFile.deleteOnExit();
+                final FileOutputStream keyStoreOutputStream = new FileOutputStream(keyStoreJksFile);
+                try {
+                    byte[] bytes = X509TestHelpers.certAndPrivateKeyToJavaKeyStoreBytes(
+                            keyStoreCertificate, keyStoreKeyPair.getPrivate(), keyStorePassword);
+                    keyStoreOutputStream.write(bytes);
+                    keyStoreOutputStream.flush();
+                } finally {
+                    keyStoreOutputStream.close();
+                }
+                this.keyStoreJksFile = keyStoreJksFile;
+            } catch (GeneralSecurityException e) {
+                throw new IOException(e);
+            }
+        }
+        return keyStoreJksFile;
+    }
+
+    /**
+     * Sets the SSL system properties such that the given X509Util object can be used to create SSL Contexts that
+     * will use the trust store and key store files created by this test context. Example usage:
+     * <pre>
+     *     X509TestContext testContext = ...; // create the test context
+     *     X509Util x509Util = new QuorumX509Util();
+     *     testContext.setSystemProperties(x509Util, X509Util.StoreFileType.JKS, X509Util.StoreFileType.JKS);
+     *     // The returned context will use the key store and trust store created by the test context.
+     *     SSLContext ctx = x509Util.getDefaultSSLContext();
+     * </pre>
+     * @param x509Util the X509Util.
+     * @param keyStoreFileType the store file type to use for the key store (JKS or PEM).
+     * @param trustStoreFileType the store file type to use for the trust store (JKS or PEM).
+     * @throws IOException if there is an error creating the key store file or trust store file.
+     */
+    public void setSystemProperties(X509Util x509Util,
+                                    X509Util.StoreFileType keyStoreFileType,
+                                    X509Util.StoreFileType trustStoreFileType) throws IOException {
+        System.setProperty(
+                x509Util.getSslKeystoreLocationProperty(),
+                this.getKeyStoreFile(keyStoreFileType).getAbsolutePath());
+        System.setProperty(x509Util.getSslKeystorePasswdProperty(), this.getKeyStorePassword());
+        System.setProperty(
+                x509Util.getSslTruststoreLocationProperty(),
+                this.getTrustStoreFile(trustStoreFileType).getAbsolutePath());
+        System.setProperty(x509Util.getSslTruststorePasswdProperty(), this.getTrustStorePassword());
+        if (hostnameVerification != null) {
+            System.setProperty(x509Util.getSslHostnameVerificationEnabledProperty(), hostnameVerification.toString());
+        } else {
+            System.clearProperty(x509Util.getSslHostnameVerificationEnabledProperty());
+        }
+    }
+
+    /**
+     * Builder class, used for creating new instances of X509TestContext.
+     */
+    public static class Builder {
+        public static final long DEFAULT_CERT_EXPIRATION_MILLIS = 1000L * 60 * 60 * 24; // 1 day
+        private File tempDir;
+        private X509KeyType trustStoreKeyType;
+        private String trustStorePassword;
+        private long trustStoreCertExpirationMillis;
+        private X509KeyType keyStoreKeyType;
+        private String keyStorePassword;
+        private long keyStoreCertExpirationMillis;
+        private Boolean hostnameVerification;
+
+        /**
+         * Creates an empty builder.
+         */
+        public Builder() {
+            trustStoreKeyType = X509KeyType.EC;
+            trustStorePassword = "";
+            trustStoreCertExpirationMillis = DEFAULT_CERT_EXPIRATION_MILLIS;
+            keyStoreKeyType = X509KeyType.EC;
+            keyStorePassword = "";
+            keyStoreCertExpirationMillis = DEFAULT_CERT_EXPIRATION_MILLIS;
+            hostnameVerification = null;
+        }
+
+        /**
+         * Builds a new X509TestContext from this builder.
+         * @return a new X509TestContext
+         * @throws IOException
+         * @throws GeneralSecurityException
+         * @throws OperatorCreationException
+         */
+        public X509TestContext build() throws IOException, GeneralSecurityException, OperatorCreationException {
+            KeyPair trustStoreKeyPair = X509TestHelpers.generateKeyPair(trustStoreKeyType);
+            KeyPair keyStoreKeyPair = X509TestHelpers.generateKeyPair(keyStoreKeyType);
+            return new X509TestContext(
+                    tempDir,
+                    trustStoreKeyPair,
+                    trustStoreCertExpirationMillis,
+                    trustStorePassword,
+                    keyStoreKeyPair,
+                    keyStoreCertExpirationMillis,
+                    keyStorePassword,
+                    hostnameVerification);
+        }
+
+        /**
+         * Sets the temporary directory. Certificate and private key files will be created in this directory.
+         * @param tempDir the temp directory.
+         * @return this Builder.
+         */
+        public Builder setTempDir(File tempDir) {
+            this.tempDir = tempDir;
+            return this;
+        }
+
+        /**
+         * Sets the trust store key type. The CA key generated for the test context will be of this type.
+         * @param keyType the key type.
+         * @return this Builder.
+         */
+        public Builder setTrustStoreKeyType(X509KeyType keyType) {
+            trustStoreKeyType = keyType;
+            return this;
+        }
+
+        /**
+         * Sets the trust store password. Ignored for PEM trust stores, JKS trust stores will be encrypted with this
+         * password.
+         * @param password the password.
+         * @return this Builder.
+         */
+        public Builder setTrustStorePassword(String password) {
+            trustStorePassword = password;
+            return this;
+        }
+
+        /**
+         * Sets the trust store certificate's expiration, in milliseconds from when <code>build()</code> is called.
+         * @param expirationMillis expiration in milliseconds.
+         * @return this Builder.
+         */
+        public Builder setTrustStoreCertExpirationMillis(long expirationMillis) {
+            trustStoreCertExpirationMillis = expirationMillis;
+            return this;
+        }
+
+        /**
+         * Sets the key store key type. The private key generated for the test context will be of this type.
+         * @param keyType the key type.
+         * @return this Builder.
+         */
+        public Builder setKeyStoreKeyType(X509KeyType keyType) {
+            keyStoreKeyType = keyType;
+            return this;
+        }
+
+        /**
+         * Sets the key store password. The private key (PEM, JKS) and certificate (JKS only) will be encrypted with
+         * this password.
+         * @param password the password.
+         * @return this Builder.
+         */
+        public Builder setKeyStorePassword(String password) {
+            keyStorePassword = password;
+            return this;
+        }
+
+        /**
+         * Sets the key store certificate's expiration, in milliseconds from when <code>build()</code> is called.
+         * @param expirationMillis expiration in milliseconds.
+         * @return this Builder.
+         */
+        public Builder setKeyStoreCertExpirationMillis(long expirationMillis) {
+            keyStoreCertExpirationMillis = expirationMillis;
+            return this;
+        }
+
+        /**
+         * Sets the hostname verification behavior. If null is provided, reverts the behavior to the default, otherwise
+         * explicitly sets hostname verification to true or false.
+         * @param hostnameVerification new value for the hostname verification setting.
+         * @return this Builder.
+         */
+        public Builder setHostnameVerification(Boolean hostnameVerification) {
+            this.hostnameVerification = hostnameVerification;
+            return this;
+        }
+    }
+
+    /**
+     * Returns a new default-constructed Builder.
+     * @return a new Builder.
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+}

--- a/src/java/test/org/apache/zookeeper/common/X509TestContext.java
+++ b/src/java/test/org/apache/zookeeper/common/X509TestContext.java
@@ -1,6 +1,5 @@
 package org.apache.zookeeper.common;
 
-import org.apache.commons.codec.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
@@ -11,6 +10,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.Security;
@@ -189,7 +189,7 @@ public class X509TestContext {
             FileUtils.writeStringToFile(
                     trustStorePemFile,
                     X509TestHelpers.pemEncodeX509Certificate(trustStoreCertificate),
-                    Charsets.US_ASCII,
+                    StandardCharsets.US_ASCII,
                     false);
             this.trustStorePemFile = trustStorePemFile;
         }
@@ -272,7 +272,7 @@ public class X509TestContext {
                         keyStorePemFile,
                         X509TestHelpers.pemEncodeCertAndPrivateKey(
                                 keyStoreCertificate, keyStoreKeyPair.getPrivate(), keyStorePassword),
-                        Charsets.US_ASCII,
+                        StandardCharsets.US_ASCII,
                         false);
                 this.keyStorePemFile = keyStorePemFile;
             } catch (OperatorCreationException e) {

--- a/src/java/test/org/apache/zookeeper/common/X509TestHelpers.java
+++ b/src/java/test/org/apache/zookeeper/common/X509TestHelpers.java
@@ -1,0 +1,317 @@
+package org.apache.zookeeper.common;
+
+import org.bouncycastle.asn1.DERIA5String;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.crypto.util.PrivateKeyFactory;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder;
+import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.bc.BcContentSignerBuilder;
+import org.bouncycastle.operator.bc.BcECContentSignerBuilder;
+import org.bouncycastle.operator.bc.BcRSAContentSignerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.RSAKeyGenParameterSpec;
+import java.util.Date;
+
+/**
+ * This class contains helper methods for creating X509 certificates and key pairs, and for serializing them
+ * to JKS files. Support for PEM serialization will be added in a later diff.
+ */
+public class X509TestHelpers {
+    private static final Logger LOG = LoggerFactory.getLogger(X509TestHelpers.class);
+
+    private static final SecureRandom PRNG = new SecureRandom();
+    private static final int DEFAULT_RSA_KEY_SIZE_BITS = 2048;
+    private static final BigInteger DEFAULT_RSA_PUB_EXPONENT = RSAKeyGenParameterSpec.F4; // 65537
+    private static final String DEFAULT_ELLIPTIC_CURVE_NAME = "secp256r1";
+    // Per RFC 5280 section 4.1.2.2, X509 certificates can use up to 20 bytes == 160 bits for serial numbers.
+    private static final int SERIAL_NUMBER_MAX_BITS = 20 * Byte.SIZE;
+
+    /**
+     * Uses the private key of the given key pair to create a self-signed CA certificate with the public half of the
+     * key pair and the given subject and expiration. The issuer of the new cert will be equal to the subject.
+     * Returns the new certificate.
+     * The returned certificate should be used as the trust store. The private key of the input key pair should be
+     * used to sign certificates that are used by test peers to establish TLS connections to each other.
+     * @param subject the subject of the new certificate being created.
+     * @param keyPair the key pair to use. The public key will be embedded in the new certificate, and the private key
+     *                will be used to self-sign the certificate.
+     * @param expirationMillis expiration of the new certificate, in milliseconds from now.
+     * @return a new self-signed CA certificate.
+     * @throws IOException
+     * @throws OperatorCreationException
+     * @throws GeneralSecurityException
+     */
+    public static X509Certificate newSelfSignedCACert(
+            X500Name subject,
+            KeyPair keyPair,
+            long expirationMillis) throws IOException, OperatorCreationException, GeneralSecurityException {
+        Date now = new Date();
+        X509v3CertificateBuilder builder = initCertBuilder(
+                subject, // for self-signed certs, issuer == subject
+                now,
+                new Date(now.getTime() + expirationMillis),
+                subject,
+                keyPair.getPublic());
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true)); // is a CA
+        builder.addExtension(
+                Extension.keyUsage,
+                true,
+                new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyCertSign | KeyUsage.cRLSign));
+        return buildAndSignCertificate(keyPair.getPrivate(), builder);
+    }
+
+    /**
+     * Using the private key of the given CA key pair and the Subject of the given CA cert as the Issuer, issues a
+     * new cert with the given subject and public key. The returned certificate, combined with the private key half
+     * of the <code>certPublicKey</code>, should be used as the key store.
+     * @param caCert the certificate of the CA that's doing the signing.
+     * @param caKeyPair the key pair of the CA. The private key will be used to sign. The public key must match the
+     *                  public key in the <code>caCert</code>.
+     * @param certSubject the subject field of the new cert being issued.
+     * @param certPublicKey the public key of the new cert being issued.
+     * @param expirationMillis the expiration of the cert being issued, in milliseconds from now.
+     * @return a new certificate signed by the CA's private key.
+     * @throws IOException
+     * @throws OperatorCreationException
+     * @throws GeneralSecurityException
+     */
+    public static X509Certificate newCert(
+            X509Certificate caCert,
+            KeyPair caKeyPair,
+            X500Name certSubject,
+            PublicKey certPublicKey,
+            long expirationMillis) throws IOException, OperatorCreationException, GeneralSecurityException {
+        if (!caKeyPair.getPublic().equals(caCert.getPublicKey())) {
+            throw new IllegalArgumentException("CA private key does not match the public key in the CA cert");
+        }
+        Date now = new Date();
+        X509v3CertificateBuilder builder = initCertBuilder(
+                new X500Name(caCert.getIssuerDN().getName()),
+                now,
+                new Date(now.getTime() + expirationMillis),
+                certSubject,
+                certPublicKey);
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false)); // not a CA
+        builder.addExtension(
+                Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyAgreement));
+        builder.addExtension(
+                Extension.extendedKeyUsage,
+                true,
+                new ExtendedKeyUsage(new KeyPurposeId[] { KeyPurposeId.id_kp_serverAuth, KeyPurposeId.id_kp_clientAuth }));
+
+        builder.addExtension(
+                Extension.subjectAlternativeName,
+                false,
+                getLocalhostSubjectAltNames());
+        return buildAndSignCertificate(caKeyPair.getPrivate(), builder);
+    }
+
+    /**
+     * Returns subject alternative names for "localhost".
+     * @return the subject alternative names for "localhost".
+     */
+    private static GeneralNames getLocalhostSubjectAltNames() throws UnknownHostException {
+        InetAddress[] localAddresses = InetAddress.getAllByName("localhost");
+        GeneralName[] generalNames = new GeneralName[localAddresses.length + 1];
+        for (int i = 0; i < localAddresses.length; i++) {
+            generalNames[i] = new GeneralName(GeneralName.iPAddress, new DEROctetString(localAddresses[i].getAddress()));
+        }
+        generalNames[generalNames.length - 1] = new GeneralName(GeneralName.dNSName, new DERIA5String("localhost"));
+        return new GeneralNames(generalNames);
+    }
+
+    /**
+     * Helper method for newSelfSignedCACert() and newCert(). Initializes a X509v3CertificateBuilder with
+     * logic that's common to both methods.
+     * @param issuer Issuer field of the new cert.
+     * @param notBefore date before which the new cert is not valid.
+     * @param notAfter date after which the new cert is not valid.
+     * @param subject Subject field of the new cert.
+     * @param subjectPublicKey public key to store in the new cert.
+     * @return a X509v3CertificateBuilder that can be further customized to finish creating the new cert.
+     */
+    private static X509v3CertificateBuilder initCertBuilder(
+            X500Name issuer,
+            Date notBefore,
+            Date notAfter,
+            X500Name subject,
+            PublicKey subjectPublicKey) {
+        return new X509v3CertificateBuilder(
+                issuer,
+                new BigInteger(SERIAL_NUMBER_MAX_BITS, PRNG),
+                notBefore,
+                notAfter,
+                subject,
+                SubjectPublicKeyInfo.getInstance(subjectPublicKey.getEncoded()));
+    }
+
+    /**
+     * Signs the certificate being built by the given builder using the given private key and returns the certificate.
+     * @param privateKey the private key to sign the certificate with.
+     * @param builder the cert builder that contains the certificate data.
+     * @return the signed certificate.
+     * @throws IOException
+     * @throws OperatorCreationException
+     * @throws CertificateException
+     */
+    private static X509Certificate buildAndSignCertificate(
+            PrivateKey privateKey,
+            X509v3CertificateBuilder builder) throws IOException, OperatorCreationException, CertificateException {
+        BcContentSignerBuilder signerBuilder;
+        if (privateKey.getAlgorithm().contains("RSA")) { // a little hacky way to detect key type, but it works
+            AlgorithmIdentifier signatureAlgorithm = new DefaultSignatureAlgorithmIdentifierFinder().find(
+                    "SHA256WithRSAEncryption");
+            AlgorithmIdentifier digestAlgorithm = new DefaultDigestAlgorithmIdentifierFinder().find(signatureAlgorithm);
+            signerBuilder = new BcRSAContentSignerBuilder(signatureAlgorithm, digestAlgorithm);
+        } else { // if not RSA, assume EC
+            AlgorithmIdentifier signatureAlgorithm = new DefaultSignatureAlgorithmIdentifierFinder().find(
+                    "SHA256withECDSA");
+            AlgorithmIdentifier digestAlgorithm = new DefaultDigestAlgorithmIdentifierFinder().find(signatureAlgorithm);
+            signerBuilder = new BcECContentSignerBuilder(signatureAlgorithm, digestAlgorithm);
+        }
+        AsymmetricKeyParameter privateKeyParam = PrivateKeyFactory.createKey(privateKey.getEncoded());
+        ContentSigner signer = signerBuilder.build(privateKeyParam);
+        return toX509Cert(builder.build(signer));
+    }
+
+    /**
+     * Generates a new asymmetric key pair of the given type.
+     * @param keyType the type of key pair to generate.
+     * @return the new key pair.
+     * @throws GeneralSecurityException if your java crypto providers are messed up.
+     */
+    public static KeyPair generateKeyPair(X509KeyType keyType) throws GeneralSecurityException {
+        switch (keyType) {
+            case RSA:
+                return generateRSAKeyPair();
+            case EC:
+                return generateECKeyPair();
+            default:
+                throw new IllegalArgumentException("Invalid X509KeyType");
+        }
+    }
+
+    /**
+     * Generates an RSA key pair with a 2048-bit private key and F4 (65537) as the public exponent.
+     * @return the key pair.
+     */
+    public static KeyPair generateRSAKeyPair() throws GeneralSecurityException {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        RSAKeyGenParameterSpec keyGenSpec = new RSAKeyGenParameterSpec(
+                DEFAULT_RSA_KEY_SIZE_BITS, DEFAULT_RSA_PUB_EXPONENT);
+        keyGen.initialize(keyGenSpec, PRNG);
+        return keyGen.generateKeyPair();
+    }
+
+    /**
+     * Generates an elliptic curve key pair using the "secp256r1" aka "prime256v1" aka "NIST P-256" curve.
+     * @return the key pair.
+     */
+    public static KeyPair generateECKeyPair() throws GeneralSecurityException {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+        keyGen.initialize(new ECGenParameterSpec(DEFAULT_ELLIPTIC_CURVE_NAME), PRNG);
+        return keyGen.generateKeyPair();
+    }
+
+    /**
+     * Encodes the given X509Certificate as a JKS TrustStore, optionally protecting the cert with a password (though
+     * it's unclear why one would do this since certificates only contain public information and do not need to be
+     * kept secret). Returns the byte array encoding of the trust store, which may be written to a file and loaded to
+     * instantiate the trust store at a later point or in another process.
+     * @param cert the certificate to serialize.
+     * @param keyPassword an optional password to encrypt the trust store. If empty or null, the cert will not be encrypted.
+     * @return the serialized bytes of the JKS trust store.
+     * @throws IOException
+     * @throws GeneralSecurityException
+     */
+    public static byte[] certToJavaTrustStoreBytes(
+            X509Certificate cert,
+            String keyPassword) throws IOException, GeneralSecurityException {
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        char[] keyPasswordChars = keyPassword == null ? new char[0] : keyPassword.toCharArray();
+        trustStore.load(null, keyPasswordChars);
+        trustStore.setCertificateEntry(cert.getSubjectDN().toString(), cert);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        trustStore.store(outputStream, keyPasswordChars);
+        outputStream.flush();
+        byte[] result = outputStream.toByteArray();
+        outputStream.close();
+        return result;
+    }
+
+    /**
+     * Encodes the given X509Certificate and private key as a JKS KeyStore, optionally protecting the private key
+     * (and possibly the cert?) with a password. Returns the byte array encoding of the key store, which may be written
+     * to a file and loaded to instantiate the key store at a later point or in another process.
+     * @param cert the X509 certificate to serialize.
+     * @param privateKey the private key to serialize.
+     * @param keyPassword an optional key password. If empty or null, the private key will not be encrypted.
+     * @return the serialized bytes of the JKS key store.
+     * @throws IOException
+     * @throws GeneralSecurityException
+     */
+    public static byte[] certAndPrivateKeyToJavaKeyStoreBytes(
+            X509Certificate cert,
+            PrivateKey privateKey,
+            String keyPassword) throws IOException, GeneralSecurityException {
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        char[] keyPasswordChars = keyPassword == null ? new char[0] : keyPassword.toCharArray();
+        keyStore.load(null, keyPasswordChars);
+        keyStore.setKeyEntry(
+                "key",
+                privateKey,
+                keyPasswordChars,
+                new Certificate[] { cert });
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        keyStore.store(outputStream, keyPasswordChars);
+        outputStream.flush();
+        byte[] result = outputStream.toByteArray();
+        outputStream.close();
+        return result;
+    }
+
+    /**
+     * Convenience method to convert a bouncycastle X509CertificateHolder to a java X509Certificate.
+     * @param certHolder a bouncycastle X509CertificateHolder.
+     * @return a java X509Certificate
+     * @throws CertificateException if the conversion fails.
+     */
+    public static X509Certificate toX509Cert(X509CertificateHolder certHolder) throws CertificateException {
+        return new JcaX509CertificateConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME).getCertificate(certHolder);
+    }
+}

--- a/src/java/test/org/apache/zookeeper/common/X509UtilTest.java
+++ b/src/java/test/org/apache/zookeeper/common/X509UtilTest.java
@@ -402,6 +402,34 @@ public class X509UtilTest extends ZKTestCase {
                 true);
     }
 
+    @Test
+    public void testGetSslHandshakeDetectionTimeoutMillisProperty() {
+        X509Util x509Util = new ClientX509Util();
+        Assert.assertEquals(
+                X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS,
+                x509Util.getSslHandshakeTimeoutMillis());
+        try {
+            String newPropertyString = Integer.toString(X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS + 1);
+            System.setProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty(), newPropertyString);
+            // Note: need to create a new ClientX509Util to pick up modified property value
+            Assert.assertEquals(
+                    X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS + 1,
+                    new ClientX509Util().getSslHandshakeTimeoutMillis());
+            // 0 value not allowed, will return the default
+            System.setProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty(), "0");
+            Assert.assertEquals(
+                    X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS,
+                    new ClientX509Util().getSslHandshakeTimeoutMillis());
+            // Negative value not allowed, will return the default
+            System.setProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty(), "-1");
+            Assert.assertEquals(
+                    X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS,
+                    new ClientX509Util().getSslHandshakeTimeoutMillis());
+        } finally {
+            System.clearProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty());
+        }
+    }
+
     // Warning: this will reset the x509Util
     private void setCustomCipherSuites() {
         System.setProperty(x509Util.getCipherSuitesProperty(), customCipherSuites[0] + "," + customCipherSuites[1]);

--- a/src/java/test/org/apache/zookeeper/common/X509UtilTest.java
+++ b/src/java/test/org/apache/zookeeper/common/X509UtilTest.java
@@ -225,11 +225,74 @@ public class X509UtilTest extends ZKTestCase {
     }
 
     @Test
+    public void testLoadPEMKeyStore() throws Exception {
+        // Make sure we can instantiate a key manager from the PEM file on disk
+        X509KeyManager km = X509Util.createKeyManager(
+                x509TestContext.getKeyStoreFile(X509Util.StoreFileType.PEM).getAbsolutePath(),
+                x509TestContext.getKeyStorePassword(),
+                X509Util.StoreFileType.PEM);
+    }
+
+    @Test
+    public void testLoadPEMKeyStoreAutodetectStoreFileType() throws Exception {
+        // Make sure we can instantiate a key manager from the PEM file on disk
+        X509KeyManager km = X509Util.createKeyManager(
+                x509TestContext.getKeyStoreFile(X509Util.StoreFileType.PEM).getAbsolutePath(),
+                x509TestContext.getKeyStorePassword(),
+                null /* null StoreFileType means 'autodetect from file extension' */);
+    }
+
+    @Test(expected = X509Exception.KeyManagerException.class)
+    public void testLoadPEMKeyStoreWithWrongPassword() throws Exception {
+        // Attempting to load with the wrong key password should fail
+        X509KeyManager km = X509Util.createKeyManager(
+                x509TestContext.getKeyStoreFile(X509Util.StoreFileType.PEM).getAbsolutePath(),
+                "wrong password", // intentionally use the wrong password
+                X509Util.StoreFileType.PEM);
+    }
+
+    @Test
+    public void testLoadPEMTrustStore() throws Exception {
+        // Make sure we can instantiate a trust manager from the PEM file on disk
+        X509TrustManager tm = X509Util.createTrustManager(
+                x509TestContext.getTrustStoreFile(X509Util.StoreFileType.PEM).getAbsolutePath(),
+                x509TestContext.getTrustStorePassword(),
+                X509Util.StoreFileType.PEM,
+                false,
+                false,
+                true,
+                true);
+    }
+
+    @Test
+    public void testLoadPEMTrustStoreAutodetectStoreFileType() throws Exception {
+        // Make sure we can instantiate a trust manager from the PEM file on disk
+        X509TrustManager tm = X509Util.createTrustManager(
+                x509TestContext.getTrustStoreFile(X509Util.StoreFileType.PEM).getAbsolutePath(),
+                x509TestContext.getTrustStorePassword(),
+                null,  // null StoreFileType means 'autodetect from file extension'
+                false,
+                false,
+                true,
+                true);
+    }
+
+    @Test
     public void testLoadJKSKeyStore() throws Exception {
         // Make sure we can instantiate a key manager from the JKS file on disk
         X509KeyManager km = X509Util.createKeyManager(
                 x509TestContext.getKeyStoreFile(X509Util.StoreFileType.JKS).getAbsolutePath(),
-                x509TestContext.getKeyStorePassword());
+                x509TestContext.getKeyStorePassword(),
+                X509Util.StoreFileType.JKS);
+    }
+
+    @Test
+    public void testLoadJKSKeyStoreAutodetectStoreFileType() throws Exception {
+        // Make sure we can instantiate a key manager from the JKS file on disk
+        X509KeyManager km = X509Util.createKeyManager(
+                x509TestContext.getKeyStoreFile(X509Util.StoreFileType.JKS).getAbsolutePath(),
+                x509TestContext.getKeyStorePassword(),
+                null /* null StoreFileType means 'autodetect from file extension' */);
     }
 
     @Test(expected = X509Exception.KeyManagerException.class)
@@ -237,7 +300,8 @@ public class X509UtilTest extends ZKTestCase {
         // Attempting to load with the wrong key password should fail
         X509KeyManager km = X509Util.createKeyManager(
                 x509TestContext.getKeyStoreFile(X509Util.StoreFileType.JKS).getAbsolutePath(),
-                "wrong password");
+                "wrong password",
+                X509Util.StoreFileType.JKS);
     }
 
     @Test
@@ -246,6 +310,20 @@ public class X509UtilTest extends ZKTestCase {
         X509TrustManager tm = X509Util.createTrustManager(
                 x509TestContext.getTrustStoreFile(X509Util.StoreFileType.JKS).getAbsolutePath(),
                 x509TestContext.getTrustStorePassword(),
+                X509Util.StoreFileType.JKS,
+                true,
+                true,
+                true,
+                true);
+    }
+
+    @Test
+    public void testLoadJKSTrustStoreAutodetectStoreFileType() throws Exception {
+        // Make sure we can instantiate a trust manager from the JKS file on disk
+        X509TrustManager tm = X509Util.createTrustManager(
+                x509TestContext.getTrustStoreFile(X509Util.StoreFileType.JKS).getAbsolutePath(),
+                x509TestContext.getTrustStorePassword(),
+                null,  // null StoreFileType means 'autodetect from file extension'
                 true,
                 true,
                 true,
@@ -258,6 +336,7 @@ public class X509UtilTest extends ZKTestCase {
         X509TrustManager tm = X509Util.createTrustManager(
                 x509TestContext.getTrustStoreFile(X509Util.StoreFileType.JKS).getAbsolutePath(),
                 "wrong password",
+                X509Util.StoreFileType.JKS,
                 true,
                 true,
                 true,

--- a/src/java/test/org/apache/zookeeper/common/X509UtilTest.java
+++ b/src/java/test/org/apache/zookeeper/common/X509UtilTest.java
@@ -120,8 +120,10 @@ public class X509UtilTest extends ZKTestCase {
     public void cleanUp() {
         System.clearProperty(x509Util.getSslKeystoreLocationProperty());
         System.clearProperty(x509Util.getSslKeystorePasswdProperty());
+        System.clearProperty(x509Util.getSslKeystoreTypeProperty());
         System.clearProperty(x509Util.getSslTruststoreLocationProperty());
         System.clearProperty(x509Util.getSslTruststorePasswdProperty());
+        System.clearProperty(x509Util.getSslTruststoreTypeProperty());
         System.clearProperty(x509Util.getSslHostnameVerificationEnabledProperty());
         System.clearProperty(x509Util.getSslOcspEnabledProperty());
         System.clearProperty(x509Util.getSslCrlEnabledProperty());
@@ -149,7 +151,7 @@ public class X509UtilTest extends ZKTestCase {
         Assert.assertEquals(protocol, sslContext.getProtocol());
     }
 
-    @Test(timeout = 5000, expected = X509Exception.SSLContextException.class)
+    @Test(timeout = 5000)
     public void testCreateSSLContextWithoutKeyStoreLocation() throws Exception {
         System.clearProperty(x509Util.getSslKeystoreLocationProperty());
         x509Util.getDefaultSSLContext();
@@ -234,6 +236,18 @@ public class X509UtilTest extends ZKTestCase {
     }
 
     @Test
+    public void testLoadPEMKeyStoreNullPassword() throws Exception {
+        if (!x509TestContext.getKeyStorePassword().isEmpty()) {
+            return;
+        }
+        // Make sure that empty password and null password are treated the same
+        X509KeyManager km = X509Util.createKeyManager(
+                x509TestContext.getKeyStoreFile(X509Util.StoreFileType.PEM).getAbsolutePath(),
+                null,
+                X509Util.StoreFileType.PEM);
+    }
+
+    @Test
     public void testLoadPEMKeyStoreAutodetectStoreFileType() throws Exception {
         // Make sure we can instantiate a key manager from the PEM file on disk
         X509KeyManager km = X509Util.createKeyManager(
@@ -265,6 +279,23 @@ public class X509UtilTest extends ZKTestCase {
     }
 
     @Test
+    public void testLoadPEMTrustStoreNullPassword() throws Exception {
+        if (!x509TestContext.getTrustStorePassword().isEmpty()) {
+            return;
+        }
+        // Make sure that empty password and null password are treated the same
+        X509TrustManager tm = X509Util.createTrustManager(
+                x509TestContext.getTrustStoreFile(X509Util.StoreFileType.PEM).getAbsolutePath(),
+                null,
+                X509Util.StoreFileType.PEM,
+                false,
+                false,
+                true,
+                true);
+
+    }
+
+    @Test
     public void testLoadPEMTrustStoreAutodetectStoreFileType() throws Exception {
         // Make sure we can instantiate a trust manager from the PEM file on disk
         X509TrustManager tm = X509Util.createTrustManager(
@@ -283,6 +314,18 @@ public class X509UtilTest extends ZKTestCase {
         X509KeyManager km = X509Util.createKeyManager(
                 x509TestContext.getKeyStoreFile(X509Util.StoreFileType.JKS).getAbsolutePath(),
                 x509TestContext.getKeyStorePassword(),
+                X509Util.StoreFileType.JKS);
+    }
+
+    @Test
+    public void testLoadJKSKeyStoreNullPassword() throws Exception {
+        if (!x509TestContext.getKeyStorePassword().isEmpty()) {
+            return;
+        }
+        // Make sure that empty password and null password are treated the same
+        X509KeyManager km = X509Util.createKeyManager(
+                x509TestContext.getKeyStoreFile(X509Util.StoreFileType.JKS).getAbsolutePath(),
+                null,
                 X509Util.StoreFileType.JKS);
     }
 
@@ -313,6 +356,22 @@ public class X509UtilTest extends ZKTestCase {
                 X509Util.StoreFileType.JKS,
                 true,
                 true,
+                true,
+                true);
+    }
+
+    @Test
+    public void testLoadJKSTrustStoreNullPassword() throws Exception {
+        if (!x509TestContext.getTrustStorePassword().isEmpty()) {
+            return;
+        }
+        // Make sure that empty password and null password are treated the same
+        X509TrustManager tm = X509Util.createTrustManager(
+                x509TestContext.getTrustStoreFile(X509Util.StoreFileType.JKS).getAbsolutePath(),
+                null,
+                X509Util.StoreFileType.JKS,
+                false,
+                false,
                 true,
                 true);
     }

--- a/src/java/test/org/apache/zookeeper/common/X509UtilTest.java
+++ b/src/java/test/org/apache/zookeeper/common/X509UtilTest.java
@@ -1,0 +1,264 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.common;
+
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.client.ZKClientConfig;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
+import java.io.FileOutputStream;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Random;
+
+import static org.apache.zookeeper.test.ClientBase.createTmpDir;
+
+public class X509UtilTest extends ZKTestCase {
+
+    private static final char[] PASSWORD = "password".toCharArray();
+    private X509Certificate rootCertificate;
+
+    private String truststorePath;
+    private String keystorePath;
+    private static KeyPair rootKeyPair;
+
+    private X509Util x509Util;
+    private String[] customCipherSuites = new String[]{"SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA", "SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA"};
+
+    @BeforeClass
+    public static void createKeyPair() throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
+        keyPairGenerator.initialize(4096);
+        rootKeyPair = keyPairGenerator.genKeyPair();
+    }
+
+    @AfterClass
+    public static void removeBouncyCastleProvider() throws Exception {
+        Security.removeProvider("BC");
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        rootCertificate = createSelfSignedCertifcate(rootKeyPair);
+
+        String tmpDir = createTmpDir().getAbsolutePath();
+        truststorePath = tmpDir + "/truststore.jks";
+        keystorePath = tmpDir + "/keystore.jks";
+
+        x509Util = new ClientX509Util();
+
+        writeKeystore(rootCertificate, rootKeyPair, keystorePath);
+
+        System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY, "org.apache.zookeeper.server.NettyServerCnxnFactory");
+        System.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET, "org.apache.zookeeper.ClientCnxnSocketNetty");
+        System.setProperty(x509Util.getSslKeystoreLocationProperty(), keystorePath);
+        System.setProperty(x509Util.getSslKeystorePasswdProperty(), new String(PASSWORD));
+        System.setProperty(x509Util.getSslTruststoreLocationProperty(), truststorePath);
+        System.setProperty(x509Util.getSslTruststorePasswdProperty(), new String(PASSWORD));
+        System.setProperty(x509Util.getSslHostnameVerificationEnabledProperty(), "false");
+
+        writeTrustStore(PASSWORD);
+    }
+
+    private void writeKeystore(X509Certificate certificate, KeyPair keyPair, String path) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(null, PASSWORD);
+        keyStore.setKeyEntry("alias", keyPair.getPrivate(), PASSWORD, new Certificate[] { certificate });
+        FileOutputStream outputStream = new FileOutputStream(path);
+        keyStore.store(outputStream, PASSWORD);
+        outputStream.flush();
+        outputStream.close();
+    }
+
+    private void writeTrustStore(char[] password) throws Exception {
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null, password);
+        trustStore.setCertificateEntry(rootCertificate.getSubjectDN().toString(), rootCertificate);
+        FileOutputStream outputStream = new FileOutputStream(truststorePath);
+        if (password == null) {
+            trustStore.store(outputStream, new char[0]);
+        } else {
+            trustStore.store(outputStream, password);
+        }
+        outputStream.flush();
+        outputStream.close();
+    }
+
+    private X509Certificate createSelfSignedCertifcate(KeyPair keyPair) throws Exception {
+        X500NameBuilder nameBuilder = new X500NameBuilder(BCStyle.INSTANCE);
+        nameBuilder.addRDN(BCStyle.CN, "localhost");
+        Date notBefore = new Date();
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(notBefore);
+        cal.add(Calendar.YEAR, 1);
+        Date notAfter = cal.getTime();
+        BigInteger serialNumber = new BigInteger(128, new Random());
+
+        X509v3CertificateBuilder certificateBuilder =
+                new JcaX509v3CertificateBuilder(nameBuilder.build(), serialNumber, notBefore, notAfter, nameBuilder.build(), keyPair.getPublic())
+                        .addExtension(Extension.basicConstraints, true, new BasicConstraints(0))
+                        .addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyCertSign | KeyUsage.cRLSign));
+
+        ContentSigner contentSigner = new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(keyPair.getPrivate());
+
+        return new JcaX509CertificateConverter().getCertificate(certificateBuilder.build(contentSigner));
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        System.clearProperty(x509Util.getSslKeystoreLocationProperty());
+        System.clearProperty(x509Util.getSslKeystorePasswdProperty());
+        System.clearProperty(x509Util.getSslTruststoreLocationProperty());
+        System.clearProperty(x509Util.getSslTruststorePasswdProperty());
+        System.clearProperty(x509Util.getSslHostnameVerificationEnabledProperty());
+        System.clearProperty(x509Util.getSslOcspEnabledProperty());
+        System.clearProperty(x509Util.getSslCrlEnabledProperty());
+        System.clearProperty(x509Util.getCipherSuitesProperty());
+        System.clearProperty("com.sun.net.ssl.checkRevocation");
+        System.clearProperty("com.sun.security.enableCRLDP");
+        Security.setProperty("com.sun.security.enableCRLDP", "false");
+    }
+
+    @Test(timeout = 5000)
+    public void testCreateSSLContextWithoutCustomProtocol() throws Exception {
+        SSLContext sslContext = x509Util.getDefaultSSLContext();
+        Assert.assertEquals(X509Util.DEFAULT_PROTOCOL, sslContext.getProtocol());
+    }
+
+    @Test(timeout = 5000)
+    public void testCreateSSLContextWithCustomProtocol() throws Exception {
+        final String protocol = "TLSv1.1";
+        System.setProperty(x509Util.getSslProtocolProperty(), protocol);
+        SSLContext sslContext = x509Util.getDefaultSSLContext();
+        Assert.assertEquals(protocol, sslContext.getProtocol());
+    }
+
+    @Test(timeout = 5000)
+    public void testCreateSSLContextWithoutTrustStorePassword() throws Exception {
+        writeTrustStore(null);
+        System.clearProperty(x509Util.getSslTruststorePasswdProperty());
+        x509Util.getDefaultSSLContext();
+    }
+
+    @Test(timeout = 5000, expected = X509Exception.SSLContextException.class)
+    public void testCreateSSLContextWithoutKeyStoreLocation() throws Exception {
+        System.clearProperty(x509Util.getSslKeystoreLocationProperty());
+        x509Util.getDefaultSSLContext();
+    }
+
+    @Test(timeout = 5000, expected = X509Exception.SSLContextException.class)
+    public void testCreateSSLContextWithoutKeyStorePassword() throws Exception {
+        System.clearProperty(x509Util.getSslKeystorePasswdProperty());
+        x509Util.getDefaultSSLContext();
+    }
+
+    @Test(timeout = 5000)
+    public void testCreateSSLContextWithCustomCipherSuites() throws Exception {
+        setCustomCipherSuites();
+        SSLSocket sslSocket = x509Util.createSSLSocket();
+        Assert.assertArrayEquals(customCipherSuites, sslSocket.getEnabledCipherSuites());
+    }
+
+    // It would be great to test the value of PKIXBuilderParameters#setRevocationEnabled but it does not appear to be
+    // possible
+    @Test(timeout = 5000)
+    public void testCRLEnabled() throws Exception {
+        System.setProperty(x509Util.getSslCrlEnabledProperty(), "true");
+        x509Util.getDefaultSSLContext();
+        Assert.assertTrue(Boolean.valueOf(System.getProperty("com.sun.net.ssl.checkRevocation")));
+        Assert.assertTrue(Boolean.valueOf(System.getProperty("com.sun.security.enableCRLDP")));
+        Assert.assertFalse(Boolean.valueOf(Security.getProperty("ocsp.enable")));
+    }
+
+    @Test(timeout = 5000)
+    public void testCRLDisabled() throws Exception {
+        x509Util.getDefaultSSLContext();
+        Assert.assertFalse(Boolean.valueOf(System.getProperty("com.sun.net.ssl.checkRevocation")));
+        Assert.assertFalse(Boolean.valueOf(System.getProperty("com.sun.security.enableCRLDP")));
+        Assert.assertFalse(Boolean.valueOf(Security.getProperty("ocsp.enable")));
+    }
+
+    @Test(timeout = 5000)
+    public void testOCSPEnabled() throws Exception {
+        System.setProperty(x509Util.getSslOcspEnabledProperty(), "true");
+        x509Util.getDefaultSSLContext();
+        Assert.assertTrue(Boolean.valueOf(System.getProperty("com.sun.net.ssl.checkRevocation")));
+        Assert.assertTrue(Boolean.valueOf(System.getProperty("com.sun.security.enableCRLDP")));
+        Assert.assertTrue(Boolean.valueOf(Security.getProperty("ocsp.enable")));
+    }
+
+    @Test(timeout = 5000)
+    public void testCreateSSLSocket() throws Exception {
+        setCustomCipherSuites();
+        SSLSocket sslSocket = x509Util.createSSLSocket();
+        Assert.assertArrayEquals(customCipherSuites, sslSocket.getEnabledCipherSuites());
+    }
+
+    @Test(timeout = 5000)
+    public void testCreateSSLServerSocketWithoutPort() throws Exception {
+        setCustomCipherSuites();
+        SSLServerSocket sslServerSocket = x509Util.createSSLServerSocket();
+        Assert.assertArrayEquals(customCipherSuites, sslServerSocket.getEnabledCipherSuites());
+        Assert.assertTrue(sslServerSocket.getNeedClientAuth());
+    }
+
+    @Test(timeout = 5000)
+    public void testCreateSSLServerSocketWithPort() throws Exception {
+        int port = PortAssignment.unique();
+        setCustomCipherSuites();
+        SSLServerSocket sslServerSocket = x509Util.createSSLServerSocket(port);
+        Assert.assertEquals(sslServerSocket.getLocalPort(), port);
+        Assert.assertArrayEquals(customCipherSuites, sslServerSocket.getEnabledCipherSuites());
+        Assert.assertTrue(sslServerSocket.getNeedClientAuth());
+    }
+
+    // Warning: this will reset the x509Util
+    private void setCustomCipherSuites() {
+        System.setProperty(x509Util.getCipherSuitesProperty(), customCipherSuites[0] + "," + customCipherSuites[1]);
+        x509Util = new ClientX509Util();
+    }
+}

--- a/src/java/test/org/apache/zookeeper/common/ZKTrustManagerTest.java
+++ b/src/java/test/org/apache/zookeeper/common/ZKTrustManagerTest.java
@@ -1,0 +1,248 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.common;
+
+import org.apache.zookeeper.ZKTestCase;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.net.ssl.X509ExtendedTrustManager;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Random;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// We can only test calls to ZKTrustManager using Sockets (not SSLEngines). This can be fine since the logic is the same.
+public class ZKTrustManagerTest extends ZKTestCase {
+
+    private static KeyPair keyPair;
+
+    private X509ExtendedTrustManager mockX509ExtendedTrustManager;
+    private static final String IP_ADDRESS = "127.0.0.1";
+    private static final String HOSTNAME = "localhost";
+
+    private InetAddress mockInetAddress;
+    private Socket mockSocket;
+
+    @BeforeClass
+    public static void createKeyPair() throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
+        keyPairGenerator.initialize(4096);
+        keyPair = keyPairGenerator.genKeyPair();
+    }
+
+    @AfterClass
+    public static void removeBouncyCastleProvider() throws Exception {
+        Security.removeProvider("BC");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        mockX509ExtendedTrustManager = mock(X509ExtendedTrustManager.class);
+
+        mockInetAddress = mock(InetAddress.class);
+        when(mockInetAddress.getHostAddress()).thenAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return IP_ADDRESS;
+            }
+        });
+
+        when(mockInetAddress.getHostName()).thenAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return HOSTNAME;
+            }
+        });
+
+        mockSocket = mock(Socket.class);
+        when(mockSocket.getInetAddress()).thenAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return mockInetAddress;
+            }
+        });
+    }
+
+    private X509Certificate[] createSelfSignedCertifcateChain(String ipAddress, String hostname) throws Exception {
+        X500NameBuilder nameBuilder = new X500NameBuilder(BCStyle.INSTANCE);
+        nameBuilder.addRDN(BCStyle.CN, "NOT_LOCALHOST");
+        Date notBefore = new Date();
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(notBefore);
+        cal.add(Calendar.YEAR, 1);
+        Date notAfter = cal.getTime();
+        BigInteger serialNumber = new BigInteger(128, new Random());
+
+        X509v3CertificateBuilder certificateBuilder =
+                new JcaX509v3CertificateBuilder(nameBuilder.build(), serialNumber, notBefore, notAfter, nameBuilder.build(), keyPair.getPublic())
+                        .addExtension(Extension.basicConstraints, true, new BasicConstraints(0))
+                        .addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyCertSign | KeyUsage.cRLSign));
+
+        List<GeneralName> generalNames = new ArrayList<>();
+        if (ipAddress != null) {
+            generalNames.add(new GeneralName(GeneralName.iPAddress, ipAddress));
+        }
+        if (hostname != null) {
+            generalNames.add(new GeneralName(GeneralName.dNSName, hostname));
+        }
+
+        if (!generalNames.isEmpty()) {
+            certificateBuilder.addExtension(Extension.subjectAlternativeName,  true,  new GeneralNames(generalNames.toArray(new GeneralName[] {})));
+        }
+
+        ContentSigner contentSigner = new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(keyPair.getPrivate());
+
+        return new X509Certificate[] { new JcaX509CertificateConverter().getCertificate(certificateBuilder.build(contentSigner)) };
+    }
+
+    @Test
+    public void testServerHostnameVerificationWithHostnameVerificationDisabled() throws Exception {
+        ZKTrustManager zkTrustManager = new ZKTrustManager(mockX509ExtendedTrustManager, false, false);
+
+        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(IP_ADDRESS, HOSTNAME);
+        zkTrustManager.checkServerTrusted(certificateChain, null, mockSocket);
+
+        verify(mockInetAddress, times(0)).getHostAddress();
+        verify(mockInetAddress, times(0)).getHostName();
+
+        verify(mockX509ExtendedTrustManager, times(1)).checkServerTrusted(certificateChain, null, mockSocket);
+    }
+
+    @Test
+    public void testServerHostnameVerificationWithHostnameVerificationDisabledAndClientHostnameVerificationEnabled() throws Exception {
+        ZKTrustManager zkTrustManager = new ZKTrustManager(mockX509ExtendedTrustManager, false, true);
+
+        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(IP_ADDRESS, HOSTNAME);
+        zkTrustManager.checkServerTrusted(certificateChain, null, mockSocket);
+
+        verify(mockInetAddress, times(0)).getHostAddress();
+        verify(mockInetAddress, times(0)).getHostName();
+
+        verify(mockX509ExtendedTrustManager, times(1)).checkServerTrusted(certificateChain, null, mockSocket);
+    }
+
+    @Test
+    public void testServerHostnameVerificationWithIPAddress() throws Exception {
+        ZKTrustManager zkTrustManager = new ZKTrustManager(mockX509ExtendedTrustManager, true, false);
+
+        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(IP_ADDRESS, null);
+        zkTrustManager.checkServerTrusted(certificateChain, null, mockSocket);
+
+        verify(mockInetAddress, times(1)).getHostAddress();
+        verify(mockInetAddress, times(0)).getHostName();
+
+        verify(mockX509ExtendedTrustManager, times(1)).checkServerTrusted(certificateChain, null, mockSocket);
+    }
+
+    @Test
+    public void testServerHostnameVerificationWithHostname() throws Exception {
+        ZKTrustManager zkTrustManager = new ZKTrustManager(mockX509ExtendedTrustManager, true, false);
+
+        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(null, HOSTNAME);
+        zkTrustManager.checkServerTrusted(certificateChain, null, mockSocket);
+
+        verify(mockInetAddress, times(1)).getHostAddress();
+        verify(mockInetAddress, times(1)).getHostName();
+
+        verify(mockX509ExtendedTrustManager, times(1)).checkServerTrusted(certificateChain, null, mockSocket);
+    }
+
+    @Test
+    public void testClientHostnameVerificationWithHostnameVerificationDisabled() throws Exception {
+        ZKTrustManager zkTrustManager = new ZKTrustManager(mockX509ExtendedTrustManager, false, true);
+
+        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(null, HOSTNAME);
+        zkTrustManager.checkClientTrusted(certificateChain, null, mockSocket);
+
+        verify(mockInetAddress, times(0)).getHostAddress();
+        verify(mockInetAddress, times(0)).getHostName();
+
+        verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mockSocket);
+    }
+
+    @Test
+    public void testClientHostnameVerificationWithClientHostnameVerificationDisabled() throws Exception {
+        ZKTrustManager zkTrustManager = new ZKTrustManager(mockX509ExtendedTrustManager, true, false);
+
+        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(null, HOSTNAME);
+        zkTrustManager.checkClientTrusted(certificateChain, null, mockSocket);
+
+        verify(mockInetAddress, times(0)).getHostAddress();
+        verify(mockInetAddress, times(0)).getHostName();
+
+        verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mockSocket);
+    }
+
+    @Test
+    public void testClientHostnameVerificationWithIPAddress() throws Exception {
+        ZKTrustManager zkTrustManager = new ZKTrustManager(mockX509ExtendedTrustManager, true, true);
+
+        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(IP_ADDRESS, null);
+        zkTrustManager.checkClientTrusted(certificateChain, null, mockSocket);
+
+        verify(mockInetAddress, times(1)).getHostAddress();
+        verify(mockInetAddress, times(0)).getHostName();
+
+        verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mockSocket);
+    }
+
+    @Test
+    public void testClientHostnameVerificationWithHostname() throws Exception {
+        ZKTrustManager zkTrustManager = new ZKTrustManager(mockX509ExtendedTrustManager, true, true);
+
+        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(null, HOSTNAME);
+        zkTrustManager.checkClientTrusted(certificateChain, null, mockSocket);
+
+        verify(mockInetAddress, times(1)).getHostAddress();
+        verify(mockInetAddress, times(1)).getHostName();
+
+        verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mockSocket);
+    }
+}

--- a/src/java/test/org/apache/zookeeper/common/ZKTrustManagerTest.java
+++ b/src/java/test/org/apache/zookeeper/common/ZKTrustManagerTest.java
@@ -201,8 +201,8 @@ public class ZKTrustManagerTest extends ZKTestCase {
         X509Certificate[] certificateChain = createSelfSignedCertifcateChain(null, HOSTNAME);
         zkTrustManager.checkClientTrusted(certificateChain, null, mockSocket);
 
-        verify(mockInetAddress, times(0)).getHostAddress();
-        verify(mockInetAddress, times(0)).getHostName();
+        verify(mockInetAddress, times(1)).getHostAddress();
+        verify(mockInetAddress, times(1)).getHostName();
 
         verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mockSocket);
     }

--- a/src/java/test/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.server.quorum;
 
 import org.apache.jute.OutputArchive;
 import org.apache.jute.Record;
+import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
@@ -51,7 +52,7 @@ public class LeaderBeanTest {
     private QuorumPeer qp;
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() throws IOException, X509Exception {
         qp = new QuorumPeer();
         QuorumVerifier quorumVerifierMock = mock(QuorumVerifier.class);
         qp.setQuorumVerifier(quorumVerifierMock, false);

--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumBeanTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumBeanTest.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.quorum;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class QuorumBeanTest {
+    @Test
+    public void testGetNameProperty() {
+        QuorumPeer qpMock = mock(QuorumPeer.class);
+        when(qpMock.getId()).thenReturn(1L);
+        QuorumBean qb = new QuorumBean(qpMock);
+
+        assertThat("getName property should return Bean name in the right format", qb.getName(), equalTo("ReplicatedServer_id1"));
+    }
+
+    @Test
+    public void testIsHiddenProperty() {
+        QuorumPeer qpMock = mock(QuorumPeer.class);
+        QuorumBean qb = new QuorumBean(qpMock);
+        assertThat("isHidden should return false", qb.isHidden(), equalTo(false));
+    }
+
+    @Test
+    public void testGetQuorumSizeProperty() {
+        QuorumPeer qpMock = mock(QuorumPeer.class);
+        QuorumBean qb = new QuorumBean(qpMock);
+
+        when(qpMock.getQuorumSize()).thenReturn(5);
+        assertThat("getQuorumSize property should return value of peet.getQuorumSize()", qb.getQuorumSize(), equalTo(5));
+    }
+
+    @Test
+    public void testSslQuorumProperty() {
+        QuorumPeer qpMock = mock(QuorumPeer.class);
+        QuorumBean qb = new QuorumBean(qpMock);
+
+        when(qpMock.isSslQuorum()).thenReturn(true);
+        assertThat("isSslQuorum property should return value of peer.isSslQuorum()", qb.isSslQuorum(), equalTo(true));
+        when(qpMock.isSslQuorum()).thenReturn(false);
+        assertThat("isSslQuorum property should return value of peer.isSslQuorum()", qb.isSslQuorum(), equalTo(false));
+    }
+
+    @Test
+    public void testPortUnificationProperty() {
+        QuorumPeer qpMock = mock(QuorumPeer.class);
+        QuorumBean qb = new QuorumBean(qpMock);
+
+        when(qpMock.shouldUsePortUnification()).thenReturn(true);
+        assertThat("isPortUnification property should return value of peer.shouldUsePortUnification()", qb.isPortUnification(), equalTo(true));
+        when(qpMock.shouldUsePortUnification()).thenReturn(false);
+        assertThat("isPortUnification property should return value of peer.shouldUsePortUnification()", qb.isPortUnification(), equalTo(false));
+    }
+}

--- a/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerConfigTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/QuorumPeerConfigTest.java
@@ -26,6 +26,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 
+import org.apache.zookeeper.common.ClientX509Util;
+import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.common.ZKConfig;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig.ConfigException;
 import org.junit.Test;
@@ -91,7 +93,7 @@ public class QuorumPeerConfigTest {
     @Test
     public void testCustomSSLAuth()
             throws IOException{
-        System.setProperty(ZKConfig.SSL_AUTHPROVIDER, "y509");
+        System.setProperty(new ClientX509Util().getSslAuthProviderProperty(), "y509");
         QuorumPeerConfig quorumPeerConfig = new QuorumPeerConfig();
         try {
             Properties zkProp = getDefaultZKProperties();

--- a/src/java/test/org/apache/zookeeper/server/quorum/RaceConditionTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/RaceConditionTest.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.server.FinalRequestProcessor;
 import org.apache.zookeeper.server.PrepRequestProcessor;
 import org.apache.zookeeper.server.Request;
@@ -182,7 +183,7 @@ public class RaceConditionTest extends QuorumPeerTestBase {
         }
 
         @Override
-        protected Leader makeLeader(FileTxnSnapLog logFactory) throws IOException {
+        protected Leader makeLeader(FileTxnSnapLog logFactory) throws IOException, X509Exception {
             LeaderZooKeeperServer zk = new LeaderZooKeeperServer(logFactory, this, this.getZkDb()) {
                 @Override
                 protected void setupRequestProcessors() {

--- a/src/java/test/org/apache/zookeeper/server/quorum/UnifiedServerSocketTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/UnifiedServerSocketTest.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.client.ZKClientConfig;
+import org.apache.zookeeper.common.ClientX509Util;
+import org.apache.zookeeper.common.Time;
+import org.apache.zookeeper.common.X509Util;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.net.ssl.HandshakeCompletedEvent;
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.SSLSocket;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+public class UnifiedServerSocketTest {
+
+    private static final int MAX_RETRIES = 5;
+    private static final int TIMEOUT = 1000;
+
+    private X509Util x509Util;
+    private int port;
+    private volatile boolean handshakeCompleted;
+
+    @Before
+    public void setUp() throws Exception {
+        handshakeCompleted = false;
+
+        port = PortAssignment.unique();
+
+        String testDataPath = System.getProperty("test.data.dir", "build/test/data");
+        System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY, "org.apache.zookeeper.server.NettyServerCnxnFactory");
+        System.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET, "org.apache.zookeeper.ClientCnxnSocketNetty");
+        System.setProperty(ZKClientConfig.SECURE_CLIENT, "true");
+
+        x509Util = new ClientX509Util();
+
+        System.setProperty(x509Util.getSslKeystoreLocationProperty(), testDataPath + "/ssl/testKeyStore.jks");
+        System.setProperty(x509Util.getSslKeystorePasswdProperty(), "testpass");
+        System.setProperty(x509Util.getSslTruststoreLocationProperty(), testDataPath + "/ssl/testTrustStore.jks");
+        System.setProperty(x509Util.getSslTruststorePasswdProperty(), "testpass");
+        System.setProperty(x509Util.getSslHostnameVerificationEnabledProperty(), "false");
+    }
+
+    @Test
+    public void testConnectWithSSL() throws Exception {
+        class ServerThread extends Thread {
+            public void run() {
+                try {
+                    Socket unifiedSocket = new UnifiedServerSocket(x509Util, port).accept();
+                    ((SSLSocket)unifiedSocket).getSession(); // block until handshake completes
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        ServerThread serverThread = new ServerThread();
+        serverThread.start();
+
+        SSLSocket sslSocket = null;
+        int retries = 0;
+        while (retries < MAX_RETRIES) {
+            try {
+                sslSocket = x509Util.createSSLSocket();
+                sslSocket.setSoTimeout(TIMEOUT);
+                sslSocket.connect(new InetSocketAddress(port), TIMEOUT);
+                break;
+            } catch (ConnectException connectException) {
+                connectException.printStackTrace();
+                Thread.sleep(TIMEOUT);
+            }
+            retries++;
+        }
+
+        sslSocket.addHandshakeCompletedListener(new HandshakeCompletedListener() {
+            @Override
+            public void handshakeCompleted(HandshakeCompletedEvent handshakeCompletedEvent) {
+                completeHandshake();
+            }
+        });
+        sslSocket.startHandshake();
+
+        serverThread.join(TIMEOUT);
+
+        long start = Time.currentElapsedTime();
+        while (Time.currentElapsedTime() < start + TIMEOUT) {
+            if (handshakeCompleted) {
+                return;
+            }
+        }
+
+        Assert.fail("failed to complete handshake");
+    }
+
+    private void completeHandshake() {
+        handshakeCompleted = true;
+    }
+
+    @Test
+    public void testConnectWithoutSSL() throws Exception {
+        final byte[] testData = "hello there".getBytes();
+
+        class ServerThread extends Thread {
+            public void run() {
+                try {
+                    Socket unifiedSocket = new UnifiedServerSocket(x509Util, port).accept();
+                    unifiedSocket.getOutputStream().write(testData);
+                    unifiedSocket.getOutputStream().flush();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        ServerThread serverThread = new ServerThread();
+        serverThread.start();
+
+        Socket socket = null;
+        int retries = 0;
+        while (retries < MAX_RETRIES) {
+            try {
+                socket = new Socket();
+                socket.setSoTimeout(TIMEOUT);
+                socket.connect(new InetSocketAddress(port), TIMEOUT);
+                break;
+            } catch (ConnectException connectException) {
+                connectException.printStackTrace();
+                Thread.sleep(TIMEOUT);
+            }
+            retries++;
+        }
+
+        socket.getOutputStream().write("hello".getBytes());
+        socket.getOutputStream().flush();
+
+        byte[] readBytes = new byte[testData.length];
+        socket.getInputStream().read(readBytes, 0, testData.length);
+
+        serverThread.join(TIMEOUT);
+
+        Assert.assertArrayEquals(testData, readBytes);
+    }
+}

--- a/src/java/test/org/apache/zookeeper/server/quorum/UnifiedServerSocketTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/UnifiedServerSocketTest.java
@@ -38,6 +38,7 @@ import org.junit.runners.Parameterized;
 import javax.net.ssl.HandshakeCompletedEvent;
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLSocket;
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.ConnectException;
@@ -180,6 +181,8 @@ public class UnifiedServerSocketTest {
                     unifiedSocket.setSoTimeout(TIMEOUT);
                     final boolean keepAlive = rnd.nextBoolean();
                     unifiedSocket.setKeepAlive(keepAlive);
+                    // Note: getting the input stream should not block the thread or trigger mode detection.
+                    BufferedInputStream bis = new BufferedInputStream(unifiedSocket.getInputStream());
                     Thread t = new Thread(new Runnable() {
                         @Override
                         public void run() {

--- a/src/java/test/org/apache/zookeeper/server/quorum/UnifiedServerSocketTest.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/UnifiedServerSocketTest.java
@@ -35,6 +35,9 @@ import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 public class UnifiedServerSocketTest {
 
     private static final int MAX_RETRIES = 5;
@@ -121,6 +124,7 @@ public class UnifiedServerSocketTest {
     @Test
     public void testConnectWithoutSSL() throws Exception {
         final byte[] testData = "hello there".getBytes();
+        final String[] dataReadFromClient = {null};
 
         class ServerThread extends Thread {
             public void run() {
@@ -128,6 +132,9 @@ public class UnifiedServerSocketTest {
                     Socket unifiedSocket = new UnifiedServerSocket(x509Util, port).accept();
                     unifiedSocket.getOutputStream().write(testData);
                     unifiedSocket.getOutputStream().flush();
+                    byte[] inputbuff = new byte[5];
+                    unifiedSocket.getInputStream().read(inputbuff, 0, 5);
+                    dataReadFromClient[0] = new String(inputbuff);
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -151,7 +158,7 @@ public class UnifiedServerSocketTest {
             retries++;
         }
 
-        socket.getOutputStream().write("hello".getBytes());
+        socket.getOutputStream().write("hellobello".getBytes());
         socket.getOutputStream().flush();
 
         byte[] readBytes = new byte[testData.length];
@@ -160,5 +167,6 @@ public class UnifiedServerSocketTest {
         serverThread.join(TIMEOUT);
 
         Assert.assertArrayEquals(testData, readBytes);
+        assertThat("Data sent by the client is invalid", dataReadFromClient[0], equalTo("hello"));
     }
 }

--- a/src/java/test/org/apache/zookeeper/server/quorum/Zab1_0Test.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/Zab1_0Test.java
@@ -50,6 +50,7 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.ByteBufferInputStream;
 import org.apache.zookeeper.server.ByteBufferOutputStream;

--- a/src/java/test/org/apache/zookeeper/server/quorum/ZabUtils.java
+++ b/src/java/test/org/apache/zookeeper/server/quorum/ZabUtils.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server.quorum;
 
 import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZKDatabase;
@@ -74,13 +75,13 @@ public class ZabUtils {
     }
 
     public static Leader createLeader(File tmpDir, QuorumPeer peer)
-            throws IOException, NoSuchFieldException, IllegalAccessException {
+            throws IOException, NoSuchFieldException, IllegalAccessException, X509Exception {
         LeaderZooKeeperServer zk = prepareLeader(tmpDir, peer);
         return new Leader(peer, zk);
     }
 
     public static Leader createMockLeader(File tmpDir, QuorumPeer peer)
-            throws IOException, NoSuchFieldException, IllegalAccessException {
+            throws IOException, NoSuchFieldException, IllegalAccessException, X509Exception {
         LeaderZooKeeperServer zk = prepareLeader(tmpDir, peer);
         return new MockLeader(peer, zk);
     }
@@ -146,7 +147,7 @@ public class ZabUtils {
     public static final class MockLeader extends Leader {
 
         MockLeader(QuorumPeer qp, LeaderZooKeeperServer zk)
-                throws IOException {
+                throws IOException, X509Exception {
             super(qp, zk);
         }
 

--- a/src/java/test/org/apache/zookeeper/test/ClientSSLTest.java
+++ b/src/java/test/org/apache/zookeeper/test/ClientSSLTest.java
@@ -27,7 +27,7 @@ import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.client.ZKClientConfig;
-import org.apache.zookeeper.common.ZKConfig;
+import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
 import org.junit.After;
@@ -35,7 +35,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SSLTest extends QuorumPeerTestBase {
+public class ClientSSLTest extends QuorumPeerTestBase {
+
+    private ClientX509Util clientX509Util = new ClientX509Util();
 
     @Before
     public void setup() {
@@ -43,10 +45,10 @@ public class SSLTest extends QuorumPeerTestBase {
         System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY, "org.apache.zookeeper.server.NettyServerCnxnFactory");
         System.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET, "org.apache.zookeeper.ClientCnxnSocketNetty");
         System.setProperty(ZKClientConfig.SECURE_CLIENT, "true");
-        System.setProperty(ZKConfig.SSL_KEYSTORE_LOCATION, testDataPath + "/ssl/testKeyStore.jks");
-        System.setProperty(ZKConfig.SSL_KEYSTORE_PASSWD, "testpass");
-        System.setProperty(ZKConfig.SSL_TRUSTSTORE_LOCATION, testDataPath + "/ssl/testTrustStore.jks");
-        System.setProperty(ZKConfig.SSL_TRUSTSTORE_PASSWD, "testpass");
+        System.setProperty(clientX509Util.getSslKeystoreLocationProperty(), testDataPath + "/ssl/testKeyStore.jks");
+        System.setProperty(clientX509Util.getSslKeystorePasswdProperty(), "testpass");
+        System.setProperty(clientX509Util.getSslTruststoreLocationProperty(), testDataPath + "/ssl/testTrustStore.jks");
+        System.setProperty(clientX509Util.getSslTruststorePasswdProperty(), "testpass");
     }
 
     @After
@@ -54,14 +56,14 @@ public class SSLTest extends QuorumPeerTestBase {
         System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
         System.clearProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET);
         System.clearProperty(ZKClientConfig.SECURE_CLIENT);
-        System.clearProperty(ZKConfig.SSL_KEYSTORE_LOCATION);
-        System.clearProperty(ZKConfig.SSL_KEYSTORE_PASSWD);
-        System.clearProperty(ZKConfig.SSL_TRUSTSTORE_LOCATION);
-        System.clearProperty(ZKConfig.SSL_TRUSTSTORE_PASSWD);
+        System.clearProperty(clientX509Util.getSslKeystoreLocationProperty());
+        System.clearProperty(clientX509Util.getSslKeystorePasswdProperty());
+        System.clearProperty(clientX509Util.getSslTruststoreLocationProperty());
+        System.clearProperty(clientX509Util.getSslTruststorePasswdProperty());
     }
 
     /**
-     * This test checks that SSL works in cluster setup of ZK servers, which includes:
+     * This test checks that client <-> server SSL works in cluster setup of ZK servers, which includes:
      * 1. setting "secureClientPort" in "zoo.cfg" file.
      * 2. setting jvm flags for serverCnxn, keystore, truststore.
      * Finally, a zookeeper client should be able to connect to the secure port and
@@ -70,7 +72,7 @@ public class SSLTest extends QuorumPeerTestBase {
      * Note that in this test a ZK server has two ports -- clientPort and secureClientPort.
      */
     @Test
-    public void testSecureQuorumServer() throws Exception {
+    public void testClientServerSSL() throws Exception {
         final int SERVER_COUNT = 3;
         final int clientPorts[] = new int[SERVER_COUNT];
         final Integer secureClientPorts[] = new Integer[SERVER_COUNT];

--- a/src/java/test/org/apache/zookeeper/test/QuorumSSLTest.java
+++ b/src/java/test/org/apache/zookeeper/test/QuorumSSLTest.java
@@ -146,12 +146,16 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
 
     private Date certStartTime;
     private Date certEndTime;
+
+    private int originalTimeout;
     
     @Rule
     public Timeout timeout = Timeout.builder().withTimeout(5, TimeUnit.MINUTES).withLookingForStuckThread(true).build();
 
     @Before
     public void setup() throws Exception {
+        originalTimeout = CONNECTION_TIMEOUT;
+        CONNECTION_TIMEOUT = 5000;
         ClientBase.setupTestEnv();
 
         tmpDir = createTmpDir().getAbsolutePath();
@@ -368,6 +372,7 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
 
     @After
     public void cleanUp() throws Exception {
+        CONNECTION_TIMEOUT = originalTimeout;
         clearSSLSystemProperties();
         q1.shutdown();
         q2.shutdown();
@@ -674,7 +679,7 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
     @Test
     public void testCipherSuites() throws Exception {
         System.setProperty(quorumX509Util.getCipherSuitesProperty(),
-                "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA,SSL_RSA_WITH_RC4_128_MD5");
+                "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_RSA_WITH_RC4_128_MD5");
 
         q1 = new MainThread(1, clientPortQp1, quorumConfiguration, SSL_QUORUM_ENABLED);
         q2 = new MainThread(2, clientPortQp2, quorumConfiguration, SSL_QUORUM_ENABLED);

--- a/src/java/test/org/apache/zookeeper/test/QuorumSSLTest.java
+++ b/src/java/test/org/apache/zookeeper/test/QuorumSSLTest.java
@@ -147,15 +147,11 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
     private Date certStartTime;
     private Date certEndTime;
 
-    private int originalTimeout;
-    
     @Rule
     public Timeout timeout = Timeout.builder().withTimeout(5, TimeUnit.MINUTES).withLookingForStuckThread(true).build();
 
     @Before
     public void setup() throws Exception {
-        originalTimeout = CONNECTION_TIMEOUT;
-        CONNECTION_TIMEOUT = 5000;
         ClientBase.setupTestEnv();
 
         tmpDir = createTmpDir().getAbsolutePath();
@@ -372,11 +368,16 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
 
     @After
     public void cleanUp() throws Exception {
-        CONNECTION_TIMEOUT = originalTimeout;
         clearSSLSystemProperties();
-        q1.shutdown();
-        q2.shutdown();
-        q3.shutdown();
+        if (q1 != null) {
+            q1.shutdown();
+        }
+        if (q2 != null) {
+            q2.shutdown();
+        }
+        if (q3 != null) {
+            q3.shutdown();
+        }
 
         Security.removeProvider("BC");
     }
@@ -679,7 +680,7 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
     @Test
     public void testCipherSuites() throws Exception {
         System.setProperty(quorumX509Util.getCipherSuitesProperty(),
-                "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_RSA_WITH_RC4_128_MD5");
+                "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_RSA_WITH_RC4_128_MD5,SSL_DHE_RSA_WITH_DES_CBC_SHA");
 
         q1 = new MainThread(1, clientPortQp1, quorumConfiguration, SSL_QUORUM_ENABLED);
         q2 = new MainThread(2, clientPortQp2, quorumConfiguration, SSL_QUORUM_ENABLED);

--- a/src/java/test/org/apache/zookeeper/test/QuorumSSLTest.java
+++ b/src/java/test/org/apache/zookeeper/test/QuorumSSLTest.java
@@ -522,7 +522,6 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
      */
     private void testHostnameVerification(String keystorePath, boolean expectSuccess) throws Exception {
         System.setProperty(quorumX509Util.getSslHostnameVerificationEnabledProperty(), "false");
-        System.setProperty(quorumX509Util.getSslClientHostnameVerificationEnabledProperty(), "false");
 
         q1 = new MainThread(1, clientPortQp1, quorumConfiguration, SSL_QUORUM_ENABLED);
         q2 = new MainThread(2, clientPortQp2, quorumConfiguration, SSL_QUORUM_ENABLED);
@@ -551,7 +550,6 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
 
         setSSLSystemProperties();
         System.clearProperty(quorumX509Util.getSslHostnameVerificationEnabledProperty());
-        System.clearProperty(quorumX509Util.getSslClientHostnameVerificationEnabledProperty());
 
         q1.start();
         q2.start();

--- a/src/java/test/org/apache/zookeeper/test/QuorumSSLTest.java
+++ b/src/java/test/org/apache/zookeeper/test/QuorumSSLTest.java
@@ -735,7 +735,7 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
         System.setProperty(quorumX509Util.getSslProtocolProperty(), "TLSv1.1");
 
         // This server should fail to join the quorum as it is not using TLSv1.2
-        q3 = new MainThread(3, clientPortQp3, quorumConfiguration);
+        q3 = new MainThread(3, clientPortQp3, quorumConfiguration, SSL_QUORUM_ENABLED);
         q3.start();
 
         Assert.assertFalse(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));

--- a/src/java/test/org/apache/zookeeper/test/QuorumSSLTest.java
+++ b/src/java/test/org/apache/zookeeper/test/QuorumSSLTest.java
@@ -1,0 +1,719 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.test;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.client.ZKClientConfig;
+import org.apache.zookeeper.common.QuorumX509Util;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
+import org.bouncycastle.asn1.ocsp.OCSPResponse;
+import org.bouncycastle.asn1.ocsp.OCSPResponseStatus;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x509.AuthorityInformationAccess;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.CRLDistPoint;
+import org.bouncycastle.asn1.x509.CRLNumber;
+import org.bouncycastle.asn1.x509.CRLReason;
+import org.bouncycastle.asn1.x509.DistributionPoint;
+import org.bouncycastle.asn1.x509.DistributionPointName;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.asn1.x509.X509ObjectIdentifiers;
+import org.bouncycastle.cert.X509CRLHolder;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509ExtensionUtils;
+import org.bouncycastle.cert.X509v2CRLBuilder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.bc.BcX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509v2CRLBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.cert.ocsp.BasicOCSPResp;
+import org.bouncycastle.cert.ocsp.BasicOCSPRespBuilder;
+import org.bouncycastle.cert.ocsp.CertificateID;
+import org.bouncycastle.cert.ocsp.CertificateStatus;
+import org.bouncycastle.cert.ocsp.OCSPException;
+import org.bouncycastle.cert.ocsp.OCSPReq;
+import org.bouncycastle.cert.ocsp.OCSPResp;
+import org.bouncycastle.cert.ocsp.OCSPRespBuilder;
+import org.bouncycastle.cert.ocsp.Req;
+import org.bouncycastle.cert.ocsp.UnknownStatus;
+import org.bouncycastle.cert.ocsp.jcajce.JcaBasicOCSPRespBuilder;
+import org.bouncycastle.cert.ocsp.jcajce.JcaCertificateID;
+import org.bouncycastle.crypto.util.PublicKeyFactory;
+import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.MiscPEMGenerator;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.DigestCalculator;
+import org.bouncycastle.operator.OperatorException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+import org.bouncycastle.util.io.pem.PemWriter;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
+import static org.apache.zookeeper.test.ClientBase.createTmpDir;
+
+public class QuorumSSLTest extends QuorumPeerTestBase {
+
+    private static final String SSL_QUORUM_ENABLED = "sslQuorum=true\n";
+    private static final String PORT_UNIFICATION_ENABLED = "portUnification=true\n";
+    private static final String PORT_UNIFICATION_DISABLED = "portUnification=false\n";
+
+    private static final char[] PASSWORD = "testpass".toCharArray();
+    private static final String HOSTNAME = "localhost";
+
+    private QuorumX509Util quorumX509Util = new QuorumX509Util();
+
+    private MainThread q1;
+    private MainThread q2;
+    private MainThread q3;
+
+    private int clientPortQp1;
+    private int clientPortQp2;
+    private int clientPortQp3;
+
+    private String tmpDir;
+
+    private String quorumConfiguration;
+    private String validKeystorePath;
+    private String truststorePath;
+
+    private KeyPair rootKeyPair;
+    private X509Certificate rootCertificate;
+
+    private KeyPair defaultKeyPair;
+
+    private ContentSigner contentSigner;
+
+    private Date certStartTime;
+    private Date certEndTime;
+    
+    @Rule
+    public Timeout timeout = Timeout.builder().withTimeout(5, TimeUnit.MINUTES).withLookingForStuckThread(true).build();
+
+    @Before
+    public void setup() throws Exception {
+        ClientBase.setupTestEnv();
+
+        tmpDir = createTmpDir().getAbsolutePath();
+
+        clientPortQp1 = PortAssignment.unique();
+        clientPortQp2 = PortAssignment.unique();
+        clientPortQp3 = PortAssignment.unique();
+
+        validKeystorePath = tmpDir + "/valid.jks";
+        truststorePath = tmpDir + "/truststore.jks";
+
+        quorumConfiguration = generateQuorumConfiguration();
+
+        Security.addProvider(new BouncyCastleProvider());
+
+        certStartTime = new Date();
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(certStartTime);
+        cal.add(Calendar.YEAR, 1);
+        certEndTime = cal.getTime();
+
+        rootKeyPair = createKeyPair();
+        contentSigner = new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(rootKeyPair.getPrivate());
+        rootCertificate = createSelfSignedCertifcate(rootKeyPair);
+
+        // Write the truststore
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null, PASSWORD);
+        trustStore.setCertificateEntry(rootCertificate.getSubjectDN().toString(), rootCertificate);
+        FileOutputStream outputStream = new FileOutputStream(truststorePath);
+        trustStore.store(outputStream, PASSWORD);
+        outputStream.flush();
+        outputStream.close();
+
+        defaultKeyPair = createKeyPair();
+        X509Certificate validCertificate = buildEndEntityCert(defaultKeyPair, rootCertificate, rootKeyPair.getPrivate(),
+                HOSTNAME, null, null, null);
+        writeKeystore(validCertificate, defaultKeyPair, validKeystorePath);
+
+        setSSLSystemProperties();
+    }
+
+    private void writeKeystore(X509Certificate certificate, KeyPair entityKeyPair, String path) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(null, PASSWORD);
+        keyStore.setKeyEntry("alias", entityKeyPair.getPrivate(), PASSWORD, new Certificate[] { certificate });
+        FileOutputStream outputStream = new FileOutputStream(path);
+        keyStore.store(outputStream, PASSWORD);
+        outputStream.flush();
+        outputStream.close();
+    }
+
+    private class OCSPHandler implements HttpHandler {
+
+        private X509Certificate revokedCert;
+
+        // Builds an OCSPHandler that responds with a good status for all certificates
+        // except revokedCert.
+        public OCSPHandler(X509Certificate revokedCert) {
+            this.revokedCert = revokedCert;
+        }
+
+        @Override
+        public void handle(com.sun.net.httpserver.HttpExchange httpExchange) throws IOException {
+            byte[] responseBytes;
+            try {
+                InputStream request = httpExchange.getRequestBody();
+                byte[] requestBytes = new byte[10000];
+                request.read(requestBytes);
+
+                OCSPReq ocspRequest = new OCSPReq(requestBytes);
+                Req[] requestList = ocspRequest.getRequestList();
+
+                DigestCalculator digestCalculator = new JcaDigestCalculatorProviderBuilder().build().get(CertificateID.HASH_SHA1);
+
+                BasicOCSPRespBuilder responseBuilder = new JcaBasicOCSPRespBuilder(rootKeyPair.getPublic(), digestCalculator);
+                for ( Req req : requestList ) {
+                    CertificateID certId = req.getCertID();
+                    CertificateID revokedCertId = new JcaCertificateID(digestCalculator, rootCertificate, revokedCert.getSerialNumber());
+                    CertificateStatus certificateStatus;
+                    if (revokedCertId.equals(certId)) {
+                        certificateStatus = new UnknownStatus();
+                    } else {
+                        certificateStatus = CertificateStatus.GOOD;
+                    }
+
+                    responseBuilder.addResponse(certId, certificateStatus,null);
+                }
+
+                X509CertificateHolder[] chain = new X509CertificateHolder[] { new JcaX509CertificateHolder(rootCertificate) };
+                ContentSigner signer = new JcaContentSignerBuilder("SHA1withRSA").setProvider("BC").build(rootKeyPair.getPrivate());
+                BasicOCSPResp ocspResponse = responseBuilder.build(signer, chain, Calendar.getInstance().getTime() );
+
+                responseBytes = new OCSPRespBuilder().build(OCSPRespBuilder.SUCCESSFUL, ocspResponse).getEncoded();
+            } catch (OperatorException | CertificateEncodingException | OCSPException exception) {
+                responseBytes = new OCSPResp(new OCSPResponse(new OCSPResponseStatus(OCSPRespBuilder.INTERNAL_ERROR), null)).getEncoded();
+            }
+
+            Headers rh = httpExchange.getResponseHeaders();
+            rh.set("Content-Type", "application/ocsp-response");
+            httpExchange.sendResponseHeaders(200, responseBytes.length);
+
+            OutputStream os = httpExchange.getResponseBody();
+            os.write(responseBytes);
+            os.close();
+        }
+    }
+
+    private X509Certificate createSelfSignedCertifcate(KeyPair keyPair) throws Exception {
+        X500NameBuilder nameBuilder = new X500NameBuilder(BCStyle.INSTANCE);
+        nameBuilder.addRDN(BCStyle.CN, HOSTNAME);
+        BigInteger serialNumber = new BigInteger(128, new Random());
+
+        X509v3CertificateBuilder certificateBuilder =
+                new JcaX509v3CertificateBuilder(nameBuilder.build(), serialNumber, certStartTime, certEndTime, nameBuilder.build(), keyPair.getPublic())
+                .addExtension(Extension.basicConstraints, true, new BasicConstraints(0))
+                .addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyCertSign | KeyUsage.cRLSign));
+
+        return new JcaX509CertificateConverter().getCertificate(certificateBuilder.build(contentSigner));
+    }
+
+    private void buildCRL(X509Certificate x509Certificate, String crlPath) throws Exception {
+        X509v2CRLBuilder builder = new JcaX509v2CRLBuilder(x509Certificate.getIssuerX500Principal(), certStartTime);
+        builder.addCRLEntry(x509Certificate.getSerialNumber(), certStartTime, CRLReason.cACompromise);
+        builder.setNextUpdate(certEndTime);
+        builder.addExtension(Extension.authorityKeyIdentifier, false, new JcaX509ExtensionUtils().createAuthorityKeyIdentifier(rootCertificate));
+        builder.addExtension(Extension.cRLNumber, false, new CRLNumber(new BigInteger("1000")));
+
+        X509CRLHolder cRLHolder = builder.build(contentSigner);
+
+        PemWriter pemWriter = new PemWriter(new FileWriter(crlPath));
+        pemWriter.writeObject(new MiscPEMGenerator(cRLHolder));
+        pemWriter.flush();
+        pemWriter.close();
+    }
+
+    public X509Certificate buildEndEntityCert(KeyPair keyPair, X509Certificate caCert, PrivateKey caPrivateKey,
+                                              String hostname, String ipAddress, String crlPath, Integer ocspPort) throws Exception {
+        X509CertificateHolder holder = new JcaX509CertificateHolder(caCert);
+        ContentSigner signer =new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(caPrivateKey);
+
+        List<GeneralName> generalNames = new ArrayList<>();
+        if (hostname != null) {
+            generalNames.add(new GeneralName(GeneralName.dNSName, hostname));
+        }
+
+        if (ipAddress != null) {
+            generalNames.add(new GeneralName(GeneralName.iPAddress, ipAddress));
+        }
+
+        SubjectPublicKeyInfo entityKeyInfo =
+                SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(PublicKeyFactory.createKey(keyPair.getPublic().getEncoded()));
+        X509ExtensionUtils extensionUtils = new BcX509ExtensionUtils();
+        X509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(holder.getSubject(), new BigInteger(128, new Random()),
+                certStartTime, certEndTime, new X500Name("CN=Test End Entity Certificate"), keyPair.getPublic())
+                .addExtension(Extension.authorityKeyIdentifier, false, extensionUtils.createAuthorityKeyIdentifier(holder))
+                .addExtension(Extension.subjectKeyIdentifier, false, extensionUtils.createSubjectKeyIdentifier(entityKeyInfo))
+                .addExtension(Extension.basicConstraints, true, new BasicConstraints(false))
+                .addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment));
+
+        if (!generalNames.isEmpty()) {
+            certificateBuilder.addExtension(Extension.subjectAlternativeName,  true,  new GeneralNames(generalNames.toArray(new GeneralName[] {})));
+        }
+
+        if (crlPath != null) {
+            DistributionPointName distPointOne = new DistributionPointName(new GeneralNames(
+                    new GeneralName(GeneralName.uniformResourceIdentifier,"file://" + crlPath)));
+
+            certificateBuilder.addExtension(Extension.cRLDistributionPoints, false,
+                    new CRLDistPoint(new DistributionPoint[] { new DistributionPoint(distPointOne, null, null) }));
+        }
+
+        if (ocspPort != null) {
+            certificateBuilder.addExtension(Extension.authorityInfoAccess, false, new AuthorityInformationAccess(X509ObjectIdentifiers.ocspAccessMethod,
+                    new GeneralName(GeneralName.uniformResourceIdentifier, "http://" + hostname + ":" + ocspPort)));
+        }
+
+        return new JcaX509CertificateConverter().getCertificate(certificateBuilder.build(signer));
+    }
+
+
+    private KeyPair createKeyPair() throws NoSuchProviderException, NoSuchAlgorithmException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
+        keyPairGenerator.initialize(4096);
+        KeyPair keyPair = keyPairGenerator.genKeyPair();
+        return keyPair;
+    }
+
+    private String generateQuorumConfiguration() {
+        int portQp1 = PortAssignment.unique();
+        int portQp2 = PortAssignment.unique();
+        int portQp3 = PortAssignment.unique();
+
+        int portLe1 = PortAssignment.unique();
+        int portLe2 = PortAssignment.unique();
+        int portLe3 = PortAssignment.unique();
+
+
+
+        return "server.1=127.0.0.1:" + (portQp1) + ":" + (portLe1) + ";" +  clientPortQp1 + "\n" +
+               "server.2=127.0.0.1:" + (portQp2) + ":" + (portLe2) + ";" + clientPortQp2 + "\n" +
+               "server.3=127.0.0.1:" + (portQp3) + ":" + (portLe3) + ";" + clientPortQp3;
+    }
+
+
+    public void setSSLSystemProperties() {
+        System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY, "org.apache.zookeeper.server.NettyServerCnxnFactory");
+        System.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET, "org.apache.zookeeper.ClientCnxnSocketNetty");
+        System.setProperty(quorumX509Util.getSslKeystoreLocationProperty(), validKeystorePath);
+        System.setProperty(quorumX509Util.getSslKeystorePasswdProperty(), "testpass");
+        System.setProperty(quorumX509Util.getSslTruststoreLocationProperty(), truststorePath);
+        System.setProperty(quorumX509Util.getSslTruststorePasswdProperty(), "testpass");
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        clearSSLSystemProperties();
+        q1.shutdown();
+        q2.shutdown();
+        q3.shutdown();
+
+        Security.removeProvider("BC");
+    }
+
+    private void clearSSLSystemProperties() {
+        System.clearProperty(quorumX509Util.getSslKeystoreLocationProperty());
+        System.clearProperty(quorumX509Util.getSslKeystorePasswdProperty());
+        System.clearProperty(quorumX509Util.getSslTruststoreLocationProperty());
+        System.clearProperty(quorumX509Util.getSslTruststorePasswdProperty());
+        System.clearProperty(quorumX509Util.getSslHostnameVerificationEnabledProperty());
+        System.clearProperty(quorumX509Util.getSslOcspEnabledProperty());
+        System.clearProperty(quorumX509Util.getSslCrlEnabledProperty());
+        System.clearProperty(quorumX509Util.getCipherSuitesProperty());
+        System.clearProperty(quorumX509Util.getSslProtocolProperty());
+    }
+
+    @Test
+    public void testQuorumSSL() throws Exception {
+        q1 = new MainThread(1, clientPortQp1, quorumConfiguration, SSL_QUORUM_ENABLED);
+        q2 = new MainThread(2, clientPortQp2, quorumConfiguration, SSL_QUORUM_ENABLED);
+
+
+        q1.start();
+        q2.start();
+
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
+
+        clearSSLSystemProperties();
+
+        // This server should fail to join the quorum as it is not using ssl.
+        q3 = new MainThread(3, clientPortQp3, quorumConfiguration);
+        q3.start();
+
+        Assert.assertFalse(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
+    }
+
+    @Test
+    public void testRollingUpgrade() throws Exception {
+        // Form a quorum without ssl
+        q1 = new MainThread(1, clientPortQp1, quorumConfiguration);
+        q2 = new MainThread(2, clientPortQp2, quorumConfiguration);
+        q3 = new MainThread(3, clientPortQp3, quorumConfiguration);
+
+
+        Map<Integer, MainThread> members = new HashMap<>();
+        members.put(clientPortQp1, q1);
+        members.put(clientPortQp2, q2);
+        members.put(clientPortQp3, q3);
+
+        for (MainThread member : members.values()) {
+            member.start();
+        }
+
+        for (int clientPort : members.keySet()) {
+            Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPort, CONNECTION_TIMEOUT));
+        }
+
+        // Set SSL system properties and port unification, begin restarting servers
+        setSSLSystemProperties();
+
+        stopAppendConfigRestartAll(members, PORT_UNIFICATION_ENABLED);
+        stopAppendConfigRestartAll(members, SSL_QUORUM_ENABLED);
+        stopAppendConfigRestartAll(members, PORT_UNIFICATION_DISABLED);
+    }
+
+    private void stopAppendConfigRestartAll(Map<Integer, MainThread> members, String config) throws Exception {
+        for (Map.Entry<Integer, MainThread> entry : members.entrySet()) {
+            int clientPort = entry.getKey();
+            MainThread member = entry.getValue();
+
+            member.shutdown();
+            Assert.assertTrue(ClientBase.waitForServerDown("127.0.0.1:" + clientPort, CONNECTION_TIMEOUT));
+
+            FileWriter fileWriter = new FileWriter(member.getConfFile(), true);
+            fileWriter.write(config);
+            fileWriter.flush();
+            fileWriter.close();
+
+            member.start();
+
+            Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPort, CONNECTION_TIMEOUT));
+        }
+    }
+
+    @Test
+    public void testHostnameVerificationWithInvalidHostname() throws Exception {
+        String badhostnameKeystorePath = tmpDir + "/badhost.jks";
+        X509Certificate badHostCert = buildEndEntityCert(defaultKeyPair, rootCertificate, rootKeyPair.getPrivate(),
+                "bleepbloop", null, null, null);
+        writeKeystore(badHostCert, defaultKeyPair, badhostnameKeystorePath);
+
+        testHostnameVerification(badhostnameKeystorePath, false);
+    }
+
+    @Test
+    public void testHostnameVerificationWithInvalidIPAddress() throws Exception {
+        String badhostnameKeystorePath = tmpDir + "/badhost.jks";
+        X509Certificate badHostCert = buildEndEntityCert(defaultKeyPair, rootCertificate, rootKeyPair.getPrivate(),
+                null, "140.211.11.105",null, null);
+        writeKeystore(badHostCert, defaultKeyPair, badhostnameKeystorePath);
+
+        testHostnameVerification(badhostnameKeystorePath, false);
+    }
+
+    @Test
+    public void testHostnameVerificationWithInvalidIpAddressAndInvalidHostname() throws Exception {
+        String badhostnameKeystorePath = tmpDir + "/badhost.jks";
+        X509Certificate badHostCert = buildEndEntityCert(defaultKeyPair, rootCertificate, rootKeyPair.getPrivate(),
+                "bleepbloop", "140.211.11.105", null, null);
+        writeKeystore(badHostCert, defaultKeyPair, badhostnameKeystorePath);
+
+        testHostnameVerification(badhostnameKeystorePath, false);
+    }
+
+    @Test
+    public void testHostnameVerificationWithInvalidIpAddressAndValidHostname() throws Exception {
+        String badhostnameKeystorePath = tmpDir + "/badhost.jks";
+        X509Certificate badHostCert = buildEndEntityCert(defaultKeyPair, rootCertificate, rootKeyPair.getPrivate(),
+                "localhost", "140.211.11.105", null, null);
+        writeKeystore(badHostCert, defaultKeyPair, badhostnameKeystorePath);
+
+        testHostnameVerification(badhostnameKeystorePath, true);
+    }
+
+    @Test
+    public void testHostnameVerificationWithValidIpAddressAndInvalidHostname() throws Exception {
+        String badhostnameKeystorePath = tmpDir + "/badhost.jks";
+        X509Certificate badHostCert = buildEndEntityCert(defaultKeyPair, rootCertificate, rootKeyPair.getPrivate(),
+                "bleepbloop", "127.0.0.1", null, null);
+        writeKeystore(badHostCert, defaultKeyPair, badhostnameKeystorePath);
+
+        testHostnameVerification(badhostnameKeystorePath, true);
+    }
+
+    /**
+     * @param keystorePath The keystore to use
+     * @param expectSuccess True for expecting the keystore to pass hostname verification, false for expecting failure
+     * @throws Exception
+     */
+    private void testHostnameVerification(String keystorePath, boolean expectSuccess) throws Exception {
+        System.setProperty(quorumX509Util.getSslHostnameVerificationEnabledProperty(), "false");
+
+        q1 = new MainThread(1, clientPortQp1, quorumConfiguration, SSL_QUORUM_ENABLED);
+        q2 = new MainThread(2, clientPortQp2, quorumConfiguration, SSL_QUORUM_ENABLED);
+
+        q1.start();
+        q2.start();
+
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
+
+        System.setProperty(quorumX509Util.getSslKeystoreLocationProperty(), keystorePath);
+
+        // This server should join successfully
+        q3 = new MainThread(3, clientPortQp3, quorumConfiguration, SSL_QUORUM_ENABLED);
+        q3.start();
+
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
+
+        q1.shutdown();
+        q2.shutdown();
+        q3.shutdown();
+
+        Assert.assertTrue(ClientBase.waitForServerDown("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
+        Assert.assertTrue(ClientBase.waitForServerDown("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
+        Assert.assertTrue(ClientBase.waitForServerDown("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
+
+        setSSLSystemProperties();
+        System.clearProperty(quorumX509Util.getSslHostnameVerificationEnabledProperty());
+
+        q1.start();
+        q2.start();
+
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
+
+        System.setProperty(quorumX509Util.getSslKeystoreLocationProperty(), keystorePath);
+        q3.start();
+
+        Assert.assertEquals(expectSuccess, ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
+    }
+
+
+    @Test
+    public void testCertificateRevocationList() throws Exception {
+        q1 = new MainThread(1, clientPortQp1, quorumConfiguration, SSL_QUORUM_ENABLED);
+        q2 = new MainThread(2, clientPortQp2, quorumConfiguration, SSL_QUORUM_ENABLED);
+
+        q1.start();
+        q2.start();
+
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
+
+        String revokedInCRLKeystorePath = tmpDir + "/crl_revoked.jks";
+        String crlPath = tmpDir + "/crl.pem";
+        X509Certificate revokedInCRLCert = buildEndEntityCert(defaultKeyPair, rootCertificate, rootKeyPair.getPrivate(),
+                HOSTNAME, null, crlPath, null);
+        writeKeystore(revokedInCRLCert, defaultKeyPair, revokedInCRLKeystorePath);
+        buildCRL(revokedInCRLCert, crlPath);
+
+        System.setProperty(quorumX509Util.getSslKeystoreLocationProperty(), revokedInCRLKeystorePath);
+
+        // This server should join successfully
+        q3 = new MainThread(3, clientPortQp3, quorumConfiguration, SSL_QUORUM_ENABLED);
+        q3.start();
+
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
+
+
+        q1.shutdown();
+        q2.shutdown();
+        q3.shutdown();
+
+        Assert.assertTrue(ClientBase.waitForServerDown("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
+        Assert.assertTrue(ClientBase.waitForServerDown("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
+        Assert.assertTrue(ClientBase.waitForServerDown("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
+
+        setSSLSystemProperties();
+        System.setProperty(quorumX509Util.getSslCrlEnabledProperty(), "true");
+
+        X509Certificate validCertificate = buildEndEntityCert(defaultKeyPair, rootCertificate, rootKeyPair.getPrivate(),
+                HOSTNAME, null, crlPath, null);
+        writeKeystore(validCertificate, defaultKeyPair, validKeystorePath);
+
+        q1.start();
+        q2.start();
+
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
+
+        System.setProperty(quorumX509Util.getSslKeystoreLocationProperty(), revokedInCRLKeystorePath);
+        q3.start();
+
+        Assert.assertFalse(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
+    }
+
+    @Test
+    public void testOCSP() throws Exception {
+        Integer ocspPort = PortAssignment.unique();
+
+        q1 = new MainThread(1, clientPortQp1, quorumConfiguration, SSL_QUORUM_ENABLED);
+        q2 = new MainThread(2, clientPortQp2, quorumConfiguration, SSL_QUORUM_ENABLED);
+
+        q1.start();
+        q2.start();
+
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
+
+        String revokedInOCSPKeystorePath = tmpDir + "/ocsp_revoked.jks";
+        X509Certificate revokedInOCSPCert = buildEndEntityCert(defaultKeyPair, rootCertificate, rootKeyPair.getPrivate(),
+                HOSTNAME, null,null, ocspPort);
+        writeKeystore(revokedInOCSPCert, defaultKeyPair, revokedInOCSPKeystorePath);
+
+        HttpServer ocspServer = HttpServer.create(new InetSocketAddress(ocspPort), 0);
+        try {
+            ocspServer.createContext("/", new OCSPHandler(revokedInOCSPCert));
+            ocspServer.start();
+
+            System.setProperty(quorumX509Util.getSslKeystoreLocationProperty(), revokedInOCSPKeystorePath);
+
+            // This server should join successfully
+            q3 = new MainThread(3, clientPortQp3, quorumConfiguration, SSL_QUORUM_ENABLED);
+            q3.start();
+
+            Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
+
+            q1.shutdown();
+            q2.shutdown();
+            q3.shutdown();
+
+            Assert.assertTrue(ClientBase.waitForServerDown("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
+            Assert.assertTrue(ClientBase.waitForServerDown("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
+            Assert.assertTrue(ClientBase.waitForServerDown("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
+
+            setSSLSystemProperties();
+            System.setProperty(quorumX509Util.getSslOcspEnabledProperty(), "true");
+
+            X509Certificate validCertificate = buildEndEntityCert(defaultKeyPair, rootCertificate, rootKeyPair.getPrivate(),
+                    HOSTNAME, null,null, ocspPort);
+            writeKeystore(validCertificate, defaultKeyPair, validKeystorePath);
+
+            q1.start();
+            q2.start();
+
+            Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
+            Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
+
+            System.setProperty(quorumX509Util.getSslKeystoreLocationProperty(), revokedInOCSPKeystorePath);
+            q3.start();
+
+            Assert.assertFalse(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
+        } finally {
+            ocspServer.stop(0);
+        }
+    }
+
+    @Test
+    public void testCipherSuites() throws Exception {
+        System.setProperty(quorumX509Util.getCipherSuitesProperty(),
+                "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA,SSL_RSA_WITH_RC4_128_MD5");
+
+        q1 = new MainThread(1, clientPortQp1, quorumConfiguration, SSL_QUORUM_ENABLED);
+        q2 = new MainThread(2, clientPortQp2, quorumConfiguration, SSL_QUORUM_ENABLED);
+
+        q1.start();
+        q2.start();
+
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
+
+        System.setProperty(quorumX509Util.getCipherSuitesProperty(), "TLS_RSA_WITH_AES_128_CBC_SHA");
+
+        // This server should fail to join the quorum as it is not using one of the supported suites from the other
+        // quorum members
+        q3 = new MainThread(3, clientPortQp3, quorumConfiguration);
+        q3.start();
+
+        Assert.assertFalse(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
+    }
+
+    @Test
+    public void testProtocolVersion() throws Exception {
+        System.setProperty(quorumX509Util.getSslProtocolProperty(), "TLSv1.2");
+
+        q1 = new MainThread(1, clientPortQp1, quorumConfiguration, SSL_QUORUM_ENABLED);
+        q2 = new MainThread(2, clientPortQp2, quorumConfiguration, SSL_QUORUM_ENABLED);
+
+        q1.start();
+        q2.start();
+
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
+        Assert.assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
+
+        System.setProperty(quorumX509Util.getSslProtocolProperty(), "TLSv1.1");
+
+        // This server should fail to join the quorum as it is not using TLSv1.2
+        q3 = new MainThread(3, clientPortQp3, quorumConfiguration);
+        q3.start();
+
+        Assert.assertFalse(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
+    }
+}

--- a/src/java/test/org/apache/zookeeper/test/QuorumSSLTest.java
+++ b/src/java/test/org/apache/zookeeper/test/QuorumSSLTest.java
@@ -522,6 +522,7 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
      */
     private void testHostnameVerification(String keystorePath, boolean expectSuccess) throws Exception {
         System.setProperty(quorumX509Util.getSslHostnameVerificationEnabledProperty(), "false");
+        System.setProperty(quorumX509Util.getSslClientHostnameVerificationEnabledProperty(), "false");
 
         q1 = new MainThread(1, clientPortQp1, quorumConfiguration, SSL_QUORUM_ENABLED);
         q2 = new MainThread(2, clientPortQp2, quorumConfiguration, SSL_QUORUM_ENABLED);
@@ -550,6 +551,7 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
 
         setSSLSystemProperties();
         System.clearProperty(quorumX509Util.getSslHostnameVerificationEnabledProperty());
+        System.clearProperty(quorumX509Util.getSslClientHostnameVerificationEnabledProperty());
 
         q1.start();
         q2.start();

--- a/src/java/test/org/apache/zookeeper/test/SSLAuthTest.java
+++ b/src/java/test/org/apache/zookeeper/test/SSLAuthTest.java
@@ -23,7 +23,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.TestableZooKeeper;
 import org.apache.zookeeper.client.ZKClientConfig;
-import org.apache.zookeeper.common.ZKConfig;
+import org.apache.zookeeper.common.ClientX509Util;
+import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.junit.After;
 import org.junit.Assert;
@@ -31,17 +32,20 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class SSLAuthTest extends ClientBase {
+    
+    private ClientX509Util clientX509Util = new ClientX509Util();
+    
     @Before
     public void setUp() throws Exception {
         String testDataPath = System.getProperty("test.data.dir", "build/test/data");
         System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY, "org.apache.zookeeper.server.NettyServerCnxnFactory");
         System.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET, "org.apache.zookeeper.ClientCnxnSocketNetty");
         System.setProperty(ZKClientConfig.SECURE_CLIENT, "true");
-        System.setProperty(ZKConfig.SSL_AUTHPROVIDER, "x509");
-        System.setProperty(ZKConfig.SSL_KEYSTORE_LOCATION, testDataPath + "/ssl/testKeyStore.jks");
-        System.setProperty(ZKConfig.SSL_KEYSTORE_PASSWD, "testpass");
-        System.setProperty(ZKConfig.SSL_TRUSTSTORE_LOCATION, testDataPath + "/ssl/testTrustStore.jks");
-        System.setProperty(ZKConfig.SSL_TRUSTSTORE_PASSWD, "testpass");
+        System.setProperty(clientX509Util.getSslAuthProviderProperty(), "x509");
+        System.setProperty(clientX509Util.getSslKeystoreLocationProperty(), testDataPath + "/ssl/testKeyStore.jks");
+        System.setProperty(clientX509Util.getSslKeystorePasswdProperty(), "testpass");
+        System.setProperty(clientX509Util.getSslTruststoreLocationProperty(), testDataPath + "/ssl/testTrustStore.jks");
+        System.setProperty(clientX509Util.getSslTruststorePasswdProperty(), "testpass");
         System.setProperty("javax.net.debug", "ssl");
         System.setProperty("zookeeper.authProvider.x509", "org.apache.zookeeper.server.auth.X509AuthenticationProvider");
 
@@ -60,11 +64,11 @@ public class SSLAuthTest extends ClientBase {
         System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
         System.clearProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET);
         System.clearProperty(ZKClientConfig.SECURE_CLIENT);
-        System.clearProperty(ZKConfig.SSL_AUTHPROVIDER);
-        System.clearProperty(ZKConfig.SSL_KEYSTORE_LOCATION);
-        System.clearProperty(ZKConfig.SSL_KEYSTORE_PASSWD);
-        System.clearProperty(ZKConfig.SSL_TRUSTSTORE_LOCATION);
-        System.clearProperty(ZKConfig.SSL_TRUSTSTORE_PASSWD);
+        System.clearProperty(clientX509Util.getSslAuthProviderProperty());
+        System.clearProperty(clientX509Util.getSslKeystoreLocationProperty());
+        System.clearProperty(clientX509Util.getSslKeystorePasswdProperty());
+        System.clearProperty(clientX509Util.getSslTruststoreLocationProperty());
+        System.clearProperty(clientX509Util.getSslTruststorePasswdProperty());
         System.clearProperty("javax.net.debug");
         System.clearProperty("zookeeper.authProvider.x509");
     }
@@ -74,8 +78,8 @@ public class SSLAuthTest extends ClientBase {
         String testDataPath = System.getProperty("test.data.dir", "build/test/data");
 
         // Replace trusted keys with a valid key that is not trusted by the server
-        System.setProperty(ZKConfig.SSL_KEYSTORE_LOCATION, testDataPath + "/ssl/testUntrustedKeyStore.jks");
-        System.setProperty(ZKConfig.SSL_KEYSTORE_PASSWD, "testpass");
+        System.setProperty(clientX509Util.getSslKeystoreLocationProperty(), testDataPath + "/ssl/testUntrustedKeyStore.jks");
+        System.setProperty(clientX509Util.getSslKeystorePasswdProperty(), "testpass");
 
         CountdownWatcher watcher = new CountdownWatcher();
 
@@ -87,11 +91,11 @@ public class SSLAuthTest extends ClientBase {
 
     @Test
     public void testMisconfiguration() throws Exception {
-        System.clearProperty(ZKConfig.SSL_AUTHPROVIDER);
-        System.clearProperty(ZKConfig.SSL_KEYSTORE_LOCATION);
-        System.clearProperty(ZKConfig.SSL_KEYSTORE_PASSWD);
-        System.clearProperty(ZKConfig.SSL_TRUSTSTORE_LOCATION);
-        System.clearProperty(ZKConfig.SSL_TRUSTSTORE_PASSWD);
+        System.clearProperty(clientX509Util.getSslAuthProviderProperty());
+        System.clearProperty(clientX509Util.getSslKeystoreLocationProperty());
+        System.clearProperty(clientX509Util.getSslKeystorePasswdProperty());
+        System.clearProperty(clientX509Util.getSslTruststoreLocationProperty());
+        System.clearProperty(clientX509Util.getSslTruststorePasswdProperty());
 
         CountdownWatcher watcher = new CountdownWatcher();
         new TestableZooKeeper(hostPort, CONNECTION_TIMEOUT, watcher);

--- a/src/java/test/org/apache/zookeeper/util/PemReaderTest.java
+++ b/src/java/test/org/apache/zookeeper/util/PemReaderTest.java
@@ -1,0 +1,160 @@
+package org.apache.zookeeper.util;
+
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.common.X509KeyType;
+import org.apache.zookeeper.common.X509TestContext;
+import org.apache.zookeeper.common.X509Util;
+import org.apache.zookeeper.test.ClientBase;
+import org.apache.zookeeper.util.PemReader;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStoreException;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RunWith(Parameterized.class)
+public class PemReaderTest extends ZKTestCase {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> params() {
+        ArrayList<Object[]> result = new ArrayList<>();
+        int paramIndex = 0;
+        for (X509KeyType caKeyType : X509KeyType.values()) {
+            for (X509KeyType certKeyType : X509KeyType.values()) {
+                for (String keyPassword : new String[]{"", "pa$$w0rd"}) {
+                    result.add(new Object[]{caKeyType, certKeyType, keyPassword, paramIndex++});
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Because key generation and writing / deleting files is kind of expensive, we cache the certs and on-disk files
+     * between test cases. None of the test cases modify any of this data so it's safe to reuse between tests. This
+     * caching makes all test cases after the first one for a given parameter combination complete almost instantly.
+     */
+    private static Map<Integer, X509TestContext> cachedTestContexts;
+    static File tempDir;
+
+    X509TestContext x509TestContext;
+
+    public PemReaderTest(
+            X509KeyType caKeyType,
+            X509KeyType certKeyType,
+            String keyPassword,
+            Integer paramIndex) throws Exception {
+        if (cachedTestContexts.containsKey(paramIndex)) {
+            x509TestContext = cachedTestContexts.get(paramIndex);
+        } else {
+            x509TestContext = X509TestContext.newBuilder()
+                    .setTempDir(tempDir)
+                    .setKeyStoreKeyType(certKeyType)
+                    .setTrustStoreKeyType(caKeyType)
+                    .setKeyStorePassword(keyPassword)
+                    .build();
+            cachedTestContexts.put(paramIndex, x509TestContext);
+        }
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws IOException {
+        Security.addProvider(new BouncyCastleProvider());
+        cachedTestContexts = new HashMap<>();
+        tempDir = ClientBase.createEmptyTestDir();
+    }
+
+    @AfterClass
+    public static void cleanUpClass() {
+        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+        cachedTestContexts.clear();
+        cachedTestContexts = null;
+    }
+
+    @Test
+    public void testLoadPrivateKeyFromKeyStore() throws IOException, GeneralSecurityException {
+        Optional<String> optPassword = x509TestContext.getKeyStorePassword().length() > 0
+                ? Optional.of(x509TestContext.getKeyStorePassword())
+                : Optional.empty();
+        PrivateKey privateKey = PemReader.loadPrivateKey(
+                x509TestContext.getKeyStoreFile(X509Util.StoreFileType.PEM), optPassword);
+        Assert.assertEquals(x509TestContext.getKeyStoreKeyPair().getPrivate(), privateKey);
+    }
+
+    // Try to load a password-protected private key without providing a password
+    @Test(expected = GeneralSecurityException.class)
+    public void testLoadEncryptedPrivateKeyFromKeyStoreWithoutPassword() throws GeneralSecurityException, IOException {
+        if (!x509TestContext.isKeyStoreEncrypted()) {
+            throw new GeneralSecurityException(); // this case is not tested so throw the expected exception
+        }
+        PemReader.loadPrivateKey(x509TestContext.getKeyStoreFile(X509Util.StoreFileType.PEM), Optional.empty());
+    }
+
+    // Try to load a password-protected private key with the wrong password
+    @Test(expected = GeneralSecurityException.class)
+    public void testLoadEncryptedPrivateKeyFromKeyStoreWithWrongPassword() throws GeneralSecurityException, IOException {
+        if (!x509TestContext.isKeyStoreEncrypted()) {
+            throw new GeneralSecurityException(); // this case is not tested so throw the expected exception
+        }
+        PemReader.loadPrivateKey(
+                x509TestContext.getKeyStoreFile(X509Util.StoreFileType.PEM),
+                Optional.of("wrong password"));
+    }
+
+    // Try to load a non-protected private key while providing a password
+    @Test(expected = IOException.class)
+    public void testLoadUnencryptedPrivateKeyFromKeyStoreWithWrongPassword() throws GeneralSecurityException, IOException {
+        if (x509TestContext.isKeyStoreEncrypted()) {
+            throw new IOException();
+        }
+        PemReader.loadPrivateKey(
+                x509TestContext.getKeyStoreFile(X509Util.StoreFileType.PEM),
+                Optional.of("wrong password"));
+    }
+
+    // Expect this to fail, the trust store does not contain a private key
+    @Test(expected = KeyStoreException.class)
+    public void testLoadPrivateKeyFromTrustStore() throws IOException, GeneralSecurityException {
+        PemReader.loadPrivateKey(
+                x509TestContext.getTrustStoreFile(X509Util.StoreFileType.PEM), Optional.empty());
+    }
+
+    // Expect this to fail, the trust store does not contain a private key
+    @Test(expected = KeyStoreException.class)
+    public void testLoadPrivateKeyFromTrustStoreWithPassword() throws IOException, GeneralSecurityException {
+        PemReader.loadPrivateKey(
+                x509TestContext.getTrustStoreFile(X509Util.StoreFileType.PEM), Optional.of("foobar"));
+    }
+
+    @Test
+    public void testLoadCertificateFromKeyStore() throws IOException, GeneralSecurityException {
+        List<X509Certificate> certs = PemReader.readCertificateChain(
+                x509TestContext.getKeyStoreFile(X509Util.StoreFileType.PEM));
+        Assert.assertEquals(1, certs.size());
+        Assert.assertEquals(x509TestContext.getKeyStoreCertificate(), certs.get(0));
+    }
+
+    @Test
+    public void testLoadCertificateFromTrustStore() throws IOException, GeneralSecurityException {
+        List<X509Certificate> certs = PemReader.readCertificateChain(
+                x509TestContext.getTrustStoreFile(X509Util.StoreFileType.PEM));
+        Assert.assertEquals(1, certs.size());
+        Assert.assertEquals(x509TestContext.getTrustStoreCertificate(), certs.get(0));
+    }
+}


### PR DESCRIPTION
# Overview
These are fixes and improvements to #184 that we've coded up at Facebook while testing that PR internally. This is meant to be in addition to #184, and should be stacked on top of it (and in fact includes the commits from that pull request). Most notable changes:

## Fixed networking issues/bugs in UnifiedServerSocket
- don't crash the accept() thread if the client closes the connection without sending any data
- don't corrupt the connection if the client sends fewer than 5 bytes for the initial read
- delay the detection of TLS vs. plaintext mode until a socket stream is read from or written to. This prevents the accept() thread from getting blocked on a `read()` operation from the newly connected socket.
- prepending 5 bytes to `PrependableSocket` and then trying to read >5 bytes would only return the first 5 bytes, even if more bytes were available. This is fixed.

## Added support for PEM formatted key stores and trust stores
- key store and trust store files can now be in PEM format as well as JKS.
- Added config properties to tell ZK what type of trust/key store to load:
- `zookeeper.ssl.keyStore.type` and `zookeeper.ssl.trustStore.type` for ClientX509Util
- `zookeeper.ssl.quorum.keyStore.type` and `zookeeper.ssl.quorum.trustStore.type` for QuorumX509Util
- store type properties could have the values "JKS", "PEM", or not set
- leaving the type properties unset will cause auto-detection of the store type based on the file extension (".jks" or ".pem")

## Added support for reloading key/trust stores when the file on disk changes
- new property `sslQuorumReloadCertFiles` which controls the behavior for reloading the key and trust store files for `QuorumX509Util`. Reloading of key and trust store for `ClientX509Util` is not in this PR but could be added easily
- this allows a ZK server to keep running on a machine that uses short-lived certs that refresh frequently without having to restart the ZK process.

## Added test utilities for easily creating X509 certs and using them in unit tests
- added new class `X509TestContext` and its friend, `X509TestHelpers`
- rewrote some existing unit tests to use these classes, and added new tests that use them
- some existing tests (i.e. `QuorumSSLTest`) should probably be ported to use this as well, haven't got around to it yet

## Added more options for ssl settings to X509Util and encapsulate them better
- previously, some SSL settings came from a ZKConfig and others came from global `System.getProperties()`. This made it hard to isolate certain settings in tests.
- now all SSL-related settings come from the ZKConfig object used to create the context
- new settings added:
- `zookeeper.ssl(.quorum).enabledProtocols` - list of enabled protocols. If not set, defaults to a single-entry list with the value of `zookeeper.ssl(.quorum).protocol`.
- `zookeeper.ssl(.quorum).clientAuth` - can be "NONE", "WANT", or "NEED". This controls whether the server doesn't want / allows / requires the client to present an X509 certificate.
- `zookeeper.ssl(.quorum).handshakeDetectionTimeoutMillis` - timeout for the first read of 5 bytes to detect the transport mode (TLS or plaintext) of a client connection made to a `UnifiedServerSocket`

## Fixed odd plaintext perf regression caused by new dependency on `org.apache.httpcomponents`
- internal regression testing showed a >10% perf degradation in plaintext mode that was tracked down to the addition of the `org.apache.httpcomponents` dependency.
- Removing the dependency and implementing the hostname verification by mostly copy-pasting the hostname verification code from `httpcomponents` fixed the regression.

There may be some other changes that I'm forgetting, but those are the main ones.

We believe that #184 should not be accepted without this PR coming close behind, mainly because of the issues with UnifiedServerSocket. We were able to put clusters into a bad state pretty easily simply by having a participant disconnect immediately after connecting to the quorum port. This crashed the accept thread in the Leader and prevented any other participants from connecting. This could happen due to network hick-ups, etc. Ideally, both PRs get +1s around the same time and can land with a small delay one after another.

We have started testing internal builds with #184 and the code in this PR. Quorums with TLS disabled have shown no perf or stability regressions, so we believe it's safe to merge this code to master as it's purely opt-in at this point, gated behind config options. We've done correctness testing of quorums with TLS enabled, but have not done perf testing to measure the impact of enabling quorum TLS yet. That should happen in the near future, and I will update this PR with our perf test results once we have them.