### PR TITLE
ZOOKEEPER-3217 owasp job flagging slf4j on trunk

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1705,6 +1705,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
                           reportoutputdirectory="${owasp.out.dir}"
                           reportformat="ALL"
                           failBuildOnCVSS="0">
+            <suppressionfile path="${basedir}/owaspSuppressions.xml" />
 
             <fileset dir="${ivy.lib}">
                 <include name="**/*.jar"/>

--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
    <suppress>
       <!-- ZOOKEEPER-3217 -->

--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+   <suppress>
+      <!-- ZOOKEEPER-3217 -->
+      <cve>CVE-2018-8088</cve>
+   </suppress>
+</suppressions>


### PR DESCRIPTION
Disable OWASP checks about slf4j.
We are not using EventData, so ZooKeeper is not subject to https://nvd.nist.gov/vuln/detail/CVE-2018-8088