### PR TITLE
ZOOKEEPER-3234: Add Travis-CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,14 @@
 language: java
 sudo: false
+jdk:
+  - openjdk8
+  - openjdk11
 
 cache:
   directories:
   - "$HOME/.m2"
 
-before_script:
-  # Add an IPv6 config - see the corresponding Travis issue
-  # https://github.com/travis-ci/travis-ci/issues/8361
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then 
-      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
-      ulimit -s 1082768;
-    fi
-
-jobs:
-  include:
-  - stage: test
-    jdk: openjdk11
-    script: travis_wait 30 mvn verify -Dmaven.test.redirectTestOutputToFile=true -Dsurefire-forkcount=4
+script: mvn clean install -DskipTests spotbugs:check
 
 branches:
   only:


### PR DESCRIPTION
Use Travis-CI in order to build ZooKeeper on multiple JDKs and run spotbugs on every supported JDK