### PR TITLE
[ZOOKEEPER-3163] Use session map in the Netty to improve close session performance

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -112,6 +112,8 @@ public class NettyServerCnxn extends ServerCnxn {
                         + Long.toHexString(sessionId));
             }
 
+            factory.removeCnxnFromSessionMap(this);
+
             synchronized (factory.ipMap) {
                 Set<NettyServerCnxn> s =
                     factory.ipMap.get(((InetSocketAddress)channel
@@ -198,6 +200,7 @@ public class NettyServerCnxn extends ServerCnxn {
     @Override
     public void setSessionId(long sessionId) {
         this.sessionId = sessionId;
+        factory.addSession(sessionId, this);
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -417,24 +417,6 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
     }
 
     @Override
-    public boolean closeSession(long sessionId) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("closeSession sessionid:0x" + sessionId);
-        }
-        for (ServerCnxn cnxn : cnxns) {
-            if (cnxn.getSessionId() == sessionId) {
-                try {
-                    cnxn.close();
-                } catch (Exception e) {
-                    LOG.warn("exception during session close", e);
-                }
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
     public void configure(InetSocketAddress addr, int maxClientCnxns, boolean secure)
             throws IOException
     {


### PR DESCRIPTION
This is a refactor to make the Netty able to use the same closeSession logic in NIOServerCnxn, which is more efficient with the sessionMap. Rely on the existing tests for the refactor work here.