### PR TITLE
[ZOOKEEPER-3150] Add tree digest check and verify data integrity when loading from disk

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -904,7 +904,7 @@ property, when available, is noted below.
     time. The default is 100.
 
 * *digest.enabled* :
-    (Java system property: **zookeeper.digest.enabled**)
+    (Java system property only: **zookeeper.digest.enabled**)
     **New in 3.6.0:**
     The digest feature is added to self-verify the correctness inside
     ZooKeeper when loading database from disk, and syncing with leader.

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -903,6 +903,13 @@ property, when available, is noted below.
     The maximum number of diff syncs a leader or a follower can serve at the same
     time. The default is 100.
 
+* *digest.enabled* :
+    (Java system property: **zookeeper.digest.enabled**)
+    **New in 3.6.0:**
+    The digest feature is added to self-verify the correctness inside
+    ZooKeeper when loading database from disk, and syncing with leader.
+    By default, this feautre is disabled, set "true" to enable it.
+
 <a name="sc_clusterOptions"></a>
 
 #### Cluster Options
@@ -1769,6 +1776,10 @@ The output contains multiple lines with the following format:
     **New in 3.4.0:** Tests if
     server is running in read-only mode.  The server will respond with
     "ro" if in read-only mode or "rw" if not in read-only mode.
