### PR TITLE
ZOOKEEPER-2847: Cannot bind to client port when reconfig based on old static config

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -137,6 +137,8 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
         public String hostname;
         
         public LearnerType type = LearnerType.PARTICIPANT;
+
+        public boolean isClientAddrFromStatic = false;
         
         private List<InetSocketAddress> myAddrs;
 
@@ -306,7 +308,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
             }           
             if (type == LearnerType.OBSERVER) sw.append(":observer");
             else if (type == LearnerType.PARTICIPANT) sw.append(":participant");            
-            if (clientAddr!=null){
+            if (clientAddr!=null && !isClientAddrFromStatic){
                 sw.append(";");
                 sw.append(delimitedHostString(clientAddr));
                 sw.append(":");
@@ -1602,7 +1604,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
 
     private boolean needEraseClientInfoFromStaticConfig() {
         QuorumServer server = quorumVerifier.getAllMembers().get(getId());
-        return (server != null && server.clientAddr != null);
+        return (server != null && server.clientAddr != null && !server.isClientAddrFromStatic);
     }
 
     /**

--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -712,7 +712,10 @@ public class QuorumPeerConfig {
                         " is different from client address found in dynamic file: " + qs.clientAddr);
         }
         if (qs != null && qs.clientAddr != null) clientPortAddress = qs.clientAddr;
-        if (qs != null && qs.clientAddr == null) qs.clientAddr = clientPortAddress;
+        if (qs != null && qs.clientAddr == null) {
+            qs.clientAddr = clientPortAddress;
+            qs.isClientAddrFromStatic = true;
+        }
     }
 
     private void setupPeerType() {


### PR DESCRIPTION
PR No.2: Prevent removing client info from static config file to fix ReconfigLegacyTest