### PR TITLE
ZOOKEEPER-2641:AvgRequestLatency metric improves to be more accurate

### DIFF
--- a/zookeeper-common/src/test/java/org/apache/zookeeper/test/FourLetterWordsTest.java
+++ b/zookeeper-common/src/test/java/org/apache/zookeeper/test/FourLetterWordsTest.java
@@ -146,7 +146,7 @@ public class FourLetterWordsTest extends ClientBase {
         Assert.assertTrue(count >= 2);
 
         line = in.readLine();
-        Assert.assertTrue(Pattern.matches("^Latency min/avg/max: \\d+/\\d+/\\d+$", line));
+        Assert.assertTrue(Pattern.matches("^Latency min/avg/max: \\d+/-?[0-9]*.?[0-9]*/\\d+$", line));
         line = in.readLine();
         Assert.assertTrue(Pattern.matches("^Received: \\d+$", line));
         line = in.readLine();

--- a/zookeeper-docs/src/documentation/content/xdocs/zookeeperAdmin.xml
+++ b/zookeeper-docs/src/documentation/content/xdocs/zookeeperAdmin.xml
@@ -1562,7 +1562,7 @@ server.3=zoo3:2888:3888</programlisting>
             <programlisting>$ echo mntr | nc localhost 2185
 
 zk_version  3.4.0
-zk_avg_latency  0
+zk_avg_latency  0.7561              - be account to four decimal places
 zk_max_latency  0
 zk_min_latency  0
 zk_packets_received 70

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -819,7 +819,11 @@ public class NIOServerCnxn extends ServerCnxn {
             }
         }
 
-        private void print(String key, Object number) {
+        private void print(String key, long number) {
+            print(key, "" + number);
+        }
+        
+        private void print(String key, double number) {
             print(key, "" + number);
         }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -819,7 +819,7 @@ public class NIOServerCnxn extends ServerCnxn {
             }
         }
 
-        private void print(String key, long number) {
+        private void print(String key, Object number) {
             print(key, "" + number);
         }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -599,10 +599,14 @@ public class NettyServerCnxn extends ServerCnxn {
             }
         }
 
