### PR TITLE
ZOOKEEPER-3277: Add trace listener in NettyServerCnxnFactory only if trace logging is enabled

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -205,15 +205,17 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
         }
 
         // Use a single listener instance to reduce GC
-        private final GenericFutureListener<Future<Void>> onWriteCompletedListener = (f) -> {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("write {}", f.isSuccess() ? "complete" : "failed");
-            }
+        // Note: this listener is only added when LOG.isTraceEnabled() is true,
+        // so it should not do any work other than trace logging.
+        private final GenericFutureListener<Future<Void>> onWriteCompletedTracer = (f) -> {
+            LOG.trace("write {}", f.isSuccess() ? "complete" : "failed");
         };
 
         @Override
         public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-            promise.addListener(onWriteCompletedListener);
+            if (LOG.isTraceEnabled()) {
+                promise.addListener(onWriteCompletedTracer);
+            }
             super.write(ctx, msg, promise);
         }
 


### PR DESCRIPTION
Based on the code review discussion in #819