### PR TITLE
Zookeeper-3188: Improve resilience to network

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -1129,24 +1129,22 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                 cnxn.disableRecv();
             }
             return;
+        } else if (h.getType() == OpCode.sasl) {
+            Record rsp = processSasl(incomingBuffer,cnxn);
+            ReplyHeader rh = new ReplyHeader(h.getXid(), 0, KeeperException.Code.OK.intValue());
+            cnxn.sendResponse(rh,rsp, "response"); // not sure about 3rd arg..what is it?
+            return;
         } else {
-            if (h.getType() == OpCode.sasl) {
-                Record rsp = processSasl(incomingBuffer,cnxn);
-                ReplyHeader rh = new ReplyHeader(h.getXid(), 0, KeeperException.Code.OK.intValue());
-                cnxn.sendResponse(rh,rsp, "response"); // not sure about 3rd arg..what is it?
-                return;
-            }
-            else {
-                Request si = new Request(cnxn, cnxn.getSessionId(), h.getXid(),
-                  h.getType(), incomingBuffer, cnxn.getAuthInfo());
-                si.setOwner(ServerCnxn.me);
-                // Always treat packet from the client as a possible
-                // local request.
-                setLocalSessionFlag(si);
-                submitRequest(si);
-            }
+            cnxn.incrOutstandingRequests(h);
+            Request si = new Request(cnxn, cnxn.getSessionId(), h.getXid(),
+              h.getType(), incomingBuffer, cnxn.getAuthInfo());
+            si.setOwner(ServerCnxn.me);
+            // Always treat packet from the client as a possible
+            // local request.
+            setLocalSessionFlag(si);
+            submitRequest(si);
+            return;
         }
