### PR TITLE
ZOOKEEPER-3140: Allow Followers to host Observers

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -550,6 +550,13 @@ in the configuration file:
     Note that SSL feature will be enabled when user plugs-in
     zookeeper.serverCnxnFactory, zookeeper.clientCnxnSocket as Netty.
 
+* *observerMasterPort* :
+    the port to listen for observer connections; that is, the
+    port that observers attempt to connect to.
+    if the property is set then the server will host observer connections
+    when in follower mode in addition to when in leader mode and correspondingly
+    attempt to connect to any voting peer when in observer mode.
+
 * *dataDir* :
     the location where ZooKeeper will store the in-memory
     database snapshots and, unless specified otherwise, the

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperObservers.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperObservers.md
@@ -81,6 +81,38 @@ specified in every config file. You should see a command line prompt
 through which you can issue commands like _ls_ to query
 the ZooKeeper service.
 
+<a name="ch_ObserverMasters"></a>
+
+## How to use Observer Masters
+
+Observers function simple as non-voting members of the ensemble, sharing
+the Learner interface with Followers and holding only a slightly difference
+internal pipeline. Both maintain connections along the quorum port with the
+Leader by which they learn of all new proposals on the ensemble.
+
+By default, Observers connect to the Leader of the quorum along its
+quorum port and this is how they learn of all new proposals on the
+ensemble. There are benefits to allowing Observers to connect to the
+Followers instead as a means of plugging in to the commit stream in place
+of connecting to the Leader. It shifts the burden of supporting Observers
+off the Leader and allow it to focus on coordinating the commit of writes.
+This means better performance when the Leader is under high load,
+particularly high network load such as can happen after a leader election
+when many Learners need to sync. It reduces the total network connections
+maintained on the Leader when there are a high number of observers.
+Activating Followers to support Observers allow the overall number of
+Observers to scale into the hundreds. One the other end, Observer
+availability is improved since it will take shorter time for a high
+number of Observers to finish syncing and start serving client traffic.
+
+This feature can be activated by letting all members of the ensemble know
+which port will be used by the Followers to listen for Observer
+connections. The following entry, when added to the server config file,
+will instruct Observers to connect to peers (Leaders and Followers) on
+port 2191 and instruct Followers to create an ObserverMaster thread to
+listen and serve on that port.
+
+    observerMasterPort=2191
 <a name="ch_UseCases"></a>
 
 ## Example use cases

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ObserverBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ObserverBean.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.server;
 
 import org.apache.zookeeper.server.quorum.Observer;
 import org.apache.zookeeper.server.quorum.ObserverMXBean;
+import org.apache.zookeeper.server.quorum.QuorumPeer;
 
 /**
  * ObserverBean
@@ -46,4 +47,17 @@ public class ObserverBean extends ZooKeeperServerBean implements ObserverMXBean{
         return observer.getSocket().toString();
     }
 
+    public String getLearnerMaster() {
+        QuorumPeer.QuorumServer learnerMaster = observer.getCurrentLearnerMaster();
+        if (learnerMaster == null || learnerMaster.addr == null) {
+            return "Unknown";
+        }
+        return learnerMaster.addr.getAddress().getHostAddress() + ":" + learnerMaster.addr.getPort();
+    }
+
+    public void setLearnerMaster(String learnerMaster) {
+        if (!observer.setLearnerMaster(learnerMaster)) {
+            throw new IllegalArgumentException("Not a valid learner master");
+        }
+    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Commands.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Commands.java
@@ -37,10 +37,13 @@ import org.apache.zookeeper.server.ServerStats;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.ZooTrace;
+import org.apache.zookeeper.server.quorum.Follower;
+import org.apache.zookeeper.server.quorum.FollowerZooKeeperServer;
 import org.apache.zookeeper.server.quorum.Leader;
 import org.apache.zookeeper.server.quorum.LeaderZooKeeperServer;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.server.quorum.QuorumZooKeeperServer;
+import org.apache.zookeeper.server.quorum.ObserverZooKeeperServer;
 import org.apache.zookeeper.server.quorum.ReadOnlyZooKeeperServer;
 import org.apache.zookeeper.server.util.OSMXBean;
 import org.slf4j.Logger;
@@ -373,6 +376,18 @@ public class Commands {
                 response.put("last_proposal_size", leader.getProposalStats().getLastBufferSize());
                 response.put("max_proposal_size", leader.getProposalStats().getMaxBufferSize());
                 response.put("min_proposal_size", leader.getProposalStats().getMinBufferSize());
+            }
+
+            if (zkServer instanceof FollowerZooKeeperServer) {
+                Follower follower = ((FollowerZooKeeperServer) zkServer).getFollower();
+                Integer syncedObservers = follower.getSyncedObserverSize();
+                if (syncedObservers != null) {
+                    response.put("synced_observers", syncedObservers);
+                }
+            }
+
+            if (zkServer instanceof ObserverZooKeeperServer) {
+                response.put("observer_master_id", ((ObserverZooKeeperServer)zkServer).getObserver().getLearnerMasterId());
             }
 
             response.putAll(ServerMetrics.getAllValues());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerBean.java
@@ -52,4 +52,17 @@ public class FollowerBean extends ZooKeeperServerBean implements FollowerMXBean 
     public long getElectionTimeTaken() {
         return follower.self.getElectionTimeTaken();
     }
+
+    @Override
+    public int getObserverMasterPacketSizeLimit() {
+        return follower.om == null ? -1 : follower.om.getPktsSizeLimit();
+    }
+
+    @Override
+    public void setObserverMasterPacketSizeLimit(int sizeLimit) {
+        ObserverMaster om = follower.om;
+        if (om != null) {
+            om.setPktsSizeLimit(sizeLimit);
+        }
+    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerBean.java
@@ -60,9 +60,6 @@ public class FollowerBean extends ZooKeeperServerBean implements FollowerMXBean 
 
     @Override
     public void setObserverMasterPacketSizeLimit(int sizeLimit) {
-        ObserverMaster om = follower.om;
-        if (om != null) {
-            om.setPktsSizeLimit(sizeLimit);
-        }
+        ObserverMaster.setPktsSizeLimit(sizeLimit);
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerMXBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerMXBean.java
@@ -43,4 +43,14 @@ public interface FollowerMXBean extends ZooKeeperServerMXBean {
      * @return time taken for leader election in milliseconds.
      */
     public long getElectionTimeTaken();
