### PR TITLE
ZOOKEEPER-3176: Quorum TLS - add SSL config options

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/SSLContextAndOptions.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/SSLContextAndOptions.java
@@ -1,0 +1,192 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.common;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.Socket;
+import java.util.Arrays;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Wrapper class for an SSLContext + some config options that can't be set on the context when it is created but
+ * must be set on a secure socket created by the context after the socket creation. By wrapping the options in this
+ * class we avoid reading from global system properties during socket configuration. This makes testing easier
+ * since we can create different X509Util instances with different configurations in a single test process, and
+ * unit test interactions between them.
+ */
+public class SSLContextAndOptions {
+    private static final Logger LOG = LoggerFactory.getLogger(SSLContextAndOptions.class);
+
+    private final X509Util x509Util;
+    private final String[] enabledProtocols;
+    private final String[] cipherSuites;
+    private final X509Util.ClientAuth clientAuth;
+    private final SSLContext sslContext;
+    private final int handshakeDetectionTimeoutMillis;
+
+    /**
+     * Note: constructor is intentionally package-private, only the X509Util class should be creating instances of this
+     * class.
+     * @param x509Util the X509Util that created this object.
+     * @param config a ZKConfig that holds config properties.
+     * @param sslContext the SSLContext.
+     */
+    SSLContextAndOptions(final X509Util x509Util, final ZKConfig config, final SSLContext sslContext) {
+        this.x509Util = requireNonNull(x509Util);
+        this.sslContext = requireNonNull(sslContext);
+        this.enabledProtocols = getEnabledProtocols(requireNonNull(config), sslContext);
+        this.cipherSuites = getCipherSuites(config);
+        this.clientAuth = getClientAuth(config);
+        this.handshakeDetectionTimeoutMillis = getHandshakeDetectionTimeoutMillis(config);
+    }
+
+    public SSLContext getSSLContext() {
+        return sslContext;
+    }
+
+    public SSLSocket createSSLSocket() throws IOException {
+        return configureSSLSocket((SSLSocket) sslContext.getSocketFactory().createSocket(), true);
+    }
+
+    public SSLSocket createSSLSocket(Socket socket, byte[] pushbackBytes) throws IOException {
+        SSLSocket sslSocket;
+        if (pushbackBytes != null && pushbackBytes.length > 0) {
+            sslSocket = (SSLSocket) sslContext.getSocketFactory().createSocket(
+                    socket, new ByteArrayInputStream(pushbackBytes), true);
+        } else {
+            sslSocket = (SSLSocket) sslContext.getSocketFactory().createSocket(
+                    socket, null, socket.getPort(), true);
+        }
+        return configureSSLSocket(sslSocket, false);
+    }
+
+    public SSLServerSocket createSSLServerSocket() throws IOException {
+        SSLServerSocket sslServerSocket =
+                (SSLServerSocket) sslContext.getServerSocketFactory().createServerSocket();
+        return configureSSLServerSocket(sslServerSocket);
+    }
+
+    public SSLServerSocket createSSLServerSocket(int port) throws IOException {
+        SSLServerSocket sslServerSocket =
+                (SSLServerSocket) sslContext.getServerSocketFactory().createServerSocket(port);
+        return configureSSLServerSocket(sslServerSocket);
+    }
+
+    public int getHandshakeDetectionTimeoutMillis() {
+        return handshakeDetectionTimeoutMillis;
+    }
+
+    private SSLSocket configureSSLSocket(SSLSocket socket, boolean isClientSocket) {
+        SSLParameters sslParameters = socket.getSSLParameters();
+        configureSslParameters(sslParameters, isClientSocket);
+        socket.setSSLParameters(sslParameters);
+        socket.setUseClientMode(isClientSocket);
+        return socket;
+    }
+
+    private SSLServerSocket configureSSLServerSocket(SSLServerSocket socket) {
+        SSLParameters sslParameters = socket.getSSLParameters();
+        configureSslParameters(sslParameters, false);
+        socket.setSSLParameters(sslParameters);
+        socket.setUseClientMode(false);
+        return socket;
+    }
+
+    private void configureSslParameters(SSLParameters sslParameters, boolean isClientSocket) {
+        if (cipherSuites != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Setup cipher suites for {} socket: {}",
+                        isClientSocket ? "client" : "server",
+                        Arrays.toString(cipherSuites));
+            }
+            sslParameters.setCipherSuites(cipherSuites);
+        }
+        if (enabledProtocols != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Setup enabled protocols for {} socket: {}",
+                        isClientSocket ? "client" : "server",
+                        Arrays.toString(enabledProtocols));
+            }
+            sslParameters.setProtocols(enabledProtocols);
+        }
+        if (!isClientSocket) {
+            switch (clientAuth) {
+                case NEED:
+                    sslParameters.setNeedClientAuth(true);
+                    break;
+                case WANT:
+                    sslParameters.setWantClientAuth(true);
+                    break;
+                default:
+                    sslParameters.setNeedClientAuth(false); // also clears the wantClientAuth flag according to docs
+                    break;
+            }
+        }
+    }
+
+    private String[] getEnabledProtocols(final ZKConfig config, final SSLContext sslContext) {
+        String enabledProtocolsInput = config.getProperty(x509Util.getSslEnabledProtocolsProperty());
+        if (enabledProtocolsInput == null) {
+            return new String[] { sslContext.getProtocol() };
+        }
+        return enabledProtocolsInput.split(",");
+    }
+
+    private String[] getCipherSuites(final ZKConfig config) {
+        String cipherSuitesInput = config.getProperty(x509Util.getSslCipherSuitesProperty());
+        if (cipherSuitesInput == null) {
+            return X509Util.getDefaultCipherSuites();
+        } else {
+            return cipherSuitesInput.split(",");
+        }
+    }
+
+    private X509Util.ClientAuth getClientAuth(final ZKConfig config) {
+        return X509Util.ClientAuth.fromPropertyValue(config.getProperty(x509Util.getSslClientAuthProperty()));
+    }
+
+    private int getHandshakeDetectionTimeoutMillis(final ZKConfig config) {
+        String propertyString = config.getProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty());
+        int result;
+        if (propertyString == null) {
+            result = X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS;
+        } else {
+            result = Integer.parseInt(propertyString);
+            if (result < 1) {
+                // Timeout of 0 is not allowed, since an infinite timeout can permanently lock up an
+                // accept() thread.
+                LOG.warn("Invalid value for {}: {}, using the default value of {}",
+                        x509Util.getSslHandshakeDetectionTimeoutMillisProperty(),
+                        result,
+                        X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS);
+                result = X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS;
+            }
+        }
+        return result;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKConfig.java
@@ -115,6 +115,12 @@ public class ZKConfig {
     }
     
     private void putSSLProperties(X509Util x509Util) {
+        properties.put(x509Util.getSslProtocolProperty(),
+                System.getProperty(x509Util.getSslProtocolProperty()));
+        properties.put(x509Util.getSslEnabledProtocolsProperty(),
+                System.getProperty(x509Util.getSslEnabledProtocolsProperty()));
+        properties.put(x509Util.getSslCipherSuitesProperty(),
+                System.getProperty(x509Util.getSslCipherSuitesProperty()));
         properties.put(x509Util.getSslKeystoreLocationProperty(),
                 System.getProperty(x509Util.getSslKeystoreLocationProperty()));
         properties.put(x509Util.getSslKeystorePasswdProperty(),
@@ -133,6 +139,8 @@ public class ZKConfig {
                 System.getProperty(x509Util.getSslCrlEnabledProperty()));
         properties.put(x509Util.getSslOcspEnabledProperty(),
                 System.getProperty(x509Util.getSslOcspEnabledProperty()));
+        properties.put(x509Util.getSslClientAuthProperty(),
+                System.getProperty(x509Util.getSslClientAuthProperty()));
         properties.put(x509Util.getSslHandshakeDetectionTimeoutMillisProperty(),
                 System.getProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty()));
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
@@ -482,6 +482,46 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
         }
     }
 
