### PR TITLE
ZOOKEEPER-3113 EphemeralType.get() fails to verify ephemeralOwner when currentElapsedTime() is small enough

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/Emulate353TTLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/Emulate353TTLTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+
 public class Emulate353TTLTest extends ClientBase {
     private TestableZooKeeper zk;
 
@@ -81,6 +83,16 @@ public class Emulate353TTLTest extends ClientBase {
         fakeElapsed.set(1000);
         containerManager.checkContainers();
         Assert.assertNull("Ttl node should have been deleted", zk.exists("/foo", false));
+    }
+
+    @Test
+    public void testEphemeralOwner_emulationTTL() {
+        Assert.assertThat(EphemeralType.get(-1), equalTo(EphemeralType.TTL));
+    }
+
+    @Test
+    public void testEphemeralOwner_emulationContainer() {
+        Assert.assertThat(EphemeralType.get(EphemeralType.CONTAINER_EPHEMERAL_OWNER), equalTo(EphemeralType.CONTAINER));
     }
 
     private ContainerManager newContainerManager(final AtomicLong fakeElapsed) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/EphemeralTypeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/EphemeralTypeTest.java
@@ -70,15 +70,14 @@ public class EphemeralTypeTest {
 
     @Test
     public void testServerIds() {
-        for ( int i = 0; i < 255; ++i ) {
-            Assert.assertEquals(EphemeralType.NORMAL, EphemeralType.get(SessionTrackerImpl.initializeNextSession(i)));
+        for ( int i = 0; i <= EphemeralType.MAX_EXTENDED_SERVER_ID; ++i ) {
+            EphemeralType.validateServerId(i);
         }
         try {
-            Assert.assertEquals(EphemeralType.TTL, EphemeralType.get(SessionTrackerImpl.initializeNextSession(255)));
-            Assert.fail("Should have thrown IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
+            EphemeralType.validateServerId(EphemeralType.MAX_EXTENDED_SERVER_ID + 1);
+            Assert.fail("Should have thrown RuntimeException");
+        } catch (RuntimeException e) {
             // expected
         }
-        Assert.assertEquals(EphemeralType.NORMAL, EphemeralType.get(SessionTrackerImpl.initializeNextSession(EphemeralType.MAX_EXTENDED_SERVER_ID)));
     }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/EphemeralTypeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/EphemeralTypeTest.java
@@ -24,6 +24,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+
 public class EphemeralTypeTest {
     @Before
     public void setUp() {
@@ -79,5 +81,19 @@ public class EphemeralTypeTest {
         } catch (RuntimeException e) {
             // expected
         }
+    }
+
+    @Test
+    public void testEphemeralOwner_extendedFeature_TTL() {
+        // 0xff = Extended feature is ON
+        // 0x0000 = Extended type id TTL (0)
+        Assert.assertThat(EphemeralType.get(0xff00000000000000L), equalTo(EphemeralType.TTL));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEphemeralOwner_extendedFeature_extendedTypeUnsupported() {
+        // 0xff = Extended feature is ON
+        // 0x0001 = Unsupported extended type id (1)
+        EphemeralType.get(0xff00010000000000L);
     }
 }


### PR DESCRIPTION
I refactored the unit test `testServerIds` to verify server id verification code explicitly instead of through `EphemeralType.get()` method. 

Reasons:
- The original test doesn't work on machines which booted recently, because the generated `Time.currentElapsedTime()` value is not high enough and it's possible to generate a valid ephemeralOwner even with high 0xff byte. Server ID cannot be verified reliably this way.
- EphemeralType.get() is already covered in other unit tests,  
- Unit tests should test the smallest piece of logic and call the method under testing directly.
