### PR TITLE
ZOOKEEPER-3262: Update dependencies flagged by OWASP report

### DIFF
--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -22,4 +22,8 @@
       <!-- ZOOKEEPER-3217 -->
       <cve>CVE-2018-8088</cve>
    </suppress>
+   <suppress>
+      <!-- ZOOKEEPER-3262 -->
+      <cve>CVE-2018-8012</cve>
+   </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -271,12 +271,9 @@
     <hamcrest.version>1.3</hamcrest.version>
     <commons-cli.version>1.2</commons-cli.version>
     <netty.version>3.10.6.Final</netty.version>
-    <jetty.version>9.4.10.v20180503</jetty.version>
-    <jackson.version>2.9.5</jackson.version>
     <json.version>1.1.1</json.version>
     <jline.version>0.9.94</jline.version>
     <kerby.version>1.1.0</kerby.version>
-    <bouncycastle.version>1.56</bouncycastle.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-lang.version>2.4</commons-lang.version>
     <apache-directory-server.version>2.0.0-M15</apache-directory-server.version>
@@ -344,16 +341,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
-        <version>${bouncycastle.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
-        <version>${bouncycastle.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
@@ -398,11 +385,6 @@
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
         <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.json-simple</groupId>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -76,28 +76,8 @@
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
     </dependency>
     <dependency>
       <groupId>jline</groupId>


### PR DESCRIPTION
- Dropped unused dependencies BounceCastle, Jackson and Jetty
- Suppress false positives against ZooKeeper itself: CVE-2018-8012
