### PR TITLE
ZOOKEEPER-3222. Flaky: multiple intermittent segfaults in C++ tests

### DIFF
--- a/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
@@ -669,15 +669,6 @@ public:
         CPPUNIT_ASSERT(count == 1);
         count  = 0;
         CPPUNIT_ASSERT_EQUAL((int) ZOK, zookeeper_close(zk_auth));
-        
-        // [ZOOKEEPER-800] zoo_add_auth should return ZINVALIDSTATE if
-        // the connection is closed. 
-        zhandle_t *zk2 = zookeeper_init(hostPorts, NULL, 10000, 0, NULL, 0);
-        sleep(1);
-        CPPUNIT_ASSERT_EQUAL((int) ZOK, zookeeper_close(zk2));
-        CPPUNIT_ASSERT_EQUAL(0, zoo_state(zk2)); // 0 ==> ZOO_CLOSED_STATE
-        rc = zoo_add_auth(zk2, "digest", "pat:passwd", 10, voidCompletion, (void*)ZOK);
-        CPPUNIT_ASSERT_EQUAL((int) ZINVALIDSTATE, rc);
 
         struct sockaddr addr;
         socklen_t addr_len = sizeof(addr);
@@ -1351,9 +1342,9 @@ public:
       int blen = sizeof(buf);		
       int rc;
       watchctx_t ctx;
-			zhandle_t *zk;
+      zhandle_t *zk;
 
-			/* setup path */
+      /* setup path */
       zk = createClient(&ctx);
       CPPUNIT_ASSERT(zk);
 
@@ -1408,6 +1399,8 @@ public:
       rc = zoo_remove_watches(zk, path, ZWATCHTYPE_DATA,
                                watcher_rw, NULL, 0);
       CPPUNIT_ASSERT_EQUAL((int)ZCONNECTIONLOSS, rc);
+
+      zookeeper_close(zk);
 
       /* bring the server back */
       startServer();


### PR DESCRIPTION
1. Removed the failing test case: client cannot be validated after closing.
2. Explicitly close the client before creating new.