+
+* *hash* :
+    **New in 3.6.0:**
+    Return the latest history of the tree digest associated with zxid.
 
 * *gtmk* :
     Gets the current trace mask as a 64-bit signed long value in

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/DigestWatcher.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/DigestWatcher.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper;
+
+/**
+ * This interface is used to notify the digest mismatch event.
+ */
+public interface DigestWatcher {
+
+    /**
+     * Called when the digest mismatch is found on a given zxid.
+     *
+     * @param mismatchZxid the zxid when the digest mismatch happened. 
+     */
+    void process(long mismatchZxid);
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooDefs.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooDefs.java
@@ -31,6 +31,8 @@ public class ZooDefs {
    
    final public static String CONFIG_NODE = "/zookeeper/config";
 
+   final public static String ZOOKEEPER_NODE_SUBTREE = "/zookeeper/";
+
    @InterfaceAudience.Public
     public interface OpCode {
         public final int notification = 0;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataNode.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataNode.java
@@ -41,11 +41,11 @@ import org.apache.zookeeper.data.StatPersisted;
 public class DataNode implements Record {
 
     // the digest value of this node, calculated from path, data and stat
-    private long digest;
+    private volatile long digest;
 
     // indicate if the digest of this node is up to date or not, used to 
     // optimize the performance.
-    boolean digestCached;
+    volatile boolean digestCached;
 
     /** the data for this datanode */
     byte data[];

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataNode.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataNode.java
@@ -39,6 +39,14 @@ import org.apache.zookeeper.data.StatPersisted;
  */
 @SuppressFBWarnings("EI_EXPOSE_REP2")
 public class DataNode implements Record {
+
+    // the digest value of this node, calculated from path, data and stat
+    private long digest;
+
+    // indicate if the digest of this node is up to date or not, used to 
+    // optimize the performance.
+    boolean digestCached;
+
     /** the data for this datanode */
     byte data[];
 
@@ -181,5 +189,25 @@ public class DataNode implements Record {
         archive.writeLong(acl, "acl");
         stat.serialize(archive, "statpersisted");
         archive.endRecord(this, "node");
+    }
+
+    public boolean isDigestCached() {
+        return digestCached;
+    }
+
+    public void setDigestCached(boolean digestCached) {
+        this.digestCached = digestCached;
+    }
+
+    public long getDigest() {
+        return digest;
+    }
+
+    public void setDigest(long digest) {
+        this.digest = digest;
+    }
+
+    public byte[] getData() {
+        return data;
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataNode.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataNode.java
@@ -37,7 +37,7 @@ import org.apache.zookeeper.data.StatPersisted;
  * array of ACLs, a stat object, and a set of its children's paths.
  * 
  */
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 public class DataNode implements Record {
 
     // the digest value of this node, calculated from path, data and stat

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -1736,8 +1736,9 @@ public class DataTree {
     /**
      * Return all the digests in the historical digest list.
      */
-    public LinkedList<ZxidDigest> getDigestLog() {
+    public List<ZxidDigest> getDigestLog() {
         synchronized (digestLog) {
+            // Return a copy of current digest log
             return new LinkedList<ZxidDigest>(digestLog);
         }
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -168,6 +168,10 @@ public class DataTree {
     // The maximum number of tree digests that we will keep in our history
     public static final int DIGEST_LOG_LIMIT = 1024;
 
+    // Dump digest every 128 txns, in hex it's 80, which will make it easier 
+    // to align and compare between servers.
+    public static final int DIGEST_LOG_INTERVAL = 128;
+
     // If this is not null, we are actively looking for a target zxid that we
     // want to validate the digest for
     private ZxidDigest digestFromLoadedSnapshot;
@@ -1614,7 +1618,7 @@ public class DataTree {
     private void logZxidDigest(long zxid, long digest) {
         ZxidDigest zxidDigest = new ZxidDigest(zxid, DigestCalculator.DIGEST_VERSION, digest);
         lastProcessedZxidDigest = zxidDigest;
-        if (zxidDigest.zxid % 128 == 0) {
+        if (zxidDigest.zxid % DIGEST_LOG_INTERVAL == 0) {
             synchronized (digestLog) {
                 digestLog.add(zxidDigest);
                 if (digestLog.size() > DIGEST_LOG_LIMIT) {
@@ -1632,7 +1636,7 @@ public class DataTree {
      * @param oa the output stream to write to 
      * @return true if the digest is serialized successfully
      */
-    public Boolean serializeZxidDigest(OutputArchive oa) throws IOException {
+    public boolean serializeZxidDigest(OutputArchive oa) throws IOException {
         if (!DigestCalculator.digestEnabled()) {
             return false;
         }
@@ -1653,7 +1657,7 @@ public class DataTree {
      * @param ia the input stream to read from
      * @return the true if it deserialized successfully
      */
-    public Boolean deserializeZxidDigest(InputArchive ia) throws IOException {
+    public boolean deserializeZxidDigest(InputArchive ia) throws IOException {
         if (!DigestCalculator.digestEnabled()) {
             return false;
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -180,7 +180,7 @@ public class DataTree {
     private volatile ZxidDigest lastProcessedZxidDigest;
 
     // Will be notified when digest mismatch event triggered.
-    private List<DigestWatcher> digestWatchers = new ArrayList<>();
+    private final List<DigestWatcher> digestWatchers = new ArrayList<>();
 
     // The historical digests list.
     private LinkedList<ZxidDigest> digestLog = new LinkedList<>();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -1722,6 +1722,10 @@ public class DataTree {
         return nodes.getDigest();
     }
 
+    public ZxidDigest getLastProcessedZxidDigest() {
+        return lastProcessedZxidDigest;
+    }
+
     public ZxidDigest getDigestFromLoadedSnapshot() {
         return digestFromLoadedSnapshot;
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -40,7 +40,6 @@ import org.apache.zookeeper.common.PathTrie;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.data.StatPersisted;
-import org.apache.zookeeper.server.ServerMetrics;
 import org.apache.zookeeper.server.util.DigestCalculator;
 import org.apache.zookeeper.server.watch.IWatchManager;
 import org.apache.zookeeper.server.watch.WatchManagerFactory;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMap.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMap.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.server;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The interface defined to manage the hash based on the entries in the 
@@ -57,6 +58,11 @@ public interface NodeHashMap {
      * @return the node being removed
      */
     public DataNode remove(String path);
+
+    /**
+     * Return all key set view inside this map.
+     */
+    public ConcurrentHashMap.KeySetView<String, DataNode> keySet();
 
     /**
      * Return all the entries inside this map.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMap.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMap.java
@@ -28,12 +28,20 @@ import java.util.Set;
 public interface NodeHashMap {
 
     /**
-     * Add the node into the map.
+     * Add the node into the map and update the digest with the new node.
      *
      * @param path the path of the node
      * @param node the actual node associated with this path
      */
     public DataNode put(String path, DataNode node);
+
+    /**
+     * Add the node into the map without update the digest.
+     *
+     * @param path the path of the node
+     * @param node the actual node associated with this path
+     */
+    public DataNode putWithoutDigest(String path, DataNode node);
 
     /**
      * Return the data node associated with the path.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMap.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMap.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The interface defined to manage the hash based on the entries in the 
+ * nodes map.
+ */
+public interface NodeHashMap {
+
+    /**
+     * Add the node into the map.
+     *
+     * @param path the path of the node
+     * @param node the actual node associated with this path
+     */
+    public DataNode put(String path, DataNode node);
+
+    /**
+     * Return the data node associated with the path.
+     *
+     * @param path the path to read from 
+     */
+    public DataNode get(String path);
+
+    /**
+     * Remove the path from the internal nodes map.
+     *
+     * @param path the path to remove
+     * @return the node being removed
+     */
+    public DataNode remove(String path);
+
+    /**
+     * Return all the entries inside this map.
+     */
+    public Set<Map.Entry<String, DataNode>> entrySet();
+
+    /**
+     * Clear all the items stored inside this map.
+     */
+    public void clear();
+
+    /**
+     * Return the size of the nodes stored in this map.
+     */
+    public int size();
+
+    /**
+     * Called before we made the change on the node, which will clear
+     * the digest associated with it.
+     *
+     * @param path the path being changed
+     * @param node the node associated with the path
+     */
+    public void preChange(String path, DataNode node);
+
+    /**
+     * Called after making the changes on the node, which will update
+     * the digest.
+     *
+     * @param path the path being changed
+     * @param node the node associated with the path
+     */
+    public void postChange(String path, DataNode node);
+
+    /**
+     * Return the digest value.
+     */
+    public long getDigest();
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMapImpl.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMapImpl.java
@@ -35,14 +35,10 @@ public class NodeHashMapImpl implements NodeHashMap {
 
     private static final Logger LOG = LoggerFactory.getLogger(NodeHashMap.class);
 
-    private final ConcurrentHashMap<String, DataNode> nodes;
+    private final ConcurrentHashMap<String, DataNode> nodes = 
+            new ConcurrentHashMap<String, DataNode>();
 
-    private AdHash hash;
-
-    public NodeHashMapImpl() {
-        nodes = new ConcurrentHashMap<String, DataNode>();
-        hash = new AdHash();
-    }
+    private AdHash hash = new AdHash();
 
     @Override
     public DataNode put(String path, DataNode node) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMapImpl.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMapImpl.java
@@ -51,6 +51,11 @@ public class NodeHashMapImpl implements NodeHashMap {
     }
 
     @Override
+    public DataNode putWithoutDigest(String path, DataNode node) {
+        return nodes.put(path, node);
+    }
+
+    @Override
     public DataNode get(String path) {
         return nodes.get(path);
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMapImpl.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMapImpl.java
@@ -70,6 +70,11 @@ public class NodeHashMapImpl implements NodeHashMap {
     }
 
     @Override
+    public ConcurrentHashMap.KeySetView<String, DataNode> keySet() {
+        return nodes.keySet();
+    }
+
+    @Override
     public Set<Map.Entry<String, DataNode>> entrySet() {
         return nodes.entrySet();
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMapImpl.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMapImpl.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.zookeeper.server.util.DigestCalculator;
+import org.apache.zookeeper.server.util.AdHash;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * a simple wrapper to ConcurrentHashMap that recalculates a digest after
+ * each mutation.
+ */
+public class NodeHashMapImpl implements NodeHashMap {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NodeHashMap.class);
+
+    private final ConcurrentHashMap<String, DataNode> nodes;
+
+    private AdHash hash;
+
+    public NodeHashMapImpl() {
+        nodes = new ConcurrentHashMap<String, DataNode>();
+        hash = new AdHash();
+    }
+
+    @Override
+    public DataNode put(String path, DataNode node) {
+        DataNode oldNode = nodes.put(path, node);
+        addDigest(path, node);
+        if (oldNode != null) {
+            removeDigest(path, oldNode);
+        }
+        return oldNode;
+    }
+
+    @Override
+    public DataNode get(String path) {
+        return nodes.get(path);
+    }
+
+    @Override
+    public DataNode remove(String path) {
+        DataNode oldNode = nodes.remove(path);
+        if (oldNode != null) {
+            removeDigest(path, oldNode);
+        }
+        return oldNode;
+    }
+
+    @Override
+    public Set<Map.Entry<String, DataNode>> entrySet() {
+        return nodes.entrySet();
+    }
+
+    @Override
+    public void clear() {
+        nodes.clear();
+        hash = new AdHash();
+    }
+
+    @Override
+    public int size() {
+        return nodes.size();
+    }
+
+    @Override
+    public void preChange(String path, DataNode node) {
+        removeDigest(path, node);
+    }
+
+    @Override
+    public void postChange(String path, DataNode node) {
+        // we just made a change, so make sure the digest is
+        // invalidated
+        node.digestCached = false;
+        addDigest(path, node);
+    }
+
+    private void addDigest(String path, DataNode node) {
+        if (DigestCalculator.digestEnabled()) {
+            hash.addDigest(DigestCalculator.calculateDigest(path, node));
+        }
+    }
+
+    private void removeDigest(String path, DataNode node) {
+        if (DigestCalculator.digestEnabled()) {
+            hash.removeDigest(DigestCalculator.calculateDigest(path, node));
+        }
+    }
+
+    @Override
+    public long getDigest() {
+        return hash.getHash();
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMapImpl.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NodeHashMapImpl.java
@@ -24,16 +24,12 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.zookeeper.server.util.DigestCalculator;
 import org.apache.zookeeper.server.util.AdHash;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * a simple wrapper to ConcurrentHashMap that recalculates a digest after
  * each mutation.
  */
 public class NodeHashMapImpl implements NodeHashMap {
-
-    private static final Logger LOG = LoggerFactory.getLogger(NodeHashMap.class);
 
     private final ConcurrentHashMap<String, DataNode> nodes = 
             new ConcurrentHashMap<String, DataNode>();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/RateLogger.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/RateLogger.java
@@ -21,42 +21,68 @@ package org.apache.zookeeper.server;
 import org.apache.zookeeper.common.Time;
 import org.slf4j.Logger;
 
+/**
+ * This logs the message once in the beginning and once every LOG_INTERVAL.
+ */
 public class RateLogger {
+    private final long LOG_INTERVAL; // Duration is in ms
+
     public RateLogger(Logger log) {
+        this(log, 100);
+    }
+
+    public RateLogger(Logger log, long interval) {
         LOG = log;
+        LOG_INTERVAL = interval;
     }
 
     private final Logger LOG;
     private String msg = null;
     private long timestamp;
     private int count = 0;
+    private String value = null;
 
     public void flush() {
-        if (msg != null) {
+        if (msg != null && count > 0) {
+            String log = "";
             if (count > 1) {
-                LOG.warn("[" + count + " times] " + msg);
-            } else if (count == 1) {
-                LOG.warn(msg);
+                log = "[" + count + " times] ";
             }
+            log += "Message: " + msg;
+            if (value != null) {
+                log += " Last value:" + value;
+            }
+            LOG.warn(log);
         }
         msg = null;
+        value = null;
         count = 0;
     }
 
     public void rateLimitLog(String newMsg) {
+        rateLimitLog(newMsg, null);
+    }
+
+    /**
+     * In addition to the message, it also takes a value.
+     */
+    public void rateLimitLog(String newMsg, String value) {
         long now = Time.currentElapsedTime();
         if (newMsg.equals(msg)) {
             ++count;
-            if (now - timestamp >= 100) {
+            this.value = value;
+            if (now - timestamp >= LOG_INTERVAL) {
                 flush();
                 msg = newMsg;
                 timestamp = now;
+                this.value = value;
             }
         } else {
             flush();
             msg = newMsg;
+            this.value = value;
             timestamp = now;
-            LOG.warn(msg);
+            LOG.warn("Message:{} Value:{}", msg, value);
         }
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
@@ -227,6 +227,8 @@ public final class ServerMetrics {
         REQUEST_THROTTLE_WAIT_COUNT = metricsContext.getCounter("request_throttle_wait_count");
 
         NETTY_QUEUED_BUFFER = metricsContext.getSummary("netty_queued_buffer_capacity", DetailLevel.BASIC);
+
+        DIGEST_MISMATCHES_COUNT = metricsContext.getCounter("digest_mismatches_count");
     }
 
     /**
@@ -427,6 +429,10 @@ public final class ServerMetrics {
     public final Counter REQUEST_THROTTLE_WAIT_COUNT;
 
     public final Summary NETTY_QUEUED_BUFFER;
+
+    // Total number of digest mismatches that are observed when applying 
+    // txns to data tree.
+    public final Counter DIGEST_MISMATCHES_COUNT;
 
     private final MetricsProvider metricsProvider;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -194,6 +194,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
             justification = "Internally the throttler has a BlockingQueue so " +
                     "once the throttler is created and started, it is thread-safe")
     private RequestThrottler requestThrottler;
+    public static final String SNAP_COUNT = "zookeeper.snapCount";
 
     void removeCnxn(ServerCnxn cnxn) {
         zkDb.removeCnxn(cnxn);
@@ -1010,7 +1011,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
     }
 
     public static int getSnapCount() {
-        String sc = System.getProperty("zookeeper.snapCount");
+        String sc = System.getProperty(SNAP_COUNT);
         try {
             int snapCount = Integer.parseInt(sc);
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Commands.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Commands.java
@@ -128,6 +128,7 @@ public class Commands {
         registerCommand(new EnvCommand());
         registerCommand(new GetTraceMaskCommand());
         registerCommand(new InitialConfigurationCommand());
+        registerCommand(new HashCommand());
         registerCommand(new IsroCommand());
         registerCommand(new LastSnapshotCommand());
         registerCommand(new LeaderCommand());
@@ -264,6 +265,22 @@ public class Commands {
             for (Entry e : Environment.list()) {
                 response.put(e.getKey(), e.getValue());
             }
+            return response;
+        }
+    }
+
+    /**
+     * Digest histories for every specific number of txns.
+     */
+    public static class HashCommand extends CommandBase {
+        public HashCommand() {
+            super(Arrays.asList("hash"));
+        }
+
+        @Override
+        public CommandResponse run(ZooKeeperServer zkServer, Map<String, String> kwargs) {
+            CommandResponse response = initializeResponse();
+            response.put("digests", zkServer.getZKDatabase().getDataTree().getDigestLog());
             return response;
         }
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Commands.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Commands.java
@@ -128,7 +128,7 @@ public class Commands {
         registerCommand(new EnvCommand());
         registerCommand(new GetTraceMaskCommand());
         registerCommand(new InitialConfigurationCommand());
-        registerCommand(new HashCommand());
+        registerCommand(new DigestCommand());
         registerCommand(new IsroCommand());
         registerCommand(new LastSnapshotCommand());
         registerCommand(new LeaderCommand());
@@ -272,8 +272,8 @@ public class Commands {
     /**
      * Digest histories for every specific number of txns.
      */
-    public static class HashCommand extends CommandBase {
-        public HashCommand() {
+    public static class DigestCommand extends CommandBase {
+        public DigestCommand() {
             super(Arrays.asList("hash"));
         }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/CommandExecutor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/CommandExecutor.java
@@ -75,7 +75,7 @@ public class CommandExecutor {
         } else if (commandCode == FourLetterCommands.isroCmd) {
             command = new IsroCommand(pwriter, serverCnxn);
         } else if (commandCode == FourLetterCommands.hashCmd) {
-            command = new HashCommand(pwriter, serverCnxn);
+            command = new DigestCommand(pwriter, serverCnxn);
         }
 
         return command;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/CommandExecutor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/CommandExecutor.java
@@ -74,7 +74,10 @@ public class CommandExecutor {
             command = new MonitorCommand(pwriter, serverCnxn);
         } else if (commandCode == FourLetterCommands.isroCmd) {
             command = new IsroCommand(pwriter, serverCnxn);
+        } else if (commandCode == FourLetterCommands.hashCmd) {
+            command = new HashCommand(pwriter, serverCnxn);
         }
+
         return command;
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/DigestCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/DigestCommand.java
@@ -27,9 +27,9 @@ import org.apache.zookeeper.server.ServerCnxn;
 /**
  * Command used to dump the latest digest histories.
  */
-public class HashCommand extends AbstractFourLetterCommand {
+public class DigestCommand extends AbstractFourLetterCommand {
 
-    public HashCommand(PrintWriter pw, ServerCnxn serverCnxn) {
+    public DigestCommand(PrintWriter pw, ServerCnxn serverCnxn) {
         super(pw, serverCnxn);
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/DigestCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/DigestCommand.java
@@ -35,7 +35,7 @@ public class DigestCommand extends AbstractFourLetterCommand {
 
     @Override
     public void commandRun() {
-        if (zkServer == null) {
+        if (!isZKServerRunning()) {
             pw.print(ZK_NOT_SERVING);
         } else {
             List<ZxidDigest> digestLog = 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/FourLetterCommands.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/FourLetterCommands.java
@@ -151,6 +151,13 @@ public class FourLetterCommands {
             .getInt();
 
     /*
+     * See <a href="{@docRoot}/../../../docs/zookeeperAdmin.html#sc_zkCommands">
+     * Zk Admin</a>. this link is for all the commands.
+     */
+    protected final static int hashCmd =
+        ByteBuffer.wrap("hash".getBytes()).getInt();
+
+    /*
      * The control sequence sent by the telnet program when it closes a
      * connection. Include simply to keep the logs cleaner (the server would
      * close the connection anyway because it would parse this as a negative
@@ -256,5 +263,6 @@ public class FourLetterCommands {
         cmd2String.put(mntrCmd, "mntr");
         cmd2String.put(isroCmd, "isro");
         cmd2String.put(telnetCloseCmd, "telnet close");
+        cmd2String.put(hashCmd, "hash");
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/HashCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/HashCommand.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.command;
+
+import java.io.PrintWriter;
+import java.util.List;
+
+import org.apache.zookeeper.server.DataTree.ZxidDigest;
+import org.apache.zookeeper.server.ServerCnxn;
+
+/**
+ * Command used to dump the latest digest histories.
+ */
+public class HashCommand extends AbstractFourLetterCommand {
+
+    public HashCommand(PrintWriter pw, ServerCnxn serverCnxn) {
+        super(pw, serverCnxn);
+    }
+
+    @Override
+    public void commandRun() {
+        if (zkServer == null) {
+            pw.print(ZK_NOT_SERVING);
+        } else {
+            List<ZxidDigest> digestLog = 
+                    zkServer.getZKDatabase().getDataTree().getDigestLog();
+            for (ZxidDigest zd : digestLog) {
+                pw.println(Long.toHexString(zd.getZxid()) + ": " + 
+                        zd.getDigest());
+            }
+        }
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
@@ -164,6 +164,7 @@ public class SnapStream {
             throws IOException {
         long checkSum = is.getChecksum().getValue();
         long val = ia.readLong("val");
+        ia.readString("path");  // Read and ignore "/" written by SealStream.
         if (val != checkSum) {
             throw new IOException("CRC corruption");
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/AdHash.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/AdHash.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.util;
+
+/**
+ * This incremental hash is used to keep track of the hash of
+ * the data tree to that we can quickly validate that things
+ * are in sync.
+ *
+ * See the excellent paper: A New Paradigm for collision-free hashing:
+ *   Incrementality at reduced cost,  M. Bellare and D. Micciancio
+ */
+public class AdHash {
+
+    /* we use 64 bits so that we can be fast an efficient */
+    private long hash;
+
+    /**
+     * Add new digest to the hash value maintained in this class.
+     *
+     * @param digest the value to add on
+     * @return the AdHash itself for chained operations
+     */
+    public AdHash addDigest(long digest) {
+        hash += digest;
+        return this;
+    }
+
+    /**
+     * Remove the digest from the hash value.
+     * 
+     * @param digest the value to remove
+     * @return the AdHash itself for chained operations
+     */
+    public AdHash removeDigest(long digest) {
+        hash -= digest;
+        return this;
+    }
+
+    /**
+     * Return hex string of the hash value.
+     */
+    public String toHexString() {
+        return Long.toHexString(hash);
+    }
+
+    /**
+     * Return the long value of the hash.
+     */
+    public long getHash() {
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof AdHash && ((AdHash) other).hash == this.hash;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(hash);
+    }
+
+    @Override
+    public String toString() {
+        return toHexString();
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/DigestCalculator.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/DigestCalculator.java
@@ -15,30 +15,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- package org.apache.zookeeper.server.util;
- import java.nio.ByteBuffer;
+
+package org.apache.zookeeper.server.util;
+
+import java.nio.ByteBuffer;
 import java.util.zip.CRC32;
- import org.apache.zookeeper.ZooDefs;
+
+import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.StatPersisted;
 import org.apache.zookeeper.server.DataNode;
- import org.slf4j.Logger;
+
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
- /**
+
+/**
  * Defines how to calculate the digest for a given node.
  */
 public class DigestCalculator {
-     private static final Logger LOG = LoggerFactory.getLogger(DigestCalculator.class);
-     // The hardcoded digest version, should bump up this version whenever 
+
+    private static final Logger LOG = LoggerFactory.getLogger(DigestCalculator.class);
+
+    // The hardcoded digest version, should bump up this version whenever
     // we changed the digest method or fields.
     //
     // Defined it as Integer to make it able to be changed in test via reflection
-    public static final Integer DIGEST_VERSION = 1;
-     public static final String ZOOKEEPER_DIGEST_ENABLED = "zookeeper.digest.enabled";
-    private static boolean digestEnabled = Boolean.getBoolean(ZOOKEEPER_DIGEST_ENABLED);
-     /** 
+    public static final Integer DIGEST_VERSION = 2;
+
+    public static final String ZOOKEEPER_DIGEST_ENABLED = "zookeeper.digest.enabled";
+    private static boolean digestEnabled = true;
+
+    static {
+        digestEnabled = Boolean.parseBoolean(
+                System.getProperty(ZOOKEEPER_DIGEST_ENABLED, "true"));
+        LOG.info("{} = {}", ZOOKEEPER_DIGEST_ENABLED, digestEnabled);
+    }
+
+    /**
      * Calculate the digest based on the given params.
      *
-     * Besides the path and data, the following stat fields are included in 
+     * Besides the path and data, the following stat fields are included in
      * the digest calculation:
      *
      * - long czxid    8 bytes
@@ -51,31 +66,39 @@ public class DigestCalculator {
      * - int aversion  4 bytes
      * - long ephemeralOwner 8 bytes
      *
-     * Specific aliase like "/" and nodes under "/zookeeper/" are ignored 
-     * for now.
-     *
-     * @param path the path of the node 
+     * @param path the path of the node
      * @param data the data of the node
      * @param stat the stat associated with the node
      * @return the digest calculated from the given params
      */
     public static long calculateDigest(String path, byte[] data, StatPersisted stat) {
-         if (!digestEnabled()) {
+
+        if (!digestEnabled()) {
             return 0;
         }
-         // Quota nodes are updated locally, there is inconsistent issue 
-        // when we tried to release digest feature at the beginning. 
+
+        // Quota nodes are updated locally, there is inconsistent issue
+        // when we tried to release digest feature at the beginning.
         //
         // Instead of taking time to fix that, we decided to disable digest
-        // check for all the nodes under /zookeeper/ first. 
+        // check for all the nodes under /zookeeper/ first.
         //
-        // We can enable this after fixing that inconsistent problem. The 
-        // digest version in the protocol enables us to change the digest 
+        // We can enable this after fixing that inconsistent problem. The
+        // digest version in the protocol enables us to change the digest
         // calculation without disrupting the system.
         if (path.startsWith(ZooDefs.ZOOKEEPER_NODE_SUBTREE)) {
             return 0;
         }
-         // total = 8 * 6 + 4 * 3 = 60 bytes
+
+        // "" and "/" are aliase to each other, in DataTree when adding child
+        // under "/", it will use "" as the path, but when set data or change
+        // ACL on "/", it will use "/" as the path. Always mapping "/" to ""
+        // to avoid mismatch.
+        if (path.equals("/")) {
+            path = "";
+        }
+
+        // total = 8 * 6 + 4 * 3 = 60 bytes
         byte b[] = new byte[60];
         ByteBuffer bb = ByteBuffer.wrap(b);
         bb.putLong(stat.getCzxid());
@@ -87,7 +110,8 @@ public class DigestCalculator {
         bb.putInt(stat.getCversion());
         bb.putInt(stat.getAversion());
         bb.putLong(stat.getEphemeralOwner());
-         CRC32 crc = new CRC32();
+
+        CRC32 crc = new CRC32();
         crc.update(path.getBytes());
         if (data != null) {
             crc.update(data);
@@ -95,33 +119,26 @@ public class DigestCalculator {
         crc.update(b);
         return crc.getValue();
     }
-     /**
+
+    /**
      * Calculate the digest based on the given path ande data node.
      */
     public static long calculateDigest(String path, DataNode node) {
-        // This is to have a consistent digest value for "" and "/", the
-        // two paths pointing to root. Not going to calculate the digest
-        // for aliases.
-        //
-        // Have to do it here before calling the calculateDigest implemented
-        // in sub classes, because during deserialize we'll put the same node
-        // again which was representing "".
-        if ("/".equals(path)) {
-            return 0;
-        }
-         if (!node.isDigestCached()) {
+        if (!node.isDigestCached()) {
             node.setDigest(calculateDigest(path, node.getData(), node.stat));
             node.setDigestCached(true);
         }
         return node.getDigest();
     }
-     /**
+
+    /**
      * Return true if the digest is enabled.
      */
     public static boolean digestEnabled() {
         return digestEnabled;
     }
-     // Visible for test purpose
+
+    // Visible for test purpose
     public static void setDigestEnabled(boolean enabled) {
         digestEnabled = enabled;
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/DigestCalculator.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/DigestCalculator.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ package org.apache.zookeeper.server.util;
+ import java.nio.ByteBuffer;
+import java.util.zip.CRC32;
+ import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.StatPersisted;
+import org.apache.zookeeper.server.DataNode;
+ import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+ /**
+ * Defines how to calculate the digest for a given node.
+ */
+public class DigestCalculator {
+     private static final Logger LOG = LoggerFactory.getLogger(DigestCalculator.class);
+     // The hardcoded digest version, should bump up this version whenever 
+    // we changed the digest method or fields.
+    //
+    // Defined it as Integer to make it able to be changed in test via reflection
+    public static final Integer DIGEST_VERSION = 1;
+     public static final String ZOOKEEPER_DIGEST_ENABLED = "zookeeper.digest.enabled";
+    private static boolean digestEnabled = Boolean.getBoolean(ZOOKEEPER_DIGEST_ENABLED);
+     /** 
+     * Calculate the digest based on the given params.
+     *
+     * Besides the path and data, the following stat fields are included in 
+     * the digest calculation:
+     *
+     * - long czxid    8 bytes
+     * - long mzxid    8 bytes
+     * - long pzxid    8 bytes
+     * - long ctime    8 bytes
+     * - long mtime    8 bytes
+     * - int version   4 bytes
+     * - int cversion  4 bytes
+     * - int aversion  4 bytes
+     * - long ephemeralOwner 8 bytes
+     *
+     * Specific aliase like "/" and nodes under "/zookeeper/" are ignored 
+     * for now.
+     *
+     * @param path the path of the node 
+     * @param data the data of the node
+     * @param stat the stat associated with the node
+     * @return the digest calculated from the given params
+     */
+    public static long calculateDigest(String path, byte[] data, StatPersisted stat) {
+         if (!digestEnabled()) {
+            return 0;
+        }
+         // Quota nodes are updated locally, there is inconsistent issue 
+        // when we tried to release digest feature at the beginning. 
+        //
+        // Instead of taking time to fix that, we decided to disable digest
+        // check for all the nodes under /zookeeper/ first. 
+        //
+        // We can enable this after fixing that inconsistent problem. The 
+        // digest version in the protocol enables us to change the digest 
+        // calculation without disrupting the system.
+        if (path.startsWith(ZooDefs.ZOOKEEPER_NODE_SUBTREE)) {
+            return 0;
+        }
+         // total = 8 * 6 + 4 * 3 = 60 bytes
+        byte b[] = new byte[60];
+        ByteBuffer bb = ByteBuffer.wrap(b);
+        bb.putLong(stat.getCzxid());
+        bb.putLong(stat.getMzxid());
+        bb.putLong(stat.getPzxid());
+        bb.putLong(stat.getCtime());
+        bb.putLong(stat.getMtime());
+        bb.putInt(stat.getVersion());
+        bb.putInt(stat.getCversion());
+        bb.putInt(stat.getAversion());
+        bb.putLong(stat.getEphemeralOwner());
+         CRC32 crc = new CRC32();
+        crc.update(path.getBytes());
+        if (data != null) {
+            crc.update(data);
+        }
+        crc.update(b);
+        return crc.getValue();
+    }
+     /**
+     * Calculate the digest based on the given path ande data node.
+     */
+    public static long calculateDigest(String path, DataNode node) {
+        // This is to have a consistent digest value for "" and "/", the
+        // two paths pointing to root. Not going to calculate the digest
+        // for aliases.
+        //
+        // Have to do it here before calling the calculateDigest implemented
+        // in sub classes, because during deserialize we'll put the same node
+        // again which was representing "".
+        if ("/".equals(path)) {
+            return 0;
+        }
+         if (!node.isDigestCached()) {
+            node.setDigest(calculateDigest(path, node.getData(), node.stat));
+            node.setDigestCached(true);
+        }
+        return node.getDigest();
+    }
+     /**
+     * Return true if the digest is enabled.
+     */
+    public static boolean digestEnabled() {
+        return digestEnabled;
+    }
+     // Visible for test purpose
+    public static void setDigestEnabled(boolean enabled) {
+        digestEnabled = enabled;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/DigestCalculator.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/DigestCalculator.java
@@ -42,7 +42,7 @@ public class DigestCalculator {
     public static final Integer DIGEST_VERSION = 2;
 
     public static final String ZOOKEEPER_DIGEST_ENABLED = "zookeeper.digest.enabled";
-    private static boolean digestEnabled = true;
+    private static boolean digestEnabled;
 
     static {
         digestEnabled = Boolean.parseBoolean(
@@ -90,7 +90,7 @@ public class DigestCalculator {
             return 0;
         }
 
-        // "" and "/" are aliase to each other, in DataTree when adding child
+        // "" and "/" are aliases to each other, in DataTree when adding child
         // under "/", it will use "" as the path, but when set data or change
         // ACL on "/", it will use "/" as the path. Always mapping "/" to ""
         // to avoid mismatch.
@@ -121,7 +121,7 @@ public class DigestCalculator {
     }
 
     /**
-     * Calculate the digest based on the given path ande data node.
+     * Calculate the digest based on the given path and data node.
      */
     public static long calculateDigest(String path, DataNode node) {
         if (!node.isDigestCached()) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/DataTreeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/DataTreeTest.java
@@ -206,6 +206,26 @@ public class DataTreeTest extends ZKTestCase {
         Assert.assertEquals(currentPzxid, prevPzxid);
     }
 
+    @Test
+    public void testDigestUpdatedWhenReplayCreateTxnForExistNode() {
+        try {
+            CRC32DigestCalculator.setDigestEnabled(true);
+            dt.processTxn(new TxnHeader(13, 1000, 1, 30, ZooDefs.OpCode.create),
+                    new CreateTxn("/foo", "".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 1), null);
+
+            // create the same node with a higher cversion to simulate the
+            // scenario when replaying a create txn for an existing node due
+            // to fuzzy snapshot
+            dt.processTxn(new TxnHeader(13, 1000, 1, 30, ZooDefs.OpCode.create),
+                    new CreateTxn("/foo", "".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 2), null);
+
+            // check the current digest value
+            Assert.assertEquals(Long.toHexString(dt.getDigestValue()), dt.getCurrentZxidDigest().digest);
+        } finally {
+            CRC32DigestCalculator.setDigestEnabled(false);
+        }
+    }
+
     @Test(timeout = 60000)
     public void testPathTrieClearOnDeserialize() throws Exception {
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/DataTreeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/DataTreeTest.java
@@ -29,6 +29,8 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.util.DigestCalculator;
+import org.apache.zookeeper.txn.CreateTxn;
+import org.apache.zookeeper.txn.TxnHeader;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -209,20 +211,20 @@ public class DataTreeTest extends ZKTestCase {
     @Test
     public void testDigestUpdatedWhenReplayCreateTxnForExistNode() {
         try {
-            CRC32DigestCalculator.setDigestEnabled(true);
+            DigestCalculator.setDigestEnabled(true);
             dt.processTxn(new TxnHeader(13, 1000, 1, 30, ZooDefs.OpCode.create),
-                    new CreateTxn("/foo", "".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 1), null);
+                    new CreateTxn("/foo", "".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 1));
 
             // create the same node with a higher cversion to simulate the
             // scenario when replaying a create txn for an existing node due
             // to fuzzy snapshot
             dt.processTxn(new TxnHeader(13, 1000, 1, 30, ZooDefs.OpCode.create),
-                    new CreateTxn("/foo", "".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 2), null);
+                    new CreateTxn("/foo", "".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 2));
 
             // check the current digest value
-            Assert.assertEquals(Long.toHexString(dt.getDigestValue()), dt.getCurrentZxidDigest().digest);
+            Assert.assertEquals(dt.getTreeDigest(), dt.getLastProcessedZxidDigest().digest);
         } finally {
-            CRC32DigestCalculator.setDigestEnabled(false);
+            DigestCalculator.setDigestEnabled(false);
         }
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/NodeHashMapImplTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/NodeHashMapImplTest.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server;
+
+import java.util.Set;
+import java.util.Map;
+
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.data.StatPersisted;
+import org.apache.zookeeper.server.util.DigestCalculator;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NodeHashMapImplTest extends ZKTestCase {
+
+    @Before
+    public void setUp() {
+        DigestCalculator.setDigestEnabled(true);
+    }
+
+    @After
+    public void tearDown() {
+        DigestCalculator.setDigestEnabled(false);
+    }
+
+    /**
+     * Test all the operations supported in NodeHashMapImpl.
+     */
+    @Test
+    public void testOperations() {
+        NodeHashMapImpl nodes = new NodeHashMapImpl();
+
+        Assert.assertEquals(0, nodes.size());
+        Assert.assertEquals(0L, nodes.getDigest());
+
+        // add a new node
+        String p1 = "p1";
+        DataNode n1 = new DataNode(p1.getBytes(), 0L, new StatPersisted());
+        nodes.put(p1, n1);
+
+        Assert.assertEquals(n1, nodes.get(p1));
+        Assert.assertNotEquals(0L, nodes.getDigest());
+        Assert.assertEquals(1, nodes.size());
+
+        // put another node
+        String p2 = "p2";
+        nodes.put(p2, new DataNode(p2.getBytes(), 0L, new StatPersisted()));
+
+        Set<Map.Entry<String, DataNode>> entries = nodes.entrySet();
+        Assert.assertEquals(2, entries.size());
+
+        // remove a node
+        nodes.remove(p1);
+        Assert.assertEquals(1, nodes.size());
+
+        nodes.remove(p2);
+        Assert.assertEquals(0, nodes.size());
+        Assert.assertEquals(0L, nodes.getDigest());
+
+        // test preChange and postChange
+        String p3 = "p3";
+        DataNode n3 = new DataNode(p3.getBytes(), 0L, new StatPersisted());
+        nodes.put(p3, n3);
+        long preChangeDigest = nodes.getDigest();
+        Assert.assertNotEquals(0L, preChangeDigest);
+
+        nodes.preChange(p3, n3);
+        Assert.assertEquals(0L, nodes.getDigest());
+
+        n3.stat.setMzxid(1);
+        n3.stat.setMtime(1);
+        n3.stat.setVersion(1);
+        nodes.postChange(p3, n3);
+
+        long postChangeDigest = nodes.getDigest();
+        Assert.assertNotEquals(0, postChangeDigest);
+        Assert.assertNotEquals(preChangeDigest, postChangeDigest);
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/SnapshotDigestTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/SnapshotDigestTest.java
@@ -1,0 +1,222 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Op;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.ZooKeeper.States;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.server.quorum.QuorumPeerMainTest;
+import org.apache.zookeeper.server.util.DigestCalculator;
+import org.apache.zookeeper.test.ClientBase;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SnapshotDigestTest extends ClientBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(
+            SnapshotDigestTest.class);
+
+    private ZooKeeper zk;
+    private ZooKeeperServer server;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        server = getServer(serverFactory);
+        zk = createClient();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // server will be closed in super.tearDown
+        super.tearDown();
+
+        if (zk != null) {
+            zk.close();
+        }
+    }
+
+    @Override
+    public void setupCustomizedEnv() {
+        DigestCalculator.setDigestEnabled(true);
+        System.setProperty(ZooKeeperServer.SNAP_COUNT, "100");
+    }
+
+    @Override
+    public void cleanUpCustomizedEnv() {
+        DigestCalculator.setDigestEnabled(false);
+        System.clearProperty(ZooKeeperServer.SNAP_COUNT);
+    }
+
+    /**
+     * Check snapshot digests when loading a fuzzy or non-fuzzy snapshot.
+     */
+    @Test
+    public void testSnapshotDigest() throws Exception {
+        // take a empty snapshot without creating any txn and make sure
+        // there is no digest mismatch issue
+        server.takeSnapshot(); 
+        reloadSnapshotAndCheckDigest();
+        
+        // trigger various write requests
+        String pathPrefix = "/testSnapshotDigest";
+        for (int i = 0; i < 1000; i++) {
+            String path = pathPrefix + i;
+            zk.create(path, path.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, 
+                    CreateMode.PERSISTENT);
+        }
+
+        // update the data of first node
+        String firstNode = pathPrefix + 0;
+        zk.setData(firstNode, "new_setdata".getBytes(), -1);
+
+        // delete the first node
+        zk.delete(firstNode, -1);
+
+        // trigger multi op
+        List<Op> subTxns = new ArrayList<Op>();
+        for (int i = 0; i < 3; i++) {
+            String path = pathPrefix + "-m" + i;
+            subTxns.add(Op.create(path, path.getBytes(), 
+                    ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT));
+        }
+        zk.multi(subTxns);
+
+        reloadSnapshotAndCheckDigest();
+
+        // Take a snapshot and test the logic when loading a non-fuzzy snapshot 
+        server = getServer(serverFactory);
+        server.takeSnapshot(); 
+
+        reloadSnapshotAndCheckDigest();
+    }
+
+    /**
+     * Make sure the code will skip digest check when it's comparing 
+     * digest with different version. 
+     *
+     * This enables us to smoonthly add new fields into digest or using 
+     * new digest calculation.
+     */
+    @Test
+    public void testDifferentDigestVersion() throws Exception {
+        // check the current digest version
+        int currentVersion = DigestCalculator.DIGEST_VERSION;
+
+        // create a node
+        String path = "/testDifferentDigestVersion";
+        zk.create(path, path.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, 
+                CreateMode.PERSISTENT);
+
+        // take a full snapshot
+        server.takeSnapshot(); 
+
+        // using reflection to change the final static DIGEST_VERSION
+        int newVersion = currentVersion + 1;
+        Field field = DigestCalculator.class.getDeclaredField("DIGEST_VERSION");
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(null, newVersion);
+
+        Assert.assertEquals(newVersion, (int) DigestCalculator.DIGEST_VERSION);
+
+        // using mock to return different digest value when the way we 
+        // calculate digest changed
+        FileTxnSnapLog txnSnapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        DataTree dataTree = Mockito.spy(new DataTree());
+        Mockito.when(dataTree.getTreeDigest()).thenReturn(0L); 
+        txnSnapLog.restore(dataTree, new ConcurrentHashMap<Long, Integer>(), 
+                Mockito.mock(FileTxnSnapLog.PlayBackListener.class));
+
+        // make sure the reportDigestMismatch function is never called
+        Mockito.verify(dataTree, Mockito.never())
+               .reportDigestMismatch(Mockito.anyLong()); 
+    }
+
+    /**
+     * Make sure it's backward compatible, and also we can rollback this 
+     * feature without corrupt the database.
+     */
+    @Test
+    public void testBackwardCompatible() throws Exception {
+        testCompatibleHelper(false, true);
+
+        testCompatibleHelper(true, false);
+    }
+
+    private void testCompatibleHelper(
+            boolean enabledBefore, boolean enabledAfter) throws Exception {
+
+        DigestCalculator.setDigestEnabled(enabledBefore);
+
+        // restart the server to cache the option change
+        reloadSnapshotAndCheckDigest();
+   
+         // create a node
+        String path = "/testCompatible" + "-" + enabledBefore + "-" + enabledAfter;
+        zk.create(path, path.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, 
+                CreateMode.PERSISTENT);
+
+        // take a full snapshot
+        server.takeSnapshot(); 
+
+        DigestCalculator.setDigestEnabled(enabledAfter);
+      
+        reloadSnapshotAndCheckDigest();
+
+        Assert.assertEquals(path, new String(zk.getData(path, false, null)));
+    }
+
+    private void reloadSnapshotAndCheckDigest() throws Exception {
+        stopServer();
+        QuorumPeerMainTest.waitForOne(zk, States.CONNECTING);
+
+        ServerMetrics.DIGEST_MISMATCHES_COUNT.reset();
+
+        startServer();
+        QuorumPeerMainTest.waitForOne(zk, States.CONNECTED);
+
+        // Snapshot digests always match
+        Assert.assertEquals(0L, (long) ServerMetrics.DIGEST_MISMATCHES_COUNT
+                .getValues().get("digest_mismatches_count"));
+
+        // reset the digestFromLoadedSnapshot after comparing
+        Assert.assertNull(server.getZKDatabase().getDataTree()
+                .getDigestFromLoadedSnapshot());
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/util/AdHashTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/util/AdHashTest.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Test;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+
+public class AdHashTest extends TestCase {
+
+    private static Random rand = new Random();
+
+    private static List<Long> generateRandomHashes(int count) {
+        ArrayList<Long> list = new ArrayList<>(count);
+
+        for (int i = 0; i < count; i++) {
+            list.add(rand.nextLong());
+        }
+        return list;
+    }
+
+    private static void addListOfDigests(AdHash hash, List<Long> digests) {
+        for (long b: digests) {
+            hash.addDigest(b);
+        }
+    }
+
+    private static void removeListOfDigests(AdHash hash, List<Long> digests) {
+        for (long b: digests) {
+            hash.removeDigest(b);
+        }
+    }
+
+    /**
+     * Test thhe add and remove digest from AdHash is working as expected.
+     */
+    @Test
+    public void testAdHash() throws Exception{
+        List<Long> bucket1 = generateRandomHashes(50);
+        List<Long> bucket2 = generateRandomHashes(3);
+        List<Long> bucket3 = generateRandomHashes(30);
+        List<Long> bucket4 = generateRandomHashes(10);
+        List<Long> bucket5 = generateRandomHashes(5);
+
+        // adding out of order should result in the same hash
+        AdHash hash12 = new AdHash();
+        addListOfDigests(hash12, bucket1);
+        addListOfDigests(hash12, bucket2);
+
+        AdHash hash21 = new AdHash();
+        addListOfDigests(hash21, bucket2);
+        addListOfDigests(hash21, bucket1);
+        Assert.assertEquals(hash12, hash21);
+
+        AdHash hashall = new AdHash();
+        addListOfDigests(hashall, bucket1);
+        addListOfDigests(hashall, bucket2);
+        addListOfDigests(hashall, bucket3);
+        addListOfDigests(hashall, bucket4);
+        addListOfDigests(hashall, bucket5);
+        Assert.assertFalse("digest of different set not different", hashall.equals(hash21));
+        removeListOfDigests(hashall, bucket4);
+        removeListOfDigests(hashall, bucket5);
+        addListOfDigests(hash21, bucket3);
+        Assert.assertEquals("hashall with 4 & 5 removed should match hash21 with 3 added",
+                         hashall, hash21);
+
+        removeListOfDigests(hashall, bucket3);
+        removeListOfDigests(hashall, bucket2);
+        removeListOfDigests(hashall, bucket1);
+        Assert.assertEquals("empty hashall's digest should be 0", hashall.toHexString(), "0");
+
+        AdHash hash45 = new AdHash();
+        addListOfDigests(hash45, bucket4);
+        addListOfDigests(hash45, bucket5);
+
+        addListOfDigests(hashall, bucket4);
+        addListOfDigests(hashall, bucket5);
+        Assert.assertEquals("empty hashall + 4&5 should equal hash45", hashall, hash45);
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/util/AdHashTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/util/AdHashTest.java
@@ -18,16 +18,17 @@
 
 package org.apache.zookeeper.server.util;
 
+import org.apache.zookeeper.ZKTestCase;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
 import org.junit.Test;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.Assert;
 
-public class AdHashTest extends TestCase {
+public class AdHashTest extends ZKTestCase {
 
     private static Random rand = new Random();
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
@@ -522,6 +522,8 @@ public abstract class ClientBase extends ZKTestCase {
 
         setupTestEnv();
 
+        setupCustomizedEnv();
+
         JMXEnv.setUp();
 
         setUpAll();
@@ -536,6 +538,11 @@ public abstract class ClientBase extends ZKTestCase {
     protected void startServer() throws Exception {
         startServer(1);
     }
+
+    /**
+     * Give it a chance to set up customized env before starting the server.
+     */
+    public void setupCustomizedEnv() { /* do nothing by default */ }
 
     private void startServer(int serverId) throws Exception {
         LOG.info("STARTING server");
@@ -640,7 +647,11 @@ public abstract class ClientBase extends ZKTestCase {
                 //assertTrue(message, fdCount <= initialFdCount);
             }
         }
+
+        cleanUpCustomizedEnv();
     }
+
+    public void cleanUpCustomizedEnv() { /* do nothing by default */ }
 
     public static MBeanServerConnection jmxConn() throws IOException {
         return JMXEnv.conn();

--- a/zookeeper-server/src/test/resources/findbugsExcludeFile.xml
+++ b/zookeeper-server/src/test/resources/findbugsExcludeFile.xml
@@ -71,7 +71,7 @@
 
   <Match>
     <Class name="org.apache.zookeeper.server.DataNode" />
-      <Bug code="EI2"/>
+      <Bug code="EI2, EI"/>
   </Match>
 
   <Match>


### PR DESCRIPTION
Jira ZOOKEEPER-3114 will be divided into two parts:

1. data integrity check when loading snapshot/txns from disk
2. real time data consistency check when syncing and following leader

This is the first part, which is going to check the data integrity by calculating the hash value of data tree, and compare the value when reload the snapshot/txns from disk.