### PR TITLE
ZOOKEEPER-3165. Java 9: X509UtilTest.testCreateSSLContextWithoutTrustStorePassword fails

### DIFF
--- a/zookeeper-common/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
+++ b/zookeeper-common/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
@@ -105,7 +105,7 @@ public class X509UtilTest extends ZKTestCase {
     }
 
     private void writeKeystore(X509Certificate certificate, KeyPair keyPair, String path) throws Exception {
-        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        KeyStore keyStore = KeyStore.getInstance("JKS");
         keyStore.load(null, PASSWORD);
         keyStore.setKeyEntry("alias", keyPair.getPrivate(), PASSWORD, new Certificate[] { certificate });
         FileOutputStream outputStream = new FileOutputStream(path);
@@ -115,7 +115,7 @@ public class X509UtilTest extends ZKTestCase {
     }
 
     private void writeTrustStore(char[] password) throws Exception {
-        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        KeyStore trustStore = KeyStore.getInstance("JKS");
         trustStore.load(null, password);
         trustStore.setCertificateEntry(rootCertificate.getSubjectDN().toString(), rootCertificate);
         FileOutputStream outputStream = new FileOutputStream(truststorePath);


### PR DESCRIPTION
We use JKS format explicitly, but the tests created the keystore and truststore with the default format. This has been changed in Java 9 from JKS to PKCS12 which caused the test failing on Java 9+ builds.