+    @Test
+    public void testGetDefaultCipherSuitesJava8() {
+        String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("1.8");
+        // Java 8 default should have the CBC suites first
+        Assert.assertTrue(cipherSuites[0].contains("CBC"));
+    }
+
+    @Test
+    public void testGetDefaultCipherSuitesJava9() {
+        String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("9");
+        // Java 9+ default should have the GCM suites first
+        Assert.assertTrue(cipherSuites[0].contains("GCM"));
+    }
+
+    @Test
+    public void testGetDefaultCipherSuitesJava10() {
+        String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("10");
+        // Java 9+ default should have the GCM suites first
+        Assert.assertTrue(cipherSuites[0].contains("GCM"));
+    }
+
+    @Test
+    public void testGetDefaultCipherSuitesJava11() {
+        String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("11");
+        // Java 9+ default should have the GCM suites first
+        Assert.assertTrue(cipherSuites[0].contains("GCM"));
+    }
+
+    @Test
+    public void testGetDefaultCipherSuitesUnknownVersion() {
+        String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("notaversion");
+        // If version can't be parsed, use the more conservative Java 8 default
+        Assert.assertTrue(cipherSuites[0].contains("CBC"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetDefaultCipherSuitesNullVersion() {
+        X509Util.getDefaultCipherSuitesForJavaVersion(null);
+    }
+
     // Warning: this will reset the x509Util
     private void setCustomCipherSuites() {
         System.setProperty(x509Util.getCipherSuitesProperty(), customCipherSuites[0] + "," + customCipherSuites[1]);


### PR DESCRIPTION
Add  SSL config options for enabled protocols and client auth mode.
Improve handling of SSL config options for protocols and cipher suites - previously these came from system properties, now they can come from ZKConfig which means they are easier to isolate in tests, and now we don't need to parse system properties every time we create a secure socket.

## Added more options for ssl settings to X509Util and encapsulate them better
- previously, some SSL settings came from a `ZKConfig` and others came from global `System.getProperties()`. This made it hard to isolate certain settings in tests.
- now all SSL-related settings come from the `ZKConfig` object used to create the SSL context
- new settings added:
- `zookeeper.ssl(.quorum).enabledProtocols` - list of enabled protocols. If not set, defaults to a single-entry list with the value of `zookeeper.ssl(.quorum).protocol`.
- `zookeeper.ssl(.quorum).clientAuth` - can be "NONE", "WANT", or "NEED". This controls whether the server doesn't want / allows / requires the client to present an X509 certificate.
- `zookeeper.ssl(.quorum).handshakeDetectionTimeoutMillis` - timeout for the first read of 5 bytes to detect the transport mode (TLS or plaintext) of a client connection made to a `UnifiedServerSocket`