### PR TITLE
ZOOKEEPER-3228: [TLS] Fix key usage extension in test certs

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509TestHelpers.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509TestHelpers.java
@@ -152,7 +152,7 @@ public class X509TestHelpers {
                 certPublicKey);
         builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false)); // not a CA
         builder.addExtension(
-                Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyAgreement));
+                Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment));
         builder.addExtension(
                 Extension.extendedKeyUsage,
                 true,


### PR DESCRIPTION
Key usage extension is wrong in test certs created by X509TestHelpers. This works with Java SSL stack because it allows sloppy certs, but breaks with Netty's OpenSSL stack. My Netty OpenSSL code is not ready for upstream yet, but fixing the test cert extensions is a prerequisite and can go in separately.