-        cnxn.incrOutstandingRequests(h);
     }
 
     private Record processSasl(ByteBuffer incomingBuffer, ServerCnxn cnxn) throws IOException {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderElection.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderElection.java
@@ -184,7 +184,7 @@ public class LeaderElection implements Election  {
                 for (QuorumServer server : self.getVotingView().values()) {
                     LOG.info("Server address: " + server.addr);
                     try {
-                        requestPacket.setSocketAddress(server.addr);
+                        requestPacket.setSocketAddress(server.addr.getValidAddress());
                     } catch (IllegalArgumentException e) {
                         // Sun doesn't include the address that causes this
                         // exception to be thrown, so we wrap the exception

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LocalPeerBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LocalPeerBean.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server.quorum;
 
 
+import java.util.stream.Collectors;
 
 /**
  * Implementation of the local peer MBean interface.
@@ -79,8 +80,9 @@ public class LocalPeerBean extends ServerBean implements LocalPeerMXBean {
     }
 
     public String getElectionAddress() {
-        return peer.getElectionAddress().getHostString() + ":" +
-            peer.getElectionAddress().getPort();
+        return peer.getElectionAddress().getAllAddresses().stream()
+                .map(address -> String.format("%s:%d", address.getHostString(), address.getPort()))
+                .collect(Collectors.joining(","));
     }
 
     public String getClientAddress() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/MultipleAddresses.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/MultipleAddresses.java
@@ -80,7 +80,7 @@ public class MultipleAddresses {
             }
         }
 
-        addresses = temp;
+        addresses.addAll(temp);
     }
 
     private List<InetSocketAddress> resolveFqdnToAddress(InetSocketAddress addr) throws UnknownHostException {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/MultipleAddresses.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/MultipleAddresses.java
@@ -31,15 +31,6 @@ public class MultipleAddresses {
         return addresses.isEmpty();
     }
 
-    public boolean isReachable() {
-        try {
-            getValidAddress();
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
     public List<InetSocketAddress> getAllAddresses() {
         return new LinkedList<>(addresses);
     }
@@ -74,21 +65,14 @@ public class MultipleAddresses {
 
         for(InetSocketAddress addr : addresses) {
             try {
-                temp.addAll(resolveFqdnToAddress(addr));
+                temp.add(new InetSocketAddress(InetAddress.getByName(addr.getHostString()), addr.getPort()));
             } catch (UnknownHostException e) {
                 temp.add(addr);
             }
         }
 
+        addresses.clear();
         addresses.addAll(temp);
-    }
-
-    private List<InetSocketAddress> resolveFqdnToAddress(InetSocketAddress addr) throws UnknownHostException {
-        String host = addr.getHostString();
-        int port = addr.getPort();
-
-        return Arrays.stream(InetAddress.getAllByName(host))
-                .map(address -> new InetSocketAddress(address, port)).collect(Collectors.toList());
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/MultipleAddresses.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/MultipleAddresses.java
@@ -60,13 +60,20 @@ public class MultipleAddresses {
     }
 
     public InetSocketAddress getValidAddress() {
+        //InetSocketAddress wrongAddress = null;
+
         for(InetSocketAddress addr : addresses) {
             try {
-                if(addr.getAddress().isReachable(100))
+                if (addr.getAddress().isReachable(100))
                     return addr;
+            } catch (NullPointerException e) {
+                //wrongAddress = addr;
             } catch (IOException ignored) {
             }
         }
+
+//        if(wrongAddress != null)
+//            return wrongAddress;
 
         throw new RuntimeNoReachableHostException("No valid address among " + addresses);
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/MultipleAddresses.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/MultipleAddresses.java
@@ -6,27 +6,24 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class MultipleAddresses {
 
-    private List<InetSocketAddress> addresses;
+    private Set<InetSocketAddress> addresses;
 
     public MultipleAddresses() {
-        addresses = new LinkedList<>();
+        addresses = new HashSet<>();
     }
 
     public MultipleAddresses(List<InetSocketAddress> addresses) {
-        addresses = new LinkedList<>();
+        this.addresses = new HashSet<>();
         this.addresses.addAll(addresses);
     }
 
     public MultipleAddresses(InetSocketAddress address) {
-        addresses = new LinkedList<>();
+        addresses = new HashSet<>();
         addresses.add(address);
     }
 
@@ -60,26 +57,20 @@ public class MultipleAddresses {
     }
 
     public InetSocketAddress getValidAddress() {
-        //InetSocketAddress wrongAddress = null;
 
         for(InetSocketAddress addr : addresses) {
             try {
                 if (addr.getAddress().isReachable(100))
                     return addr;
-            } catch (NullPointerException e) {
-                //wrongAddress = addr;
-            } catch (IOException ignored) {
+            } catch (NullPointerException | IOException e) {
             }
         }
-
-//        if(wrongAddress != null)
-//            return wrongAddress;
 
         throw new RuntimeNoReachableHostException("No valid address among " + addresses);
     }
 
     public void recreateSocketAddresses() {
-        List<InetSocketAddress> temp = new LinkedList<>();
+        Set<InetSocketAddress> temp = new HashSet<>();
 
         for(InetSocketAddress addr : addresses) {
             try {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/MultipleAddresses.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/MultipleAddresses.java
@@ -1,0 +1,118 @@
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.server.quorum.exception.RuntimeNoReachableHostException;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class MultipleAddresses {
+
+    private List<InetSocketAddress> addresses;
+
+    public MultipleAddresses() {
+        addresses = new LinkedList<>();
+    }
+
+    public MultipleAddresses(List<InetSocketAddress> addresses) {
+        addresses = new LinkedList<>();
+        this.addresses.addAll(addresses);
+    }
+
+    public MultipleAddresses(InetSocketAddress address) {
+        addresses = new LinkedList<>();
+        addresses.add(address);
+    }
+
+    public boolean isEmpty() {
+        return addresses.isEmpty();
+    }
+
+    public boolean isReachable() {
+        try {
+            getValidAddress();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public List<InetSocketAddress> getAllAddresses() {
+        return new LinkedList<>(addresses);
+    }
+
+    public List<InetSocketAddress> getAllAddressesForAllPorts() {
+       return addresses.stream().map(a -> new InetSocketAddress(a.getPort())).distinct().collect(Collectors.toList());
+    }
+
+    public List<Integer> getAllPorts() {
+        return addresses.stream().map(InetSocketAddress::getPort).collect(Collectors.toList());
+    }
+
+    public void addAddress(InetSocketAddress address) {
+        addresses.add(address);
+    }
+
+    public InetSocketAddress getValidAddress() {
+        for(InetSocketAddress addr : addresses) {
+            try {
+                if(addr.getAddress().isReachable(100))
+                    return addr;
+            } catch (IOException ignored) {
+            }
+        }
+
+        throw new RuntimeNoReachableHostException("No valid address among " + addresses);
+    }
+
+    public void recreateSocketAddresses() {
+        List<InetSocketAddress> temp = new LinkedList<>();
+
+        for(InetSocketAddress addr : addresses) {
+            try {
+                temp.addAll(resolveFqdnToAddress(addr));
+            } catch (UnknownHostException e) {
+                temp.add(addr);
+            }
+        }
+
+        addresses = temp;
+    }
+
+    private List<InetSocketAddress> resolveFqdnToAddress(InetSocketAddress addr) throws UnknownHostException {
+        String host = addr.getHostString();
+        int port = addr.getPort();
+
+        return Arrays.stream(InetAddress.getAllByName(host))
+                .map(address -> new InetSocketAddress(address, port)).collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MultipleAddresses that = (MultipleAddresses) o;
+        return Objects.equals(addresses, that.addresses);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(addresses);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder result = new StringBuilder();
+
+        addresses.forEach(addr -> result.append(String.format("%s.", addr)));
+        result.deleteCharAt(result.length() - 1);
+
+        return result.toString();
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/MultipleAddresses.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/MultipleAddresses.java
@@ -7,6 +7,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class MultipleAddresses {
@@ -14,16 +15,16 @@ public class MultipleAddresses {
     private Set<InetSocketAddress> addresses;
 
     public MultipleAddresses() {
-        addresses = new HashSet<>();
+        addresses = Collections.newSetFromMap(new ConcurrentHashMap<>());
     }
 
     public MultipleAddresses(List<InetSocketAddress> addresses) {
-        this.addresses = new HashSet<>();
+        this.addresses = Collections.newSetFromMap(new ConcurrentHashMap<>());
         this.addresses.addAll(addresses);
     }
 
     public MultipleAddresses(InetSocketAddress address) {
-        addresses = new HashSet<>();
+        addresses = Collections.newSetFromMap(new ConcurrentHashMap<>());
         addresses.add(address);
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -862,7 +862,7 @@ public class QuorumCnxManager {
                 threadPool.shutdown();
 
                 try {
-                    while (!shutdown)
+                    while (true)
                         if (threadPool.awaitTermination(10, TimeUnit.MILLISECONDS))
                             break;
                 } catch (InterruptedException ie) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -31,15 +31,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -324,20 +317,28 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
 
         public String toString(){
             StringWriter sw = new StringWriter();
-            //addr should never be null, but just to make sure
+
             List<InetSocketAddress> addrList = addr.getAllAddresses();
             List<InetSocketAddress> electionAddrList = electionAddr.getAllAddresses();
-            sw.append(IntStream.range(0, addrList.size()).mapToObj(i -> String.format("%s:%d:%d",
-                    delimitedHostString(addrList.get(i)), addrList.get(i).getPort(), electionAddrList.get(i).getPort()))
-                    .collect(Collectors.joining(",")));
+
+            if(addrList.size() > 0 && electionAddrList.size() > 0) {
+                addrList.sort(Comparator.comparing(InetSocketAddress::getHostString));
+                electionAddrList.sort(Comparator.comparing(InetSocketAddress::getHostString));
+                sw.append(IntStream.range(0, addrList.size()).mapToObj(i -> String.format("%s:%d:%d",
+                        delimitedHostString(addrList.get(i)), addrList.get(i).getPort(), electionAddrList.get(i).getPort()))
+                        .collect(Collectors.joining(",")));
+            }
+
             if (type == LearnerType.OBSERVER) sw.append(":observer");
-            else if (type == LearnerType.PARTICIPANT) sw.append(":participant");            
+            else if (type == LearnerType.PARTICIPANT) sw.append(":participant");
+
             if (clientAddr!=null){
                 sw.append(";");
                 sw.append(delimitedHostString(clientAddr));
                 sw.append(":");
                 sw.append(String.valueOf(clientAddr.getPort()));
             }
+
             return sw.toString();       
         }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -294,8 +294,10 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
         public QuorumServer(long id, InetSocketAddress addr,
                 InetSocketAddress electionAddr, InetSocketAddress clientAddr, LearnerType type) {
             this.id = id;
-            this.addr.addAddress(addr);
-            this.electionAddr.addAddress(electionAddr);
+            if(addr != null)
+                this.addr.addAddress(addr);
+            if(electionAddr != null)
+                this.electionAddr.addAddress(electionAddr);
             this.type = type;
             this.clientAddr = clientAddr;
 
@@ -728,8 +730,8 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
 
     DatagramSocket udpSocket;
 
-    private MultipleAddresses myQuorumAddr;
-    private MultipleAddresses myElectionAddr = null;
+    private MultipleAddresses myQuorumAddr  = new MultipleAddresses();
+    private MultipleAddresses myElectionAddr = new MultipleAddresses();
     private InetSocketAddress myClientAddr = null;
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -658,7 +658,7 @@ public class QuorumPeerConfig {
              */            
            if (eAlg != 0) {
                for (QuorumServer s : qv.getVotingMembers().values()) {
-                   if (s.electionAddr == null)
+                   if (s.electionAddr.isEmpty())
                        throw new IllegalArgumentException(
                                "Missing election port for server: " + s.id);
                }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
@@ -20,6 +20,8 @@ package org.apache.zookeeper.server.quorum;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -173,9 +175,11 @@ public abstract class QuorumZooKeeperServer extends ZooKeeperServer {
         pwriter.print("electionAlg=");
         pwriter.println(self.getElectionType());
         pwriter.print("electionPort=");
-        pwriter.println(self.getElectionAddress().getPort());
+        pwriter.println(self.getElectionAddress().getAllPorts()
+                .stream().map(Objects::toString).collect(Collectors.joining(",")));
         pwriter.print("quorumPort=");
-        pwriter.println(self.getQuorumAddress().getPort());
+        pwriter.println(self.getQuorumAddress().getAllPorts()
+                        .stream().map(Objects::toString).collect(Collectors.joining(",")));
         pwriter.print("peerType=");
         pwriter.println(self.getLearnerType().ordinal());
         pwriter.println("membership: ");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyZooKeeperServer.java
@@ -19,6 +19,8 @@
 package org.apache.zookeeper.server.quorum;
 
 import java.io.PrintWriter;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.server.DataTreeBean;
@@ -166,9 +168,11 @@ public class ReadOnlyZooKeeperServer extends ZooKeeperServer {
         pwriter.print("electionAlg=");
         pwriter.println(self.getElectionType());
         pwriter.print("electionPort=");
-        pwriter.println(self.getElectionAddress().getPort());
+        pwriter.println(self.getElectionAddress().getAllPorts()
+                .stream().map(Objects::toString).collect(Collectors.joining(",")));
         pwriter.print("quorumPort=");
-        pwriter.println(self.getQuorumAddress().getPort());
+        pwriter.println(self.getQuorumAddress().getAllPorts()
+                .stream().map(Objects::toString).collect(Collectors.joining(",")));
         pwriter.print("peerType=");
         pwriter.println(self.getLearnerType().ordinal());
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/RemotePeerBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/RemotePeerBean.java
@@ -20,6 +20,8 @@ package org.apache.zookeeper.server.quorum;
 
 import org.apache.zookeeper.jmx.ZKMBeanInfo;
 
+import java.util.stream.Collectors;
+
 /**
  * A remote peer bean only provides limited information about the remote peer,
  * and the peer cannot be managed remotely. 
@@ -45,11 +47,15 @@ public class RemotePeerBean implements RemotePeerMXBean,ZKMBeanInfo {
     }
 
     public String getQuorumAddress() {
-        return peer.addr.getHostString()+":"+peer.addr.getPort();
+        return peer.addr.getAllAddresses().stream()
+                .map(address -> String.format("%s:%d", address.getHostString(), address.getPort()))
+                .collect(Collectors.joining(","));
     }
 
     public String getElectionAddress() {
-        return peer.electionAddr.getHostString() + ":" + peer.electionAddr.getPort();
+        return peer.electionAddr.getAllAddresses().stream()
+                .map(address -> String.format("%s:%d", address.getHostString(), address.getPort()))
+                .collect(Collectors.joining(","));
     }
 
     public String getClientAddress() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/exception/RuntimeConfigException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/exception/RuntimeConfigException.java
@@ -1,0 +1,15 @@
+package org.apache.zookeeper.server.quorum.exception;
+
+public class RuntimeConfigException extends RuntimeException {
+
+    private static final long serialVersionUID = -9025894204684855418L;
+
+    public RuntimeConfigException() {
+        super();
+    }
+
+    public RuntimeConfigException(String message) {
+        super(message);
+    }
+
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/exception/RuntimeLearnerException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/exception/RuntimeLearnerException.java
@@ -12,4 +12,8 @@ public class RuntimeLearnerException extends RuntimeException {
         super(cause);
     }
 
+    public RuntimeLearnerException(String message) {
+        super(message);
+    }
+
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/exception/RuntimeLearnerException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/exception/RuntimeLearnerException.java
@@ -1,0 +1,15 @@
+package org.apache.zookeeper.server.quorum.exception;
+
+public class RuntimeLearnerException extends RuntimeException {
+
+    private static final long serialVersionUID = 9164642202468819481L;
+
+    public RuntimeLearnerException() {
+        super();
+    }
+
+    public RuntimeLearnerException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/exception/RuntimeNoReachableHostException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/exception/RuntimeNoReachableHostException.java
@@ -1,0 +1,15 @@
+package org.apache.zookeeper.server.quorum.exception;
+
+public class RuntimeNoReachableHostException extends RuntimeException {
+
+    private static final long serialVersionUID = -8118892361652577058L;
+
+    public RuntimeNoReachableHostException() {
+        super();
+    }
+
+    public RuntimeNoReachableHostException(String message) {
+        super(message);
+    }
+
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerTest.java
@@ -35,6 +35,7 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.server.quorum.exception.RuntimeLearnerException;
 import org.apache.zookeeper.test.TestUtils;
 import org.apache.zookeeper.txn.CreateTxn;
 import org.apache.zookeeper.txn.TxnHeader;
@@ -98,7 +99,7 @@ public class LearnerTest extends ZKTestCase {
         }
     }
 
-    @Test(expected=IOException.class)
+    @Test(expected= RuntimeLearnerException.class)
     public void connectionRetryTimeoutTest() throws Exception {
         Learner learner = new TimeoutLearner();
         learner.self = new QuorumPeer();
@@ -110,7 +111,7 @@ public class LearnerTest extends ZKTestCase {
         InetSocketAddress addr = new InetSocketAddress(1111);
 
         // we expect this to throw an IOException since we're faking socket connect errors every time
-        learner.connectToLeader(addr, "");
+        learner.connectToLeader(new MultipleAddresses(addr), "");
     }
     @Test
     public void connectionInitLimitTimeoutTest() throws Exception {
@@ -130,9 +131,9 @@ public class LearnerTest extends ZKTestCase {
 
         // we expect this to throw an IOException since we're faking socket connect errors every time
         try {
-            learner.connectToLeader(addr, "");
+            learner.connectToLeader(new MultipleAddresses(addr), "");
             Assert.fail("should have thrown IOException!");
-        } catch (IOException e) {
+        } catch (RuntimeLearnerException e) {
             //good, wanted to see that, let's make sure we ran out of time
             Assert.assertTrue(learner.nanoTime() > 2000*5*1000000);
             Assert.assertEquals(3, learner.getSockConnectAttempt());

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerMainTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerMainTest.java
@@ -381,8 +381,9 @@ public class QuorumPeerMainTest extends QuorumPeerTestBase {
           Assert.assertTrue("All servers should join the quorum", servers.mt[falseLeader].main.quorumPeer.follower != null);
 
           // to keep the quorum peer running and force it to go into the looking state, we kill leader election
-          // and close the connection to the leader
+          // and disable reconnect, close the connection to the leader
           servers.mt[falseLeader].main.quorumPeer.electionAlg.shutdown();
+          servers.mt[falseLeader].main.quorumPeer.follower.disableReconnect();
           servers.mt[falseLeader].main.quorumPeer.follower.getSocket().close();
 
           // wait for the falseLeader to disconnect

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/RaceConditionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/RaceConditionTest.java
@@ -36,6 +36,7 @@ import org.apache.zookeeper.server.SyncRequestProcessor;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.quorum.QuorumPeer.ServerState;
+import org.apache.zookeeper.server.quorum.exception.RuntimeLearnerException;
 import org.apache.zookeeper.test.ClientBase;
 import org.junit.After;
 import org.junit.Assert;
@@ -174,7 +175,7 @@ public class RaceConditionTest extends QuorumPeerTestBase {
                 protected void processPacket(QuorumPacket qp) throws Exception {
                     if (stopPing && qp.getType() == Leader.PING) {
                         LOG.info("Follower skipped ping");
-                        throw new SocketException("Socket time out while sending the ping response");
+                        throw new RuntimeLearnerException("Socket time out while sending the ping response");
                     } else {
                         super.processPacket(qp);
                     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ReconfigFailureCasesTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ReconfigFailureCasesTest.java
@@ -78,8 +78,8 @@ public class ReconfigFailureCasesTest extends QuorumPeerTestBase {
 
         for (int i = 1; i <= 5; i++) {
             members.add("server." + i + "=127.0.0.1:"
-                    + qu.getPeer(i).peer.getQuorumAddress().getPort() + ":"
-                    + qu.getPeer(i).peer.getElectionAddress().getPort() + ";"
+                    + qu.getPeer(i).peer.getQuorumAddress().getAllPorts().get(0)+ ":"
+                    + qu.getPeer(i).peer.getElectionAddress().getAllPorts().get(0) + ";"
                     + "127.0.0.1:" + qu.getPeer(i).peer.getClientPort());
         }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
@@ -450,6 +450,7 @@ public class Zab1_0Test extends ZKTestCase {
             conversation.converseWithFollower(ia, oa, follower);
         } finally {
             if (follower != null) {
+                follower.disableReconnect();
                 follower.shutdown();
             }
             if (followerThread != null) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/CnxManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/CnxManagerTest.java
@@ -30,10 +30,12 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.net.Socket;
 
 import org.apache.zookeeper.common.Time;
+import org.apache.zookeeper.server.quorum.exception.RuntimeNoReachableHostException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
@@ -183,12 +185,12 @@ public class CnxManagerTest extends ZKTestCase {
         Assert.assertFalse(cnxManager.listener.isAlive());
     }
 
-    @Test
+    @Test(expected = RuntimeNoReachableHostException.class)
     public void testCnxManagerTimeout() throws Exception {
         Random rand = new Random();
-        byte b = (byte) rand.nextInt();
+        int address = ThreadLocalRandom.current().nextInt(1, 255);
         int deadPort = PortAssignment.unique();
-        String deadAddress = "10.1.1." + b;
+        String deadAddress = "10.1.1." + address;
 
         LOG.info("This is the dead address I'm trying: " + deadAddress);
 
@@ -235,19 +237,18 @@ public class CnxManagerTest extends ZKTestCase {
         } else {
             LOG.error("Null listener when initializing cnx manager");
         }
-
-        int port = peers.get(peer.getId()).electionAddr.getPort();
-        LOG.info("Election port: " + port);
+        InetSocketAddress address = peers.get(peer.getId()).electionAddr.getValidAddress();
+        LOG.info("Election port: " + address.getPort());
 
         Thread.sleep(1000);
 
         SocketChannel sc = SocketChannel.open();
-        sc.socket().connect(peers.get(1L).electionAddr, 5000);
+        sc.socket().connect(address, 5000);
 
-        InetSocketAddress otherAddr = peers.get(new Long(2)).electionAddr;
+        InetSocketAddress otherAddr = peers.get(2L).electionAddr.getValidAddress();
         DataOutputStream dout = new DataOutputStream(sc.socket().getOutputStream());
         dout.writeLong(QuorumCnxManager.PROTOCOL_VERSION);
-        dout.writeLong(new Long(2));
+        dout.writeLong(2L);
         String addr = otherAddr.getHostString()+ ":" + otherAddr.getPort();
         byte[] addr_bytes = addr.getBytes();
         dout.writeInt(addr_bytes.length);
@@ -300,13 +301,13 @@ public class CnxManagerTest extends ZKTestCase {
         } else {
             LOG.error("Null listener when initializing cnx manager");
         }
-        int port = peers.get(peer.getId()).electionAddr.getPort();
-        LOG.info("Election port: " + port);
+        InetSocketAddress address = peers.get(peer.getId()).electionAddr.getValidAddress();
+        LOG.info("Election port: " + address.getPort());
 
         Thread.sleep(1000);
 
         SocketChannel sc = SocketChannel.open();
-        sc.socket().connect(peers.get(1L).electionAddr, 5000);
+        sc.socket().connect(address, 5000);
 
         /*
          * Write id (3.4.6 protocol). This previously caused a NPE in
@@ -347,12 +348,12 @@ public class CnxManagerTest extends ZKTestCase {
         } else {
             LOG.error("Null listener when initializing cnx manager");
         }
-        int port = peers.get(peer.getId()).electionAddr.getPort();
-        LOG.info("Election port: " + port);
+        InetSocketAddress address = peers.get(peer.getId()).electionAddr.getValidAddress();
+        LOG.info("Election port: " + address.getPort());
         Thread.sleep(1000);
 
         Socket sock = new Socket();
-        sock.connect(peers.get(1L).electionAddr, 5000);
+        sock.connect(address, 5000);
         long begin = Time.currentElapsedTime();
         // Read without sending data. Verify timeout.
         cnxManager.receiveConnection(sock);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/LENonTerminateTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/LENonTerminateTest.java
@@ -101,7 +101,7 @@ public class LENonTerminateTest extends ZKTestCase {
                 {
                     LOG.info("Server address: " + server.addr);
                     try {
-                        requestPacket.setSocketAddress(server.addr);
+                        requestPacket.setSocketAddress(server.addr.getValidAddress());
                     } catch (IllegalArgumentException e) {
                         // Sun doesn't include the address that causes this
                         // exception to be thrown, so we wrap the exception
@@ -355,8 +355,8 @@ public class LENonTerminateTest extends ZKTestCase {
         byte b[] = new byte[36];
         ByteBuffer responseBuffer = ByteBuffer.wrap(b);
         DatagramPacket packet = new DatagramPacket(b, b.length);
-        QuorumServer server = peers.get(Long.valueOf(2));
-        DatagramSocket udpSocket = new DatagramSocket(server.addr.getPort());
+        QuorumServer server = peers.get(2L);
+        DatagramSocket udpSocket = new DatagramSocket(server.addr.getAllPorts().get(0));
         LOG.info("In MockServer");
         mockLatch.countDown();
         Vote current = new Vote(2, 1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumUtil.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumUtil.java
@@ -148,7 +148,7 @@ public class QuorumUtil {
 
         LOG.info("Checking ports " + hostPort);
         for (String hp : hostPort.split(",")) {
-            Assert.assertTrue("waiting for server up", ClientBase.waitForServerUp(hp,
+            Assert.assertTrue("waiting for server " + hp + " up", ClientBase.waitForServerUp(hp,
                     ClientBase.CONNECTION_TIMEOUT));
             LOG.info(hp + " is accepting client connections");
         }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigExceptionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigExceptionTest.java
@@ -204,8 +204,8 @@ public class ReconfigExceptionTest extends ZKTestCase {
             leaderId++;
         int followerId = leaderId == 1 ? 2 : 1;
         joiningServers.add("server." + followerId + "=localhost:"
-                + qu.getPeer(followerId).peer.getQuorumAddress().getPort() /*quorum port*/
-                + ":" + qu.getPeer(followerId).peer.getElectionAddress().getPort() /*election port*/
+                + qu.getPeer(followerId).peer.getQuorumAddress().getAllPorts().get(0) /*quorum port*/
+                + ":" + qu.getPeer(followerId).peer.getElectionAddress().getAllPorts().get(0) /*election port*/
                 + ":participant;localhost:" + PortAssignment.unique()/* new client port */);
         zkAdmin.reconfigure(joiningServers, null, null, -1, new Stat());
         return true;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigMisconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigMisconfigTest.java
@@ -119,8 +119,8 @@ public class ReconfigMisconfigTest extends ZKTestCase {
             leaderId++;
         int followerId = leaderId == 1 ? 2 : 1;
         joiningServers.add("server." + followerId + "=localhost:"
-                + qu.getPeer(followerId).peer.getQuorumAddress().getPort() /*quorum port*/
-                + ":" + qu.getPeer(followerId).peer.getElectionAddress().getPort() /*election port*/
+                + qu.getPeer(followerId).peer.getQuorumAddress().getAllPorts().get(0) /*quorum port*/
+                + ":" + qu.getPeer(followerId).peer.getElectionAddress().getAllPorts().get(0) /*election port*/
                 + ":participant;localhost:" + PortAssignment.unique()/* new client port */);
         zkAdmin.reconfigure(joiningServers, null, null, -1, new Stat());
         return true;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
@@ -138,12 +138,13 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         String configStr = new String(config);
         if (joiningServers != null) {
             for (String joiner : joiningServers) {
-               Assert.assertTrue(configStr.contains(joiner));
+                Assert.assertTrue("Config:<" + configStr + ">\n" + joiner, configStr.contains(joiner));
             }
         }
         if (leavingServers != null) {
             for (String leaving : leavingServers)
-                Assert.assertFalse(configStr.contains("server.".concat(leaving)));
+                Assert.assertFalse("Config:<" + configStr + ">\n" + leaving,
+                        configStr.contains("server.".concat(leaving)));
         }
 
         return configStr;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
@@ -284,11 +284,10 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
             joiningServers.add("server."
                     + leavingIndex
                     + "=localhost:"
-                    + qu.getPeer(leavingIndex).peer.getQuorumAddress()
-                            .getPort()
+                    + qu.getPeer(leavingIndex).peer.getQuorumAddress().getAllPorts().get(0)
                     + ":"
-                    + qu.getPeer(leavingIndex).peer.getElectionAddress()
-                            .getPort() + ":participant;localhost:"
+                    + qu.getPeer(leavingIndex).peer.getElectionAddress().getAllPorts().get(0)
+                    + ":participant;localhost:"
                     + qu.getPeer(leavingIndex).peer.getClientPort());
 
             String configStr = reconfig(zkAdmin1, null, leavingServers, null, -1);
@@ -363,17 +362,17 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
 
         // remember these servers so we can add them back later
         joiningServers.add("server." + leavingIndex1 + "=localhost:"
-                + qu.getPeer(leavingIndex1).peer.getQuorumAddress().getPort()
+                + qu.getPeer(leavingIndex1).peer.getQuorumAddress().getAllPorts().get(0)
                 + ":"
-                + qu.getPeer(leavingIndex1).peer.getElectionAddress().getPort()
+                + qu.getPeer(leavingIndex1).peer.getElectionAddress().getAllPorts().get(0)
                 + ":participant;localhost:"
                 + qu.getPeer(leavingIndex1).peer.getClientPort());
 
         // this server will be added back as an observer
         joiningServers.add("server." + leavingIndex2 + "=localhost:"
-                + qu.getPeer(leavingIndex2).peer.getQuorumAddress().getPort()
+                + qu.getPeer(leavingIndex2).peer.getQuorumAddress().getAllPorts().get(0)
                 + ":"
-                + qu.getPeer(leavingIndex2).peer.getElectionAddress().getPort()
+                + qu.getPeer(leavingIndex2).peer.getElectionAddress().getAllPorts().get(0)
                 + ":observer;localhost:"
                 + qu.getPeer(leavingIndex2).peer.getClientPort());
 
@@ -547,11 +546,10 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
             joiningServers.add("server."
                     + changingIndex
                     + "=localhost:"
-                    + qu.getPeer(changingIndex).peer.getQuorumAddress()
-                            .getPort()
+                    + qu.getPeer(changingIndex).peer.getQuorumAddress().getAllPorts().get(0)
                     + ":"
-                    + qu.getPeer(changingIndex).peer.getElectionAddress()
-                            .getPort() + ":" + newRole + ";localhost:"
+                    + qu.getPeer(changingIndex).peer.getElectionAddress().getAllPorts().get(0)
+                    + ":" + newRole + ";localhost:"
                     + qu.getPeer(changingIndex).peer.getClientPort());
 
             reconfig(zkAdmin1, joiningServers, null, null, -1);
@@ -599,8 +597,8 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
 
         // modify follower's client port
 
-        int quorumPort = qu.getPeer(followerIndex).peer.getQuorumAddress().getPort();
-        int electionPort = qu.getPeer(followerIndex).peer.getElectionAddress().getPort(); 
+        int quorumPort = qu.getPeer(followerIndex).peer.getQuorumAddress().getAllPorts().get(0);
+        int electionPort = qu.getPeer(followerIndex).peer.getElectionAddress().getAllPorts().get(0);
         int oldClientPort = qu.getPeer(followerIndex).peer.getClientPort();
         int newClientPort = PortAssignment.unique();
         joiningServers.add("server." + followerIndex + "=localhost:" + quorumPort
@@ -668,7 +666,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         joiningServers.add("server." + leaderIndex + "=localhost:"
                 + newQuorumPort
                 + ":"
-                + qu.getPeer(leaderIndex).peer.getElectionAddress().getPort()
+                + qu.getPeer(leaderIndex).peer.getElectionAddress().getAllPorts().get(0)
                 + ":participant;localhost:"
                 + qu.getPeer(leaderIndex).peer.getClientPort());
 
@@ -676,8 +674,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
 
         testNormalOperation(zkArr[followerIndex], zkArr[leaderIndex]);
 
-        Assert.assertTrue(qu.getPeer(leaderIndex).peer.getQuorumAddress()
-                .getPort() == newQuorumPort);
+        Assert.assertEquals((int) qu.getPeer(leaderIndex).peer.getQuorumAddress().getAllPorts().get(0), newQuorumPort);
 
         joiningServers.clear();
 
@@ -685,7 +682,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
 
         for (int i = 1; i <= 3; i++) {
             joiningServers.add("server." + i + "=localhost:"
-                    + qu.getPeer(i).peer.getQuorumAddress().getPort() + ":"
+                    + qu.getPeer(i).peer.getQuorumAddress().getAllPorts().get(0) + ":"
                     + PortAssignment.unique() + ":participant;localhost:"
                     + qu.getPeer(i).peer.getClientPort());
         }
@@ -733,8 +730,8 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         int reconfigIndex = testLeader ? followerIndex : leaderIndex;
 
         // modify server's client port
-        int quorumPort = qu.getPeer(serverIndex).peer.getQuorumAddress().getPort();
-        int electionPort = qu.getPeer(serverIndex).peer.getElectionAddress().getPort();
+        int quorumPort = qu.getPeer(serverIndex).peer.getQuorumAddress().getAllPorts().get(0);
+        int electionPort = qu.getPeer(serverIndex).peer.getElectionAddress().getAllPorts().get(0);
         int oldClientPort = qu.getPeer(serverIndex).peer.getClientPort();
         int newClientPort = PortAssignment.unique();
 
@@ -832,8 +829,8 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
 
         for (int i = 1; i <= 5; i++) {
             members.add("server." + i + "=127.0.0.1:"
-                    + qu.getPeer(i).peer.getQuorumAddress().getPort() + ":"
-                    + qu.getPeer(i).peer.getElectionAddress().getPort() + ";"
+                    + qu.getPeer(i).peer.getQuorumAddress().getAllPorts().get(0) + ":"
+                    + qu.getPeer(i).peer.getElectionAddress().getAllPorts().get(0) + ";"
                     + "127.0.0.1:" + qu.getPeer(i).peer.getClientPort());
         }
 
@@ -864,8 +861,8 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         members.clear();
         for (int i = 1; i <= 3; i++) {
             members.add("server." + i + "=127.0.0.1:"
-                    + qu.getPeer(i).peer.getQuorumAddress().getPort() + ":"
-                    + qu.getPeer(i).peer.getElectionAddress().getPort() + ";"
+                    + qu.getPeer(i).peer.getQuorumAddress().getAllPorts().get(0) + ":"
+                    + qu.getPeer(i).peer.getElectionAddress().getAllPorts().get(0) + ";"
                     + "127.0.0.1:" + qu.getPeer(i).peer.getClientPort());
         }
 
@@ -946,9 +943,9 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
 
         // remember this server so we can add it back later
         joiningServers.add("server." + leavingIndex + "=127.0.0.1:"
-                + qu.getPeer(leavingIndex).peer.getQuorumAddress().getPort()
+                + qu.getPeer(leavingIndex).peer.getQuorumAddress().getAllPorts().get(0)
                 + ":"
-                + qu.getPeer(leavingIndex).peer.getElectionAddress().getPort()
+                + qu.getPeer(leavingIndex).peer.getElectionAddress().getAllPorts().get(0)
                 + ":participant;127.0.0.1:"
                 + qu.getPeer(leavingIndex).peer.getClientPort());
 
@@ -1026,9 +1023,9 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
 
         // exactly as it is now, except for role change
         joiningServers.add("server." + changingIndex + "=127.0.0.1:"
-                + qu.getPeer(changingIndex).peer.getQuorumAddress().getPort()
+                + qu.getPeer(changingIndex).peer.getQuorumAddress().getAllPorts().get(0)
                 + ":"
-                + qu.getPeer(changingIndex).peer.getElectionAddress().getPort()
+                + qu.getPeer(changingIndex).peer.getElectionAddress().getAllPorts().get(0)
                 + ":" + newRole + ";127.0.0.1:"
                 + qu.getPeer(changingIndex).peer.getClientPort());
 
@@ -1067,7 +1064,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
                 qp.getClientAddress().getHostString() + ":" + qp.getClientAddress().getPort(),
                 JMXEnv.ensureBeanAttribute(beanName, "ClientAddress"));
         Assert.assertEquals("Mismatches LearnerType!",
-                qp.getElectionAddress().getHostString() + ":" + qp.getElectionAddress().getPort(),
+                qp.getElectionAddress().getAllAddresses().get(0).getHostString() + ":" + qp.getElectionAddress().getAllAddresses().get(0).getPort(),
                 JMXEnv.ensureBeanAttribute(beanName, "ElectionAddress"));
         Assert.assertEquals("Mismatches PartOfEnsemble!", isPartOfEnsemble,
                 JMXEnv.ensureBeanAttribute(beanName, "PartOfEnsemble"));
@@ -1105,10 +1102,10 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
                 getNumericalAddrPort(qs.clientAddr.getHostString() + ":" + qs.clientAddr.getPort()),
                 getAddrPortFromBean(beanName, "ClientAddress") );
         Assert.assertEquals("Mismatches ElectionAddress!",
-                getNumericalAddrPort(qs.electionAddr.getHostString() + ":" + qs.electionAddr.getPort()),
+                getNumericalAddrPort(qs.electionAddr.getAllAddresses().get(0).getHostString() + ":" + qs.electionAddr.getAllAddresses().get(0).getPort()),
                 getAddrPortFromBean(beanName, "ElectionAddress") );
         Assert.assertEquals("Mismatches QuorumAddress!",
-                getNumericalAddrPort(qs.addr.getHostString() + ":" + qs.addr.getPort()),
+                getNumericalAddrPort(qs.addr.getAllAddresses().get(0).getHostString() + ":" + qs.addr.getAllAddresses().get(0).getPort()),
                 getAddrPortFromBean(beanName, "QuorumAddress") );
     }
 }


### PR DESCRIPTION
According to issue [ZOOKEEPER-3188](https://issues.apache.org/jira/browse/ZOOKEEPER-3188) added ability to specify several addresses for quorum operations. Also added reconnection attempts if connection to leader lost.