+
+    /**
+     * @return the size limit in bytes for the observer master commit packet queue
+     */
+    public int getObserverMasterPacketSizeLimit();
+
+    /**
+     * set the size limit in bytes for the observer master commit packet queue
+     */
+    public void setObserverMasterPacketSizeLimit(int sizeLimit);
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
@@ -116,7 +116,7 @@ public class FollowerZooKeeperServer extends LearnerZooKeeperServer {
     }
 
     synchronized public void sync(){
-        if(pendingSyncs.size() == 0){
+        if(pendingSyncs.size() == 0) {
             LOG.warn("Not expecting a sync.");
             return;
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.apache.jute.Record;
+import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.server.ExitCode;
@@ -33,6 +34,8 @@ import org.apache.zookeeper.server.SyncRequestProcessor;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.txn.TxnHeader;
+
+import javax.management.JMException;
 
 /**
  * Just like the standard ZooKeeperServer. We just replace the request
@@ -113,13 +116,17 @@ public class FollowerZooKeeperServer extends LearnerZooKeeperServer {
     }
 
     synchronized public void sync(){
-        if(pendingSyncs.size() ==0){
+        if(pendingSyncs.size() == 0){
             LOG.warn("Not expecting a sync.");
             return;
         }
 
         Request r = pendingSyncs.remove();
-		commitProcessor.commit(r);
+        if (r instanceof LearnerSyncRequest) {
+            LearnerSyncRequest lsr = (LearnerSyncRequest)r;
+            lsr.fh.queuePacket(new QuorumPacket(Leader.SYNC, 0, null, null));
+        }
+        commitProcessor.commit(r);
     }
 
     @Override
@@ -138,5 +145,26 @@ public class FollowerZooKeeperServer extends LearnerZooKeeperServer {
     @Override
     public Learner getLearner() {
         return getFollower();
+    }
+
+    /**
+     * Process a request received from external Learner through the LearnerMaster
+     * These requests have already passed through validation and checks for
+     * session upgrade and can be injected into the middle of the pipeline.
+     *
+     * @param request received from external Learner
+     */
+    void processObserverRequest(Request request) {
+        ((FollowerRequestProcessor)firstProcessor).processRequest(request, false);
+    }
+
+    boolean registerJMX(LearnerHandlerBean handlerBean) {
+        try {
+            MBeanRegistry.getInstance().register(handlerBean, jmxServerBean);
+            return true;
+        } catch (JMException e) {
+            LOG.warn("Could not register connection", e);
+        }
+        return false;
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -19,6 +19,10 @@
 package org.apache.zookeeper.server.quorum;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.BindException;
 import java.net.ServerSocket;
@@ -41,15 +45,20 @@ import java.util.concurrent.ConcurrentMap;
 
 import javax.security.sasl.SaslException;
 
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs.OpCode;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.common.X509Exception;
+import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.server.FinalRequestProcessor;
 import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.RequestProcessor;
 import org.apache.zookeeper.server.ServerMetrics;
 import org.apache.zookeeper.server.ZooKeeperCriticalThread;
 import org.apache.zookeeper.server.quorum.QuorumPeer.LearnerType;
+import org.apache.zookeeper.server.ZKDatabase;
+import org.apache.zookeeper.server.ZooTrace;
+import org.apache.zookeeper.server.quorum.auth.QuorumAuthServer;
 import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
 import org.apache.zookeeper.server.util.SerializeUtils;
 import org.apache.zookeeper.server.util.ZxidUtils;
@@ -60,7 +69,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This class has the control logic for the Leader.
  */
-public class Leader {
+public class Leader implements LearnerMaster {
     private static final Logger LOG = LoggerFactory.getLogger(Leader.class);
 
     static final private boolean nodelay = System.getProperty("leader.nodelay", "true").equals("true");
@@ -117,6 +126,9 @@ public class Leader {
         return new LearnerSnapshotThrottler(
                 maxConcurrentSnapshots, maxConcurrentSnapshotTimeout);
     }
+
+    // beans for all learners
+    private final ConcurrentHashMap<LearnerHandler, LearnerHandlerBean> connectionBeans = new ConcurrentHashMap<>();
 
     /**
      * Returns a copy of the current learner snapshot
@@ -181,7 +193,8 @@ public class Leader {
      * @param learner
      *                instance of learner handle
      */
-    void addLearnerHandler(LearnerHandler learner) {
+    @Override
+    public void addLearnerHandler(LearnerHandler learner) {
         synchronized (learners) {
             learners.add(learner);
         }
@@ -192,7 +205,8 @@ public class Leader {
      *
      * @param peer
      */
-    void removeLearnerHandler(LearnerHandler peer) {
+    @Override
+    public void removeLearnerHandler(LearnerHandler peer) {
         synchronized (forwardingFollowers) {
             forwardingFollowers.remove(peer);
         }
@@ -866,6 +880,7 @@ public class Leader {
      * @param sid, the id of the server that sent the ack
      * @param followerAddr
      */
+    @Override
     synchronized public void processAck(long sid, long zxid, SocketAddress followerAddr) {
         if (!allowedToCommit) return; // last op committed was a leader change - from now on
                                      // the new leader should commit
@@ -1064,23 +1079,30 @@ public class Leader {
         sendObserverPacket(qp);
     }
 
+    public static QuorumPacket buildInformAndActivePacket(long zxid,
+            long designatedLeader, byte[] proposalData) {
+        byte[] data = new byte[proposalData.length + 8];
+        ByteBuffer buffer = ByteBuffer.wrap(data);
+        buffer.putLong(designatedLeader);
+        buffer.put(proposalData);
+
+        return new QuorumPacket(Leader.INFORMANDACTIVATE, zxid, data, null);
+    }
 
     /**
      * Create an inform&activate packet and send it to all observers.
      */
     public void informAndActivate(Proposal proposal, long designatedLeader) {
-       byte[] proposalData = proposal.packet.getData();
-        byte[] data = new byte[proposalData.length + 8];
-        ByteBuffer buffer = ByteBuffer.wrap(data);
-       buffer.putLong(designatedLeader);
-       buffer.put(proposalData);
-
-        QuorumPacket qp = new QuorumPacket(Leader.INFORMANDACTIVATE, proposal.request.zxid, data, null);
-        sendObserverPacket(qp);
+        sendObserverPacket(buildInformAndActivePacket(proposal.request.zxid,
+                designatedLeader, proposal.packet.getData()));
     }
 
     long lastProposed;
 
+    @Override
+    synchronized public long getLastProposed() {
+        return lastProposed;
+    }
 
     /**
      * Returns the current epoch of the leader.
@@ -1146,6 +1168,7 @@ public class Leader {
         return p;
     }
 
+    @Override
     public LearnerSnapshotThrottler getLearnerSnapshotThrottler() {
         return learnerSnapshotThrottler;
     }
@@ -1185,6 +1208,7 @@ public class Leader {
      * @return last proposed zxid
      * @throws InterruptedException
      */
+    @Override
     synchronized public long startForwarding(LearnerHandler handler,
             long lastSeenZxid) {
         // Queue up any outstanding requests enabling the receipt of
@@ -1221,6 +1245,16 @@ public class Leader {
 
         return lastProposed;
     }
+
+    @Override
+    public void waitForStartup() throws InterruptedException {
+        synchronized(zk){
+            while(!zk.isRunning() && !Thread.currentThread().isInterrupted()){
+                zk.wait(20);
+            }
+        }
+    }
+
     // VisibleForTesting
     protected final Set<Long> connectingFollowers = new HashSet<Long>();
 
@@ -1277,6 +1311,7 @@ public class Leader {
         }
     }
 
+    @Override
     public long getEpochToPropose(long sid, long lastAcceptedEpoch) throws InterruptedException, IOException {
         synchronized(connectingFollowers) {
             if (!waitingForNewEpoch) {
@@ -1313,10 +1348,17 @@ public class Leader {
         }
     }
 
+    @Override
+    public ZKDatabase getZKDatabase() {
+        return zk.getZKDatabase();
+    }
+
     // VisibleForTesting
     protected final Set<Long> electingFollowers = new HashSet<Long>();
     // VisibleForTesting
     protected boolean electionFinished = false;
+
+    @Override
     public void waitForEpochAck(long id, StateSummary ss) throws IOException, InterruptedException {
         synchronized(electingFollowers) {
             if (electionFinished) {
@@ -1417,6 +1459,7 @@ public class Leader {
      * @param sid
      * @throws InterruptedException
      */
+    @Override
     public void waitForNewLeaderAck(long sid, long zxid)
             throws InterruptedException {
 
@@ -1516,5 +1559,108 @@ public class Leader {
 
     private boolean isParticipant(long sid) {
         return self.getQuorumVerifier().getVotingMembers().containsKey(sid);
+    }
+
+    @Override
+    public int getCurrentTick() {
+        return self.tick.get();
+    }
+
+    @Override
+    public int syncTimeout() {
+        return self.tickTime * self.syncLimit;
+    }
+
+    @Override
+    public int getTickOfNextAckDeadline() {
+        return self.tick.get() + self.syncLimit;
+    }
+
+    @Override
+    public int getTickOfInitialAckDeadline() {
+        return self.tick.get() + self.initLimit + self.syncLimit;
+    }
+
+    @Override
+    public long getAndDecrementFollowerCounter() {
+        return followerCounter.getAndDecrement();
+    }
+
+    @Override
+    public void touch(long sess, int to) {
+        zk.touch(sess, to);
+    }
+
+    @Override
+    public void submitLearnerRequest(Request si) {
+        zk.submitLearnerRequest(si);
+    }
+
+    @Override
+    public long getQuorumVerifierVersion() {
+        return self.getQuorumVerifier().getVersion();
+    }
+
+    @Override
+    public String getPeerInfo(long sid) {
+        QuorumPeer.QuorumServer server = self.getView().get(sid);
+        return server == null ? "" : server.toString();
+    }
+
+    @Override
+    public byte[] getQuorumVerifierBytes() {
+        return self.getLastSeenQuorumVerifier().toString().getBytes();
+    }
+
+    @Override
+    public QuorumAuthServer getQuorumAuthServer() {
+        return (self == null) ? null : self.authServer;
+    }
+
+    @Override
+    public void revalidateSession(QuorumPacket qp, LearnerHandler learnerHandler) throws IOException {
+        ByteArrayInputStream bis = new ByteArrayInputStream(qp.getData());
+        DataInputStream dis = new DataInputStream(bis);
+        long id = dis.readLong();
+        int to = dis.readInt();
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos);
+        dos.writeLong(id);
+        boolean valid = zk.checkIfValidGlobalSession(id, to);
+        if (valid) {
+            try {
+                //set the session owner
+                // as the follower that
+                // owns the session
+                zk.setOwner(id, learnerHandler);
+            } catch (KeeperException.SessionExpiredException e) {
+                LOG.error("Somehow session " + Long.toHexString(id) + " expired right after being renewed! (impossible)", e);
+            }
+        }
+        if (LOG.isTraceEnabled()) {
+            ZooTrace.logTraceMessage(LOG,
+                    ZooTrace.SESSION_TRACE_MASK,
+                    "Session 0x" + Long.toHexString(id)
+                            + " is valid: "+ valid);
+        }
+        dos.writeBoolean(valid);
+        qp.setData(bos.toByteArray());
+        learnerHandler.queuePacket(qp);
+    }
+
+    @Override
+    public void registerLearnerHandlerBean(final LearnerHandler learnerHandler, Socket socket) {
+        LearnerHandlerBean bean = new LearnerHandlerBean(learnerHandler, socket);
+        if (zk.registerJMX(bean)) {
+            connectionBeans.put(learnerHandler, bean);
+        }
+    }
+
+    @Override
+    public void unregisterLearnerHandlerBean(final LearnerHandler learnerHandler) {
+        LearnerHandlerBean bean = connectionBeans.remove(learnerHandler);
+        if (bean != null){
+            MBeanRegistry.getInstance().unregister(bean);
+        }
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -1248,8 +1248,8 @@ public class Leader implements LearnerMaster {
 
     @Override
     public void waitForStartup() throws InterruptedException {
-        synchronized(zk){
-            while(!zk.isRunning() && !Thread.currentThread().isInterrupted()){
+        synchronized(zk) {
+            while(!zk.isRunning() && !Thread.currentThread().isInterrupted()) {
                 zk.wait(20);
             }
         }
@@ -1629,9 +1629,7 @@ public class Leader implements LearnerMaster {
         boolean valid = zk.checkIfValidGlobalSession(id, to);
         if (valid) {
             try {
-                //set the session owner
-                // as the follower that
-                // owns the session
+                // set the session owner as the follower that owns the session
                 zk.setOwner(id, learnerHandler);
             } catch (KeeperException.SessionExpiredException e) {
                 LOG.error("Somehow session " + Long.toHexString(id) + " expired right after being renewed! (impossible)", e);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderZooKeeperServer.java
@@ -30,6 +30,7 @@ import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 
+import javax.management.JMException;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -184,6 +185,16 @@ public class LeaderZooKeeperServer extends QuorumZooKeeperServer {
             LOG.warn("Failed to register with JMX", e);
             jmxServerBean = null;
         }
+    }
+
+    boolean registerJMX(LearnerHandlerBean handlerBean) {
+        try {
+            MBeanRegistry.getInstance().register(handlerBean, jmxServerBean);
+            return true;
+        } catch (JMException e) {
+            LOG.warn("Could not register connection", e);
+        }
+        return false;
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -257,7 +257,7 @@ public class Learner {
 
         for (int tries = 0; tries < 5; tries++) {
             try {
-                // recalculate the init limit time because retries sleep for 500 milliseconds
+                // recalculate the init limit time because retries sleep for 1000 milliseconds
                 remainingInitLimitTime = initLimitTime - (int)((nanoTime() - startNanoTime) / 1000000);
                 if (remainingInitLimitTime <= 0) {
                     LOG.error("initLimit exceeded on retries.");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -87,13 +87,17 @@ public class Learner {
     
     protected static final Logger LOG = LoggerFactory.getLogger(Learner.class);
 
+    /**
+     * Time to wait after connection attempt with the Leader or LearnerMaster before this
+     * Learner tries to connect again.
+     */
     private static final int leaderConnectDelayDuringRetryMs =
             Integer.getInteger("zookeeper.leaderConnectDelayDuringRetryMs", 100);
 
     static final private boolean nodelay = System.getProperty("follower.nodelay", "true").equals("true");
     static {
-        LOG.info("leaderConnectDelayDuringRetryMs: " + leaderConnectDelayDuringRetryMs);
-        LOG.info("TCP NoDelay set to: " + nodelay);
+        LOG.info("leaderConnectDelayDuringRetryMs: {}", leaderConnectDelayDuringRetryMs);
+        LOG.info("TCP NoDelay set to: {}", nodelay);
     }   
     
     final ConcurrentHashMap<Long, ServerCnxn> pendingRevalidations =

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -244,8 +244,9 @@ public class Learner {
 
     /**
      * Establish a connection with the LearnerMaster found by findLearnerMaster.
+     * Followers only connect to Leaders, Observers can connect to any active LearnerMaster.
      * Retries until either initLimit time has elapsed or 5 tries have happened.
-     * @param addr - the address of the Leader to connect to.
+     * @param addr - the address of the Peer to connect to.
      * @throws IOException - if the socket connection fails on the 5th attempt
      * <li>if there is an authentication failure while connecting to leader</li>
      * @throws ConnectException
@@ -317,8 +318,8 @@ public class Learner {
     }
 
     /**
-     * Once connected to the leader, perform the handshake protocol to
-     * establish a following / observing connection. 
+     * Once connected to the leader or learner master, perform the handshake
+     * protocol to establish a following / observing connection.
      * @param pktType
      * @return the zxid the Leader sends for synchronization purposes.
      * @throws IOException
@@ -377,7 +378,8 @@ public class Learner {
     } 
     
     /**
-     * Finally, synchronize our history with the Leader. 
+     * Finally, synchronize our history with the Leader (if Follower)
+     * or the LearnerMaster (if Observer).
      * @param newLeaderZxid
      * @throws IOException
      * @throws InterruptedException

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandlerBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandlerBean.java
@@ -1,0 +1,49 @@
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.jmx.MBeanRegistry;
+import org.apache.zookeeper.jmx.ZKMBeanInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.ObjectName;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+public class LearnerHandlerBean implements LearnerHandlerMXBean, ZKMBeanInfo{
+    private static final Logger LOG = LoggerFactory.getLogger(LearnerHandlerBean.class);
+
+    private final LearnerHandler learnerHandler;
+    private final String remoteAddr;
+
+    public LearnerHandlerBean(final LearnerHandler learnerHandler, final Socket socket) {
+        this.learnerHandler = learnerHandler;
+        InetSocketAddress sockAddr = (InetSocketAddress) socket.getRemoteSocketAddress();
+        if (sockAddr == null) {
+            this.remoteAddr = "Unknown";
+        } else {
+            this.remoteAddr = sockAddr.getAddress().getHostAddress() + ":" + sockAddr.getPort();
+        }
+    }
+
+    @Override
+    public String getName() {
+        return MBeanRegistry.getInstance().makeFullPath("Learner_Connections", ObjectName.quote(remoteAddr),
+                String.format("\"id:%d\"", learnerHandler.getSid()));
+    }
+
+    @Override
+    public boolean isHidden() {
+        return false;
+    }
+
+    @Override
+    public void terminateConnection() {
+        LOG.info("terminating learner handler connection on demand " + toString());
+        learnerHandler.shutdown();
+    }
+
+    @Override
+    public String toString() {
+        return "LearnerHandlerBean{remoteIP=" + remoteAddr + ",ServerId=" + learnerHandler.getSid() + "}";
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandlerBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandlerBean.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zookeeper.server.quorum;
 
 import org.apache.zookeeper.jmx.MBeanRegistry;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandlerMXBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandlerMXBean.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zookeeper.server.quorum;
 
 /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandlerMXBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandlerMXBean.java
@@ -1,0 +1,12 @@
+package org.apache.zookeeper.server.quorum;
+
+/**
+ * This MBean represents a server connection for a learner.
+ */
+public interface LearnerHandlerMXBean {
+    /**
+     * Terminate the connection. The learner will attempt to reconnect to
+     * the leader or to the next ObserverMaster if that feature is enabled
+     */
+    public void terminateConnection();
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerMaster.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerMaster.java
@@ -1,0 +1,196 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.server.Request;
+import org.apache.zookeeper.server.ZKDatabase;
+import org.apache.zookeeper.server.quorum.auth.QuorumAuthServer;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.net.SocketAddress;
+
+/**
+ * interface for keeping Observers in sync
+ */
+public interface LearnerMaster {
+    /**
+     * start tracking a learner handler
+     * @param learnerHandler to track
+     */
+    void addLearnerHandler(LearnerHandler learnerHandler);
+
+    /**
+     * stop tracking a learner handler
+     * @param learnerHandler to drop
+     */
+    void removeLearnerHandler(LearnerHandler learnerHandler);
+
+    /**
+     * wait for the leader of the new epoch to be confirmed by followers
+     * @param sid learner id
+     * @param ss
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    void waitForEpochAck(long sid, StateSummary ss) throws IOException, InterruptedException;
+
+    /**
+     * snapshot throttler
+     * @return snapshot throttler
+     */
+    LearnerSnapshotThrottler getLearnerSnapshotThrottler();
+
+    /**
+     * wait for server to start
+     * @throws InterruptedException
+     */
+    void waitForStartup() throws InterruptedException;
+
+    /**
+     * get the first zxid of the next epoch
+     * @param sid learner id
+     * @param lastAcceptedEpoch
+     * @return
+     * @throws InterruptedException
+     * @throws IOException
+     */
+    long getEpochToPropose(long sid, long lastAcceptedEpoch) throws InterruptedException, IOException;
+
+    /**
+     * ZKDatabase
+     * @return ZKDatabase
+     */
+    ZKDatabase getZKDatabase();
+
+    /**
+     * wait for new leader to settle
+     * @param sid id of learner
+     * @param zxid zxid at learner
+     * @throws InterruptedException
+     */
+    void waitForNewLeaderAck(long sid, long zxid) throws InterruptedException;
+
+    /**
+     * last proposed zxid
+     * @return last proposed zxid
+     */
+    long getLastProposed();
+
+    /**
+     * the current tick
+     * @return the current tick
+     */
+    int getCurrentTick();
+
+    /**
+     * time allowed for sync response
+     * @return time allowed for sync response
+     */
+    int syncTimeout();
+
+    /**
+     * deadline tick marking observer sync (initial)
+     * @return deadline tick marking observer sync (initial)
+     */
+    int getTickOfNextAckDeadline();
+
+    /**
+     * next deadline tick marking observer sync (steady state)
+     * @return next deadline tick marking observer sync (steady state)
+     */
+    int getTickOfInitialAckDeadline();
+
+    /**
+     * decrement follower count
+     * @return previous follower count
+     */
+    long getAndDecrementFollowerCounter();
+
+    /**
+     * handle ack packet
+     * @param sid leader id
+     * @param zxid packet zxid
+     * @param localSocketAddress forwarder's address
+     */
+    void processAck(long sid, long zxid, SocketAddress localSocketAddress);
+
+    /**
+     * mark session as alive
+     * @param sess session id
+     * @param to timeout
+     */
+    void touch(long sess, int to);
+
+    /**
+     * handle revalidate packet
+     * @param qp session packet
+     * @param learnerHandler learner
+     * @throws IOException
+     */
+    void revalidateSession(QuorumPacket qp, LearnerHandler learnerHandler) throws IOException;
+
+    /**
+     * proxy request from learner to server
+     * @param si request
+     */
+    void submitLearnerRequest(Request si);
+
+    /**
+     * begin forwarding packets to learner handler
+     * @param learnerHandler learner
+     * @param lastSeenZxid zxid of learner
+     * @return last zxid forwarded
+     */
+    long startForwarding(LearnerHandler learnerHandler, long lastSeenZxid);
+
+    /**
+     * version of current quorum verifier
+     * @return version of current quorum verifier
+     */
+    long getQuorumVerifierVersion();
+
+    /**
+     *
+     * @param sid server id
+     * @return server information in the view
+     */
+    String getPeerInfo(long sid);
+
+    /**
+     * identifier of current quorum verifier for new leader
+     * @return identifier of current quorum verifier for new leader
+     */
+    byte[] getQuorumVerifierBytes();
+
+    QuorumAuthServer getQuorumAuthServer();
+
+    /**
+     * registers the handler's bean
+     * @param learnerHandler handler
+     * @param socket connection to learner
+     */
+    void registerLearnerHandlerBean(final LearnerHandler learnerHandler, Socket socket);
+
+    /**
+     * unregisters the handler's bean
+     * @param learnerHandler handler
+     */
+    void unregisterLearnerHandlerBean(final LearnerHandler learnerHandler);
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Observer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Observer.java
@@ -132,7 +132,11 @@ public class Observer extends Learner{
                 self.findLearnerMaster(findLeader()) :
                 prescribedLearnerMaster;
         currentLearnerMaster = master;
-        LOG.info("Observing new leader sid={} addr={}", master == null ? -1 : master.id, master.addr);
+        if (master == null) {
+            LOG.warn("No learner master found");
+        } else {
+            LOG.info("Observing new leader sid={} addr={}", master.id, master.addr);
+        }
         return master;
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMXBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMXBean.java
@@ -34,4 +34,16 @@ public interface ObserverMXBean extends ZooKeeperServerMXBean {
      * @return socket address
      */
     public String getQuorumAddress();
+
+    /**
+     * @return address of the current learner master
+     */
+    public String getLearnerMaster();
+
+    /**
+     * requests the Observer switch to a new learner master
+     *
+     * @param learnerMaster address of the desired learner master
+     */
+    public void setLearnerMaster(String learnerMaster);
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
@@ -266,6 +266,7 @@ public class ObserverMaster implements LearnerMaster, Runnable {
         }
         itr.remove();
         LearnerHandler learnerHandler = revalidation.handler;
+        // create a copy here as the qp object is reused by the Follower and may be mutated
         QuorumPacket deepCopy = new QuorumPacket(qp.getType(), qp.getZxid(),
                 Arrays.copyOf(qp.getData(), qp.getData().length),
                 qp.getAuthinfo() == null ? null : new ArrayList<>(qp.getAuthinfo()));

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
@@ -1,0 +1,513 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.jmx.MBeanRegistry;
+import org.apache.zookeeper.server.Request;
+import org.apache.zookeeper.server.ZKDatabase;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.zookeeper.server.quorum.auth.QuorumAuthServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Used by Followers to host Observers. This reduces the network load on the Leader process by pushing
+ * the responsibility for keeping Observers in sync off the leading peer.
+ *
+ * It is expected that Observers will continue to perform the initial vetting of clients and requests.
+ * Observers send the request to the follower where it is received by an ObserverMaster.
+ *
+ * The ObserverMaster forwards a copy of the request to the ensemble Leader and inserts it into its own
+ * request processor pipeline where it can be matched with the response comes back. All commits received
+ * from the Leader will be forwarded along to every Learner connected to the ObserverMaster.
+ *
+ * New Learners connecting to a Follower will receive a LearnerHandler object and be party to its syncing logic
+ * to be brought up to date.
+ *
+ * The logic is quite a bit simpler than the corresponding logic in Leader because it only hosts observers.
+ */
+public class ObserverMaster implements LearnerMaster, Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(ObserverMaster.class);
+
+    //Follower counter
+    private final AtomicLong followerCounter = new AtomicLong(-1);
+
+    private QuorumPeer self;
+    private FollowerZooKeeperServer zks;
+    private int port;
+
+    private Set<LearnerHandler> activeObservers = Collections.newSetFromMap(new ConcurrentHashMap<LearnerHandler,Boolean>());
+
+    private final ConcurrentHashMap<LearnerHandler, LearnerHandlerBean> connectionBeans = new ConcurrentHashMap<>();
+
+    /**
+     * we want to keep a log of past txns so that observers can sync up with us when we connect,
+     * but we can't keep everything in memory, so this limits how much memory will be dedicated
+     * to keeping recent txns.
+     */
+    private final static int PKTS_SIZE_LIMIT = 32 * 1024 * 1024;
+    private static volatile int pktsSizeLimit = Integer.getInteger("zookeeper.observerMaster.sizeLimit", PKTS_SIZE_LIMIT);
+    private ConcurrentLinkedQueue<QuorumPacket> proposedPkts = new ConcurrentLinkedQueue<>();
+    private ConcurrentLinkedQueue<QuorumPacket> committedPkts = new ConcurrentLinkedQueue<>();
+    private int pktsSize = 0;
+
+    private long lastProposedZxid;
+
+    // ensure ordering of revalidations returned to this learner
+    private final Object revalidateSessionLock = new Object();
+
+    // Throttle when there are too many concurrent snapshots being sent to observers
+    private static final String MAX_CONCURRENT_SNAPSHOTS = "zookeeper.leader.maxConcurrentSnapshots";
+    private static final int maxConcurrentSnapshots;
+
+    private static final String MAX_CONCURRENT_DIFFS = "zookeeper.leader.maxConcurrentDiffs";
+    private static final int maxConcurrentDiffs;
+    static {
+        maxConcurrentSnapshots = Integer.getInteger(MAX_CONCURRENT_SNAPSHOTS, 10);
+        LOG.info(MAX_CONCURRENT_SNAPSHOTS + " = " + maxConcurrentSnapshots);
+
+        maxConcurrentDiffs = Integer.getInteger(MAX_CONCURRENT_DIFFS, 100);
+        LOG.info(MAX_CONCURRENT_DIFFS + " = " + maxConcurrentDiffs);
+    }
+
+    private final ConcurrentLinkedQueue<Revalidation> pendingRevalidations = new ConcurrentLinkedQueue<>();
+    static class Revalidation {
+        public final long sessionId;
+        public final int timeout;
+        public final LearnerHandler handler;
+
+        Revalidation(final Long sessionId, final int timeout, final LearnerHandler handler) {
+            this.sessionId = sessionId;
+            this.timeout = timeout;
+            this.handler = handler;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            final Revalidation that = (Revalidation) o;
+            return sessionId == that.sessionId && timeout == that.timeout && handler.equals(that.handler);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = (int) (sessionId ^ (sessionId >>> 32));
+            result = 31 * result + timeout;
+            result = 31 * result + handler.hashCode();
+            return result;
+        }
+    }
+
+    private final LearnerSnapshotThrottler learnerSnapshotThrottler =
+            new LearnerSnapshotThrottler(maxConcurrentSnapshots);
+
+    private Thread thread;
+    private ServerSocket ss;
+    private boolean listenerRunning;
+    private ScheduledExecutorService pinger;
+
+    Runnable ping = new Runnable() {
+        @Override
+        public void run() {
+            for (LearnerHandler lh: activeObservers) {
+                lh.ping();
+            }
+        }
+    };
+
+    ObserverMaster(QuorumPeer self, FollowerZooKeeperServer zks, int port) {
+        this.self = self;
+        this.zks = zks;
+        this.port = port;
+    }
+
+    @Override
+    public void addLearnerHandler(LearnerHandler learnerHandler) {
+        if (!listenerRunning) {
+            throw new RuntimeException(("ObserverMaster is not running"));
+        }
+    }
+
+    @Override
+    public void removeLearnerHandler(LearnerHandler learnerHandler) {
+        activeObservers.remove(learnerHandler);
+    }
+
+    @Override
+    public int syncTimeout() {
+        return self.getSyncLimit() * self.getTickTime();
+    }
+
+    @Override
+    public int getTickOfNextAckDeadline() {
+        return self.tick.get() + self.syncLimit;
+    }
+
+    @Override
+    public int getTickOfInitialAckDeadline() {
+        return self.tick.get() + self.initLimit + self.syncLimit;
+    }
+
+    @Override
+    public long getAndDecrementFollowerCounter() {
+        return followerCounter.getAndDecrement();
+    }
+
+    @Override
+    public void waitForEpochAck(long sid, StateSummary ss) throws IOException, InterruptedException {
+        // since this is done by an active follower, we don't need to wait for anything
+    }
+
+    @Override
+    public LearnerSnapshotThrottler getLearnerSnapshotThrottler() {
+        return learnerSnapshotThrottler;
+    }
+
+    @Override
+    public void waitForStartup() throws InterruptedException {
+        // since this is done by an active follower, we don't need to wait for anything
+    }
+
+    @Override
+    synchronized public long getLastProposed() {
+        return lastProposedZxid;
+    }
+
+    @Override
+    public long getEpochToPropose(long sid, long lastAcceptedEpoch) throws InterruptedException, IOException {
+        return self.getCurrentEpoch();
+    }
+
+    @Override
+    public ZKDatabase getZKDatabase() {
+        return zks.getZKDatabase();
+    }
+
+    @Override
+    public void waitForNewLeaderAck(long sid, long zxid) throws InterruptedException {
+        // no need to wait since we are a follower
+    }
+
+    @Override
+    public int getCurrentTick() {
+        return self.tick.get();
+    }
+
+    @Override
+    public void processAck(long sid, long zxid, SocketAddress localSocketAddress) {
+        if ((zxid & 0xffffffffL) == 0) {
+            /*
+             * We no longer process NEWLEADER ack by this method. However,
+             * the learner sends ack back to the leader after it gets UPTODATE
+             * so we just ignore the message.
+             */
+            return;
+        }
+
+        throw new RuntimeException("Observers shouldn't send ACKS ack = " + Long.toHexString(zxid));
+    }
+
+    @Override
+    public void touch(long sess, int to) {
+        zks.getSessionTracker().touchSession(sess, to);
+    }
+
+    boolean revalidateLearnerSession(QuorumPacket qp) throws IOException {
+        ByteArrayInputStream bis = new ByteArrayInputStream(qp.getData());
+        DataInputStream dis = new DataInputStream(bis);
+        long id = dis.readLong();
+        boolean valid = dis.readBoolean();
+        Iterator<Revalidation> itr = pendingRevalidations.iterator();
+        if (!itr.hasNext()) {
+            // not a learner session, handle locally
+            return false;
+        }
+        Revalidation revalidation = itr.next();
+        if (revalidation.sessionId != id) {
+            // not a learner session, handle locally
+            return false;
+        }
+        itr.remove();
+        LearnerHandler learnerHandler = revalidation.handler;
+        QuorumPacket deepCopy = new QuorumPacket(qp.getType(), qp.getZxid(),
+                Arrays.copyOf(qp.getData(), qp.getData().length),
+                qp.getAuthinfo() == null ? null : new ArrayList<>(qp.getAuthinfo()));
+        learnerHandler.queuePacket(deepCopy);
+        // To keep consistent as leader, touch the session when it's
+        // revalidating the session, only update if it's a valid session.
+        if (valid) {
+            touch(revalidation.sessionId, revalidation.timeout);
+        }
+        return true;
+    }
+
+    @Override
+    public void revalidateSession(QuorumPacket qp, LearnerHandler learnerHandler) throws IOException {
+        ByteArrayInputStream bis = new ByteArrayInputStream(qp.getData());
+        DataInputStream dis = new DataInputStream(bis);
+        long id = dis.readLong();
+        int to = dis.readInt();
+        synchronized (revalidateSessionLock) {
+            pendingRevalidations.add(new Revalidation(id, to, learnerHandler));
+            Learner learner = zks.getLearner();
+            if (learner != null) {
+                learner.writePacket(qp, true);
+            }
+        }
+    }
+
+    @Override
+    public void submitLearnerRequest(Request si) {
+        zks.processObserverRequest(si);
+    }
+
+    @Override
+    synchronized public long startForwarding(LearnerHandler learnerHandler, long lastSeenZxid) {
+        Iterator<QuorumPacket> itr = committedPkts.iterator();
+        if (itr.hasNext()) {
+            QuorumPacket packet = itr.next();
+            if (packet.getZxid() > lastSeenZxid + 1) {
+                LOG.error("LearnerHandler is too far behind ({} < {}), disconnecting {} at {}", Long.toHexString(lastSeenZxid + 1),
+                        Long.toHexString(packet.getZxid()), learnerHandler.getSid(), learnerHandler.getRemoteAddress());
+                learnerHandler.shutdown();
+                return -1;
+            } else if (packet.getZxid() == lastSeenZxid + 1) {
+                learnerHandler.queuePacket(packet);
+            }
+            long queueHeadZxid = packet.getZxid();
+            long queueBytesUsed = LearnerHandler.packetSize(packet);
+            while (itr.hasNext()) {
+                packet = itr.next();
+                if (packet.getZxid() <= lastSeenZxid) {
+                    continue;
+                }
+                learnerHandler.queuePacket(packet);
+                queueBytesUsed += LearnerHandler.packetSize(packet);
+            }
+            LOG.info("finished syncing observer from retained commit queue: sid {}, " +
+                            "queue head 0x{}, queue tail 0x{}, sync position 0x{}, num packets used {}, " +
+                            "num bytes used {}",
+                    learnerHandler.getSid(),
+                    Long.toHexString(queueHeadZxid),
+                    Long.toHexString(packet.getZxid()),
+                    Long.toHexString(lastSeenZxid),
+                    packet.getZxid() - lastSeenZxid,
+                    queueBytesUsed);
+        }
+        activeObservers.add(learnerHandler);
+        return lastProposedZxid;
+    }
+
+    @Override
+    public long getQuorumVerifierVersion() {
+        return self.getQuorumVerifier().getVersion();
+    }
+
+    @Override
+    public String getPeerInfo(long sid) {
+        QuorumPeer.QuorumServer server = self.getView().get(sid);
+        return server == null ? "" : server.toString();
+    }
+
+    @Override
+    public byte[] getQuorumVerifierBytes() {
+        return self.getLastSeenQuorumVerifier().toString().getBytes();
+    }
+
+    @Override
+    public QuorumAuthServer getQuorumAuthServer() {
+        return (self == null) ? null : self.authServer;
+    }
+
+    void proposalReceived(QuorumPacket qp) {
+        proposedPkts.add(new QuorumPacket(Leader.INFORM, qp.getZxid(), qp.getData(), null));
+    }
+
+    private synchronized QuorumPacket removeProposedPacket(long zxid) {
+        QuorumPacket pkt = proposedPkts.peek();
+        if (pkt == null || pkt.getZxid() > zxid) {
+            LOG.debug("ignore missing proposal packet for {}", Long.toHexString(zxid));
+            return null;
+        }
+        if (pkt.getZxid() != zxid) {
+            final String m = String.format("Unexpected proposal packet on commit ack, expected zxid 0x%d got zxid 0x%d",
+                    zxid, pkt.getZxid());
+            LOG.error(m);
+            throw new RuntimeException(m);
+        }
+        proposedPkts.remove();
+        return pkt;
+    }
+
+    private synchronized void cacheCommittedPacket(final QuorumPacket pkt) {
+        committedPkts.add(pkt);
+        pktsSize += LearnerHandler.packetSize(pkt);
+        // remove 5 packets for every one added as we near the size limit
+        for (int i = 0; pktsSize > pktsSizeLimit * 0.8  && i < 5; i++) {
+            QuorumPacket oldPkt = committedPkts.poll();
+            if (oldPkt == null) {
+                pktsSize = 0;
+                break;
+            }
+            pktsSize -= LearnerHandler.packetSize(oldPkt);
+        }
+        // enforce the size limit as a hard cap
+        while (pktsSize > pktsSizeLimit) {
+            QuorumPacket oldPkt = committedPkts.poll();
+            if (oldPkt == null) {
+                pktsSize = 0;
+                break;
+            }
+            pktsSize -= LearnerHandler.packetSize(oldPkt);
+        }
+    }
+
+    private synchronized void sendPacket(final QuorumPacket pkt) {
+        for (LearnerHandler lh: activeObservers) {
+            lh.queuePacket(pkt);
+        }
+        lastProposedZxid = pkt.getZxid();
+    }
+
+    synchronized void proposalCommitted(long zxid) {
+        QuorumPacket pkt = removeProposedPacket(zxid);
+        if (pkt == null) {
+            return;
+        }
+        cacheCommittedPacket(pkt);
+        sendPacket(pkt);
+    }
+
+    synchronized void informAndActivate(long zxid, long suggestedLeaderId) {
+        QuorumPacket pkt = removeProposedPacket(zxid);
+        if (pkt == null) {
+            return;
+        }
+
+        // Build the INFORMANDACTIVATE packet
+        QuorumPacket informAndActivateQP = Leader.buildInformAndActivePacket(
+                zxid, suggestedLeaderId, pkt.getData());
+        cacheCommittedPacket(informAndActivateQP);
+        sendPacket(informAndActivateQP);
+    }
+
+    synchronized public void start() throws IOException {
+        if (thread != null && thread.isAlive()) {
+            return;
+        }
+        listenerRunning = true;
+        if (self.getQuorumListenOnAllIPs()) {
+            ss = new ServerSocket(port, 10 /* dog science */);
+        } else {
+            ss = new ServerSocket(port, 10 /* dog science */, self.getQuorumAddress().getAddress());
+        }
+        thread = new Thread(this, "ObserverMaster");
+        thread.start();
+        pinger = Executors.newSingleThreadScheduledExecutor();
+        pinger.scheduleAtFixedRate(ping, self.tickTime /2, self.tickTime/2, TimeUnit.MILLISECONDS);
+    }
+
+    public void run() {
+        while (listenerRunning) {
+            try {
+                Socket s = ss.accept();
+                BufferedInputStream is = new BufferedInputStream(s.getInputStream());
+                LearnerHandler lh = new LearnerHandler(s, is, this);
+                lh.start();
+            } catch (Exception e) {
+                if (listenerRunning) {
+                    LOG.debug("Ignoring accept exception (maybe shutting down)", e);
+                } else {
+                    LOG.debug("Ignoring accept exception (maybe client closed)", e);
+                }
+            }
+        }
+        /*
+         * we don't need to close ss because we only got here because listenerRunning is
+         * false and that is set and then ss is closed() in stop()
+         */
+    }
+
+    synchronized public void stop() {
+        listenerRunning = false;
+        if (pinger != null) {
+            pinger.shutdownNow();
+        }
+        if (ss != null) {
+            try {
+                ss.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        for (LearnerHandler lh: activeObservers) {
+            lh.shutdown();
+        }
+    }
+
+    int getNumActiveObservers() {
+        return activeObservers.size();
+    }
+
+    int getPktsSizeLimit() {
+        return pktsSizeLimit;
+    }
+
+    void setPktsSizeLimit(final int sizeLimit) {
+        pktsSizeLimit = sizeLimit;
+    }
+
+
+    @Override
+    public void registerLearnerHandlerBean(final LearnerHandler learnerHandler, Socket socket) {
+        LearnerHandlerBean bean = new LearnerHandlerBean(learnerHandler, socket);
+        if (zks.registerJMX(bean)) {
+            connectionBeans.put(learnerHandler, bean);
+        }
+    }
+
+    @Override
+    public void unregisterLearnerHandlerBean(final LearnerHandler learnerHandler) {
+        LearnerHandlerBean bean = connectionBeans.remove(learnerHandler);
+        if (bean != null){
+            MBeanRegistry.getInstance().unregister(bean);
+        }
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
@@ -490,7 +490,7 @@ public class ObserverMaster implements LearnerMaster, Runnable {
         return pktsSizeLimit;
     }
 
-    void setPktsSizeLimit(final int sizeLimit) {
+    static void setPktsSizeLimit(final int sizeLimit) {
         pktsSizeLimit = sizeLimit;
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -2038,7 +2038,6 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
         return useObserverMasters() ? nextObserverMaster() : leader;
     }
 
-
     /**
      * Vet a given learner master's information.
      * Allows specification by server id, ip  only, or ip and port

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -71,6 +71,7 @@ public class QuorumPeerConfig {
     protected InetSocketAddress secureClientPortAddress;
     protected boolean sslQuorum = false;
     protected boolean shouldUsePortUnification = false;
+    protected int observerMasterPort;
     protected File dataDir;
     protected File dataLogDir;
     protected String dynamicConfigFileStr = null;
@@ -239,6 +240,7 @@ public class QuorumPeerConfig {
     throws IOException, ConfigException {
         int clientPort = 0;
         int secureClientPort = 0;
+        int observerMasterPort = 0;
         String clientPortAddress = null;
         String secureClientPortAddress = null;
         VerifyingFileFactory vff = new VerifyingFileFactory.Builder(LOG).warnForRelativePath().build();
@@ -261,6 +263,8 @@ public class QuorumPeerConfig {
                 secureClientPort = Integer.parseInt(value);
             } else if (key.equals("secureClientPortAddress")){
                 secureClientPortAddress = value.trim();
+            } else if (key.equals("observerMasterPort")) {
+                observerMasterPort = Integer.parseInt(value);
             } else if (key.equals("tickTime")) {
                 tickTime = Integer.parseInt(value);
             } else if (key.equals("maxClientCnxns")) {
@@ -410,6 +414,13 @@ public class QuorumPeerConfig {
         }
         if (this.secureClientPortAddress != null) {
             configureSSLAuth();
+        }
+
+        if (observerMasterPort <= 0) {
+            LOG.info("observerMasterPort is not set");
+        } else {
+            this.observerMasterPort = observerMasterPort;
+            LOG.info("observerMasterPort is {}", observerMasterPort);
         }
 
         if (tickTime == 0) {
@@ -754,6 +765,7 @@ public class QuorumPeerConfig {
 
     public InetSocketAddress getClientPortAddress() { return clientPortAddress; }
     public InetSocketAddress getSecureClientPortAddress() { return secureClientPortAddress; }
+    public int getObserverMasterPort() { return observerMasterPort; }
     public File getDataDir() { return dataDir; }
     public File getDataLogDir() { return dataLogDir; }
     public int getTickTime() { return tickTime; }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
@@ -188,6 +188,7 @@ public class QuorumPeerMain {
           quorumPeer.setMaxSessionTimeout(config.getMaxSessionTimeout());
           quorumPeer.setInitLimit(config.getInitLimit());
           quorumPeer.setSyncLimit(config.getSyncLimit());
+          quorumPeer.setObserverMasterPort(config.getObserverMasterPort());
           quorumPeer.setConfigFileName(config.getConfigFilename());
           quorumPeer.setZKDatabase(new ZKDatabase(quorumPeer.getTxnFactory()));
           quorumPeer.setQuorumVerifier(config.getQuorumVerifier(), false);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ZKTestCase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ZKTestCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper;
 
+import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.junit.Rule;
@@ -75,4 +76,29 @@ public class ZKTestCase {
 
     };
 
+    public interface WaitForCondition {
+        /**
+         * @return true when success
+         */
+        boolean evaluate();
+    }
+
+    /**
+     * Wait for condition to be true; otherwise fail the test if it exceed
+     * timeout
+     * @param msg       error message to print when fail
+     * @param condition condition to evaluate
+     * @param timeout   timeout in seconds
+     * @throws InterruptedException
+     */
+    public void waitFor(String msg, WaitForCondition condition, int timeout)
+            throws InterruptedException {
+        for (int i = 0; i < timeout; ++i) {
+            if (condition.evaluate()) {
+                return;
+            }
+            Thread.sleep(1000);
+        }
+        Assert.fail(msg);
+    }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ZKTestCase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ZKTestCase.java
@@ -97,7 +97,7 @@ public class ZKTestCase {
             if (condition.evaluate()) {
                 return;
             }
-            Thread.sleep(1000);
+            Thread.sleep(100);
         }
         Assert.fail(msg);
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/DelayRequestProcessor.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/DelayRequestProcessor.java
@@ -23,6 +23,13 @@ import org.apache.zookeeper.server.RequestProcessor;
 
 import java.util.concurrent.LinkedBlockingQueue;
 
+/**
+ * Allows the blocking of the request processor queue on a ZooKeeperServer.
+ *
+ * This is used to simulate arbitrary length delays or to produce delays
+ * in request processing that are maximally inconvenient for a given feature
+ * for the purposes of testing it.
+ */
 public class DelayRequestProcessor implements RequestProcessor {
 
     private boolean blocking;
@@ -59,13 +66,6 @@ public class DelayRequestProcessor implements RequestProcessor {
             }
             blocking = false;
         }
-    }
-
-    public static DelayRequestProcessor injectDelayRequestProcessor(LeaderZooKeeperServer zooKeeperServer) {
-        RequestProcessor finalRequestProcessor = zooKeeperServer.commitProcessor.nextProcessor;
-        DelayRequestProcessor delayRequestProcessor = new DelayRequestProcessor(finalRequestProcessor);
-        zooKeeperServer.commitProcessor.nextProcessor = delayRequestProcessor;
-        return delayRequestProcessor;
     }
 
     public static DelayRequestProcessor injectDelayRequestProcessor(FollowerZooKeeperServer zooKeeperServer) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/DelayRequestProcessor.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/DelayRequestProcessor.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.server.Request;
+import org.apache.zookeeper.server.RequestProcessor;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class DelayRequestProcessor implements RequestProcessor {
+
+    private boolean blocking;
+    RequestProcessor next;
+
+    private LinkedBlockingQueue<Request> incomingRequests = new LinkedBlockingQueue<>();
+
+    private DelayRequestProcessor(RequestProcessor next) {
+        this.blocking = true;
+        this.next = next;
+    }
+
+    @Override
+    public void processRequest(Request request) throws RequestProcessorException {
+        if (blocking) {
+            incomingRequests.add(request);
+        } else {
+            next.processRequest(request);
+        }
+    }
+
+    public void submitRequest(Request request) throws RequestProcessorException {
+        next.processRequest(request);
+    }
+
+    @Override
+    public void shutdown() {
+    }
+
+    public void unblockQueue() throws RequestProcessorException {
+        if (blocking) {
+            for (Request request : incomingRequests) {
+                next.processRequest(request);
+            }
+            blocking = false;
+        }
+    }
+
+    public static DelayRequestProcessor injectDelayRequestProcessor(LeaderZooKeeperServer zooKeeperServer) {
+        RequestProcessor finalRequestProcessor = zooKeeperServer.commitProcessor.nextProcessor;
+        DelayRequestProcessor delayRequestProcessor = new DelayRequestProcessor(finalRequestProcessor);
+        zooKeeperServer.commitProcessor.nextProcessor = delayRequestProcessor;
+        return delayRequestProcessor;
+    }
+
+    public static DelayRequestProcessor injectDelayRequestProcessor(FollowerZooKeeperServer zooKeeperServer) {
+        RequestProcessor finalRequestProcessor = zooKeeperServer.commitProcessor.nextProcessor;
+        DelayRequestProcessor delayRequestProcessor = new DelayRequestProcessor(finalRequestProcessor);
+        zooKeeperServer.commitProcessor.nextProcessor = delayRequestProcessor;
+        return delayRequestProcessor;
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/util/PortForwarder.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/util/PortForwarder.java
@@ -16,9 +16,6 @@
  * limitations under the License.
  */
 
-/**
- * 
- */
 package org.apache.zookeeper.server.util;
 
 import java.io.IOException;
@@ -29,6 +26,8 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -36,55 +35,6 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * A utility that does bi-directional forwarding between two ports.
- * Useful, for example, to simulate network failures.
- * Example:
- * 
- *   Server 1 config file:
- *           
- *      server.1=127.0.0.1:7301:7401;8201
- *      server.2=127.0.0.1:7302:7402;8202
- *      server.3=127.0.0.1:7303:7403;8203
- *   
- *   Server 2 and 3 config files:
- *           
- *      server.1=127.0.0.1:8301:8401;8201
- *      server.2=127.0.0.1:8302:8402;8202
- *      server.3=127.0.0.1:8303:8403;8203
- *
- *   Initially forward traffic between 730x and 830x and between 740x and 830x
- *   This way server 1 can communicate with servers 2 and 3
- *  ....
- *   
- *   List<PortForwarder> pfs = startForwarding();
- *  ....
- *   // simulate a network interruption for server 1
- *   stopForwarding(pfs);
- *  ....
- *   // restore connection 
- *   pfs = startForwarding();
- *
- *
- *  private List<PortForwarder> startForwarding() throws IOException {
- *      List<PortForwarder> res = new ArrayList<PortForwarder>();
- *      res.add(new PortForwarder(8301, 7301));
- *      res.add(new PortForwarder(8401, 7401));
- *      res.add(new PortForwarder(7302, 8302));
- *      res.add(new PortForwarder(7402, 8402));
- *      res.add(new PortForwarder(7303, 8303));
- *      res.add(new PortForwarder(7403, 8403));
- *      return res;
- *  }
- *  
- *  private void stopForwarding(List<PortForwarder> pfs) throws Exception {
- *       for (PortForwarder pf : pfs) {
- *           pf.shutdown();
- *       }
- *  }
- *  
- *
- */
 public class PortForwarder extends Thread {
     private static final Logger LOG = LoggerFactory
             .getLogger(PortForwarder.class);
@@ -95,9 +45,10 @@ public class PortForwarder extends Thread {
         private final OutputStream out;
         private final Socket toClose;
         private final Socket toClose2;
+        private boolean isFinished = false;
 
         PortForwardWorker(Socket toClose, Socket toClose2, InputStream in,
-                OutputStream out) throws IOException {
+                OutputStream out) {
             this.toClose = toClose;
             this.toClose2 = toClose2;
             this.in = in;
@@ -118,50 +69,57 @@ public class PortForwarder extends Thread {
                                 this.out.write(buf, 0, read);
                             } catch (IOException e) {
                                 LOG.warn("exception during write", e);
-                                try {
-                                    toClose.close();
-                                } catch (IOException ex) {
-                                    // ignore
-                                }
-                                try {
-                                    toClose2.close();
-                                } catch (IOException ex) {
-                                    // ignore
-                                }
                                 break;
                             }
+                        } else if (read < 0) {
+                            throw new IOException("read " + read);
                         }
                     } catch (SocketTimeoutException e) {
                         LOG.error("socket timeout", e);
                     }
-                    Thread.sleep(1);
                 }
+                Thread.sleep(1);
             } catch (InterruptedException e) {
                 LOG.warn("Interrupted", e);
-                try {
-                    toClose.close();
-                } catch (IOException ex) {
-                    // ignore
-                }
-                try {
-                    toClose2.close();
-                } catch (IOException ex) {
-                    // ignore silently
-                }
             } catch (SocketException e) {
                 if (!"Socket closed".equals(e.getMessage())) {
                     LOG.error("Unexpected exception", e);
                 }
             } catch (IOException e) {
                 LOG.error("Unexpected exception", e);
+            } finally {
+                shutdown();
             }
             LOG.info("Shutting down forward for " + toClose);
+            isFinished = true;
         }
 
+        boolean waitForShutdown(long timeoutMs) throws InterruptedException {
+            synchronized (this) {
+                if (!isFinished) {
+                   this.wait(timeoutMs);
+                }
+            }
+            return isFinished;
+        }
+
+        public void shutdown() {
+            try {
+                toClose.close();
+            } catch (IOException ex) {
+                // ignore
+            }
+            try {
+                toClose2.close();
+            } catch (IOException ex) {
+                // ignore silently
+            }
+        }
     }
 
     private volatile boolean stopped = false;
-    private ExecutorService workers = Executors.newCachedThreadPool();
+    private ExecutorService workerExecutor = Executors.newCachedThreadPool();
+    private List<PortForwardWorker> workers = new ArrayList<>();
     private ServerSocket serverSocket;
     private final int to;
 
@@ -207,30 +165,31 @@ public class PortForwarder extends Thread {
                             + " to:" + to);
                     sock.setSoTimeout(30000);
                     target.setSoTimeout(30000);
-                    this.workers.execute(new PortForwardWorker(sock, target,
+
+
+                    workers.add(new PortForwardWorker(sock, target,
                             sock.getInputStream(), target.getOutputStream()));
-                    this.workers.execute(new PortForwardWorker(target, sock,
+                    workers.add(new PortForwardWorker(target, sock,
                             target.getInputStream(), sock.getOutputStream()));
-                } catch (SocketTimeoutException e) {               	
-                    LOG.warn("socket timed out local:" 
-                            + (sock != null ? sock.getLocalPort(): "")
-                            + " from:" + (sock != null ? sock.getPort(): "")
-                            + " to:" + to, e);
+                    for (PortForwardWorker worker: workers) {
+                        workerExecutor.submit(worker);
+                    }
+                } catch (SocketTimeoutException e) {
+                    LOG.warn("socket timed out", e);
                 } catch (ConnectException e) {
-                    LOG.warn("connection exception local:"
-                            + (sock != null ? sock.getLocalPort(): "")
-                            + " from:" + (sock != null ? sock.getPort(): "")
+                    LOG.warn("connection exception local:" + sock.getLocalPort()
+                            + " from:" + sock.getPort()
                             + " to:" + to, e);
                     sock.close();
                 } catch (IOException e) {
                     if (!"Socket closed".equals(e.getMessage())) {
-                        LOG.warn("unexpected exception local:" 
-                        		+ (sock != null ? sock.getLocalPort(): "")
-                                + " from:" + (sock != null ? sock.getPort(): "")
-                                + " to:" + to, e);
+                        LOG.warn("unexpected exception local:" + sock.getLocalPort()
+                            + " from:" + sock.getPort()
+                            + " to:" + to, e);
                         throw e;
                     }
                 }
+
             }
         } catch (IOException e) {
             LOG.error("Unexpected exception to:" + to, e);
@@ -242,15 +201,16 @@ public class PortForwarder extends Thread {
     public void shutdown() throws Exception {
         this.stopped = true;
         this.serverSocket.close();
-        this.workers.shutdownNow();
-        try {
-            if (!this.workers.awaitTermination(5, TimeUnit.SECONDS)) {
-                throw new Exception(
-                        "Failed to stop forwarding within 5 seconds");
-            }
-        } catch (InterruptedException e) {
-            throw new Exception("Failed to stop forwarding");
-        }
         this.join();
+        this.workerExecutor.shutdownNow();
+        for (PortForwardWorker worker: workers) {
+            worker.shutdown();
+        }
+
+        for (PortForwardWorker worker: workers) {
+            if (!worker.waitForShutdown(5000)) {
+                throw new Exception("Failed to stop forwarding within 5 seconds");
+            }
+        }
     }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/util/PortForwarder.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/util/PortForwarder.java
@@ -35,6 +35,55 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A utility that does bi-directional forwarding between two ports.
+ * Useful, for example, to simulate network failures.
+ * Example:
+ * 
+ *   Server 1 config file:
+ *           
+ *      server.1=127.0.0.1:7301:7401;8201
+ *      server.2=127.0.0.1:7302:7402;8202
+ *      server.3=127.0.0.1:7303:7403;8203
+ *   
+ *   Server 2 and 3 config files:
+ *           
+ *      server.1=127.0.0.1:8301:8401;8201
+ *      server.2=127.0.0.1:8302:8402;8202
+ *      server.3=127.0.0.1:8303:8403;8203
+ *
+ *   Initially forward traffic between 730x and 830x and between 740x and 830x
+ *   This way server 1 can communicate with servers 2 and 3
+ *  ....
+ *   
+ *   List<PortForwarder> pfs = startForwarding();
+ *  ....
+ *   // simulate a network interruption for server 1
+ *   stopForwarding(pfs);
+ *  ....
+ *   // restore connection 
+ *   pfs = startForwarding();
+ *
+ *
+ *  private List<PortForwarder> startForwarding() throws IOException {
+ *      List<PortForwarder> res = new ArrayList<PortForwarder>();
+ *      res.add(new PortForwarder(8301, 7301));
+ *      res.add(new PortForwarder(8401, 7401));
+ *      res.add(new PortForwarder(7302, 8302));
+ *      res.add(new PortForwarder(7402, 8402));
+ *      res.add(new PortForwarder(7303, 8303));
+ *      res.add(new PortForwarder(7403, 8403));
+ *      return res;
+ *  }
+ *  
+ *  private void stopForwarding(List<PortForwarder> pfs) throws Exception {
+ *       for (PortForwarder pf : pfs) {
+ *           pf.shutdown();
+ *       }
+ *  }
+ *  
+ *
+ */
 public class PortForwarder extends Thread {
     private static final Logger LOG = LoggerFactory
             .getLogger(PortForwarder.class);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ObserverMasterTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ObserverMasterTest.java
@@ -1,0 +1,764 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.jmx.CommonNames;
+import org.apache.zookeeper.jmx.MBeanRegistry;
+import org.apache.zookeeper.jmx.ZKMBeanInfo;
+import org.apache.zookeeper.server.admin.Commands;
+import org.apache.zookeeper.server.quorum.DelayRequestProcessor;
+import org.apache.zookeeper.server.quorum.FollowerZooKeeperServer;
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
+import org.apache.zookeeper.server.util.PortForwarder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException.ConnectionLossException;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.Watcher.Event.KeeperState;
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.ZooKeeper.States;
+import org.apache.zookeeper.admin.ZooKeeperAdmin;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.management.Attribute;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.InvalidAttributeValueException;
+import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.RuntimeMBeanException;
+
+@RunWith(Parameterized.class)
+public class ObserverMasterTest extends QuorumPeerTestBase implements Watcher{
+    protected static final Logger LOG = LoggerFactory.getLogger(ObserverTest.class);
+
+    public ObserverMasterTest(Boolean testObserverMaster) {
+        this.testObserverMaster = testObserverMaster;
+    }
+
+    @Parameterized.Parameters
+    public static List<Object []> data() { return Arrays.asList(new Object [][] {
+            {Boolean.TRUE},
+            {Boolean.FALSE}});
+    }
+
+    private Boolean testObserverMaster;
+
+    private CountDownLatch latch;
+    ZooKeeper zk;
+    private WatchedEvent lastEvent = null;
+
+    private int CLIENT_PORT_QP1;
+    private int CLIENT_PORT_QP2;
+    private int CLIENT_PORT_OBS;
+    private int OM_PORT;
+    private MainThread q1;
+    private MainThread q2;
+    private MainThread q3;
+
+    private PortForwarder setUp(final int omProxyPort) throws IOException {
+        ClientBase.setupTestEnv();
+
+        final int PORT_QP1 = PortAssignment.unique();
+        final int PORT_QP2 = PortAssignment.unique();
+        final int PORT_OBS = PortAssignment.unique();
+        final int PORT_QP_LE1 = PortAssignment.unique();
+        final int PORT_QP_LE2 = PortAssignment.unique();
+        final int PORT_OBS_LE = PortAssignment.unique();
+
+        CLIENT_PORT_QP1 = PortAssignment.unique();
+        CLIENT_PORT_QP2 = PortAssignment.unique();
+        CLIENT_PORT_OBS = PortAssignment.unique();
+
+        OM_PORT = PortAssignment.unique();
+
+        String quorumCfgSection =
+                "server.1=127.0.0.1:" + (PORT_QP1)
+                        + ":" + (PORT_QP_LE1) + ";" +  CLIENT_PORT_QP1
+                        + "\nserver.2=127.0.0.1:" + (PORT_QP2)
+                        + ":" + (PORT_QP_LE2) + ";" + CLIENT_PORT_QP2
+                        + "\nserver.3=127.0.0.1:"
+                        + (PORT_OBS)+ ":" + (PORT_OBS_LE) + ":observer" + ";" + CLIENT_PORT_OBS;
+        String extraCfgs = testObserverMaster ? String.format("observerMasterPort=%d%n", OM_PORT) : "";
+        String extraCfgsObs = testObserverMaster ? String.format("observerMasterPort=%d%n", omProxyPort <= 0 ? OM_PORT : omProxyPort) : "";
+
+        PortForwarder forwarder = null;
+        if (testObserverMaster && omProxyPort >= 0) {
+            forwarder = new PortForwarder(omProxyPort, OM_PORT);
+        }
+
+        q1 = new MainThread(1, CLIENT_PORT_QP1, quorumCfgSection, extraCfgs);
+        q2 = new MainThread(2, CLIENT_PORT_QP2, quorumCfgSection, extraCfgs);
+        q3 = new MainThread(3, CLIENT_PORT_OBS, quorumCfgSection, extraCfgsObs);
+        q1.start();
+        q2.start();
+        Assert.assertTrue("waiting for server 1 being up",
+                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_QP1,
+                        CONNECTION_TIMEOUT));
+        Assert.assertTrue("waiting for server 2 being up",
+                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_QP2,
+                        CONNECTION_TIMEOUT));
+        return forwarder;
+    }
+
+    private void shutdown() throws InterruptedException {
+        LOG.info("Shutting down all servers");
+        zk.close();
+
+        q1.shutdown();
+        q2.shutdown();
+        q3.shutdown();
+
+        Assert.assertTrue("Waiting for server 1 to shut down",
+                ClientBase.waitForServerDown("127.0.0.1:"+CLIENT_PORT_QP1,
+                        ClientBase.CONNECTION_TIMEOUT));
+        Assert.assertTrue("Waiting for server 2 to shut down",
+                ClientBase.waitForServerDown("127.0.0.1:"+CLIENT_PORT_QP2,
+                        ClientBase.CONNECTION_TIMEOUT));
+        Assert.assertTrue("Waiting for server 3 to shut down",
+                ClientBase.waitForServerDown("127.0.0.1:"+CLIENT_PORT_OBS,
+                        ClientBase.CONNECTION_TIMEOUT));
+    }
+
+    @Test
+    public void testLaggingObserverMaster() throws Exception {
+        final int OM_PROXY_PORT = PortAssignment.unique();
+        PortForwarder forwarder = setUp(OM_PROXY_PORT);
+
+        // find the leader and observer master
+        int leaderPort;
+        MainThread leader;
+        MainThread follower;
+        if (q1.getQuorumPeer().leader != null) {
+            leaderPort = CLIENT_PORT_QP1;
+            leader = q1;
+            follower = q2;
+        } else if (q2.getQuorumPeer().leader != null) {
+            leaderPort = CLIENT_PORT_QP2;
+            leader = q2;
+            follower = q1;
+        } else {
+            throw new RuntimeException("No leader");
+        }
+
+        // ensure the observer master has commits in the queue before observer sync
+        zk = new ZooKeeper("127.0.0.1:" + leaderPort,
+                ClientBase.CONNECTION_TIMEOUT, this);
+        for (int i = 0; i < 10; i++) {
+            zk.create("/bulk" + i, ("initial data of some size").getBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        }
+        zk.close();
+
+        q3.start();
+        Assert.assertTrue("waiting for server 3 being up",
+                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_OBS,
+                        CONNECTION_TIMEOUT));
+
+        latch = new CountDownLatch(1);
+        zk = new ZooKeeper("127.0.0.1:" + leaderPort,
+                ClientBase.CONNECTION_TIMEOUT, this);
+        latch.await();
+        Assert.assertEquals(zk.getState(), States.CONNECTED);
+
+        zk.create("/init", "first".getBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        final long lastLoggedZxid = leader.getQuorumPeer().getLastLoggedZxid();
+
+        // wait for change to propagate
+        waitFor("Timeout waiting for observer sync", new WaitForCondition() {
+            public boolean evaluate() {
+                return lastLoggedZxid == q3.getQuorumPeer().getLastLoggedZxid();
+            }
+        }, 30);
+
+        // simulate network fault
+        if (forwarder != null) {
+            forwarder.shutdown();
+        }
+
+        for (int i = 0; i < 10; i++) {
+            zk.create("/basic" + i, "second".getBytes(),Ids.OPEN_ACL_UNSAFE,
+                    CreateMode.PERSISTENT);
+        }
+
+        DelayRequestProcessor delayRequestProcessor = null;
+        if (testObserverMaster) {
+            FollowerZooKeeperServer followerZooKeeperServer = (FollowerZooKeeperServer) follower.getQuorumPeer().getActiveServer();
+            delayRequestProcessor = DelayRequestProcessor.injectDelayRequestProcessor(followerZooKeeperServer);
+        }
+
+        zk.create("/target1", "third".getBytes(),Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+        zk.create("/target2", "third".getBytes(),Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+
+        LOG.info("observer zxid " + Long.toHexString(q3.getQuorumPeer().getLastLoggedZxid()) +
+                (testObserverMaster ? "" : " observer master zxid " +
+                        Long.toHexString(follower.getQuorumPeer().getLastLoggedZxid())) +
+                " leader zxid " + Long.toHexString(leader.getQuorumPeer().getLastLoggedZxid()));
+
+        // restore network
+        forwarder = testObserverMaster ? new PortForwarder(OM_PROXY_PORT, OM_PORT) : null;
+
+        Assert.assertTrue("waiting for server 3 being up",
+                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_OBS,
+                        CONNECTION_TIMEOUT));
+        Assert.assertNotNull("Leader switched", leader.getQuorumPeer().leader);
+
+        if (delayRequestProcessor != null) {
+            delayRequestProcessor.unblockQueue();
+        }
+
+        latch = new CountDownLatch(1);
+        ZooKeeper obsZk = new ZooKeeper("127.0.0.1:" + CLIENT_PORT_OBS,
+                ClientBase.CONNECTION_TIMEOUT, this);
+        latch.await();
+        zk.create("/finalop", "fourth".getBytes(),Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+
+        Assert.assertEquals("first", new String(obsZk.getData("/init", null, null)));
+        Assert.assertEquals("third", new String(obsZk.getData("/target1", null, null)));
+
+        obsZk.close();
+        shutdown();
+
+        try {
+            if (forwarder != null) {
+                forwarder.shutdown();
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    /**
+     * This test ensures two things:
+     * 1. That Observers can successfully proxy requests to the ensemble.
+     * 2. That Observers don't participate in leader elections.
+     * The second is tested by constructing an ensemble where a leader would
+     * be elected if and only if an Observer voted.
+     */
+    @Test
+    public void testObserver() throws Exception {
+        // We expect two notifications before we want to continue
+        latch = new CountDownLatch(2);
+        setUp(-1);
+        q3.start();
+        Assert.assertTrue("waiting for server 3 being up",
+                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_OBS,
+                        CONNECTION_TIMEOUT));
+
+        if (testObserverMaster) {
+            int masterPort = q3.getQuorumPeer().observer.getSocket().getPort();
+            LOG.info("port " + masterPort + " " + OM_PORT);
+            Assert.assertEquals("observer failed to connect to observer master", masterPort, OM_PORT);
+        }
+
+        zk = new ZooKeeper("127.0.0.1:" + CLIENT_PORT_OBS,
+                ClientBase.CONNECTION_TIMEOUT, this);
+        zk.create("/obstest", "test".getBytes(),Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+
+        // Assert that commands are getting forwarded correctly
+        Assert.assertEquals(new String(zk.getData("/obstest", null, null)), "test");
+
+        // Now check that other commands don't blow everything up
+        zk.sync("/", null, null);
+        zk.setData("/obstest", "test2".getBytes(), -1);
+        zk.getChildren("/", false);
+
+        Assert.assertEquals(zk.getState(), States.CONNECTED);
+
+        LOG.info("Shutting down server 2");
+        // Now kill one of the other real servers
+        q2.shutdown();
+
+        Assert.assertTrue("Waiting for server 2 to shut down",
+                ClientBase.waitForServerDown("127.0.0.1:"+CLIENT_PORT_QP2,
+                        ClientBase.CONNECTION_TIMEOUT));
+
+        LOG.info("Server 2 down");
+
+        // Now the resulting ensemble shouldn't be quorate
+        latch.await();
+        Assert.assertNotSame("Client is still connected to non-quorate cluster",
+                KeeperState.SyncConnected,lastEvent.getState());
+
+        LOG.info("Latch returned");
+
+        try {
+            Assert.assertNotEquals("Shouldn't get a response when cluster not quorate!",
+                    "test", new String(zk.getData("/obstest", null, null)));
+        }
+        catch (ConnectionLossException c) {
+            LOG.info("Connection loss exception caught - ensemble not quorate (this is expected)");
+        }
+
+        latch = new CountDownLatch(1);
+
+        LOG.info("Restarting server 2");
+
+        // Bring it back
+        //q2 = new MainThread(2, CLIENT_PORT_QP2, quorumCfgSection, extraCfgs);
+        q2.start();
+
+        LOG.info("Waiting for server 2 to come up");
+        Assert.assertTrue("waiting for server 2 being up",
+                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_QP2,
+                        CONNECTION_TIMEOUT));
+
+        LOG.info("Server 2 started, waiting for latch");
+
+        latch.await();
+        // It's possible our session expired - but this is ok, shows we
+        // were able to talk to the ensemble
+        Assert.assertTrue("Client didn't reconnect to quorate ensemble (state was" +
+                        lastEvent.getState() + ")",
+                (KeeperState.SyncConnected==lastEvent.getState() ||
+                        KeeperState.Expired==lastEvent.getState()));
+
+        LOG.info("perform a revalidation test");
+        int leaderProxyPort = PortAssignment.unique();
+        int obsProxyPort = PortAssignment.unique();
+        int leaderPort = q1.getQuorumPeer().leader == null ? CLIENT_PORT_QP2 : CLIENT_PORT_QP1;
+        PortForwarder leaderPF = new PortForwarder(leaderProxyPort, leaderPort);
+
+        latch = new CountDownLatch(1);
+        ZooKeeper client = new ZooKeeper(String.format("127.0.0.1:%d,127.0.0.1:%d", leaderProxyPort, obsProxyPort),
+                ClientBase.CONNECTION_TIMEOUT, this);
+        latch.await();
+        client.create("/revalidtest", "test".getBytes(),Ids.OPEN_ACL_UNSAFE,
+                CreateMode.EPHEMERAL);
+        Assert.assertNotNull("Read-after write failed", client.exists("/revalidtest", null));
+
+        latch = new CountDownLatch(2);
+        PortForwarder obsPF = new PortForwarder(obsProxyPort, CLIENT_PORT_OBS);
+        try {
+            leaderPF.shutdown();
+        } catch (Exception e) {
+            // ignore?
+        }
+        latch.await();
+        Assert.assertEquals(new String(client.getData("/revalidtest", null, null)), "test");
+        client.close();
+        obsPF.shutdown();
+
+        shutdown();
+    }
+
+    @Test
+    public void testRevalidation() throws Exception {
+        setUp(-1);
+        q3.start();
+        Assert.assertTrue("waiting for server 3 being up",
+                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_OBS,
+                        CONNECTION_TIMEOUT));
+        final int leaderProxyPort = PortAssignment.unique();
+        final int obsProxyPort = PortAssignment.unique();
+
+        int leaderPort = q1.getQuorumPeer().leader == null ? CLIENT_PORT_QP2 : CLIENT_PORT_QP1;
+        PortForwarder leaderPF = new PortForwarder(leaderProxyPort, leaderPort);
+
+        latch = new CountDownLatch(1);
+        zk = new ZooKeeper(String.format("127.0.0.1:%d,127.0.0.1:%d", leaderProxyPort, obsProxyPort),
+                ClientBase.CONNECTION_TIMEOUT, this);
+        latch.await();
+        zk.create("/revalidtest", "test".getBytes(),Ids.OPEN_ACL_UNSAFE,
+                CreateMode.EPHEMERAL);
+        Assert.assertNotNull("Read-after write failed", zk.exists("/revalidtest", null));
+
+        latch = new CountDownLatch(2);
+        PortForwarder obsPF = new PortForwarder(obsProxyPort, CLIENT_PORT_OBS);
+        try {
+            leaderPF.shutdown();
+        } catch (Exception e) {
+            // ignore?
+        }
+        latch.await();
+        Assert.assertEquals(new String(zk.getData("/revalidtest", null, null)), "test");
+        obsPF.shutdown();
+
+        shutdown();
+    }
+
+    @Test
+    public void testInOrderCommits() throws Exception {
+        setUp(-1);
+
+        zk = new ZooKeeper("127.0.0.1:" + CLIENT_PORT_QP1,
+                ClientBase.CONNECTION_TIMEOUT, null);
+        for (int i = 0; i < 10; i++) {
+            zk.create("/bulk" + i, ("Initial data of some size").getBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        }
+        zk.close();
+
+        q3.start();
+        Assert.assertTrue("waiting for observer to be up",
+                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_OBS,
+                        CONNECTION_TIMEOUT));
+
+        latch = new CountDownLatch(1);
+        zk = new ZooKeeper("127.0.0.1:" + CLIENT_PORT_QP1,
+                ClientBase.CONNECTION_TIMEOUT, this);
+        latch.await();
+        Assert.assertEquals(zk.getState(), States.CONNECTED);
+
+        zk.create("/init", "first".getBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        final long zxid = q1.getQuorumPeer().getLastLoggedZxid();
+
+        // wait for change to propagate
+        waitFor("Timeout waiting for observer sync", new WaitForCondition() {
+            public boolean evaluate() {
+                return zxid == q3.getQuorumPeer().getLastLoggedZxid();
+            }
+        }, 30);
+
+        ZooKeeper obsZk = new ZooKeeper("127.0.0.1:" + CLIENT_PORT_OBS,
+                ClientBase.CONNECTION_TIMEOUT, this);
+        int followerPort = q1.getQuorumPeer().leader == null ? CLIENT_PORT_QP1 : CLIENT_PORT_QP2;
+        ZooKeeper fZk = new ZooKeeper("127.0.0.1:" + followerPort,
+                ClientBase.CONNECTION_TIMEOUT, this);
+        final int numTransactions = 10001;
+        CountDownLatch gate = new CountDownLatch(1);
+        CountDownLatch oAsyncLatch = new CountDownLatch(numTransactions);
+        Thread oAsyncWriteThread = new Thread(new AsyncWriter(obsZk, numTransactions, true, oAsyncLatch, "/obs", gate));
+        CountDownLatch fAsyncLatch = new CountDownLatch(numTransactions);
+        Thread fAsyncWriteThread = new Thread(new AsyncWriter(fZk, numTransactions, true, fAsyncLatch, "/follower", gate));
+
+        LOG.info("ASYNC WRITES");
+        oAsyncWriteThread.start();
+        fAsyncWriteThread.start();
+        gate.countDown();
+
+        oAsyncLatch.await();
+        fAsyncLatch.await();
+
+        oAsyncWriteThread.join(ClientBase.CONNECTION_TIMEOUT);
+        if (oAsyncWriteThread.isAlive()) {
+            LOG.error("asyncWriteThread is still alive");
+        }
+        fAsyncWriteThread.join(ClientBase.CONNECTION_TIMEOUT);
+        if (fAsyncWriteThread.isAlive()) {
+            LOG.error("asyncWriteThread is still alive");
+        }
+
+        obsZk.close();
+        fZk.close();
+
+        shutdown();
+    }
+
+    @Test
+    public void testAdminCommands() throws IOException, MBeanException,
+            InstanceNotFoundException, ReflectionException, InterruptedException, MalformedObjectNameException,
+            AttributeNotFoundException, InvalidAttributeValueException, KeeperException {
+        // flush all beans, then start
+        for (ZKMBeanInfo beanInfo : MBeanRegistry.getInstance().getRegisteredBeans()) {
+            MBeanRegistry.getInstance().unregister(beanInfo);
+        }
+
+        JMXEnv.setUp();
+        setUp(-1);
+        q3.start();
+        Assert.assertTrue("waiting for observer to be up",
+                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_OBS,
+                        CONNECTION_TIMEOUT));
+
+        // test stats collection
+        final Map<String, String> emptyMap = Collections.emptyMap();
+        Map<String, Object> stats = Commands.runCommand("mntr", q3.getQuorumPeer().getActiveServer(), emptyMap).toMap();
+        Assert.assertTrue("observer not emitting observer_master_id", stats.containsKey("observer_master_id"));
+        final Long learnerMasterId = (Long)stats.get("observer_master_id");
+        final long leaderId = q1.getQuorumPeer().leader == null ? 2 : 1;
+        Assert.assertFalse("observer not following leader", !testObserverMaster && learnerMasterId != leaderId);
+
+        stats = Commands.runCommand("mntr", q1.getQuorumPeer().getActiveServer(), emptyMap).toMap();
+        Assert.assertEquals("server not emitting synced_observers", testObserverMaster && leaderId != 1,
+                stats.containsKey("synced_observers"));
+        if (stats.containsKey("synced_observers")) {
+            Assert.assertEquals(learnerMasterId == 1 ? new Integer(1) : new Integer(0), stats.get("synced_observers"));
+        }
+
+        stats = Commands.runCommand("mntr", q2.getQuorumPeer().getActiveServer(), emptyMap).toMap();
+        Assert.assertEquals("server not emitting synced_observers", testObserverMaster && leaderId != 2,
+                stats.containsKey("synced_observers"));
+        if (stats.containsKey("synced_observers")) {
+            Assert.assertEquals(learnerMasterId == 2 ? new Integer(1) : new Integer(0), stats.get("synced_observers"));
+        }
+
+        // Assert that commands are getting forwarded correctly
+        zk = new ZooKeeper("127.0.0.1:" + CLIENT_PORT_OBS,
+                ClientBase.CONNECTION_TIMEOUT, this);
+        zk.create("/obstest", "test".getBytes(),Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+        Assert.assertEquals(new String(zk.getData("/obstest", null, null)), "test");
+
+        // test admin commands for disconnection
+        ObjectName connBean = null;
+        for (ObjectName bean : JMXEnv.conn().queryNames(new ObjectName(CommonNames.DOMAIN + ":*"), null)) {
+            if (bean.getCanonicalName().contains("Learner_Connections") &&
+                    bean.getCanonicalName().contains("id:" + q3.getQuorumPeer().getId())) {
+                connBean = bean;
+                break;
+            }
+        }
+        Assert.assertNotNull("could not find connection bean", connBean);
+
+        latch = new CountDownLatch(1);
+        JMXEnv.conn().invoke(connBean, "terminateConnection", new Object[0], null);
+        Assert.assertTrue("server failed to disconnect on terminate",
+                latch.await(CONNECTION_TIMEOUT/2, TimeUnit.MILLISECONDS));
+        Assert.assertTrue("waiting for server 3 being up",
+                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_OBS,
+                        CONNECTION_TIMEOUT));
+
+        final String obsBeanName =
+                String.format("org.apache.ZooKeeperService:name0=ReplicatedServer_id%d,name1=replica.%d,name2=Observer",
+                        q3.getQuorumPeer().getId(), q3.getQuorumPeer().getId());
+        Set<ObjectName> names = JMXEnv.conn().queryNames(new ObjectName(obsBeanName), null);
+        Assert.assertEquals("expecting singular observer bean", 1, names.size());
+        ObjectName obsBean = names.iterator().next();
+
+        if (testObserverMaster) {
+            // show we can move the observer using the id
+            long observerMasterId = q3.getQuorumPeer().observer.getLearnerMasterId();
+            latch = new CountDownLatch(1);
+            JMXEnv.conn().setAttribute(obsBean, new Attribute("LearnerMaster", Long.toString(3 - observerMasterId)));
+            Assert.assertTrue("server failed to disconnect on terminate",
+                    latch.await(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS));
+            Assert.assertTrue("waiting for server 3 being up",
+                    ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_OBS,
+                            CONNECTION_TIMEOUT));
+        } else {
+            // show we get an error
+            try {
+                JMXEnv.conn().setAttribute(obsBean, new Attribute("LearnerMaster", Long.toString(3 - leaderId)));
+                Assert.fail("should have seen an exception on previous command");
+            } catch (RuntimeMBeanException e) {
+                Assert.assertEquals("mbean failed for the wrong reason",
+                        IllegalArgumentException.class, e.getCause().getClass());
+            }
+        }
+
+        shutdown();
+        JMXEnv.tearDown();
+    }
+
+    private String createServerString(String type, long serverId, int clientPort) {
+        return "server." + serverId + "=127.0.0.1:" +
+                PortAssignment.unique() + ":" +
+                PortAssignment.unique() + ":" +
+                type + ";" + clientPort;
+    }
+
+    private void waitServerUp(int clientPort) {
+        Assert.assertTrue("waiting for server being up",
+                ClientBase.waitForServerUp("127.0.0.1:" + clientPort,
+                        CONNECTION_TIMEOUT));
+    }
+
+    private ZooKeeperAdmin createAdmin(int clientPort) throws IOException {
+        System.setProperty("zookeeper.DigestAuthenticationProvider.superDigest",
+                "super:D/InIHSb7yEEbrWz8b9l71RjZJU="/* password is 'test'*/);
+        QuorumPeerConfig.setReconfigEnabled(true);
+        ZooKeeperAdmin admin = new ZooKeeperAdmin("127.0.0.1:" + clientPort,
+                ClientBase.CONNECTION_TIMEOUT, new Watcher() {
+                    public void process(WatchedEvent event) {}
+                });
+        admin.addAuthInfo("digest", "super:test".getBytes());
+        return admin;
+    }
+
+    // This test is known to be flaky and fail due to "reconfig already in progress".
+    // TODO: Investigate intermittent testDynamicReconfig failures.
+    // @Test
+    public void testDynamicReconfig() throws InterruptedException, IOException,
+              KeeperException {
+        if (!testObserverMaster) {
+            return;
+        }
+
+        ClientBase.setupTestEnv();
+
+        // create a quorum running with different observer master port
+        // to make it easier to choose which server the observer is
+        // following with
+        //
+        // we have setObserverMaster function but it's broken, use this
+        // solution before we fixed that
+        int clientPort1 = PortAssignment.unique();
+        int clientPort2 = PortAssignment.unique();
+        int omPort1 = PortAssignment.unique();
+        int omPort2 = PortAssignment.unique();
+        String quorumCfgSection =
+                createServerString("participant", 1, clientPort1) + "\n" +
+                createServerString("participant", 2, clientPort2);
+
+        MainThread s1 = new MainThread(1, clientPort1, quorumCfgSection,
+                String.format("observerMasterPort=%d%n",omPort1));
+        MainThread s2 = new MainThread(2, clientPort2, quorumCfgSection,
+                String.format("observerMasterPort=%d%n", omPort2));
+        s1.start();
+        s2.start();
+        waitServerUp(clientPort1);
+        waitServerUp(clientPort2);
+
+        // create observer to follow non-leader observer master
+        long nonLeaderOMPort = s1.getQuorumPeer().leader == null ? omPort1
+                                                                 : omPort2;
+        int observerClientPort = PortAssignment.unique();
+        int observerId = 10;
+        MainThread observer = new MainThread(
+                observerId,
+                observerClientPort, quorumCfgSection + "\n" +
+                createServerString("observer", observerId,
+                        observerClientPort),
+                String.format("observerMasterPort=%d%n", nonLeaderOMPort));
+        LOG.info("starting observer");
+        observer.start();
+        waitServerUp(observerClientPort);
+
+        // create a client to the observer
+        final LinkedBlockingQueue<KeeperState> states =
+            new LinkedBlockingQueue<KeeperState>();
+        ZooKeeper observerClient = new ZooKeeper(
+                "127.0.0.1:" + observerClientPort,
+                ClientBase.CONNECTION_TIMEOUT, new Watcher() {
+                    @Override
+                    public void process(WatchedEvent event) {
+                        try {
+                            states.put(event.getState());
+                        } catch (InterruptedException e) {}
+                    }
+                });
+
+        // wait for connected
+        KeeperState state = states.poll(1000, TimeUnit.MILLISECONDS);
+        Assert.assertEquals(KeeperState.SyncConnected, state);
+
+        // issue reconfig command
+        ArrayList<String> newServers = new ArrayList<String>();
+        String server = "server.3=127.0.0.1:" + PortAssignment.unique()
+                + ":" + PortAssignment.unique() + ":participant;localhost:"
+                + PortAssignment.unique();
+        newServers.add(server);
+        ZooKeeperAdmin admin = createAdmin(clientPort1);
+        ReconfigTest.reconfig(admin, newServers, null, null, -1);
+
+        // make sure the observer has the new config
+        ReconfigTest.testServerHasConfig(observerClient, newServers, null);
+
+        // shouldn't be disconnected during reconfig, so expect to not
+        // receive any new event
+        state = states.poll(1000, TimeUnit.MILLISECONDS);
+        Assert.assertNull(state);
+
+        admin.close();
+        observerClient.close();
+        observer.shutdown();
+        s2.shutdown();
+        s1.shutdown();
+    }
+
+    /**
+     * Implementation of watcher interface.
+     */
+    public void process(WatchedEvent event) {
+        lastEvent = event;
+        if (latch != null) {
+            latch.countDown();
+        }
+        LOG.info("Latch got event :: " + event);
+    }
+
+    class AsyncWriter implements Runnable {
+        private final ZooKeeper client;
+        private final int numTransactions;
+        private final boolean issueSync;
+        private final CountDownLatch writerLatch;
+        private final String root;
+        private final CountDownLatch gate;
+
+        AsyncWriter(ZooKeeper client, int numTransactions, boolean issueSync, CountDownLatch writerLatch,
+                    String root, CountDownLatch gate) {
+            this.client = client;
+            this.numTransactions = numTransactions;
+            this.issueSync = issueSync;
+            this.writerLatch = writerLatch;
+            this.root = root;
+            this.gate = gate;
+        }
+
+        @Override
+        public void run() {
+            if (gate != null) {
+                try {
+                    gate.await();
+                } catch (InterruptedException e) {
+                    LOG.error("Gate interrupted");
+                    return;
+                }
+            }
+            for (int i = 0; i < numTransactions; i++) {
+                final boolean pleaseLog = i % 100 == 0;
+                client.create(root + i, "inner thread".getBytes(), Ids.OPEN_ACL_UNSAFE,
+                        CreateMode.PERSISTENT, new AsyncCallback.StringCallback() {
+                            @Override
+                            public void processResult(int rc, String path,
+                                                      Object ctx, String name) {
+                                writerLatch.countDown();
+                                if (pleaseLog) {
+                                    LOG.info("wrote {}", path);
+                                }
+                            }
+                        }, null);
+                if (pleaseLog) {
+                    LOG.info("async wrote {}{}", root, i);
+                    if (issueSync) {
+                        client.sync(root + "0", null, null);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ObserverTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ObserverTest.java
@@ -18,176 +18,21 @@
 
 package org.apache.zookeeper.test;
 
-import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
-
-import java.util.concurrent.CountDownLatch;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.KeeperException.ConnectionLossException;
 import org.apache.zookeeper.PortAssignment;
-import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.Watcher.Event.KeeperState;
-import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.ZooKeeper.States;
 import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ObserverTest extends QuorumPeerTestBase implements Watcher{
     protected static final Logger LOG =
-        LoggerFactory.getLogger(ObserverTest.class);    
-      
-    CountDownLatch latch;
+        LoggerFactory.getLogger(ObserverTest.class);
+
     ZooKeeper zk;
-    WatchedEvent lastEvent = null;
-          
-    /**
-     * This test ensures two things:
-     * 1. That Observers can successfully proxy requests to the ensemble.
-     * 2. That Observers don't participate in leader elections.
-     * The second is tested by constructing an ensemble where a leader would
-     * be elected if and only if an Observer voted. 
-     * @throws Exception
-     */
-    @Test
-    public void testObserver() throws Exception {
-        ClientBase.setupTestEnv();
-        // We expect two notifications before we want to continue        
-        latch = new CountDownLatch(2);
-        
-        final int PORT_QP1 = PortAssignment.unique();
-        final int PORT_QP2 = PortAssignment.unique();
-        final int PORT_OBS = PortAssignment.unique();
-        final int PORT_QP_LE1 = PortAssignment.unique();
-        final int PORT_QP_LE2 = PortAssignment.unique();
-        final int PORT_OBS_LE = PortAssignment.unique();
 
-        final int CLIENT_PORT_QP1 = PortAssignment.unique();
-        final int CLIENT_PORT_QP2 = PortAssignment.unique();
-        final int CLIENT_PORT_OBS = PortAssignment.unique();
-
-        
-        String quorumCfgSection = 
-            "server.1=127.0.0.1:" + (PORT_QP1)
-            + ":" + (PORT_QP_LE1) + ";" +  CLIENT_PORT_QP1 
-            + "\nserver.2=127.0.0.1:" + (PORT_QP2)
-            + ":" + (PORT_QP_LE2) + ";" + CLIENT_PORT_QP2  
-            + "\nserver.3=127.0.0.1:" 
-            + (PORT_OBS)+ ":" + (PORT_OBS_LE) + ":observer" + ";" + CLIENT_PORT_OBS;
-        
-        MainThread q1 = new MainThread(1, CLIENT_PORT_QP1, quorumCfgSection);
-        MainThread q2 = new MainThread(2, CLIENT_PORT_QP2, quorumCfgSection);
-        MainThread q3 = new MainThread(3, CLIENT_PORT_OBS, quorumCfgSection);
-        q1.start();
-        q2.start();
-        q3.start();
-        Assert.assertTrue("waiting for server 1 being up",
-                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_QP1,
-                        CONNECTION_TIMEOUT));
-        Assert.assertTrue("waiting for server 2 being up",
-                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_QP2,
-                        CONNECTION_TIMEOUT));
-        Assert.assertTrue("waiting for server 3 being up",
-                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_OBS,
-                        CONNECTION_TIMEOUT));        
-        
-        zk = new ZooKeeper("127.0.0.1:" + CLIENT_PORT_OBS,
-                ClientBase.CONNECTION_TIMEOUT, this);
-        zk.create("/obstest", "test".getBytes(),Ids.OPEN_ACL_UNSAFE,
-                CreateMode.PERSISTENT);
-        
-        // Assert that commands are getting forwarded correctly
-        Assert.assertEquals(new String(zk.getData("/obstest", null, null)), "test");
-        
-        // Now check that other commands don't blow everything up
-        zk.sync("/", null, null);
-        zk.setData("/obstest", "test2".getBytes(), -1);
-        zk.getChildren("/", false);
-        
-        Assert.assertEquals(zk.getState(), States.CONNECTED);
-        
-        LOG.info("Shutting down server 2");
-        // Now kill one of the other real servers        
-        q2.shutdown();
-                
-        Assert.assertTrue("Waiting for server 2 to shut down",
-                    ClientBase.waitForServerDown("127.0.0.1:"+CLIENT_PORT_QP2, 
-                                    ClientBase.CONNECTION_TIMEOUT));
-
-        LOG.info("Server 2 down");
-
-        // Now the resulting ensemble shouldn't be quorate         
-        latch.await();        
-        Assert.assertNotSame("Client is still connected to non-quorate cluster", 
-                KeeperState.SyncConnected,lastEvent.getState());
-
-        LOG.info("Latch returned");
-
-        try {
-            Assert.assertFalse("Shouldn't get a response when cluster not quorate!",
-                    new String(zk.getData("/obstest", null, null)).equals("test"));
-        }
-        catch (ConnectionLossException c) {
-            LOG.info("Connection loss exception caught - ensemble not quorate (this is expected)");
-        }
-        
-        latch = new CountDownLatch(1);
-
-        LOG.info("Restarting server 2");
-
-        // Bring it back
-        q2 = new MainThread(2, CLIENT_PORT_QP2, quorumCfgSection);
-        q2.start();
-        
-        LOG.info("Waiting for server 2 to come up");
-        Assert.assertTrue("waiting for server 2 being up",
-                ClientBase.waitForServerUp("127.0.0.1:" + CLIENT_PORT_QP2,
-                        CONNECTION_TIMEOUT));
-        
-        LOG.info("Server 2 started, waiting for latch");
-
-        latch.await();
-        // It's possible our session expired - but this is ok, shows we 
-        // were able to talk to the ensemble
-        Assert.assertTrue("Client didn't reconnect to quorate ensemble (state was" +
-                lastEvent.getState() + ")",
-                (KeeperState.SyncConnected==lastEvent.getState() ||
-                KeeperState.Expired==lastEvent.getState())); 
-
-        LOG.info("Shutting down all servers");
-
-        q1.shutdown();
-        q2.shutdown();
-        q3.shutdown();
-        
-        LOG.info("Closing zk client");
-
-        zk.close();        
-        Assert.assertTrue("Waiting for server 1 to shut down",
-                ClientBase.waitForServerDown("127.0.0.1:"+CLIENT_PORT_QP1, 
-                                ClientBase.CONNECTION_TIMEOUT));
-        Assert.assertTrue("Waiting for server 2 to shut down",
-                ClientBase.waitForServerDown("127.0.0.1:"+CLIENT_PORT_QP2, 
-                                ClientBase.CONNECTION_TIMEOUT));
-        Assert.assertTrue("Waiting for server 3 to shut down",
-                ClientBase.waitForServerDown("127.0.0.1:"+CLIENT_PORT_OBS, 
-                                ClientBase.CONNECTION_TIMEOUT));
-    
-    }
-    
-    /**
-     * Implementation of watcher interface.
-     */
-    public void process(WatchedEvent event) {
-        lastEvent = event;
-        latch.countDown();
-        LOG.info("Latch got event :: " + event);        
-    }    
-    
     /**
      * This test ensures that an Observer does not elect itself as a leader, or
      * indeed come up properly, if it is the lone member of an ensemble.

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
@@ -82,20 +82,22 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
                                   List<String> leavingServers, List<String> newMembers, long fromConfig)
             throws KeeperException, InterruptedException {
         byte[] config = null;
+        String failure = null;
         for (int j = 0; j < 30; j++) {
             try {
                 config = zkAdmin.reconfigure(joiningServers, leavingServers,
                         newMembers, fromConfig, new Stat());
+                failure = null;
                 break;
             } catch (KeeperException.ConnectionLossException e) {
-                if (j < 29) {
-                    Thread.sleep(1000);
-                } else {
-                    // test fails if we still can't connect to the quorum after
-                    // 30 seconds.
-                    Assert.fail("client could not connect to reestablished quorum: giving up after 30+ seconds.");
-                }
+                failure = "client could not connect to reestablished quorum: giving up after 30+ seconds.";
+            } catch (KeeperException.ReconfigInProgress e) {
+                failure = "reconfig still in progress: giving up after 30+ seconds.";
             }
+            Thread.sleep(1000);
+        }
+        if (failure != null) {
+            Assert.fail(failure);
         }
 
         String configStr = new String(config);

--- a/zookeeper-server/src/test/resources/findbugsExcludeFile.xml
+++ b/zookeeper-server/src/test/resources/findbugsExcludeFile.xml
@@ -199,4 +199,12 @@
     <Class name="org.apache.zookeeper.server.EphemeralType"/>
       <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT" />
   </Match>
+
+  <!-- Disable 'Inconsistent synchronization' to allow the ServerSocket to listen without
+       locking the class -->
+  <Match>
+    <Class name="org.apache.zookeeper.server.quorum.ObserverMaster"/>
+    <Field name="ss"/>
+    <Bug code="IS"/>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Creates a new abstraction, LearnerMaster, to represent the portions of the Leader logic that are used in LearnerHandler. Leader implements LearnerMaster and a new class ObserverMaster implements LearnerMaster. Followers have the option of instantiating a ObserverMaster thread when they assume their role and so support Learner traffic.

A new parameter 'observerMasterPort' is used to control which Follower instances host Observers.
