### PR TITLE
ZOOKEEPER-3172: Quorum TLS - fix port unification to allow rolling upgrades

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKConfig.java
@@ -130,6 +130,8 @@ public class ZKConfig {
                 System.getProperty(x509Util.getSslCrlEnabledProperty()));
         properties.put(x509Util.getSslOcspEnabledProperty(),
                 System.getProperty(x509Util.getSslOcspEnabledProperty()));
+        properties.put(x509Util.getSslHandshakeDetectionTimeoutMillisProperty(),
+                System.getProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty()));
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -41,7 +41,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.security.sasl.SaslException;
 
 import org.apache.zookeeper.ZooDefs.OpCode;
-import org.apache.zookeeper.common.QuorumX509Util;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.server.FinalRequestProcessor;
@@ -238,15 +237,15 @@ public class Leader {
         try {
             if (self.shouldUsePortUnification()) {
                 if (self.getQuorumListenOnAllIPs()) {
-                    ss = new UnifiedServerSocket(new QuorumX509Util(), self.getQuorumAddress().getPort());
+                    ss = new UnifiedServerSocket(self.getX509Util(), true, self.getQuorumAddress().getPort());
                 } else {
-                    ss = new UnifiedServerSocket(new QuorumX509Util());
+                    ss = new UnifiedServerSocket(self.getX509Util(), true);
                 }
             } else if (self.isSslQuorum()) {
                 if (self.getQuorumListenOnAllIPs()) {
-                    ss = new QuorumX509Util().createSSLServerSocket(self.getQuorumAddress().getPort());
+                    ss = self.getX509Util().createSSLServerSocket(self.getQuorumAddress().getPort());
                 } else {
-                    ss = new QuorumX509Util().createSSLServerSocket();
+                    ss = self.getX509Util().createSSLServerSocket();
                 }
             } else {
                 if (self.getQuorumListenOnAllIPs()) {
@@ -397,8 +396,10 @@ public class Leader {
         public void run() {
             try {
                 while (!stop) {
-                    try{
-                        Socket s = ss.accept();
+                    Socket s = null;
+                    boolean error = false;
+                    try {
+                        s = ss.accept();
 
                         // start with the initLimit, once the ack is processed
                         // in LearnerHandler switch to the syncLimit
@@ -410,6 +411,7 @@ public class Leader {
                         LearnerHandler fh = new LearnerHandler(s, is, Leader.this);
                         fh.start();
                     } catch (SocketException e) {
+                        error = true;
                         if (stop) {
                             LOG.info("exception while shutting down acceptor: "
                                     + e);
@@ -423,6 +425,19 @@ public class Leader {
                         }
                     } catch (SaslException e){
                         LOG.error("Exception while connecting to quorum learner", e);
+                        error = true;
+                    } catch (Exception e) {
+                        error = true;
+                        throw e;
+                    } finally {
+                        // Don't leak sockets on errors
+                        if (error && s != null && !s.isClosed()) {
+                            try {
+                                s.close();
+                            } catch (IOException e) {
+                                LOG.warn("Error closing socket", e);
+                            }
+                        }
                     }
                 }
             } catch (Exception e) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -33,17 +33,15 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.net.ssl.SSLSocket;
+
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
 import org.apache.jute.Record;
-import org.apache.zookeeper.common.QuorumX509Util;
-import org.apache.zookeeper.common.X509Exception;
-import org.apache.zookeeper.common.X509Util;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.ZooDefs.OpCode;
+import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ZooTrace;
@@ -53,8 +51,8 @@ import org.apache.zookeeper.server.util.SerializeUtils;
 import org.apache.zookeeper.server.util.ZxidUtils;
 import org.apache.zookeeper.txn.SetDataTxn;
 import org.apache.zookeeper.txn.TxnHeader;
-
-import javax.net.ssl.SSLSocket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is the superclass of two of the three main actors in a ZK
@@ -73,8 +71,6 @@ public class Learner {
     
     protected Socket sock;
 
-    protected X509Util x509Util;
-    
     /**
      * Socket getter
      * @return 
@@ -303,10 +299,7 @@ public class Learner {
     private Socket createSocket() throws X509Exception, IOException {
         Socket sock;
         if (self.isSslQuorum()) {
-            if (x509Util == null) {
-                x509Util = new QuorumX509Util();
-            }
-            sock = x509Util.createSSLSocket();
+            sock = self.getX509Util().createSSLSocket();
         } else {
             sock = new Socket();
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/PrependableSocket.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/PrependableSocket.java
@@ -18,16 +18,15 @@
 
 package org.apache.zookeeper.server.quorum;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.SequenceInputStream;
+import java.io.PushbackInputStream;
 import java.net.Socket;
 import java.net.SocketImpl;
 
 public class PrependableSocket extends Socket {
 
-  private SequenceInputStream sequenceInputStream;
+  private PushbackInputStream pushbackInputStream;
 
   public PrependableSocket(SocketImpl base) throws IOException {
     super(base);
@@ -35,15 +34,31 @@ public class PrependableSocket extends Socket {
 
   @Override
   public InputStream getInputStream() throws IOException {
-    if (sequenceInputStream == null) {
+    if (pushbackInputStream == null) {
       return super.getInputStream();
     }
 
-    return sequenceInputStream;
+    return pushbackInputStream;
   }
 
-  public void prependToInputStream(byte[] bytes) throws IOException {
-    sequenceInputStream = new SequenceInputStream(new ByteArrayInputStream(bytes), getInputStream());
+  /**
+   * Prepend some bytes that have already been read back to the socket's input stream. Note that this method can be
+   * called at most once with a non-0 length per socket instance.
+   * @param bytes the bytes to prepend.
+   * @param offset offset in the byte array to start at.
+   * @param length number of bytes to prepend.
+   * @throws IOException if this method was already called on the socket instance, or if super.getInputStream() throws.
+   */
+  public void prependToInputStream(byte[] bytes, int offset, int length) throws IOException {
+    if (length == 0) {
+      return; // nothing to prepend
+    }
+    if (pushbackInputStream != null) {
+      throw new IOException("prependToInputStream() called more than once");
+    }
+    PushbackInputStream pushbackInputStream = new PushbackInputStream(getInputStream(), length);
+    pushbackInputStream.unread(bytes, offset, length);
+    this.pushbackInputStream = pushbackInputStream;
   }
 
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -48,6 +48,7 @@ import javax.security.sasl.SaslException;
 import org.apache.zookeeper.KeeperException.BadArgumentsException;
 import org.apache.zookeeper.common.AtomicFileWritingIdiom;
 import org.apache.zookeeper.common.AtomicFileWritingIdiom.WriterStatement;
+import org.apache.zookeeper.common.QuorumX509Util;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.jmx.MBeanRegistry;
@@ -493,6 +494,12 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
         return shouldUsePortUnification;
     }
 
+    private final QuorumX509Util x509Util;
+
+    QuorumX509Util getX509Util() {
+        return x509Util;
+    }
+
     /**
      * This is who I think the leader currently is.
      */
@@ -813,6 +820,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
         quorumStats = new QuorumStats(this);
         jmxRemotePeerBean = new HashMap<Long, RemotePeerBean>();
         adminServer = AdminServerFactory.createAdminServer();
+        x509Util = new QuorumX509Util();
         initialize();
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -307,9 +307,8 @@ public class QuorumPeerConfig {
                 }
             } else if (key.equals("sslQuorum")){
                 sslQuorum = Boolean.parseBoolean(value);
-// TODO: UnifiedServerSocket is currently buggy, will be fixed when @ivmaykov's PRs are merged. Disable port unification until then.
-//            } else if (key.equals("portUnification")){
-//                shouldUsePortUnification = Boolean.parseBoolean(value);
+            } else if (key.equals("portUnification")){
+                shouldUsePortUnification = Boolean.parseBoolean(value);
             } else if ((key.startsWith("server.") || key.startsWith("group") || key.startsWith("weight")) && zkProp.containsKey("dynamicConfigFile")) {
                 throw new ConfigException("parameter: " + key + " must be in a separate dynamic config file");
             } else if (key.equals(QuorumAuth.QUORUM_SASL_AUTH_ENABLED)) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
@@ -18,6 +18,19 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.nio.channels.SocketChannel;
+
+import javax.net.ssl.SSLSocket;
+
 import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.common.X509Util;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -25,25 +38,101 @@ import org.jboss.netty.handler.ssl.SslHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLSocket;
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.net.Socket;
-import java.net.SocketException;
-
+/**
+ * A ServerSocket that can act either as a regular ServerSocket, as a SSLServerSocket, or as both, depending on
+ * the constructor parameters and on the type of client (TLS or plaintext) that connects to it.
+ * The constructors have the same signature as constructors of ServerSocket, with the addition of two parameters
+ * at the beginning:
+ * <ul>
+ *     <li>X509Util - provides the SSL context to construct a secure socket when a client connects with TLS.</li>
+ *     <li>boolean allowInsecureConnection - when true, acts as a hybrid server socket (plaintext / TLS). When
+ *         false, acts as a SSLServerSocket (rejects plaintext connections).</li>
+ * </ul>
+ * The <code>!allowInsecureConnection</code> mode is needed so we can update the SSLContext (in particular, the
+ * key store and/or trust store) without having to re-create the server socket. By starting with a plaintext socket
+ * and delaying the upgrade to TLS until after a client has connected and begins a handshake, we can keep the same
+ * UnifiedServerSocket instance around, and replace the default SSLContext in the provided X509Util when the key store
+ * and/or trust store file changes on disk.
+ */
 public class UnifiedServerSocket extends ServerSocket {
     private static final Logger LOG = LoggerFactory.getLogger(UnifiedServerSocket.class);
 
     private X509Util x509Util;
+    private final boolean allowInsecureConnection;
 
-    public UnifiedServerSocket(X509Util x509Util) throws IOException {
+    /**
+     * Creates an unbound unified server socket by calling {@link ServerSocket#ServerSocket()}.
+     * Secure client connections will be upgraded to TLS once this socket detects the ClientHello message (start of a
+     * TLS handshake). Plaintext client connections will either be accepted or rejected depending on the value of
+     * the <code>allowInsecureConnection</code> parameter.
+     * @param x509Util the X509Util that provides the SSLContext to use for secure connections.
+     * @param allowInsecureConnection if true, accept plaintext connections, otherwise close them.
+     * @throws IOException if {@link ServerSocket#ServerSocket()} throws.
+     */
+    public UnifiedServerSocket(X509Util x509Util, boolean allowInsecureConnection) throws IOException {
         super();
         this.x509Util = x509Util;
+        this.allowInsecureConnection = allowInsecureConnection;
     }
 
-    public UnifiedServerSocket(X509Util x509Util, int port) throws IOException {
+    /**
+     * Creates a unified server socket bound to the specified port by calling {@link ServerSocket#ServerSocket(int)}.
+     * Secure client connections will be upgraded to TLS once this socket detects the ClientHello message (start of a
+     * TLS handshake). Plaintext client connections will either be accepted or rejected depending on the value of
+     * the <code>allowInsecureConnection</code> parameter.
+     * @param x509Util the X509Util that provides the SSLContext to use for secure connections.
+     * @param allowInsecureConnection if true, accept plaintext connections, otherwise close them.
+     * @param port the port number, or {@code 0} to use a port number that is automatically allocated.
+     * @throws IOException if {@link ServerSocket#ServerSocket(int)} throws.
+     */
+    public UnifiedServerSocket(X509Util x509Util, boolean allowInsecureConnection, int port) throws IOException {
         super(port);
         this.x509Util = x509Util;
+        this.allowInsecureConnection = allowInsecureConnection;
+    }
+
+    /**
+     * Creates a unified server socket bound to the specified port, with the specified backlog, by calling
+     * {@link ServerSocket#ServerSocket(int, int)}.
+     * Secure client connections will be upgraded to TLS once this socket detects the ClientHello message (start of a
+     * TLS handshake). Plaintext client connections will either be accepted or rejected depending on the value of
+     * the <code>allowInsecureConnection</code> parameter.
+     * @param x509Util the X509Util that provides the SSLContext to use for secure connections.
+     * @param allowInsecureConnection if true, accept plaintext connections, otherwise close them.
+     * @param port the port number, or {@code 0} to use a port number that is automatically allocated.
+     * @param backlog requested maximum length of the queue of incoming connections.
+     * @throws IOException if {@link ServerSocket#ServerSocket(int, int)} throws.
+     */
+    public UnifiedServerSocket(X509Util x509Util,
+                               boolean allowInsecureConnection,
+                               int port,
+                               int backlog) throws IOException {
+        super(port, backlog);
+        this.x509Util = x509Util;
+        this.allowInsecureConnection = allowInsecureConnection;
+    }
+
+    /**
+     * Creates a unified server socket bound to the specified port, with the specified backlog, and local IP address
+     * to bind to, by calling {@link ServerSocket#ServerSocket(int, int, InetAddress)}.
+     * Secure client connections will be upgraded to TLS once this socket detects the ClientHello message (start of a
+     * TLS handshake). Plaintext client connections will either be accepted or rejected depending on the value of
+     * the <code>allowInsecureConnection</code> parameter.
+     * @param x509Util the X509Util that provides the SSLContext to use for secure connections.
+     * @param allowInsecureConnection if true, accept plaintext connections, otherwise close them.
+     * @param port the port number, or {@code 0} to use a port number that is automatically allocated.
+     * @param backlog requested maximum length of the queue of incoming connections.
+     * @param bindAddr the local InetAddress the server will bind to.
+     * @throws IOException if {@link ServerSocket#ServerSocket(int, int, InetAddress)} throws.
+     */
+    public UnifiedServerSocket(X509Util x509Util,
+                               boolean allowInsecureConnection,
+                               int port,
+                               int backlog,
+                               InetAddress bindAddr) throws IOException {
+        super(port, backlog, bindAddr);
+        this.x509Util = x509Util;
+        this.allowInsecureConnection = allowInsecureConnection;
     }
 
     @Override
@@ -56,24 +145,642 @@ public class UnifiedServerSocket extends ServerSocket {
         }
         final PrependableSocket prependableSocket = new PrependableSocket(null);
         implAccept(prependableSocket);
+        return new UnifiedSocket(x509Util, allowInsecureConnection, prependableSocket);
+    }
 
-        byte[] litmus = new byte[5];
-        int bytesRead = prependableSocket.getInputStream().read(litmus, 0, 5);
-        prependableSocket.prependToInputStream(litmus);
-
-        if (bytesRead == 5 && SslHandler.isEncrypted(ChannelBuffers.wrappedBuffer(litmus))) {
-            LOG.info(getInetAddress() + " attempting to connect over ssl");
-            SSLSocket sslSocket;
-            try {
-                sslSocket = x509Util.createSSLSocket(prependableSocket);
-            } catch (X509Exception e) {
-                throw new IOException("failed to create SSL context", e);
-            }
-            sslSocket.setUseClientMode(false);
-            return sslSocket;
-        } else {
-            LOG.info(getInetAddress() + " attempting to connect without ssl");
-            return prependableSocket;
+    /**
+     * The result of calling accept() on a UnifiedServerSocket. This is a Socket that doesn't know if it's
+     * using plaintext or SSL/TLS at the time when it is created. Calling a method that indicates a desire to
+     * read or write from the socket will cause the socket to detect if the connected client is attempting
+     * to establish a TLS or plaintext connection. This is done by doing a blocking read of 5 bytes off the
+     * socket and checking if the bytes look like the start of a TLS ClientHello message. If it looks like
+     * the client is attempting to connect with TLS, the internal socket is upgraded to a SSLSocket. If not,
+     * any bytes read from the socket are pushed back to the input stream, and the socket continues
+     * to be treated as a plaintext socket.
+     *
+     * The methods that trigger this behavior are:
+     * <ul>
+     *     <li>{@link UnifiedSocket#getInputStream()}</li>
+     *     <li>{@link UnifiedSocket#getOutputStream()}</li>
+     *     <li>{@link UnifiedSocket#sendUrgentData(int)}</li>
+     * </ul>
+     *
+     * Calling other socket methods (i.e option setters such as {@link Socket#setTcpNoDelay(boolean)}) does
+     * not trigger mode detection.
+     *
+     * Because detecting the mode is a potentially blocking operation, it should not be done in the
+     * accepting thread. Attempting to read from or write to the socket in the accepting thread opens the
+     * caller up to a denial-of-service attack, in which a client connects and then does nothing. This would
+     * prevent any other clients from connecting. Passing the socket returned by accept() to a separate
+     * thread which handles all read and write operations protects against this DoS attack.
+     *
+     * Callers can check if the socket has been upgraded to TLS by calling {@link UnifiedSocket#isSecureSocket()},
+     * and can get the underlying SSLSocket by calling {@link UnifiedSocket#getSslSocket()}.
+     */
+    public static class UnifiedSocket extends Socket {
+        private enum Mode {
+            UNKNOWN,
+            PLAINTEXT,
+            TLS
         }
+
+        private final X509Util x509Util;
+        private final boolean allowInsecureConnection;
+        private PrependableSocket prependableSocket;
+        private SSLSocket sslSocket;
+        private Mode mode;
+
+        /**
+         * Note: this constructor is intentionally private. The only intended caller is
+         * {@link UnifiedServerSocket#accept()}.
+         *
+         * @param x509Util
+         * @param allowInsecureConnection
+         * @param prependableSocket
+         */
+        private UnifiedSocket(X509Util x509Util, boolean allowInsecureConnection, PrependableSocket prependableSocket) {
+            this.x509Util = x509Util;
+            this.allowInsecureConnection = allowInsecureConnection;
+            this.prependableSocket = prependableSocket;
+            this.sslSocket = null;
+            this.mode = Mode.UNKNOWN;
+        }
+
+        /**
+         * Returns true if the socket mode has been determined to be TLS.
+         * @return true if the mode is TLS, false if it is UNKNOWN or PLAINTEXT.
+         */
+        public boolean isSecureSocket() {
+            return mode == Mode.TLS;
+        }
+
+        /**
+         * Returns true if the socket mode has been determined to be PLAINTEXT.
+         * @return true if the mode is PLAINTEXT, false if it is UNKNOWN or TLS.
+         */
+        public boolean isPlaintextSocket() {
+            return mode == Mode.PLAINTEXT;
+        }
+
+        /**
+         * Returns true if the socket mode is not yet known.
+         * @return true if the mode is UNKNOWN, false if it is PLAINTEXT or TLS.
+         */
+        public boolean isModeKnown() {
+            return mode != Mode.UNKNOWN;
+        }
+
+        /**
+         * Detects the socket mode, see comments at the top of the class for more details. This operation will block
+         * for up to {@link X509Util#getSslHandshakeTimeoutMillis()} milliseconds and should not be called in the
+         * accept() thread if possible.
+         * @throws IOException
+         */
+        private void detectMode() throws IOException {
+            byte[] litmus = new byte[5];
+            int oldTimeout = -1;
+            int bytesRead = 0;
+            int newTimeout = x509Util.getSslHandshakeTimeoutMillis();
+            try {
+                oldTimeout = prependableSocket.getSoTimeout();
+                prependableSocket.setSoTimeout(newTimeout);
+                bytesRead = prependableSocket.getInputStream().read(litmus, 0, litmus.length);
+            } catch (SocketTimeoutException e) {
+                // Didn't read anything within the timeout, fallthrough and assume the connection is plaintext.
+                LOG.warn("Socket mode detection timed out after " + newTimeout + " ms, assuming PLAINTEXT");
+            } finally {
+                // restore socket timeout to the old value
+                try {
+                    if (oldTimeout != -1) {
+                        prependableSocket.setSoTimeout(oldTimeout);
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Failed to restore old socket timeout value of " + oldTimeout + " ms", e);
+                }
+            }
+            if (bytesRead < 0) { // Got a EOF right away, definitely not using TLS. Fallthrough.
+                bytesRead = 0;
+            }
+
+            if (bytesRead == litmus.length && SslHandler.isEncrypted(ChannelBuffers.wrappedBuffer(litmus))) {
+                try {
+                    sslSocket = x509Util.createSSLSocket(prependableSocket, litmus);
+                } catch (X509Exception e) {
+                    throw new IOException("failed to create SSL context", e);
+                }
+                prependableSocket = null;
+                mode = Mode.TLS;
+            } else if (allowInsecureConnection) {
+                prependableSocket.prependToInputStream(litmus, 0, bytesRead);
+                mode = Mode.PLAINTEXT;
+            } else {
+                prependableSocket.close();
+                mode = Mode.PLAINTEXT;
+                throw new IOException("Blocked insecure connection attempt");
+            }
+        }
+
+        private Socket getSocketAllowUnknownMode() {
+            if (isSecureSocket()) {
+                return sslSocket;
+            } else { // Note: mode is UNKNOWN or PLAINTEXT
+                return prependableSocket;
+            }
+        }
+
+        /**
+         * Returns the underlying socket, detecting the socket mode if it is not yet known. This is a potentially
+         * blocking operation and should not be called in the accept() thread.
+         * @return the underlying socket, after the socket mode has been determined.
+         * @throws IOException
+         */
+        private Socket getSocket() throws IOException {
+            if (!isModeKnown()) {
+                detectMode();
+            }
+            if (mode == Mode.TLS) {
+                return sslSocket;
+            } else {
+                return prependableSocket;
+            }
+        }
+
+        /**
+         * Returns the underlying SSLSocket if the mode is TLS. If the mode is UNKNOWN, causes mode detection which is a
+         * potentially blocking operation. If the mode ends up being PLAINTEXT, this will throw a SocketException, so
+         * callers are advised to only call this method after checking that {@link UnifiedSocket#isSecureSocket()}
+         * returned true.
+         * @return the underlying SSLSocket if the mode is known to be TLS.
+         * @throws IOException if detecting the socket mode fails
+         * @throws SocketException if the mode is PLAINTEXT.
+         */
+        public SSLSocket getSslSocket() throws IOException {
+            if (!isModeKnown()) {
+                detectMode();
+            }
+            if (!isSecureSocket()) {
+                throw new SocketException("Socket mode is not TLS");
+            }
+            return sslSocket;
+        }
+
+        /**
+         * See {@link Socket#connect(SocketAddress)}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public void connect(SocketAddress endpoint) throws IOException {
+            getSocketAllowUnknownMode().connect(endpoint);
+        }
+
+        /**
+         * See {@link Socket#connect(SocketAddress, int)}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public void connect(SocketAddress endpoint, int timeout) throws IOException {
+            getSocketAllowUnknownMode().connect(endpoint, timeout);
+        }
+
+        /**
+         * See {@link Socket#bind(SocketAddress)}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public void bind(SocketAddress bindpoint) throws IOException {
+            getSocketAllowUnknownMode().bind(bindpoint);
+        }
+
+        /**
+         * See {@link Socket#getInetAddress()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public InetAddress getInetAddress() {
+            return getSocketAllowUnknownMode().getInetAddress();
+        }
+
+        /**
+         * See {@link Socket#getLocalAddress()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public InetAddress getLocalAddress() {
+            return getSocketAllowUnknownMode().getLocalAddress();
+        }
+
+        /**
+         * See {@link Socket#getPort()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public int getPort() {
+            return getSocketAllowUnknownMode().getPort();
+        }
+
+        /**
+         * See {@link Socket#getLocalPort()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public int getLocalPort() {
+            return getSocketAllowUnknownMode().getLocalPort();
+        }
+
+        /**
+         * See {@link Socket#getRemoteSocketAddress()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public SocketAddress getRemoteSocketAddress() {
+            return getSocketAllowUnknownMode().getRemoteSocketAddress();
+        }
+
+        /**
+         * See {@link Socket#getLocalSocketAddress()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public SocketAddress getLocalSocketAddress() {
+            return getSocketAllowUnknownMode().getLocalSocketAddress();
+        }
+
+        /**
+         * See {@link Socket#getChannel()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public SocketChannel getChannel() {
+            return getSocketAllowUnknownMode().getChannel();
+        }
+
+        /**
+         * See {@link Socket#getInputStream()}. If the socket mode has not yet been detected, the first read from the
+         * returned input stream will trigger mode detection, which is a potentially blocking operation. This means
+         * the accept() thread should avoid reading from this input stream if possible.
+         */
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return new UnifiedInputStream(this);
+        }
+
+        /**
+         * See {@link Socket#getOutputStream()}. If the socket mode has not yet been detected, the first read from the
+         * returned input stream will trigger mode detection, which is a potentially blocking operation. This means
+         * the accept() thread should avoid reading from this input stream if possible.
+         */
+        @Override
+        public OutputStream getOutputStream() throws IOException {
+            return new UnifiedOutputStream(this);
+        }
+
+        /**
+         * See {@link Socket#setTcpNoDelay(boolean)}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public void setTcpNoDelay(boolean on) throws SocketException {
+            getSocketAllowUnknownMode().setTcpNoDelay(on);
+        }
+
+        /**
+         * See {@link Socket#getTcpNoDelay()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public boolean getTcpNoDelay() throws SocketException {
+            return getSocketAllowUnknownMode().getTcpNoDelay();
+        }
+
+        /**
+         * See {@link Socket#setSoLinger(boolean, int)}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public void setSoLinger(boolean on, int linger) throws SocketException {
+            getSocketAllowUnknownMode().setSoLinger(on, linger);
+        }
+
+        /**
+         * See {@link Socket#getSoLinger()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public int getSoLinger() throws SocketException {
+            return getSocketAllowUnknownMode().getSoLinger();
+        }
+
+        /**
+         * See {@link Socket#sendUrgentData(int)}. Calling this method triggers mode detection, which is a potentially
+         * blocking operation, so it should not be done in the accept() thread.
+         */
+        @Override
+        public void sendUrgentData(int data) throws IOException {
+            getSocket().sendUrgentData(data);
+        }
+
+        /**
+         * See {@link Socket#setOOBInline(boolean)}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public void setOOBInline(boolean on) throws SocketException {
+            getSocketAllowUnknownMode().setOOBInline(on);
+        }
+
+        /**
+         * See {@link Socket#getOOBInline()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public boolean getOOBInline() throws SocketException {
+            return getSocketAllowUnknownMode().getOOBInline();
+        }
+
+        /**
+         * See {@link Socket#setSoTimeout(int)}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public synchronized void setSoTimeout(int timeout) throws SocketException {
+            getSocketAllowUnknownMode().setSoTimeout(timeout);
+        }
+
+        /**
+         * See {@link Socket#getSoTimeout()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public synchronized int getSoTimeout() throws SocketException {
+            return getSocketAllowUnknownMode().getSoTimeout();
+        }
+
+        /**
+         * See {@link Socket#setSendBufferSize(int)}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public synchronized void setSendBufferSize(int size) throws SocketException {
+            getSocketAllowUnknownMode().setSendBufferSize(size);
+        }
+
+        /**
+         * See {@link Socket#getSendBufferSize()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public synchronized int getSendBufferSize() throws SocketException {
+            return getSocketAllowUnknownMode().getSendBufferSize();
+        }
+
+        /**
+         * See {@link Socket#setReceiveBufferSize(int)}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public synchronized void setReceiveBufferSize(int size) throws SocketException {
+            getSocketAllowUnknownMode().setReceiveBufferSize(size);
+        }
+
+        /**
+         * See {@link Socket#getReceiveBufferSize()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public synchronized int getReceiveBufferSize() throws SocketException {
+            return getSocketAllowUnknownMode().getReceiveBufferSize();
+        }
+
+        /**
+         * See {@link Socket#setKeepAlive(boolean)}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public void setKeepAlive(boolean on) throws SocketException {
+            getSocketAllowUnknownMode().setKeepAlive(on);
+        }
+
+        /**
+         * See {@link Socket#getKeepAlive()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public boolean getKeepAlive() throws SocketException {
+            return getSocketAllowUnknownMode().getKeepAlive();
+        }
+
+        /**
+         * See {@link Socket#setTrafficClass(int)}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public void setTrafficClass(int tc) throws SocketException {
+            getSocketAllowUnknownMode().setTrafficClass(tc);
+        }
+
+        /**
+         * See {@link Socket#getTrafficClass()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public int getTrafficClass() throws SocketException {
+            return getSocketAllowUnknownMode().getTrafficClass();
+        }
+
+        /**
+         * See {@link Socket#setReuseAddress(boolean)}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public void setReuseAddress(boolean on) throws SocketException {
+            getSocketAllowUnknownMode().setReuseAddress(on);
+        }
+
+        /**
+         * See {@link Socket#getReuseAddress()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public boolean getReuseAddress() throws SocketException {
+            return getSocketAllowUnknownMode().getReuseAddress();
+        }
+
+        /**
+         * See {@link Socket#close()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public synchronized void close() throws IOException {
+            getSocketAllowUnknownMode().close();
+        }
+
+        /**
+         * See {@link Socket#shutdownInput()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public void shutdownInput() throws IOException {
+            getSocketAllowUnknownMode().shutdownInput();
+        }
+
+        /**
+         * See {@link Socket#shutdownOutput()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public void shutdownOutput() throws IOException {
+            getSocketAllowUnknownMode().shutdownOutput();
+        }
+
+        /**
+         * See {@link Socket#toString()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public String toString() {
+            return "UnifiedSocket[mode=" + mode.toString() + "socket=" + getSocketAllowUnknownMode().toString() + "]";
+        }
+
+        /**
+         * See {@link Socket#isConnected()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public boolean isConnected() {
+            return getSocketAllowUnknownMode().isConnected();
+        }
+
+        /**
+         * See {@link Socket#isBound()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public boolean isBound() {
+            return getSocketAllowUnknownMode().isBound();
+        }
+
+        /**
+         * See {@link Socket#isClosed()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public boolean isClosed() {
+            return getSocketAllowUnknownMode().isClosed();
+        }
+
+        /**
+         * See {@link Socket#isInputShutdown()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public boolean isInputShutdown() {
+            return getSocketAllowUnknownMode().isInputShutdown();
+        }
+
+        /**
+         * See {@link Socket#isOutputShutdown()}. Calling this method does not trigger mode detection.
+         */
+        @Override
+        public boolean isOutputShutdown() {
+            return getSocketAllowUnknownMode().isOutputShutdown();
+        }
+
+        /**
+         * See {@link Socket#setPerformancePreferences(int, int, int)}. Calling this method does not trigger
+         * mode detection.
+         */
+        @Override
+        public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+            getSocketAllowUnknownMode().setPerformancePreferences(connectionTime, latency, bandwidth);
+        }
+    }
+
+    /**
+     * An input stream for a UnifiedSocket. The first read from this stream will trigger mode detection on the
+     * underlying UnifiedSocket.
+     */
+    private static class UnifiedInputStream extends InputStream {
+        private final UnifiedSocket unifiedSocket;
+        private InputStream realInputStream;
+
+        private UnifiedInputStream(UnifiedSocket unifiedSocket) {
+            this.unifiedSocket = unifiedSocket;
+            this.realInputStream = null;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return getRealInputStream().read();
+        }
+
+        /**
+         * Note: SocketInputStream has optimized implementations of bulk-read operations, so we need to call them
+         * directly instead of relying on the base-class implementation which just calls the single-byte read() over
+         * and over. Not implementing these results in awful performance.
+         */
+        @Override
+        public int read(byte[] b) throws IOException {
+            return getRealInputStream().read(b);
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            return getRealInputStream().read(b, off, len);
+        }
+
+        private InputStream getRealInputStream() throws IOException {
+            if (realInputStream == null) {
+                // Note: The first call to getSocket() triggers mode detection which can block
+                realInputStream = unifiedSocket.getSocket().getInputStream();
+            }
+            return realInputStream;
+        }
+
+        @Override
+        public long skip(long n) throws IOException {
+            return getRealInputStream().skip(n);
+        }
+
+        @Override
+        public int available() throws IOException {
+            return getRealInputStream().available();
+        }
+
+        @Override
+        public void close() throws IOException {
+            getRealInputStream().close();
+        }
+
+        @Override
+        public synchronized void mark(int readlimit) {
+            try {
+                getRealInputStream().mark(readlimit);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public synchronized void reset() throws IOException {
+            getRealInputStream().reset();
+        }
+
+        @Override
+        public boolean markSupported() {
+            try {
+                return getRealInputStream().markSupported();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+    private static class UnifiedOutputStream extends OutputStream {
+        private final UnifiedSocket unifiedSocket;
+        private OutputStream realOutputStream;
+
+        private UnifiedOutputStream(UnifiedSocket unifiedSocket) {
+            this.unifiedSocket = unifiedSocket;
+            this.realOutputStream = null;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            getRealOutputStream().write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            getRealOutputStream().write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            getRealOutputStream().write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            getRealOutputStream().flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            getRealOutputStream().close();
+        }
+
+        private OutputStream getRealOutputStream() throws IOException {
+            if (realOutputStream == null) {
+                // Note: The first call to getSocket() triggers mode detection which can block
+                realOutputStream = unifiedSocket.getSocket().getOutputStream();
+            }
+            return realOutputStream;
+        }
+
     }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
@@ -356,6 +356,34 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
                 true);
     }
 
+    @Test
+    public void testGetSslHandshakeDetectionTimeoutMillisProperty() {
+        X509Util x509Util = new ClientX509Util();
+        Assert.assertEquals(
+                X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS,
+                x509Util.getSslHandshakeTimeoutMillis());
+        try {
+            String newPropertyString = Integer.toString(X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS + 1);
+            System.setProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty(), newPropertyString);
+            // Note: need to create a new ClientX509Util to pick up modified property value
+            Assert.assertEquals(
+                    X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS + 1,
+                    new ClientX509Util().getSslHandshakeTimeoutMillis());
+            // 0 value not allowed, will return the default
+            System.setProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty(), "0");
+            Assert.assertEquals(
+                    X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS,
+                    new ClientX509Util().getSslHandshakeTimeoutMillis());
+            // Negative value not allowed, will return the default
+            System.setProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty(), "-1");
+            Assert.assertEquals(
+                    X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS,
+                    new ClientX509Util().getSslHandshakeTimeoutMillis());
+        } finally {
+            System.clearProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty());
+        }
+    }
+
     // Warning: this will reset the x509Util
     private void setCustomCipherSuites() {
         System.setProperty(x509Util.getCipherSuitesProperty(), customCipherSuites[0] + "," + customCipherSuites[1]);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
@@ -80,7 +80,6 @@ import org.bouncycastle.util.io.pem.PemWriter;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -442,7 +441,6 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
         Assert.assertFalse(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp3, CONNECTION_TIMEOUT));
     }
 
-    @Ignore("portUnification is currently broken and disabled")
     @Test
     public void testRollingUpgrade() throws Exception {
         // Form a quorum without ssl

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/UnifiedServerSocketModeDetectionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/UnifiedServerSocketModeDetectionTest.java
@@ -1,0 +1,404 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server.quorum;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketOptions;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.common.ClientX509Util;
+import org.apache.zookeeper.common.KeyStoreFileType;
+import org.apache.zookeeper.common.X509KeyType;
+import org.apache.zookeeper.common.X509TestContext;
+import org.apache.zookeeper.common.X509Util;
+import org.apache.zookeeper.test.ClientBase;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This test makes sure that certain operations on a UnifiedServerSocket do not
+ * trigger blocking mode detection. This is necessary to ensure that the
+ * Leader's accept() thread doesn't get blocked.
+ */
+@RunWith(Parameterized.class)
+public class UnifiedServerSocketModeDetectionTest extends ZKTestCase {
+    private static final Logger LOG = LoggerFactory.getLogger(
+            UnifiedServerSocketModeDetectionTest.class);
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> params() {
+        ArrayList<Object[]> result = new ArrayList<>();
+        result.add(new Object[] { true });
+        result.add(new Object[] { false });
+        return result;
+    }
+
+    private static File tempDir;
+    private static X509TestContext x509TestContext;
+
+    private boolean useSecureClient;
+    private X509Util x509Util;
+    private UnifiedServerSocket listeningSocket;
+    private UnifiedServerSocket.UnifiedSocket serverSideSocket;
+    private Socket clientSocket;
+    private ExecutorService workerPool;
+    private int port;
+    private InetSocketAddress localServerAddress;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+        tempDir = ClientBase.createEmptyTestDir();
+        x509TestContext = X509TestContext.newBuilder()
+                .setTempDir(tempDir)
+                .setKeyStoreKeyType(X509KeyType.EC)
+                .setTrustStoreKeyType(X509KeyType.EC)
+                .build();
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        try {
+            FileUtils.deleteDirectory(tempDir);
+        } catch (IOException e) {
+            // ignore
+        }
+        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+    }
+
+    private static void forceClose(Socket s) {
+        if (s == null || s.isClosed()) {
+            return;
+        }
+        try {
+            s.close();
+        } catch (IOException e) {
+        }
+    }
+
+    private static void forceClose(ServerSocket s) {
+        if (s == null || s.isClosed()) {
+            return;
+        }
+        try {
+            s.close();
+        } catch (IOException e) {
+        }
+    }
+
+    public UnifiedServerSocketModeDetectionTest(Boolean useSecureClient) {
+        this.useSecureClient = useSecureClient;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        x509Util = new ClientX509Util();
+        x509TestContext.setSystemProperties(x509Util, KeyStoreFileType.JKS, KeyStoreFileType.JKS);
+        System.setProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty(), "100");
+        workerPool = Executors.newCachedThreadPool();
+        port = PortAssignment.unique();
+        localServerAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), port);
+        listeningSocket = new UnifiedServerSocket(x509Util, true);
+        listeningSocket.bind(localServerAddress);
+        Future<UnifiedServerSocket.UnifiedSocket> acceptFuture;
+        acceptFuture = workerPool.submit(new Callable<UnifiedServerSocket.UnifiedSocket>() {
+            @Override
+            public UnifiedServerSocket.UnifiedSocket call() throws Exception {
+                try {
+                    return (UnifiedServerSocket.UnifiedSocket) listeningSocket.accept();
+                } catch (IOException e) {
+                    LOG.error("Error in accept(): ", e);
+                    throw e;
+                }
+            }
+        });
+        if (useSecureClient) {
+            clientSocket = x509Util.createSSLSocket();
+            clientSocket.connect(localServerAddress);
+        } else {
+            clientSocket = new Socket();
+            clientSocket.connect(localServerAddress);
+            clientSocket.getOutputStream().write(new byte[] { 1, 2, 3, 4, 5 });
+        }
+        serverSideSocket = acceptFuture.get();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        x509TestContext.clearSystemProperties(x509Util);
+        System.clearProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty());
+        forceClose(listeningSocket);
+        forceClose(serverSideSocket);
+        forceClose(clientSocket);
+        workerPool.shutdown();
+        workerPool.awaitTermination(1000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testGetInetAddress() {
+        serverSideSocket.getInetAddress();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testGetLocalAddress() {
+        serverSideSocket.getLocalAddress();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testGetPort() {
+        serverSideSocket.getPort();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testGetLocalPort() {
+        serverSideSocket.getLocalPort();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testGetRemoteSocketAddress() {
+        serverSideSocket.getRemoteSocketAddress();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testGetLocalSocketAddress() {
+        serverSideSocket.getLocalSocketAddress();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testGetInputStream() throws IOException {
+        serverSideSocket.getInputStream();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testGetOutputStream() throws IOException {
+        serverSideSocket.getOutputStream();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testGetTcpNoDelay() throws IOException {
+        serverSideSocket.getTcpNoDelay();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testSetTcpNoDelay() throws IOException {
+        boolean tcpNoDelay = serverSideSocket.getTcpNoDelay();
+        tcpNoDelay = !tcpNoDelay;
+        serverSideSocket.setTcpNoDelay(tcpNoDelay);
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+        Assert.assertEquals(tcpNoDelay, serverSideSocket.getTcpNoDelay());
+    }
+
+    @Test
+    public void testGetSoLinger() throws IOException {
+        serverSideSocket.getSoLinger();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testSetSoLinger() throws IOException {
+        int soLinger = serverSideSocket.getSoLinger();
+        if (soLinger == -1) {
+            // enable it if disabled
+            serverSideSocket.setSoLinger(true, 1);
+            Assert.assertFalse(serverSideSocket.isModeKnown());
+            Assert.assertEquals(1, serverSideSocket.getSoLinger());
+        } else {
+            // disable it if enabled
+            serverSideSocket.setSoLinger(false, -1);
+            Assert.assertFalse(serverSideSocket.isModeKnown());
+            Assert.assertEquals(-1, serverSideSocket.getSoLinger());
+        }
+    }
+
+    @Test
+    public void testGetSoTimeout() throws IOException {
+        serverSideSocket.getSoTimeout();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testSetSoTimeout() throws IOException {
+        int timeout = serverSideSocket.getSoTimeout();
+        timeout = timeout + 10;
+        serverSideSocket.setSoTimeout(timeout);
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+        Assert.assertEquals(timeout, serverSideSocket.getSoTimeout());
+    }
+
+    @Test
+    public void testGetSendBufferSize() throws IOException {
+        serverSideSocket.getSendBufferSize();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testSetSendBufferSize() throws IOException {
+        serverSideSocket.setSendBufferSize(serverSideSocket.getSendBufferSize() + 1024);
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+        // Note: the new buffer size is a hint and socket implementation
+        // is free to ignore it, so we don't verify that we get back the
+        // same value.
+
+    }
+
+    @Test
+    public void testGetReceiveBufferSize() throws IOException {
+        serverSideSocket.getReceiveBufferSize();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testSetReceiveBufferSize() throws IOException {
+        serverSideSocket.setReceiveBufferSize(serverSideSocket.getReceiveBufferSize() + 1024);
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+        // Note: the new buffer size is a hint and socket implementation
+        // is free to ignore it, so we don't verify that we get back the
+        // same value.
+
+    }
+
+    @Test
+    public void testGetKeepAlive() throws IOException {
+        serverSideSocket.getKeepAlive();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testSetKeepAlive() throws IOException {
+        boolean keepAlive = serverSideSocket.getKeepAlive();
+        keepAlive = !keepAlive;
+        serverSideSocket.setKeepAlive(keepAlive);
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+        Assert.assertEquals(keepAlive, serverSideSocket.getKeepAlive());
+    }
+
+    @Test
+    public void testGetTrafficClass() throws IOException {
+        serverSideSocket.getTrafficClass();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testSetTrafficClass() throws IOException {
+        serverSideSocket.setTrafficClass(SocketOptions.IP_TOS);
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+        // Note: according to the Socket javadocs, setTrafficClass() may be
+        // ignored by socket implementations, so we don't check that the value
+        // we set is returned.
+    }
+
+    @Test
+    public void testGetReuseAddress() throws IOException {
+        serverSideSocket.getReuseAddress();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testSetReuseAddress() throws IOException {
+        boolean reuseAddress = serverSideSocket.getReuseAddress();
+        reuseAddress = !reuseAddress;
+        serverSideSocket.setReuseAddress(reuseAddress);
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+        Assert.assertEquals(reuseAddress, serverSideSocket.getReuseAddress());
+    }
+
+    @Test
+    public void testClose() throws IOException {
+        serverSideSocket.close();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testShutdownInput() throws IOException {
+        serverSideSocket.shutdownInput();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testShutdownOutput() throws IOException {
+        serverSideSocket.shutdownOutput();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testIsConnected() {
+        serverSideSocket.isConnected();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testIsBound() {
+        serverSideSocket.isBound();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testIsClosed() {
+        serverSideSocket.isClosed();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+    }
+
+    @Test
+    public void testIsInputShutdown() throws IOException {
+        serverSideSocket.isInputShutdown();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+        serverSideSocket.shutdownInput();
+        Assert.assertTrue(serverSideSocket.isInputShutdown());
+    }
+
+    @Test
+    public void testIsOutputShutdown() throws IOException {
+        serverSideSocket.isOutputShutdown();
+        Assert.assertFalse(serverSideSocket.isModeKnown());
+        serverSideSocket.shutdownOutput();
+        Assert.assertTrue(serverSideSocket.isOutputShutdown());
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/UnifiedServerSocketTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/UnifiedServerSocketTest.java
@@ -17,156 +17,584 @@
  */
 package org.apache.zookeeper.server.quorum;
 
-import org.apache.zookeeper.PortAssignment;
-import org.apache.zookeeper.client.ZKClientConfig;
-import org.apache.zookeeper.common.ClientX509Util;
-import org.apache.zookeeper.common.Time;
-import org.apache.zookeeper.common.X509Util;
-import org.apache.zookeeper.server.ServerCnxnFactory;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.HandshakeCompletedEvent;
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLSocket;
-import java.io.IOException;
-import java.net.ConnectException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.common.BaseX509ParameterizedTestCase;
+import org.apache.zookeeper.common.ClientX509Util;
+import org.apache.zookeeper.common.KeyStoreFileType;
+import org.apache.zookeeper.common.X509Exception;
+import org.apache.zookeeper.common.X509KeyType;
+import org.apache.zookeeper.common.X509TestContext;
+import org.apache.zookeeper.common.X509Util;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
-public class UnifiedServerSocketTest {
+@RunWith(Parameterized.class)
+public class UnifiedServerSocketTest extends BaseX509ParameterizedTestCase {
 
-    private static final int MAX_RETRIES = 5;
-    private static final int TIMEOUT = 1000;
-
-    private X509Util x509Util;
-    private int port;
-    private volatile boolean handshakeCompleted;
-
-    @Before
-    public void setUp() throws Exception {
-        handshakeCompleted = false;
-
-        port = PortAssignment.unique();
-
-        String testDataPath = System.getProperty("test.data.dir", "build/test/data");
-        System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY, "org.apache.zookeeper.server.NettyServerCnxnFactory");
-        System.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET, "org.apache.zookeeper.ClientCnxnSocketNetty");
-        System.setProperty(ZKClientConfig.SECURE_CLIENT, "true");
-
-        x509Util = new ClientX509Util();
-
-        System.setProperty(x509Util.getSslKeystoreLocationProperty(), testDataPath + "/ssl/testKeyStore.jks");
-        System.setProperty(x509Util.getSslKeystorePasswdProperty(), "testpass");
-        System.setProperty(x509Util.getSslTruststoreLocationProperty(), testDataPath + "/ssl/testTrustStore.jks");
-        System.setProperty(x509Util.getSslTruststorePasswdProperty(), "testpass");
-        System.setProperty(x509Util.getSslHostnameVerificationEnabledProperty(), "false");
-    }
-
-    @Test
-    public void testConnectWithSSL() throws Exception {
-        class ServerThread extends Thread {
-            public void run() {
-                try {
-                    Socket unifiedSocket = new UnifiedServerSocket(x509Util, port).accept();
-                    ((SSLSocket)unifiedSocket).getSession(); // block until handshake completes
-                } catch (IOException e) {
-                    e.printStackTrace();
+    @Parameterized.Parameters
+    public static Collection<Object[]> params() {
+        ArrayList<Object[]> result = new ArrayList<>();
+        int paramIndex = 0;
+        for (X509KeyType caKeyType : X509KeyType.values()) {
+            for (X509KeyType certKeyType : X509KeyType.values()) {
+                for (Boolean hostnameVerification : new Boolean[] { true, false  }) {
+                    result.add(new Object[]{
+                            caKeyType,
+                            certKeyType,
+                            hostnameVerification,
+                            paramIndex++
+                    });
                 }
             }
         }
-        ServerThread serverThread = new ServerThread();
-        serverThread.start();
+        return result;
+    }
 
+    private static final int MAX_RETRIES = 5;
+    private static final int TIMEOUT = 1000;
+    private static final byte[] DATA_TO_CLIENT = "hello client".getBytes();
+    private static final byte[] DATA_FROM_CLIENT = "hello server".getBytes();
+
+    private X509Util x509Util;
+    private InetSocketAddress localServerAddress;
+    private final Object handshakeCompletedLock = new Object();
+    // access only inside synchronized(handshakeCompletedLock) { ... } blocks
+    private boolean handshakeCompleted = false;
+
+    public UnifiedServerSocketTest(
+            final X509KeyType caKeyType,
+            final X509KeyType certKeyType,
+            final Boolean hostnameVerification,
+            final Integer paramIndex) {
+        super(paramIndex, () -> {
+            try {
+                return X509TestContext.newBuilder()
+                    .setTempDir(tempDir)
+                    .setKeyStoreKeyType(certKeyType)
+                    .setTrustStoreKeyType(caKeyType)
+                    .setHostnameVerification(hostnameVerification)
+                    .build();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        localServerAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), PortAssignment.unique());
+        x509Util = new ClientX509Util();
+        x509TestContext.setSystemProperties(x509Util, KeyStoreFileType.JKS, KeyStoreFileType.JKS);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        x509TestContext.clearSystemProperties(x509Util);
+    }
+
+    private static void forceClose(Socket s) {
+        if (s == null || s.isClosed()) {
+            return;
+        }
+        try {
+            s.close();
+        } catch (IOException e) {
+        }
+    }
+
+    private static void forceClose(ServerSocket s) {
+        if (s == null || s.isClosed()) {
+            return;
+        }
+        try {
+            s.close();
+        } catch (IOException e) {
+        }
+    }
+
+    private static final class UnifiedServerThread extends Thread {
+        private final byte[] dataToClient;
+        private List<byte[]> dataFromClients;
+        private ExecutorService workerPool;
+        private UnifiedServerSocket serverSocket;
+
+        UnifiedServerThread(X509Util x509Util,
+                            InetSocketAddress bindAddress,
+                            boolean allowInsecureConnection,
+                            byte[] dataToClient) throws IOException {
+            this.dataToClient = dataToClient;
+            dataFromClients = new ArrayList<>();
+            workerPool = Executors.newCachedThreadPool();
+            serverSocket = new UnifiedServerSocket(x509Util, allowInsecureConnection);
+            serverSocket.bind(bindAddress);
+        }
+
+        @Override
+        public void run() {
+            try {
+                Random rnd = new Random();
+                while (true) {
+                    final Socket unifiedSocket = serverSocket.accept();
+                    final boolean tcpNoDelay = rnd.nextBoolean();
+                    unifiedSocket.setTcpNoDelay(tcpNoDelay);
+                    unifiedSocket.setSoTimeout(TIMEOUT);
+                    final boolean keepAlive = rnd.nextBoolean();
+                    unifiedSocket.setKeepAlive(keepAlive);
+                    // Note: getting the input stream should not block the thread or trigger mode detection.
+                    BufferedInputStream bis = new BufferedInputStream(unifiedSocket.getInputStream());
+                    workerPool.submit(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                byte[] buf = new byte[1024];
+                                int bytesRead = unifiedSocket.getInputStream().read(buf, 0, 1024);
+                                // Make sure the settings applied above before the socket was potentially upgraded to
+                                // TLS still apply.
+                                Assert.assertEquals(tcpNoDelay, unifiedSocket.getTcpNoDelay());
+                                Assert.assertEquals(TIMEOUT, unifiedSocket.getSoTimeout());
+                                Assert.assertEquals(keepAlive, unifiedSocket.getKeepAlive());
+                                if (bytesRead > 0) {
+                                    byte[] dataFromClient = new byte[bytesRead];
+                                    System.arraycopy(buf, 0, dataFromClient, 0, bytesRead);
+                                    synchronized (dataFromClients) {
+                                        dataFromClients.add(dataFromClient);
+                                    }
+                                }
+                                unifiedSocket.getOutputStream().write(dataToClient);
+                                unifiedSocket.getOutputStream().flush();
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            } finally {
+                                forceClose(unifiedSocket);
+                            }
+                        }
+                    });
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            } finally {
+                forceClose(serverSocket);
+                workerPool.shutdown();
+            }
+        }
+
+        public void shutdown(long millis) throws InterruptedException {
+            forceClose(serverSocket); // this should break the run() loop
+            workerPool.awaitTermination(millis, TimeUnit.MILLISECONDS);
+            this.join(millis);
+        }
+
+        synchronized byte[] getDataFromClient(int index) {
+            return dataFromClients.get(index);
+        }
+    }
+
+    private SSLSocket connectWithSSL() throws IOException, X509Exception, InterruptedException {
         SSLSocket sslSocket = null;
         int retries = 0;
         while (retries < MAX_RETRIES) {
             try {
                 sslSocket = x509Util.createSSLSocket();
+                sslSocket.addHandshakeCompletedListener(new HandshakeCompletedListener() {
+                    @Override
+                    public void handshakeCompleted(HandshakeCompletedEvent handshakeCompletedEvent) {
+                        synchronized (handshakeCompletedLock) {
+                            handshakeCompleted = true;
+                            handshakeCompletedLock.notifyAll();
+                        }
+                    }
+                });
                 sslSocket.setSoTimeout(TIMEOUT);
-                sslSocket.connect(new InetSocketAddress(port), TIMEOUT);
+                sslSocket.connect(localServerAddress, TIMEOUT);
                 break;
             } catch (ConnectException connectException) {
                 connectException.printStackTrace();
+                forceClose(sslSocket);
+                sslSocket = null;
                 Thread.sleep(TIMEOUT);
             }
             retries++;
         }
 
-        sslSocket.addHandshakeCompletedListener(new HandshakeCompletedListener() {
-            @Override
-            public void handshakeCompleted(HandshakeCompletedEvent handshakeCompletedEvent) {
-                completeHandshake();
-            }
-        });
-        sslSocket.startHandshake();
-
-        serverThread.join(TIMEOUT);
-
-        long start = Time.currentElapsedTime();
-        while (Time.currentElapsedTime() < start + TIMEOUT) {
-            if (handshakeCompleted) {
-                return;
-            }
-        }
-
-        Assert.fail("failed to complete handshake");
+        Assert.assertNotNull("Failed to connect to server with SSL", sslSocket);
+        return sslSocket;
     }
 
-    private void completeHandshake() {
-        handshakeCompleted = true;
-    }
-
-    @Test
-    public void testConnectWithoutSSL() throws Exception {
-        final byte[] testData = "hello there".getBytes();
-        final String[] dataReadFromClient = {null};
-
-        class ServerThread extends Thread {
-            public void run() {
-                try {
-                    Socket unifiedSocket = new UnifiedServerSocket(x509Util, port).accept();
-                    unifiedSocket.getOutputStream().write(testData);
-                    unifiedSocket.getOutputStream().flush();
-                    byte[] inputbuff = new byte[5];
-                    unifiedSocket.getInputStream().read(inputbuff, 0, 5);
-                    dataReadFromClient[0] = new String(inputbuff);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-        ServerThread serverThread = new ServerThread();
-        serverThread.start();
-
+    private Socket connectWithoutSSL() throws IOException, InterruptedException {
         Socket socket = null;
         int retries = 0;
         while (retries < MAX_RETRIES) {
             try {
                 socket = new Socket();
                 socket.setSoTimeout(TIMEOUT);
-                socket.connect(new InetSocketAddress(port), TIMEOUT);
+                socket.connect(localServerAddress, TIMEOUT);
                 break;
             } catch (ConnectException connectException) {
                 connectException.printStackTrace();
+                forceClose(socket);
+                socket = null;
                 Thread.sleep(TIMEOUT);
             }
             retries++;
         }
+        Assert.assertNotNull("Failed to connect to server without SSL", socket);
+        return socket;
+    }
 
-        socket.getOutputStream().write("hellobello".getBytes());
+    // In the tests below, a "Strict" server means a UnifiedServerSocket that
+    // does not allow plaintext connections (in other words, it's SSL-only).
+    // A "Non Strict" server means a UnifiedServerSocket that allows both
+    // plaintext and SSL incoming connections.
+
+    /**
+     * Attempting to connect to a SSL-or-plaintext server with SSL should work.
+     */
+    @Test
+    public void testConnectWithSSLToNonStrictServer() throws Exception {
+        UnifiedServerThread serverThread = new UnifiedServerThread(
+                x509Util, localServerAddress, true, DATA_TO_CLIENT);
+        serverThread.start();
+
+        Socket sslSocket = connectWithSSL();
+        try {
+            sslSocket.getOutputStream().write(DATA_FROM_CLIENT);
+            sslSocket.getOutputStream().flush();
+            byte[] buf = new byte[DATA_TO_CLIENT.length];
+            int bytesRead = sslSocket.getInputStream().read(buf, 0, buf.length);
+            Assert.assertEquals(buf.length, bytesRead);
+            Assert.assertArrayEquals(DATA_TO_CLIENT, buf);
+
+            synchronized (handshakeCompletedLock) {
+                if (!handshakeCompleted) {
+                    handshakeCompletedLock.wait(TIMEOUT);
+                }
+                Assert.assertTrue(handshakeCompleted);
+            }
+            Assert.assertArrayEquals(DATA_FROM_CLIENT, serverThread.getDataFromClient(0));
+        } finally {
+            forceClose(sslSocket);
+            serverThread.shutdown(TIMEOUT);
+        }
+    }
+
+    /**
+     * Attempting to connect to a SSL-only server with SSL should work.
+     */
+    @Test
+    public void testConnectWithSSLToStrictServer() throws Exception {
+        UnifiedServerThread serverThread = new UnifiedServerThread(
+                x509Util, localServerAddress, false, DATA_TO_CLIENT);
+        serverThread.start();
+
+        Socket sslSocket = connectWithSSL();
+        try {
+            sslSocket.getOutputStream().write(DATA_FROM_CLIENT);
+            sslSocket.getOutputStream().flush();
+            byte[] buf = new byte[DATA_TO_CLIENT.length];
+            int bytesRead = sslSocket.getInputStream().read(buf, 0, buf.length);
+            Assert.assertEquals(buf.length, bytesRead);
+            Assert.assertArrayEquals(DATA_TO_CLIENT, buf);
+
+            synchronized (handshakeCompletedLock) {
+                if (!handshakeCompleted) {
+                    handshakeCompletedLock.wait(TIMEOUT);
+                }
+                Assert.assertTrue(handshakeCompleted);
+            }
+
+            Assert.assertArrayEquals(DATA_FROM_CLIENT, serverThread.getDataFromClient(0));
+        } finally {
+            forceClose(sslSocket);
+            serverThread.shutdown(TIMEOUT);
+        }
+    }
+
+    /**
+     * Attempting to connect to a SSL-or-plaintext server without SSL should work.
+     */
+    @Test
+    public void testConnectWithoutSSLToNonStrictServer() throws Exception {
+        UnifiedServerThread serverThread = new UnifiedServerThread(
+                x509Util, localServerAddress, true, DATA_TO_CLIENT);
+        serverThread.start();
+
+        Socket socket = connectWithoutSSL();
+        try {
+            socket.getOutputStream().write(DATA_FROM_CLIENT);
+            socket.getOutputStream().flush();
+            byte[] buf = new byte[DATA_TO_CLIENT.length];
+            int bytesRead = socket.getInputStream().read(buf, 0, buf.length);
+            Assert.assertEquals(buf.length, bytesRead);
+            Assert.assertArrayEquals(DATA_TO_CLIENT, buf);
+            Assert.assertArrayEquals(DATA_FROM_CLIENT, serverThread.getDataFromClient(0));
+        } finally {
+            forceClose(socket);
+            serverThread.shutdown(TIMEOUT);
+        }
+    }
+
+    /**
+     * Attempting to connect to a SSL-or-plaintext server without SSL with a
+     * small initial data write should work. This makes sure that sending
+     * less than 5 bytes does not break the logic in the server's initial 5
+     * byte read.
+     */
+    @Test
+    public void testConnectWithoutSSLToNonStrictServerPartialWrite() throws Exception {
+        UnifiedServerThread serverThread = new UnifiedServerThread(
+                x509Util, localServerAddress, true, DATA_TO_CLIENT);
+        serverThread.start();
+
+        Socket socket = connectWithoutSSL();
+        try {
+            // Write only 2 bytes of the message, wait a bit, then write the rest.
+            // This makes sure that writes smaller than 5 bytes don't break the plaintext mode on the server
+            // once it decides that the input doesn't look like a TLS handshake.
+            socket.getOutputStream().write(DATA_FROM_CLIENT, 0, 2);
+            socket.getOutputStream().flush();
+            Thread.sleep(TIMEOUT / 2);
+            socket.getOutputStream().write(DATA_FROM_CLIENT, 2, DATA_FROM_CLIENT.length - 2);
+            socket.getOutputStream().flush();
+            byte[] buf = new byte[DATA_TO_CLIENT.length];
+            int bytesRead = socket.getInputStream().read(buf, 0, buf.length);
+            Assert.assertEquals(buf.length, bytesRead);
+            Assert.assertArrayEquals(DATA_TO_CLIENT, buf);
+            Assert.assertArrayEquals(DATA_FROM_CLIENT, serverThread.getDataFromClient(0));
+        } finally {
+            forceClose(socket);
+            serverThread.shutdown(TIMEOUT);
+        }
+    }
+
+    /**
+     * Attempting to connect to a SSL-only server without SSL should fail.
+     */
+    @Test
+    public void testConnectWithoutSSLToStrictServer() throws Exception {
+        UnifiedServerThread serverThread = new UnifiedServerThread(
+                x509Util, localServerAddress, false, DATA_TO_CLIENT);
+        serverThread.start();
+
+        Socket socket = connectWithoutSSL();
+        socket.getOutputStream().write(DATA_FROM_CLIENT);
         socket.getOutputStream().flush();
+        byte[] buf = new byte[DATA_TO_CLIENT.length];
+        try {
+            socket.getInputStream().read(buf, 0, buf.length);
+        } catch (SocketException e) {
+            // We expect the other end to hang up the connection
+            return;
+        } finally {
+            forceClose(socket);
+            serverThread.shutdown(TIMEOUT);
+        }
+        Assert.fail("Expected server to hang up the connection. Read from server succeeded unexpectedly.");
+    }
 
-        byte[] readBytes = new byte[testData.length];
-        socket.getInputStream().read(readBytes, 0, testData.length);
+    /**
+     * This test makes sure that UnifiedServerSocket used properly (a single
+     * thread accept()-ing connections and handing the resulting sockets to
+     * other threads for processing) is not vulnerable to blocking the
+     * accept() thread while doing mode detection if a misbehaving client
+     * connects. A misbehaving client is one that either disconnects
+     * immediately, or connects but does not send any data.
+     *
+     * This version of the test uses a non-strict server socket (i.e. it
+     * accepts both TLS and plaintext connections).
+     */
+    @Test
+    public void testTLSDetectionNonBlockingNonStrictServerIdleClient() throws Exception {
+        Socket badClientSocket = null;
+        Socket clientSocket = null;
+        Socket secureClientSocket = null;
+        UnifiedServerThread serverThread = new UnifiedServerThread(
+                x509Util, localServerAddress, true, DATA_TO_CLIENT);
+        serverThread.start();
 
-        serverThread.join(TIMEOUT);
+        try {
+            badClientSocket = connectWithoutSSL(); // Leave the bad client socket idle
 
-        Assert.assertArrayEquals(testData, readBytes);
-        assertThat("Data sent by the client is invalid", dataReadFromClient[0], equalTo("hello"));
+            clientSocket = connectWithoutSSL();
+            clientSocket.getOutputStream().write(DATA_FROM_CLIENT);
+            clientSocket.getOutputStream().flush();
+            byte[] buf = new byte[DATA_TO_CLIENT.length];
+            int bytesRead = clientSocket.getInputStream().read(buf, 0, buf.length);
+            Assert.assertEquals(buf.length, bytesRead);
+            Assert.assertArrayEquals(DATA_TO_CLIENT, buf);
+            Assert.assertArrayEquals(DATA_FROM_CLIENT, serverThread.getDataFromClient(0));
+
+            synchronized (handshakeCompletedLock) {
+                Assert.assertFalse(handshakeCompleted);
+            }
+
+            secureClientSocket = connectWithSSL();
+            secureClientSocket.getOutputStream().write(DATA_FROM_CLIENT);
+            secureClientSocket.getOutputStream().flush();
+            buf = new byte[DATA_TO_CLIENT.length];
+            bytesRead = secureClientSocket.getInputStream().read(buf, 0, buf.length);
+            Assert.assertEquals(buf.length, bytesRead);
+            Assert.assertArrayEquals(DATA_TO_CLIENT, buf);
+            Assert.assertArrayEquals(DATA_FROM_CLIENT, serverThread.getDataFromClient(1));
+
+            synchronized (handshakeCompletedLock) {
+                if (!handshakeCompleted) {
+                    handshakeCompletedLock.wait(TIMEOUT);
+                }
+                Assert.assertTrue(handshakeCompleted);
+            }
+        } finally {
+            forceClose(badClientSocket);
+            forceClose(clientSocket);
+            forceClose(secureClientSocket);
+            serverThread.shutdown(TIMEOUT);
+        }
+    }
+
+    /**
+     * Like the above test, but with a strict server socket (closes non-TLS
+     * connections after seeing that there is no handshake).
+     */
+    @Test
+    public void testTLSDetectionNonBlockingStrictServerIdleClient() throws Exception {
+        Socket badClientSocket = null;
+        Socket secureClientSocket = null;
+        UnifiedServerThread serverThread = new UnifiedServerThread(
+                x509Util, localServerAddress, false, DATA_TO_CLIENT);
+        serverThread.start();
+
+        try {
+            badClientSocket = connectWithoutSSL(); // Leave the bad client socket idle
+
+            secureClientSocket = connectWithSSL();
+            secureClientSocket.getOutputStream().write(DATA_FROM_CLIENT);
+            secureClientSocket.getOutputStream().flush();
+            byte[] buf = new byte[DATA_TO_CLIENT.length];
+            int bytesRead = secureClientSocket.getInputStream().read(buf, 0, buf.length);
+            Assert.assertEquals(buf.length, bytesRead);
+            Assert.assertArrayEquals(DATA_TO_CLIENT, buf);
+
+            synchronized (handshakeCompletedLock) {
+                if (!handshakeCompleted) {
+                    handshakeCompletedLock.wait(TIMEOUT);
+                }
+                Assert.assertTrue(handshakeCompleted);
+            }
+            Assert.assertArrayEquals(DATA_FROM_CLIENT, serverThread.getDataFromClient(0));
+        } finally {
+            forceClose(badClientSocket);
+            forceClose(secureClientSocket);
+            serverThread.shutdown(TIMEOUT);
+        }
+    }
+
+    /**
+     * Similar to the tests above, but the bad client disconnects immediately
+     * without sending any data.
+     */
+    @Test
+    public void testTLSDetectionNonBlockingNonStrictServerDisconnectedClient() throws Exception {
+        Socket clientSocket = null;
+        Socket secureClientSocket = null;
+        UnifiedServerThread serverThread = new UnifiedServerThread(
+                x509Util, localServerAddress, true, DATA_TO_CLIENT);
+        serverThread.start();
+
+        try {
+            Socket badClientSocket = connectWithoutSSL();
+            forceClose(badClientSocket); // close the bad client socket immediately
+
+            clientSocket = connectWithoutSSL();
+            clientSocket.getOutputStream().write(DATA_FROM_CLIENT);
+            clientSocket.getOutputStream().flush();
+            byte[] buf = new byte[DATA_TO_CLIENT.length];
+            int bytesRead = clientSocket.getInputStream().read(buf, 0, buf.length);
+            Assert.assertEquals(buf.length, bytesRead);
+            Assert.assertArrayEquals(DATA_TO_CLIENT, buf);
+            Assert.assertArrayEquals(DATA_FROM_CLIENT, serverThread.getDataFromClient(0));
+
+            synchronized (handshakeCompletedLock) {
+                Assert.assertFalse(handshakeCompleted);
+            }
+
+            secureClientSocket = connectWithSSL();
+            secureClientSocket.getOutputStream().write(DATA_FROM_CLIENT);
+            secureClientSocket.getOutputStream().flush();
+            buf = new byte[DATA_TO_CLIENT.length];
+            bytesRead = secureClientSocket.getInputStream().read(buf, 0, buf.length);
+            Assert.assertEquals(buf.length, bytesRead);
+            Assert.assertArrayEquals(DATA_TO_CLIENT, buf);
+            Assert.assertArrayEquals(DATA_FROM_CLIENT, serverThread.getDataFromClient(1));
+
+            synchronized (handshakeCompletedLock) {
+                if (!handshakeCompleted) {
+                    handshakeCompletedLock.wait(TIMEOUT);
+                }
+                Assert.assertTrue(handshakeCompleted);
+            }
+        } finally {
+            forceClose(clientSocket);
+            forceClose(secureClientSocket);
+            serverThread.shutdown(TIMEOUT);
+        }
+    }
+
+    /**
+     * Like the above test, but with a strict server socket (closes non-TLS
+     * connections after seeing that there is no handshake).
+     */
+    @Test
+    public void testTLSDetectionNonBlockingStrictServerDisconnectedClient() throws Exception {
+        Socket secureClientSocket = null;
+        UnifiedServerThread serverThread = new UnifiedServerThread(
+                x509Util, localServerAddress, false, DATA_TO_CLIENT);
+        serverThread.start();
+
+        try {
+            Socket badClientSocket = connectWithoutSSL();
+            forceClose(badClientSocket); // close the bad client socket immediately
+
+            secureClientSocket = connectWithSSL();
+            secureClientSocket.getOutputStream().write(DATA_FROM_CLIENT);
+            secureClientSocket.getOutputStream().flush();
+            byte[] buf = new byte[DATA_TO_CLIENT.length];
+            int bytesRead = secureClientSocket.getInputStream().read(buf, 0, buf.length);
+            Assert.assertEquals(buf.length, bytesRead);
+            Assert.assertArrayEquals(DATA_TO_CLIENT, buf);
+
+            synchronized (handshakeCompletedLock) {
+                if (!handshakeCompleted) {
+                    handshakeCompletedLock.wait(TIMEOUT);
+                }
+                Assert.assertTrue(handshakeCompleted);
+            }
+            Assert.assertArrayEquals(DATA_FROM_CLIENT, serverThread.getDataFromClient(0));
+        } finally {
+            forceClose(secureClientSocket);
+            serverThread.shutdown(TIMEOUT);
+        }
     }
 }


### PR DESCRIPTION
Fix numerous problems with UnifiedServerSocket, such as hanging the accept() thread when the client doesn't send any data or crashing if less than 5 bytes are read from the socket in the initial read.

Re-enable the "portUnification" config option.

## Fixed networking issues/bugs in UnifiedServerSocket

- don't crash the accept() thread if the client closes the connection without sending any data
- don't corrupt the connection if the client sends fewer than 5 bytes for the initial read
- delay the detection of TLS vs. plaintext mode until a socket stream is read from or written to. This prevents the accept() thread from getting blocked on a read() operation from the newly connected socket.
- prepending 5 bytes to PrependableSocket and then trying to read >5 bytes would only return the first 5 bytes, even if more bytes were available. This is fixed.