### PR TITLE
ZOOKEEPER-3276: Make X509UtilTest.testCreateSSLServerSocketWithPort less flaky

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
@@ -192,8 +192,8 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
 
     @Test(timeout = 5000)
     public void testCreateSSLServerSocketWithPort() throws Exception {
-        int port = PortAssignment.unique();
         setCustomCipherSuites();
+        int port = PortAssignment.unique();
         SSLServerSocket sslServerSocket = x509Util.createSSLServerSocket(port);
         Assert.assertEquals(sslServerSocket.getLocalPort(), port);
         Assert.assertArrayEquals(customCipherSuites, sslServerSocket.getEnabledCipherSuites());


### PR DESCRIPTION
Pick the free port right before using it, so there is less time for another thread/process to grab it from under us.