### PR TITLE
ZOOKEEPER-3262 Update dependencies flagged by OWASP report

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -54,8 +54,8 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
 
     <property name="javacc.version" value="5.0"/>
 
-    <property name="jetty.version" value="9.4.10.v20180503"/>
-    <property name="jackson.version" value="2.9.5"/>
+    <property name="jetty.version" value="9.4.14.v20181114"/>
+    <property name="jackson.version" value="2.9.8"/>
     <property name="dependency-check-ant.version" value="4.0.2"/>
 
     <property name="commons-io.version" value="2.6"/>

--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -22,4 +22,17 @@
       <!-- ZOOKEEPER-3217 -->
       <cve>CVE-2018-8088</cve>
    </suppress>
+   <suppress>
+      <!-- ZOOKEEPER-3262 -->
+      <cve>CVE-2018-8012</cve>
+   </suppress>
+   <suppress>
+      <!-- ZOOKEEPER-3262 -->
+      <cve>CVE-2016-5017</cve>
+   </suppress>
+   <suppress>
+      <!-- https://github.com/jeremylong/DependencyCheck/issues/1653
+           False positive on Netty 4.x-->
+      <cve>CVE-2018-12056</cve>
+   </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -271,8 +271,8 @@
     <hamcrest.version>1.3</hamcrest.version>
     <commons-cli.version>1.2</commons-cli.version>
     <netty.version>4.1.29.Final</netty.version>
-    <jetty.version>9.4.10.v20180503</jetty.version>
-    <jackson.version>2.9.5</jackson.version>
+    <jetty.version>9.4.14.v20181114</jetty.version>
+    <jackson.version>2.9.8</jackson.version>
     <json.version>1.1.1</json.version>
     <jline.version>2.11</jline.version>
     <kerby.version>1.1.0</kerby.version>


### PR DESCRIPTION
- Upgrade Jetty to 9.4.14.v20181114
- Upgrade Jackson to 2.9.8
- Suppress a false positive about Netty  (https://github.com/jeremylong/DependencyCheck/issues/1653)
- Suppress false positives against ZooKeeper itself: CVE-2018-8012 and  CVE-2016-5017