### PR TITLE
ZOOKEEPER-3265: Fix fileset to match shell scripts and python files i…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -973,8 +973,9 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
       <chmod perm="ugo+x" type="file" parallel="false">
         <fileset dir="${dist.dir}/bin"/>
         <fileset dir="${dist.dir}/sbin"/>
-        <fileset dir="${dist.dir}/src/zookeeper-contrib/">
-          <include name="*/bin/*" />
+        <fileset dir="${dist.dir}/contrib/">
+          <include name="**/*.sh" />
+          <include name="**/*.py" />
         </fileset>
       </chmod>
     </target>


### PR DESCRIPTION
…n contrib directory.
