### PR TITLE
ZOOKEEPER-3202: Add timing margin to improve reliability of testClientServerSSL()

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientSSLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientSSLTest.java
@@ -93,6 +93,10 @@ public class ClientSSLTest extends QuorumPeerTestBase {
             mt[i].start();
         }
 
+        // Add some timing margin for the quorum to elect a leader
+        // (without this margin, timeouts have been observed in parallel test runs)
+        ClientBase.waitForServerUp("127.0.0.1:" + clientPorts[0], 2 * TIMEOUT);
+
         // Servers have been set up. Now go test if secure connection is successful.
         for (int i = 0; i < SERVER_COUNT; i++) {
             Assert.assertTrue("waiting for server " + i + " being up",


### PR DESCRIPTION
Allowing just 5 seconds for 3 quorum peers to start and elect a leader is a bit tight, at least when running 4 test processes in parallel inside a (Linux) Docker container on a (non-Linux) laptop.  Add up to 10 seconds of extra margin.