### PR TITLE
ZOOKEEPER-3158:firstConnect.countDown() will not be executed where sendThread.primeConnection() has thrown an exception

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
@@ -146,13 +146,13 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
                     } else {
                         needSasl.set(false);
                     }
-
+                    
                     // we need to wake up on first connect to avoid timeout.
-                    wakeupCnxn();
-                    firstConnect.countDown();
+                    wakeupCnxn();                
                     LOG.info("channel is connected: {}", channelFuture.getChannel());
                 } finally {
                     connectLock.unlock();
+                    firstConnect.countDown();
                 }
             }
         });


### PR DESCRIPTION
more details in [ZOOKEEPER-3158](https://issues.apache.org/jira/browse/ZOOKEEPER-3158)