### PR TITLE
reduce session revalidation time after zxid roll over

### DIFF
--- a/zookeeper-jute/src/main/resources/zookeeper.jute
+++ b/zookeeper-jute/src/main/resources/zookeeper.jute
@@ -225,6 +225,9 @@ module org.apache.zookeeper.server.quorum {
         int status;
         buffer token;
     }
+    class SessionStartTimePacket {
+        long sessionStartTime;
+    }
 }
 
 module org.apache.zookeeper.server.persistence {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/SessionTracker.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/SessionTracker.java
@@ -64,6 +64,10 @@ public interface SessionTracker {
      */
     void shutdown();
 
+    long getSessionStartTime();
+
+    void setSessionStartTime(long sessionStartTime);
+
     /**
      * @param sessionId
      */

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/SessionTrackerImpl.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/SessionTrackerImpl.java
@@ -50,6 +50,7 @@ public class SessionTrackerImpl extends ZooKeeperCriticalThread implements Sessi
     ConcurrentHashMap<Long, Integer> sessionsWithTimeout;
     long nextSessionId = 0;
     long nextExpirationTime;
+    long sessionStartTime = 0;
 
     int expirationInterval;
 
@@ -84,6 +85,14 @@ public class SessionTrackerImpl extends ZooKeeperCriticalThread implements Sessi
         HashSet<SessionImpl> sessions = new HashSet<SessionImpl>();
     }
 
+    public long getSessionStartTime() {
+        return sessionStartTime;
+    }
+
+    public void setSessionStartTime(long sessionStartTime) {
+        this.sessionStartTime = sessionStartTime;
+    }
+
     SessionExpirer expirer;
 
     private long roundToInterval(long time) {
@@ -101,6 +110,7 @@ public class SessionTrackerImpl extends ZooKeeperCriticalThread implements Sessi
         this.sessionsWithTimeout = sessionsWithTimeout;
         nextExpirationTime = roundToInterval(Time.currentElapsedTime());
         this.nextSessionId = initializeNextSession(sid);
+        sessionStartTime = System.currentTimeMillis();
         for (Entry<Long, Integer> e : sessionsWithTimeout.entrySet()) {
             addSession(e.getKey(), e.getValue());
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Follower.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Follower.java
@@ -109,6 +109,10 @@ public class Follower extends Learner{
      */
     protected void processPacket(QuorumPacket qp) throws IOException{
         switch (qp.getType()) {
+        case Leader.SESSIONTIME:
+            byte[] sessionStartTimeByte = qp.getData();
+            long sessionStartTime = TransformUtil.byteArrayToLong(sessionStartTimeByte);
+            zk.getSessionTracker().setSessionStartTime(sessionStartTime);
         case Leader.PING:            
             ping(qp);            
             break;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -262,6 +262,11 @@ public class Leader {
      * This message is used by the follow to ack a proposed epoch.
      */
     public static final int ACKEPOCH = 18;
+
+    /*
+    * When the cluster finishs reselection, it sends the timepoint to follower. （the approximate time point of the roll over）
+    * */
+    public static final int SESSIONTIME = 30;
     
     /**
      * This message type is sent to a leader to request and mutation operation.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
@@ -704,6 +704,16 @@ public class LearnerHandler extends ZooKeeperThread {
         }
     }
 
+    /**
+     *  send sessionStartTime
+     */
+    public void sendSessionStartTime() {
+        long sessionStartTime = leader.zk.getSessionTracker().getSessionStartTime();
+        byte[] sessionStartTimeByte = TransformUtil.longToByteArray(sessionStartTime);
+        QuorumPacket session = new QuorumPacket(Leader.SESSIONTIME, -1, sessionStartTimeByte, null);
+        queuePacket(session);
+    }
+
     void queuePacket(QuorumPacket p) {
         queuedPackets.add(p);
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerSessionTracker.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerSessionTracker.java
@@ -36,6 +36,7 @@ public class LearnerSessionTracker implements SessionTracker {
     HashMap<Long, Integer> touchTable = new HashMap<Long, Integer>();
     long serverId = 1;
     long nextSessionId=0;
+    long sessionStartTime = 0;
     
     private ConcurrentHashMap<Long, Integer> sessionsWithTimeouts;
 
@@ -55,6 +56,14 @@ public class LearnerSessionTracker implements SessionTracker {
     }
 
     public void shutdown() {
+    }
+
+    public long getSessionStartTime() {
+        return sessionStartTime;
+    }
+
+    public void setSessionStartTime(long sessionStartTime) {
+        this.sessionStartTime = sessionStartTime;
     }
 
     synchronized public void addSession(long sessionId, int sessionTimeout) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/TransformUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/TransformUtil.java
@@ -1,0 +1,39 @@
+package org.apache.zookeeper.server.util;
+
+
+public class TransformUtil {
+
+    public static byte[] longToByteArray(long num) {
+        byte[] result = new byte[8];
+        result[0] = (byte) (num >>> 56);
+        result[1] = (byte) (num >>> 48);
+        result[2] = (byte) (num >>> 40);
+        result[3] = (byte) (num >>> 32);
+        result[4] = (byte) (num >>> 24);
+        result[5] = (byte) (num >>> 16);
+        result[6] = (byte) (num >>> 8);
+        result[7] = (byte) (num);
+        return result;
+    }
+
+    public static long byteArrayToLong(byte[] byteArray) {
+        byte[] a = new byte[8];
+        int i = a.length - 1, j = byteArray.length - 1;
+        for (; i >= 0; i--, j--) {
+            if (j >= 0)
+                a[i] = byteArray[j];
+            else
+                a[i] = 0;
+        }
+
+        long v0 = (long) (a[0] & 0xff) << 56;
+        long v1 = (long) (a[1] & 0xff) << 48;
+        long v2 = (long) (a[2] & 0xff) << 40;
+        long v3 = (long) (a[3] & 0xff) << 32;
+        long v4 = (long) (a[4] & 0xff) << 24;
+        long v5 = (long) (a[5] & 0xff) << 16;
+        long v6 = (long) (a[6] & 0xff) << 8;
+        long v7 = (long) (a[7] & 0xff);
+        return v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7;
+    }
+}


### PR DESCRIPTION
**Problem:**
1. Sometimes Zookeeper cluster will receive a lot of connections from clients, sometimes connection number even exceeds 1W. When zxid rolls over, the clients will reconnect and revalidate the session.
2. In Zookeeper design structure, when follower server receives the session revalidation requests, it will send requests to leader server, which is designed to be responsible for session revalidation.
3. In a short time, Leader will handle lots of requests. I use a tool to get the statistics, some clients need to wait over 20s. It is too long for some special clients, like ResourceManager.

**Solution:**
1. When zookeeper cluster finishes reelection(which will cost a few seconds). The leader will send the time point TimeA to followers. （which is the approximate value of roll over）
2. Followers can judge the most session revalidations. When the timeout of the session is less than currentTime - timeA , follower will put the session on the touchTable. （Every half tickTime, followers will send sessions of touchTable to leader to validate）.
3. When the timeout of the session is larger than currentTime - timeA, the follower will send session revalidation request to leader right away.

So the leader will receive fewer requests from followers.