### PR TITLE
ZOOKEEPER-3159. Flaky: ClientRequestTimeoutTest.testClientRequestTimeout

### DIFF
--- a/zookeeper-common/src/test/java/org/apache/zookeeper/ClientRequestTimeoutTest.java
+++ b/zookeeper-common/src/test/java/org/apache/zookeeper/ClientRequestTimeoutTest.java
@@ -92,14 +92,6 @@ public class ClientRequestTimeoutTest extends QuorumPeerTestBase {
             assertEquals(KeeperException.Code.REQUESTTIMEOUT.intValue(),
                     exception.code().intValue());
         }
-        // reset the error behavior
-        dropPacket = false;
-        watch1.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
-
-        String path = "/clientHang3";
-        String create = zk.create(path, data.getBytes(), Ids.OPEN_ACL_UNSAFE,
-                CreateMode.PERSISTENT);
-        assertEquals(path, create);
 
         // do cleanup
         zk.close();


### PR DESCRIPTION
Can't see a reason why testing again the create method without packet drop. Timeout scenario has already been tested and this part seem to make the test flaky. Removed.