### PR TITLE
ZOOKEEPER-3250: typo in doc - zookeeperInternals

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperInternals.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperInternals.md
@@ -157,7 +157,7 @@ Leader activation includes leader election. We currently have two leader electio
 algorithms in ZooKeeper: LeaderElection and FastLeaderElection (AuthFastLeaderElection
 is a variant of FastLeaderElection that uses UDP and allows servers to perform a simple
 form of authentication to avoid IP spoofing). ZooKeeper messaging doesn't care about the
-exact method of electing a leader has long as the following holds:
+exact method of electing a leader as long as the following holds:
 
 * The leader has seen the highest zxid of all the followers.
 * A quorum of servers have committed to following the leader.


### PR DESCRIPTION
"has long as" -> "as long as"