### PR TITLE
Enable secure processing and disallow DTDs in the SAXParserFactory

### DIFF
--- a/zookeeper-jute/src/main/java/org/apache/jute/XmlInputArchive.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/XmlInputArchive.java
@@ -143,6 +143,8 @@ class XmlInputArchive implements InputArchive {
         valList = new ArrayList<Value>();
         DefaultHandler handler = new XMLParser(valList);
         SAXParserFactory factory = SAXParserFactory.newInstance();
+        factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         SAXParser parser = factory.newSAXParser();
         parser.parse(in, handler);
         vLen = valList.size();


### PR DESCRIPTION
It's good security practice to set the secure processing feature on SAXParserFactory and to disallow Doctypes if they aren't needed.