### PR TITLE
[ZOOKEEPER-1818] Correctly handle potential inconsistent zxid/electionEpoch and peerEpoch during leader election

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -1989,6 +1989,38 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     /**
      * Updates leader election info to avoid inconsistencies when
      * a new server tries to join the ensemble.
+     *
+     * Here is the inconsistency scenario we try to solve by updating the peer 
+     * epoch after following leader:
+     *
+     * Let's say we have an ensemble with 3 servers z1, z2 and z3.
+     *
+     * 1. z1, z2 were following z3 with peerEpoch to be 0xb8, the new epoch is 
+     *    0xb9, aka current accepted epoch on disk.
+     * 2. z2 get restarted, which will use 0xb9 as it's peer epoch when loading
+     *    the current accept epoch from disk.
+     * 3. z2 received notification from z1 and z3, which is following z3 with 
+     *    epoch 0xb8, so it started following z3 again with peer epoch 0xb8.
+     * 4. before z2 successfully connected to z3, z3 get restarted with new 
+     *    epoch 0xb9.
+     * 5. z2 will retry around a few round (default 5s) before giving up, 
+     *    meanwhile it will report z3 as leader.
+     * 6. z1 restarted, and looking with peer epoch 0xb9.
+     * 7. z1 voted z3, and z3 was elected as leader again with peer epoch 0xb9.
+     * 8. z2 successfully connected to z3 before giving up, but with peer 
+     *    epoch 0xb8.
+     * 9. z1 get restarted, looking for leader with peer epoch 0xba, but cannot 
+     *    join, because z2 is reporting peer epoch 0xb8, while z3 is reporting 
+     *    0xb9.
+     *
+     * By updating the election vote after actually following leader, we can 
+     * avoid this kind of stuck happened.
+     *
+     * Btw, the zxid and electionEpoch could be inconsistent because of the same 
+     * reason, it's better to update these as well after syncing with leader, but 
+     * that required protocol change which is non trivial. This problem is worked 
+     * around by skipping comparing the zxid and electionEpoch when counting for 
+     * votes for out of election servers during looking for leader.
      * 
      * @see https://issues.apache.org/jira/browse/ZOOKEEPER-1732
      */

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -2022,7 +2022,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
      * around by skipping comparing the zxid and electionEpoch when counting for 
      * votes for out of election servers during looking for leader.
      * 
