### PR TITLE
ZOOKEEPER-3255:add a banner to make the startup of zk server more cool

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZookeeperBanner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZookeeperBanner.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper;
+
+import org.slf4j.Logger;
+
+/**
+ * ZookeeperBanner which writes the 'Zookeeper' banner at the start of zk server.
+ *
+ */
+public class ZookeeperBanner {
+
+    private static final String[] BANNER = {"",
+            "  ______                  _                                          ",
+            " |___  /                 | |                                         ",
+            "    / /    ___     ___   | | __   ___    ___   _ __     ___   _ __   ",
+            "   / /    / _ \\   / _ \\  | |/ /  / _ \\  / _ \\ | '_ \\   / _ \\ | '__|",
+            "  / /__  | (_) | | (_) | |   <  |  __/ |  __/ | |_) | |  __/ | |    " ,
+            " /_____|  \\___/   \\___/  |_|\\_\\  \\___|  \\___| | .__/   \\___| |_|",
+            "                                              | |                     " ,
+            "                                              |_|                     ",
+            ""
+    };
+
+    public static void printBanner(Logger log) {
+        for (String line : BANNER) {
+            log.info(line);
+        }
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -48,6 +48,7 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.KeeperException.SessionExpiredException;
 import org.apache.zookeeper.ZooDefs.OpCode;
+import org.apache.zookeeper.ZookeeperBanner;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
@@ -90,6 +91,8 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
     static {
         LOG = LoggerFactory.getLogger(ZooKeeperServer.class);
+
+        ZookeeperBanner.printBanner(LOG);
 
         Environment.logEnv("Server environment:", LOG);
     }


### PR DESCRIPTION
- the best time to print that banner is just before printing the server env,which has any intrude into the main logic.
- the generated tool is supported by [this](http://patorjk.com/software/taag/#p=display&h=0&v=3&f=Big&t=Spring)  
- the test evidence is attached as the [jira](https://issues.apache.org/jira/browse/ZOOKEEPER-3255) pictures.
- apply this patch,restart your zk server ,and enjoy it!