### PR TITLE
[ZOOKEEPER-2778] QuorumPeer: encapsulate addresses

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -410,7 +410,8 @@ public class QuorumCnxManager {
             // represents protocol version (in other words - message type)
             dout.writeLong(PROTOCOL_VERSION);
             dout.writeLong(self.getId());
-            String addr = self.getElectionAddress().getHostString() + ":" + self.getElectionAddress().getPort();
+            final InetSocketAddress electionAddr = self.getElectionAddress();
+            String addr = electionAddr.getHostString() + ":" + electionAddr.getPort();
             byte[] addr_bytes = addr.getBytes();
             dout.writeInt(addr_bytes.length);
             dout.write(addr_bytes);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -126,7 +126,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
      */
     private ZKDatabase zkDb;
 
-    public static class AddressTuple {
+    public static final class AddressTuple {
         public final InetSocketAddress quorumAddr;
         public final InetSocketAddress electionAddr;
         public final InetSocketAddress clientAddr;
@@ -1088,7 +1088,10 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
             break;
         case 3:
             QuorumCnxManager qcm = createCnxnManager();
-            qcmRef.set(qcm);
+            if (!qcmRef.compareAndSet(null, qcm)) {
+                LOG.warn("Clobbering already-set QuorumCnxManager (restarting leader election?)");
+                qcmRef.set(qcm);
+            }
             QuorumCnxManager.Listener listener = qcm.listener;
             if(listener != null){
                 listener.start();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -1088,9 +1088,10 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
             break;
         case 3:
             QuorumCnxManager qcm = createCnxnManager();
-            if (!qcmRef.compareAndSet(null, qcm)) {
+            QuorumCnxManager oldQcm = qcmRef.getAndSet(qcm);
+            if (oldQcm != null) {
                 LOG.warn("Clobbering already-set QuorumCnxManager (restarting leader election?)");
-                qcmRef.set(qcm);
+                oldQcm.halt();
             }
             QuorumCnxManager.Listener listener = qcm.listener;
             if(listener != null){

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -770,31 +770,43 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     }
 
     InetSocketAddress getQuorumAddress(){
+        AddressTuple addrs = myAddrs.get();
+        if (addrs != null) {
+            return addrs.quorumAddr;
+        }
         try {
             synchronized (QV_LOCK) {
-                while (myAddrs.get() == null) {
+                addrs = myAddrs.get();
+                while (addrs == null) {
                     QV_LOCK.wait();
+                    addrs = myAddrs.get();
                 }
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
-        return myAddrs.get().quorumAddr;
+        return addrs.quorumAddr;
     }
     
     InetSocketAddress getElectionAddress(){
+        AddressTuple addrs = myAddrs.get();
+        if (addrs != null) {
+            return addrs.electionAddr;
+        }
         try {
             synchronized (QV_LOCK) {
-                while (myAddrs.get() == null) {
+                addrs = myAddrs.get();
+                while (addrs == null) {
                     QV_LOCK.wait();
+                    addrs = myAddrs.get();
                 }
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
-        return myAddrs.get().electionAddr;
+        return addrs.electionAddr;
     }
 
     private InetSocketAddress getClientAddress(){

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
@@ -21,10 +21,13 @@ package org.apache.zookeeper.server.quorum;
 import org.apache.jute.OutputArchive;
 import org.apache.jute.Record;
 import org.apache.zookeeper.common.X509Exception;
+import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
+import org.apache.zookeeper.server.quorum.QuorumPeer.LearnerType;
+import org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer;
 import org.apache.zookeeper.server.util.SerializeUtils;
 import org.apache.zookeeper.test.ClientBase;
 import org.apache.zookeeper.txn.TxnHeader;
@@ -36,6 +39,10 @@ import org.mockito.stubbing.Answer;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -43,6 +50,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class LeaderBeanTest {
     private Leader leader;
@@ -54,8 +62,22 @@ public class LeaderBeanTest {
     @Before
     public void setUp() throws IOException, X509Exception {
         qp = new QuorumPeer();
+        long myId = qp.getId();
+
+        int clientPort = PortAssignment.unique();
+        Map<Long, QuorumServer> peersView = new HashMap<Long, QuorumServer>();
+        InetAddress clientIP = InetAddress.getLoopbackAddress();
+
+        peersView.put(Long.valueOf(myId),
+                new QuorumServer(myId, new InetSocketAddress(clientIP, PortAssignment.unique()),
+                        new InetSocketAddress(clientIP, PortAssignment.unique()),
+                        new InetSocketAddress(clientIP, clientPort), LearnerType.PARTICIPANT));
+
         QuorumVerifier quorumVerifierMock = mock(QuorumVerifier.class);
+        when(quorumVerifierMock.getAllMembers()).thenReturn(peersView);
+
         qp.setQuorumVerifier(quorumVerifierMock, false);
+
         File tmpDir = ClientBase.createTmpDir();
         fileTxnSnapLog = new FileTxnSnapLog(new File(tmpDir, "data"),
                 new File(tmpDir, "data_txnlog"));

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
@@ -844,7 +844,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         testNormalOperation(zkArr[4], zkArr[5]);
 
         for (int i = 1; i <= 5; i++) {
-            if (!(qu.getPeer(i).peer.quorumVerifier instanceof QuorumHierarchical))
+            if (!(qu.getPeer(i).peer.getQuorumVerifier() instanceof QuorumHierarchical))
                 Assert.fail("peer " + i
                         + " doesn't think the quorum system is Hieararchical!");
         }
@@ -881,7 +881,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         testNormalOperation(zkArr[1], zkArr[2]);
 
         for (int i = 1; i <= 2; i++) {
-            if (!(qu.getPeer(i).peer.quorumVerifier instanceof QuorumMaj))
+            if (!(qu.getPeer(i).peer.getQuorumVerifier() instanceof QuorumMaj))
                 Assert.fail("peer "
                         + i
                         + " doesn't think the quorum system is a majority quorum system!");


### PR DESCRIPTION
[ZOOKEEPER-2778] QuorumPeer: encapsulate quorum/election/client addresses in an AddressTuple held through an AtomicReference