### PR TITLE
ZOOKEEPER-3238 - Adding noreferrer to target blank link

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-huebrowser/zkui/src/zkui/templates/tree.mako
+++ b/zookeeper-contrib/zookeeper-contrib-huebrowser/zkui/src/zkui/templates/tree.mako
@@ -69,7 +69,7 @@ ${shared.header("ZooKeeper Browser > Tree > %s > %s" % (cluster['nice_name'], pa
 </table>
 
 <br />
-<a target="_blank" href="http://zookeeper.apache.org/docs/current/zookeeperProgrammers.html#sc_zkStatStructure">Details on stat information.</a>
+<a target="_blank" rel="noopener noreferrer" href="http://zookeeper.apache.org/docs/current/zookeeperProgrammers.html#sc_zkStatStructure">Details on stat information.</a>
 
 ${shared.footer()}
 


### PR DESCRIPTION
In zookeeper-contrib-huebrowser, there is a link that uses target="_blank". Best security practise is to also add rel="noopener noreferrer". See for example: https://dev.to/ben/the-targetblank-vulnerability-by-example.

Note I did not test this as I do not use hue. However it is a fairly trivial change.