-     * @see https://issues.apache.org/jira/browse/ZOOKEEPER-1732
+     * {@see https://issues.apache.org/jira/browse/ZOOKEEPER-1732}
      */
     protected void updateElectionVote(long newEpoch) {
         Vote currentVote = getCurrentVote();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Vote.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Vote.java
@@ -125,11 +125,47 @@ public class Vote {
             return false;
         }
         Vote other = (Vote) o;
-        return (id == other.id
+
+        if ((state == ServerState.LOOKING) ||
+                (other.state == ServerState.LOOKING)) {
+            return (id == other.id
                     && zxid == other.zxid
                     && electionEpoch == other.electionEpoch
                     && peerEpoch == other.peerEpoch);
-
+        } else {
+            /*
+             * There are two things going on in the logic below:
+             * 
+             * 1. skip comparing the zxid and electionEpoch for votes for servers 
+             *    out of election. 
+             *    
+             *    Need to skip those because they can be inconsistent due to  
+             *    scenarios described in QuorumPeer.updateElectionVote. 
+             *
+             *    And given that only one ensemble can be running at a single point 
+             *    in time and that each epoch is used only once, using only id and 
+             *    epoch to compare the votes is sufficient.
+             *
+             * 2. skip comparing peerEpoch if if we're running with mixed ensemble 
+             *    with (version > 0x0) and without the change (version = 0x0) 
+             *    introduced in ZOOKEEPER-1732.
+             *
+             *    The server running with and without ZOOKEEPER-1732 will return 
+             *    different peerEpoch. During rolling upgrades, it's possible
+             *    that 2/5 servers are returning epoch 1, while the other 2/5
+             *    are returning epoch 2, the other server need to ignore the 
+             *    peerEpoch to be able to join it.
+             *
+             * {@see https://issues.apache.org/jira/browse/ZOOKEEPER-1732}
+             * {@see https://issues.apache.org/jira/browse/ZOOKEEPER-1805}
+             */
+            if ((version > 0x0) ^ (other.version > 0x0)) {
+                return id == other.id;
+            } else {
+                return (id == other.id
+                        && peerEpoch == other.peerEpoch);
+            }
+        }
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Vote.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Vote.java
@@ -146,18 +146,19 @@ public class Vote {
              *    in time and that each epoch is used only once, using only id and 
              *    epoch to compare the votes is sufficient.
              *
+             *    {@see https://issues.apache.org/jira/browse/ZOOKEEPER-1805}
+             *
              * 2. skip comparing peerEpoch if if we're running with mixed ensemble 
              *    with (version > 0x0) and without the change (version = 0x0) 
              *    introduced in ZOOKEEPER-1732.
+             *
+             *    {@see https://issues.apache.org/jira/browse/ZOOKEEPER-1732}
              *
              *    The server running with and without ZOOKEEPER-1732 will return 
              *    different peerEpoch. During rolling upgrades, it's possible
              *    that 2/5 servers are returning epoch 1, while the other 2/5
              *    are returning epoch 2, the other server need to ignore the 
              *    peerEpoch to be able to join it.
-             *
-             * {@see https://issues.apache.org/jira/browse/ZOOKEEPER-1732}
-             * {@see https://issues.apache.org/jira/browse/ZOOKEEPER-1805}
              */
             if ((version > 0x0) ^ (other.version > 0x0)) {
                 return id == other.id;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/FLEOutOfElectionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/FLEOutOfElectionTest.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server.quorum;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.server.quorum.QuorumPeer;
+import org.apache.zookeeper.server.quorum.FastLeaderElection.Notification;
+import org.apache.zookeeper.server.quorum.Vote;
+import org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer;
+import org.apache.zookeeper.server.quorum.QuorumPeer.ServerState;
+import org.apache.zookeeper.server.util.ZxidUtils;
+import org.apache.zookeeper.test.ClientBase;
+import org.apache.zookeeper.test.FLETest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test FastLeaderElection with out of election servers.
+ */
+public class FLEOutOfElectionTest {
+
+    private FastLeaderElection fle;
+
+    @Before
+    public void setUp() throws Exception {
+        File tmpdir = ClientBase.createTmpDir();
+        Map<Long, QuorumServer> peers = new HashMap<Long,QuorumServer>();
+        for(int i = 0; i < 5; i++) {
+            peers.put(Long.valueOf(i), new QuorumServer(Long.valueOf(i), 
+                    new InetSocketAddress("127.0.0.1", PortAssignment.unique())));
+        }
+        QuorumPeer peer = new QuorumPeer(peers, tmpdir, tmpdir, 
+                PortAssignment.unique(), 3, 3, 1000, 2, 2);
+        fle = new FastLeaderElection(peer, peer.createCnxnManager());
+    }
+
+    @Test
+    public void testIgnoringZxidElectionEpoch() {
+        Map<Long, Vote> votes = new HashMap<Long, Vote>();
+        votes.put(0L, new Vote(0x1, 4L, ZxidUtils.makeZxid(1, 1), 1, 2, ServerState.FOLLOWING));
+        votes.put(1L, new Vote(0x1, 4L, ZxidUtils.makeZxid(1, 2), 1, 2, ServerState.FOLLOWING));
+        votes.put(3L, new Vote(0x1, 4L, ZxidUtils.makeZxid(2, 1), 2, 2, ServerState.FOLLOWING));
+        votes.put(4L, new Vote(0x1, 4L, ZxidUtils.makeZxid(2, 1), 2, 2, ServerState.LEADING));
+
+        Assert.assertTrue(fle.getVoteTracker(votes, 
+                new Vote(4L, ZxidUtils.makeZxid(2, 1), 2, 2, ServerState.FOLLOWING)).hasAllQuorums());
+    }
+
+    @Test
+    public void testElectionWIthDifferentVersion() {
+        Map<Long, Vote> votes = new HashMap<Long, Vote>();
+        votes.put(0L, new Vote(0x1, 4L, ZxidUtils.makeZxid(1, 1), 1, 1, ServerState.FOLLOWING));
+        votes.put(1L, new Vote(0x1, 4L, ZxidUtils.makeZxid(1, 1), 1, 1, ServerState.FOLLOWING));
+        votes.put(3L, new Vote(4L, ZxidUtils.makeZxid(2, 1), 2, 2, ServerState.FOLLOWING));
+        votes.put(4L, new Vote(4L, ZxidUtils.makeZxid(2, 1), 2, 2, ServerState.LEADING));
+
+        Assert.assertTrue(fle.getVoteTracker(votes, 
+                new Vote(4L, ZxidUtils.makeZxid(2, 1), 2, 2, ServerState.FOLLOWING)).hasAllQuorums());
+    }
+
+    @Test
+    public void testLookingNormal() {
+        Map<Long, Vote> votes = new HashMap<Long, Vote>();
+        votes.put(0L, new Vote(4L, ZxidUtils.makeZxid(2, 1), 1, 1, ServerState.LOOKING));
+        votes.put(1L, new Vote(4L, ZxidUtils.makeZxid(2, 1), 1, 1, ServerState.LOOKING));
+        votes.put(3L, new Vote(4L, ZxidUtils.makeZxid(2, 1), 1, 1, ServerState.LOOKING));
+        votes.put(4L, new Vote(4L, ZxidUtils.makeZxid(2, 1), 1, 1, ServerState.LEADING));
+
+        Assert.assertTrue(fle.getVoteTracker(votes, 
+                new Vote(4L, ZxidUtils.makeZxid(2, 1), 1, 1, ServerState.LOOKING)).hasAllQuorums());
+    }
+
+    @Test
+    public void testLookingDiffRounds() {
+        HashMap<Long, Vote> votes = new HashMap<Long, Vote>();
+        votes.put(0L, new Vote(4L, ZxidUtils.makeZxid(1, 1), 1, 1, ServerState.LOOKING));
+        votes.put(1L, new Vote(4L, ZxidUtils.makeZxid(2, 1), 2, 2, ServerState.LOOKING));
+        votes.put(3L, new Vote(4L, ZxidUtils.makeZxid(2, 1), 3, 2, ServerState.LOOKING));
+        votes.put(4L, new Vote(4L, ZxidUtils.makeZxid(2, 1), 3, 2, ServerState.LEADING));
+
+        Assert.assertFalse(fle.getVoteTracker(votes,
+                new Vote(4L, ZxidUtils.makeZxid(2, 1), 2, 2, ServerState.LOOKING)).hasAllQuorums());
+    }
+
+    @Test
+    public void testOutofElection() {
+        HashMap<Long,Vote> outofelection = new HashMap<Long,Vote>();
+
+        outofelection.put(1L, new Vote(0x0, 5, ZxidUtils.makeZxid(15, 0), 0xa, 0x17, ServerState.FOLLOWING));
+        outofelection.put(2L, new Vote(0x0, 5, ZxidUtils.makeZxid(15, 0), 0xa, 0x17, ServerState.FOLLOWING));
+        outofelection.put(4L, new Vote(0x1, 5, ZxidUtils.makeZxid(15, 0), 0xa, 0x18, ServerState.FOLLOWING));
+        Vote vote = new Vote(0x1, 5, ZxidUtils.makeZxid(15, 0), 0xa, 0x18, ServerState.LEADING);
+        outofelection.put(5L, vote);
+
+        Notification n = new Notification();
+        n.version = vote.getVersion();
+        n.leader = vote.getId();
+        n.zxid = vote.getZxid();
+        n.electionEpoch = vote.getElectionEpoch();
+        n.state = vote.getState();
+        n.peerEpoch = vote.getPeerEpoch();
+        n.sid = 5L;
+        
+        // Set the logical clock to 1 on fle instance of server 3.
+        fle.logicalclock.set(0x1);
+
+        Assert.assertTrue("Termination predicate failed", 
+                fle.getVoteTracker(outofelection, new Vote(n.version, n.leader, 
+                        n.zxid, n.electionEpoch, n.peerEpoch, n.state)).hasAllQuorums());
+
+        Assert.assertTrue("Leader check failed", fle.checkLeader(outofelection, 
+                n.leader, n.electionEpoch)); 
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/FLEOutOfElectionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/FLEOutOfElectionTest.java
@@ -126,7 +126,7 @@ public class FLEOutOfElectionTest {
         // Set the logical clock to 1 on fle instance of server 3.
         fle.logicalclock.set(0x1);
 
-        Assert.assertTrue("Termination predicate failed", 
+        Assert.assertTrue("Quorum check failed", 
                 fle.getVoteTracker(outofelection, new Vote(n.version, n.leader, 
                         n.zxid, n.electionEpoch, n.peerEpoch, n.state)).hasAllQuorums());
 


### PR DESCRIPTION
This is similar to the 3.4 implementation in Jira ZOOKEEPER-1817, main differences with that:

1. removed bcVote, in Vote.equals it will skip compare peerEpoch when one of the version is 0x0.
2. added detailed scenarios which we tried to solve with peerEpoch update and the change in Vote.equals.
3. removed ooePredicate with inlined one, since master code is tracking voteSet..
4. improved the tests to make it cleaner.