### PR TITLE
ZOOKEEPER-3046: wait for clients to reconnect after restarting server

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/DisconnectedWatcherTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/DisconnectedWatcherTest.java
@@ -57,7 +57,8 @@ public class DisconnectedWatcherTest extends ClientBase {
     
     @Test
     public void testChildWatcherAutoResetWithChroot() throws Exception {
-        ZooKeeper zk1 = createClient();
+        CountdownWatcher watcher1 = new CountdownWatcher();
+        ZooKeeper zk1 = createClient(watcher1);
 
         zk1.create("/ch1", null, Ids.OPEN_ACL_UNSAFE,
                     CreateMode.PERSISTENT);
@@ -85,6 +86,7 @@ public class DisconnectedWatcherTest extends ClientBase {
         watcher.waitForDisconnected(3000);
         startServer();
         watcher.waitForConnected(3000);
+        watcher1.waitForConnected(3000);
 
         // this should trigger the watch
         zk1.create("/ch1/youshouldmatter2", null, Ids.OPEN_ACL_UNSAFE,
@@ -97,7 +99,8 @@ public class DisconnectedWatcherTest extends ClientBase {
     
     @Test
     public void testDefaultWatcherAutoResetWithChroot() throws Exception {
-        ZooKeeper zk1 = createClient();
+        CountdownWatcher watcher1 = new CountdownWatcher();
+        ZooKeeper zk1 = createClient(watcher1);
 
         zk1.create("/ch1", null, Ids.OPEN_ACL_UNSAFE,
                     CreateMode.PERSISTENT);
@@ -124,6 +127,7 @@ public class DisconnectedWatcherTest extends ClientBase {
         watcher.waitForDisconnected(3000);
         startServer();
         watcher.waitForConnected(3000);
+        watcher1.waitForConnected(3000);
 
         // this should trigger the watch
         zk1.create("/ch1/youshouldmatter2", null, Ids.OPEN_ACL_UNSAFE,
@@ -136,7 +140,8 @@ public class DisconnectedWatcherTest extends ClientBase {
     
     @Test
     public void testDeepChildWatcherAutoResetWithChroot() throws Exception {
-        ZooKeeper zk1 = createClient();
+        CountdownWatcher watcher1 = new CountdownWatcher();
+        ZooKeeper zk1 = createClient(watcher1);
 
         zk1.create("/ch1", null, Ids.OPEN_ACL_UNSAFE,
                 CreateMode.PERSISTENT);
@@ -166,6 +171,7 @@ public class DisconnectedWatcherTest extends ClientBase {
         watcher.waitForDisconnected(3000);
         startServer();
         watcher.waitForConnected(3000);
+        watcher1.waitForConnected(3000);
 
         // this should trigger the watch
         zk1.create("/ch1/here/we/are/again", null, Ids.OPEN_ACL_UNSAFE,
@@ -180,7 +186,8 @@ public class DisconnectedWatcherTest extends ClientBase {
     // watches which require multiple SetWatches calls.
     @Test(timeout = 840000)
     public void testManyChildWatchersAutoReset() throws Exception {
-        ZooKeeper zk1 = createClient();
+        CountdownWatcher watcher1 = new CountdownWatcher();
+        ZooKeeper zk1 = createClient(watcher1);
 
         MyWatcher watcher = new MyWatcher();
         ZooKeeper zk2 = createClient(watcher);
@@ -221,6 +228,7 @@ public class DisconnectedWatcherTest extends ClientBase {
         watcher.waitForDisconnected(30000);
         startServer();
         watcher.waitForConnected(30000);
+        watcher1.waitForConnected(30000);
 
         // Trigger the watches and ensure they properly propagate to the client
         i = 0;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/DisconnectedWatcherTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/DisconnectedWatcherTest.java
@@ -62,6 +62,7 @@ public class DisconnectedWatcherTest extends ClientBase {
 
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         watcher1 = new CountdownWatcher();
         zk1 = createClient(watcher1);
         watcher2 = new MyWatcher();
@@ -75,6 +76,7 @@ public class DisconnectedWatcherTest extends ClientBase {
         if (zk1 != null) {
             zk1.close();
         }
+        super.tearDown();
     }
 
     // @see jira issue ZOOKEEPER-961


### PR DESCRIPTION
Comment from ZOOKEEPER-3046, explaining what failure signature motivated this change:

Still seeing test failures; basically a variant of ZOOKEEPER-2508. (After stopping/starting the server, we have to wait for all clients to reconnect before continuing the test.)

```
422005     [junit] 2018-11-25 21:25:50,228 [myid:127.0.0.1:16611] - INFO  [Time-limited test-SendThread(127.0.0.1:16611):ClientCnxn$SendThread@1390] - Session establishment complete on serve       r localhost/127.0.0.1:16611, sessionid = 0x100007077c50001, negotiated timeout = 30000
422006     [junit] 2018-11-25 21:25:50,286 [myid:] - INFO  [Time-limited test:JUnit4ZKTestRunner$LoggedInvokeMethod@98] - TEST METHOD FAILED testManyChildWatchersAutoReset
422007     [junit] org.apache.zookeeper.KeeperException$ConnectionLossException: KeeperErrorCode = ConnectionLoss for /long-path-000000000-111111111-222222222-333333333-444444444-555555555-6       66666666-777777777-888888888-999999999/ch-0000000000/ch
422008     [junit]     at org.apache.zookeeper.KeeperException.create(KeeperException.java:102)
422009     [junit]     at org.apache.zookeeper.KeeperException.create(KeeperException.java:54)
422010     [junit]     at org.apache.zookeeper.ZooKeeper.create(ZooKeeper.java:1459)
422011     [junit]     at org.apache.zookeeper.test.DisconnectedWatcherTest.testManyChildWatchersAutoReset(DisconnectedWatcherTest.java:229)
```