### PR TITLE
ZOOKEEPER-3195: TLS - disable client-initiated renegotiation

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
@@ -66,6 +66,21 @@ import org.slf4j.LoggerFactory;
 public abstract class X509Util implements Closeable, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(X509Util.class);
 
+    private static final String REJECT_CLIENT_RENEGOTIATION_PROPERTY =
+            "jdk.tls.rejectClientInitiatedRenegotiation";
+    static {
+        // Client-initiated renegotiation in TLS is unsafe and
+        // allows MITM attacks, so we should disable it unless
+        // it was explicitly enabled by the user.
+        // A brief summary of the issue can be found at
+        // https://www.ietf.org/proceedings/76/slides/tls-7.pdf
+        if (System.getProperty(REJECT_CLIENT_RENEGOTIATION_PROPERTY) == null) {
+            LOG.info("Setting -D {}=true to disable client-initiated TLS renegotiation",
+                    REJECT_CLIENT_RENEGOTIATION_PROPERTY);
+            System.setProperty(REJECT_CLIENT_RENEGOTIATION_PROPERTY, Boolean.TRUE.toString());
+        }
+    }
+
     static final String DEFAULT_PROTOCOL = "TLSv1.2";
     private static final String[] DEFAULT_CIPHERS_JAVA8 = {
             "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",


### PR DESCRIPTION
Summary: client-initiated renegotiation is insecure and is vulnerable to MITM attacks.
Unfortunately, the feature is enabled in Java by default. This disables it.
See https://bugs.openjdk.java.net/browse/JDK-7188658 and
https://www.oracle.com/technetwork/java/javase/documentation/tlsreadme-141115.html

Test Plan: manually tested by running a secure ZK server and probing the listening port
with python's sslyze tool (using `sslyze --reneg ...`). Tested on Java 8, 9, 10, and 11.