-        private void print(String key, Object number) {
+        private void print(String key, long number) {
             print(key, "" + number);
         }
-
+        
+        private void print(String key, double number) {
+            print(key, "" + number);
+        }
+        
         private void print(String key, String value) {
             pw.print("zk_");
             pw.print(key);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -599,7 +599,7 @@ public class NettyServerCnxn extends ServerCnxn {
             }
         }
 
-        private void print(String key, long number) {
+        private void print(String key, Object number) {
             print(key, "" + number);
         }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerStats.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerStats.java
@@ -22,6 +22,7 @@ package org.apache.zookeeper.server;
 
 import org.apache.zookeeper.common.Time;
 
+import java.math.BigDecimal;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -57,7 +58,9 @@ public class ServerStats {
     synchronized public double getAvgLatency() {
         if (count != 0) {
             //be account to four decimal places
-            return (totalLatency * 10000 / count) / 10000.0;
+            double avgLatency = totalLatency / (double)count;
+            BigDecimal bg = new BigDecimal(avgLatency);
+            return bg.setScale(4, BigDecimal.ROUND_HALF_UP).doubleValue();
         }
         return 0;
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerStats.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerStats.java
@@ -37,7 +37,7 @@ public class ServerStats {
     private AtomicLong fsyncThresholdExceedCount = new AtomicLong(0);
     
     private final Provider provider;
-
+    
     public interface Provider {
         public long getOutstandingRequests();
         public long getLastProcessedZxid();
@@ -53,9 +53,10 @@ public class ServerStats {
     synchronized public long getMinLatency() {
         return minLatency == Long.MAX_VALUE ? 0 : minLatency;
     }
-
+    
     synchronized public double getAvgLatency() {
         if (count != 0) {
+            //be account to four decimal places
             return (totalLatency * 10000 / count) / 10000.0;
         }
         return 0;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerStats.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerStats.java
@@ -22,7 +22,6 @@ package org.apache.zookeeper.server;
 
 import org.apache.zookeeper.common.Time;
 
-import java.text.DecimalFormat;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -36,8 +35,6 @@ public class ServerStats {
     private long totalLatency = 0;
     private long count = 0;
     private AtomicLong fsyncThresholdExceedCount = new AtomicLong(0);
-
-    private DecimalFormat df = new DecimalFormat("#.0000");
     
     private final Provider provider;
 
@@ -59,8 +56,7 @@ public class ServerStats {
 
     synchronized public double getAvgLatency() {
         if (count != 0) {
-            String avgLatency = df.format((double)totalLatency / count);
-            return Double.parseDouble(avgLatency);
+            return (totalLatency * 10000 / count) / 10000.0;
         }
         return 0;
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerStats.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerStats.java
@@ -22,6 +22,7 @@ package org.apache.zookeeper.server;
 
 import org.apache.zookeeper.common.Time;
 
+import java.text.DecimalFormat;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -36,6 +37,8 @@ public class ServerStats {
     private long count = 0;
     private AtomicLong fsyncThresholdExceedCount = new AtomicLong(0);
 
+    private DecimalFormat df = new DecimalFormat("#.0000");
+    
     private final Provider provider;
 
     public interface Provider {
@@ -54,9 +57,10 @@ public class ServerStats {
         return minLatency == Long.MAX_VALUE ? 0 : minLatency;
     }
 
-    synchronized public long getAvgLatency() {
+    synchronized public double getAvgLatency() {
         if (count != 0) {
-            return totalLatency / count;
+            String avgLatency = df.format((double)totalLatency / count);
+            return Double.parseDouble(avgLatency);
         }
         return 0;
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerBean.java
@@ -66,7 +66,7 @@ public class ZooKeeperServerBean implements ZooKeeperServerMXBean, ZKMBeanInfo {
         return Version.getFullVersion();
     }
     
-    public long getAvgRequestLatency() {
+    public double getAvgRequestLatency() {
         return zks.serverStats().getAvgLatency();
     }
     

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMXBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMXBean.java
@@ -41,7 +41,7 @@ public interface ZooKeeperServerMXBean {
     /**
      * @return average request latency in ms
      */
-    public long getAvgRequestLatency();
+    public double getAvgRequestLatency();
     /**
      * @return max request latency in ms
      */

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ServerStatsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ServerStatsTest.java
@@ -26,7 +26,8 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
 
 public class ServerStatsTest extends ZKTestCase {
 
@@ -61,7 +62,7 @@ public class ServerStatsTest extends ZKTestCase {
         assertAllPacketsZero(serverStats);
 
     }
-
+    
     @Test
     public void testLatencyMetrics() {
         // Given ...
@@ -73,12 +74,11 @@ public class ServerStatsTest extends ZKTestCase {
 
         // Then ...
         assertThat("Max latency check", 2000L,
-                greaterThanOrEqualTo(serverStats.getMaxLatency()));
+                lessThanOrEqualTo(serverStats.getMaxLatency()));
         assertThat("Min latency check", 1000L,
-                greaterThanOrEqualTo(serverStats.getMinLatency()));
-        assertThat("Avg latency check", 1500L,
-                greaterThanOrEqualTo(serverStats.getAvgLatency()));
-
+                lessThanOrEqualTo(serverStats.getMinLatency()));
+        assertEquals((double)1500, serverStats.getAvgLatency(), (double)200);
+        
         // When reset...
         serverStats.resetLatency();
 
@@ -136,7 +136,7 @@ public class ServerStatsTest extends ZKTestCase {
     private void assertAllLatencyZero(ServerStats serverStats) {
         Assert.assertEquals(0L, serverStats.getMaxLatency());
         Assert.assertEquals(0L, serverStats.getMinLatency());
-        Assert.assertEquals(0L, serverStats.getAvgLatency());
+        Assert.assertEquals((double)0, serverStats.getAvgLatency(), (double)0.00001);
     }
 
     private void assertFsyncThresholdExceedCountZero(ServerStats serverStats) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ServerStatsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ServerStatsTest.java
@@ -85,7 +85,7 @@ public class ServerStatsTest extends ZKTestCase {
         // Then ...
         assertAllLatencyZero(serverStats);
     }
-
+    
     @Test
     public void testFsyncThresholdExceedMetrics() {
         // Given ...


### PR DESCRIPTION
- Since 4lw will be deprecated,so this patch only for branch3.4
- ZOOKEEPER-3074 is not applied to branch3.4 and Jenkins complains about [it](https://builds.apache.org/job/ZooKeeper_branch34_java10/152/testReport/junit/org.apache.zookeeper.server/ServerStatsTest/testLatencyMetrics/), I fix it without extra trouble
- still leave a work undo for discussion,what should we deal with `Ping` request?
 >Ping request should be ignored while recording the statistics or at
least should be configurable whether to ignore or not. If ping request is
not counted even other metrics will be more meaningful. 
- more details in [ZOOKEEPER-2641](https://issues.apache.org/jira/browse/ZOOKEEPER-2641) 
  