### PR TITLE
ZOOKEEPER-3281:Add a new CLI:watch

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperCLI.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperCLI.md
@@ -16,6 +16,42 @@ limitations under the License.
 
 # ZooKeeper-cli: the ZooKeeper command line interface
 
+* [Pre-requisites](#Pre-requisites)
+    
+* [CLI collections](#sc_clis)
+    * [help](#sc_help)
+    * [addauth](#sc_addauth)
+    * [close](#sc_close)
+    * [config](#sc_config)
+    * [connect](#sc_connect)
+    * [create](#sc_create)
+    * [delete](#sc_delete)
+    * [deleteall](#sc_deleteall)
+    * [delquota](#sc_delquota)
+    * [get](#sc_get)
+    * [getAcl](#sc_getAcl)
+    * [getAllChildrenNumber](#sc_getAllChildrenNumber)
+    * [getEphemerals](#sc_getEphemerals)
+    * [history](#sc_history)
+    * [listquota](#sc_listquota)
+    * [ls](#sc_ls)
+    * [ls2](#sc_ls2)
+    * [printwatches](#sc_printwatches)
+    * [quit](#sc_quit)
+    * [reconfig](#sc_reconfig)
+    * [redo](#sc_redo)
+    * [removewatches](#sc_removewatches)
+    * [rmr](#sc_rmr)
+    * [set](#sc_set)
+    * [setAcl](#sc_setAcl)
+    * [setquota](#sc_setquota)
+    * [stat](#sc_stat)
+    * [sync](#sc_sync)
+    * [version](#sc_version)
+    * [watch](#sc_watch)
+
+<a name="Pre-requisites"></a>
+
 ## Pre-requisites
 Enter into the ZooKeeper-cli
 
@@ -25,7 +61,14 @@ bin/zkCli.sh
 # connect to the remote host with timeout:3s
 bin/zkCli.sh -timeout 3000 -server remoteIP:2181
 ```
-## help
+
+<a name="sc_clis"></a>
+
+## CLI collections
+The following is the detailed usage about the CLIs.
+
+<a name="sc_help"></a>
+### help
 Showing helps about ZooKeeper commands
 
 ```bash
@@ -61,9 +104,13 @@ ZooKeeper -server host:port cmd args
 	stat [-w] path
 	sync path
 	version
+	watch [-d|-c|-e] path
+	
 ```
 
-## addauth
+<a name="sc_addauth"></a>
+
+### addauth
 Add a authorized user for ACL
 
 ```bash
@@ -79,7 +126,9 @@ Add a authorized user for ACL
 [zkshell: 12] addauth digest zookeeper:admin
 ```
 
-## close
+<a name="sc_close"></a>
+
+### close
 Close this client/session.
 
 ```bash
@@ -88,7 +137,9 @@ Close this client/session.
 	2019-03-09 06:42:22,179 [myid:] - INFO  [main:ZooKeeper@1346] - Session: 0x10007ab7c550006 closed
 ```
 
-## config
+<a name="sc_config"></a>
+
+### config
 Showing the config of quorum membership
 
 ```bash
@@ -98,7 +149,10 @@ Showing the config of quorum membership
 	server.3=[2001:db8:1:0:0:242:ac11:2]:22888:23888:participant
 	version=0
 ```
-## connect
+
+<a name="sc_connect"></a>
+
+### connect
 Connect a ZooKeeper server.
 
 ```bash
@@ -110,7 +164,10 @@ Connect a ZooKeeper server.
 # connect a remote server
 [zkshell: 5] connect remoteIP:2181
 ```
-## create
+
+<a name="sc_create"></a>
+
+### create
 Create a znode.
 
 ```bash
@@ -159,7 +216,10 @@ Create a znode.
 [zkshell: 21] get /ttl_node
 	org.apache.zookeeper.KeeperException$NoNodeException: KeeperErrorCode = NoNode for /ttl_node
 ```
-## delete
+
+<a name="sc_delete"></a>
+
+### delete
 Delete a node with a specific path
 
 ```bash
@@ -168,7 +228,9 @@ Delete a node with a specific path
 	Node does not exist: /config/topics/test
 ```
 
-## deleteall
+<a name="sc_deleteall"></a>
+
+### deleteall
 Delete all nodes under a specific path
 
 ```bash
@@ -179,7 +241,9 @@ zkshell: 1] ls /config
 	Node does not exist: /config
 ```
 
-## delquota
+<a name="sc_delquota"></a>
+
+### delquota
 Delete the quota under a path
 
 ```bash
@@ -188,7 +252,10 @@ Delete the quota under a path
 	absolute path is /zookeeper/quota/quota_test/zookeeper_limits
 	quota for /quota_test does not exist.
 ```
-## get
+
+<a name="sc_get"></a>
+
+### get
 Get the data of the specific path
 
 ```bash
@@ -218,7 +285,9 @@ Get the data of the specific path
 	WatchedEvent state:SyncConnected type:NodeDataChanged path:/latest_producer_id_block
 ```
 
-## getAcl
+<a name="sc_getAcl"></a>
+
+### getAcl
 Get the ACL permission of one path
 
 ```bash
@@ -231,7 +300,10 @@ Get the ACL permission of one path
 	'world,'anyone
 	: cdrwa
 ```
-## getAllChildrenNumber
+
+<a name="sc_getAllChildrenNumber"></a>
+
+### getAllChildrenNumber
 Get all numbers of children nodes under a specific path
 
 ```bash
@@ -242,7 +314,10 @@ Get all numbers of children nodes under a specific path
 [zkshell: 3] getAllChildrenNumber /ZooKeeper/quota
 	0
 ```
-## getEphemerals
+
+<a name="sc_getEphemerals"></a>
+
+### getEphemerals
 Get all the ephemeral nodes created by this session
 
 ```bash
@@ -262,7 +337,9 @@ Get all the ephemeral nodes created by this session
 	[/test-get-ephemerals-1]
 ```
 
-## history
+<a name="sc_history"></a>
+
+### history
 Showing the history about the recent 11 commands that you have executed
 
 ```bash
@@ -277,7 +354,9 @@ Showing the history about the recent 11 commands that you have executed
 	7 - history
 ```
 
-## listquota
+<a name="sc_listquota"></a>
+
+### listquota
 Listing the quota of one path
 
 ```bash
@@ -287,7 +366,9 @@ Listing the quota of one path
 	Output stat for /quota_test count=4,bytes=0
 ```
 
-## ls
+<a name="sc_ls"></a>
+
+### ls
 Listing the child nodes of one path
 
 ```bash
@@ -324,7 +405,9 @@ Listing the child nodes of one path
 	WatchedEvent state:SyncConnected type:NodeChildrenChanged path:/brokers
 ```
 
-## ls2
+<a name="sc_ls2"></a>
+
+### ls2
 
 'ls2' has been deprecated. Please use 'ls [-s] path' instead.
 
@@ -332,8 +415,9 @@ Listing the child nodes of one path
 [zkshell: 7] ls2 /
 	'ls2' has been deprecated. Please use 'ls [-s] path' instead.
 ```
+<a name="sc_printwatches"></a>
 
-## printwatches
+### printwatches
 A switch to turn on/off whether printing watches or not.
 
 ```bash
@@ -347,14 +431,16 @@ A switch to turn on/off whether printing watches or not.
 	printwatches is on
 ```
 
-## quit
+<a name="sc_quit"></a>
+### quit
 Quit the CLI windows.
 
 ```bash
 [zkshell: 1] quit
 ```
 
-## reconfig
+<a name="sc_reconfig"></a>
+### reconfig
 Change the membership of the ensemble during the runtime.
 
 Before using this cli,read the details in the [Dynamic Reconfiguration](zookeeperReconfig.html) about the reconfig feature,especially the "Security" part.
@@ -396,7 +482,8 @@ Pre-requisites:
 	version=220000000c
 ```
 
-## redo
+<a name="sc_redo"></a>
+### redo
 Redo the cmd with the index from history.
 
 ```bash
@@ -410,7 +497,8 @@ Redo the cmd with the index from history.
 	[backup-masters, draining, flush-table-proc, hbaseid, master-maintenance, meta-region-server, namespace, online-snapshot, replication, rs, running, splitWAL, switch, table, table-lock]
 ```
 
-## removewatches
+<a name="sc_removewatches"></a>
+### removewatches
 Remove the watches under a node.
 
 ```bash
@@ -422,7 +510,8 @@ Remove the watches under a node.
 
 ```
 
-## rmr
+<a name="sc_rmr"></a>
+### rmr
 The command 'rmr' has been deprecated. Please use 'deleteall' instead.
 
 ```bash
@@ -430,7 +519,8 @@ The command 'rmr' has been deprecated. Please use 'deleteall' instead.
 	The command 'rmr' has been deprecated. Please use 'deleteall' instead
 ```
 
-## set
+<a name="sc_set"></a>
+### set
 Set/update the data on a path.
 
 ```bash
@@ -456,7 +546,8 @@ Set/update the data on a path.
 	version No is not valid : /brokers
 ```
 
-## setAcl
+<a name="sc_setAcl"></a>
+### setAcl
 Set the Acl permission for one node.
 
 ```bash
@@ -493,7 +584,8 @@ Set the Acl permission for one node.
 [zkshell: 37] setAcl -v 3 /acl_auth_test auth:user1:12345:crwad
 ```
 
-## setquota
+<a name="sc_setquota"></a>
+### setquota
 Set the quota in one path.
 
 ```bash
@@ -516,7 +608,8 @@ Set the quota in one path.
 	WARN  [CommitProcWorkThread-7:DataTree@379] - Quota exceeded: /brokers bytes=4206 limit=5
 ```
 
-## stat
+<a name="sc_stat"></a>
+### stat
 Showing the stat/metadata of one node.
 
 ```bash
@@ -534,7 +627,8 @@ Showing the stat/metadata of one node.
 	numChildren = 15
 ```
 
-## sync
+<a name="sc_sync"></a>
+### sync
 Sync the data of one node between leader and followers(Asynchronous sync)
 
 ```bash
@@ -542,10 +636,92 @@ Sync the data of one node between leader and followers(Asynchronous sync)
 [zkshell: 15] Sync is OK
 ```
 
-## version
+<a name="sc_version"></a>
+### version
 Show the version of the ZooKeeper client/CLI
 
 ```bash
 [zkshell: 1] version
 ZooKeeper CLI version: 3.6.0-SNAPSHOT-29f9b2c1c0e832081f94d59a6b88709c5f1bb3ca, built on 05/30/2019 09:26 GMT
+```
+
+<a name="sc_watch"></a>
+### watch
+Watch a path with the watch type:data change,exist,child change.
+The watch cmd is one-off and it will be blocking until something has changed.
+
+```bash
+Terminal1:t1;Terminal2:t2;
+PART1:
+# [-d] watch the data change
+[t1]:
+watch -d /testwatch
+[t2]:
+set /testwatch mydata
+[t1]: result:
+WatchedEvent state:SyncConnected
+type:NodeDataChanged
+path:/testwatch
+new data:mydata
+----------------------------------------------------------------
+[t1]:
+watch -d /testwatch
+[t2]:
+delete /testwatch
+[t1] result:
+WatchedEvent state:SyncConnected
+type:NodeDeleted
+path:/testwatch
+
+PART2:
+# [-c] watch the child change
+[t1]:
+watch -c /testwatch
+[t2]
+create /testwatch/child_1 mydata
+[t1] reslut:
+WatchedEvent state:SyncConnected
+type:NodeChildrenChanged
+path:/testwatch
+new child list:[child_1]
+----------------------------------------------------------------
+[t1]:
+watch -c /testwatch
+[t2]:
+delete /testwatch/child_1
+[t1]:
+WatchedEvent state:SyncConnected
+type:NodeChildrenChanged
+path:/testwatch
+new child list:[]
+
+PART3:
+# [-e]the exist watch
+[t2]:
+delete /testwatch
+[t1]:
+watch -e /testwatch
+[t2]:
+create /testwatch mydata
+[t1] result:
+WatchedEvent state:SyncConnected
+type:NodeCreated
+path:/testwatch
+----------------------------------------------------------------
+[t1]:
+watch -e /testwatch
+[t2]:
+delete /testwatch
+WatchedEvent state:SyncConnected
+type:NodeDeleted
+path:/testwatch
+----------------------------------------------------------------
+[t1]:
+watch -e /testwatch
+[t2]:
+set /testwatch mydata666666666
+[t1]:
+WatchedEvent state:SyncConnected
+type:NodeDataChanged
+path:/testwatch
 ```

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperCLI.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperCLI.md
@@ -104,7 +104,7 @@ ZooKeeper -server host:port cmd args
 	stat [-w] path
 	sync path
 	version
-	watch [-d|-c|-e] path
+	watch [-b] [-d|-c|-e] path
 	
 ```
 
@@ -647,15 +647,16 @@ ZooKeeper CLI version: 3.6.0-SNAPSHOT-29f9b2c1c0e832081f94d59a6b88709c5f1bb3ca, 
 
 <a name="sc_watch"></a>
 ### watch
-Watch a path with the watch type:data change,exist,child change.
-The watch cmd is one-off and it will be blocking until something has changed.
+Watch a path with the watch type:data change, exist, child change.
+The watch cmd is one-off and will be triggered until something has changed.
+It supports nonblocking(default) or blocking mode with option:-b
 
 ```bash
 Terminal1:t1;Terminal2:t2;
 PART1:
 # [-d] watch the data change
 [t1]:
-watch -d /testwatch
+watch -b -d /testwatch
 [t2]:
 set /testwatch mydata
 [t1]: result:
@@ -665,7 +666,7 @@ path:/testwatch
 new data:mydata
 ----------------------------------------------------------------
 [t1]:
-watch -d /testwatch
+watch -b -d /testwatch
 [t2]:
 delete /testwatch
 [t1] result:
@@ -676,7 +677,7 @@ path:/testwatch
 PART2:
 # [-c] watch the child change
 [t1]:
-watch -c /testwatch
+watch -b -c /testwatch
 [t2]
 create /testwatch/child_1 mydata
 [t1] reslut:
@@ -686,7 +687,7 @@ path:/testwatch
 new child list:[child_1]
 ----------------------------------------------------------------
 [t1]:
-watch -c /testwatch
+watch -b -c /testwatch
 [t2]:
 delete /testwatch/child_1
 [t1]:
@@ -700,7 +701,7 @@ PART3:
 [t2]:
 delete /testwatch
 [t1]:
-watch -e /testwatch
+watch -b -e /testwatch
 [t2]:
 create /testwatch mydata
 [t1] result:
@@ -709,7 +710,7 @@ type:NodeCreated
 path:/testwatch
 ----------------------------------------------------------------
 [t1]:
-watch -e /testwatch
+watch -b -e /testwatch
 [t2]:
 delete /testwatch
 WatchedEvent state:SyncConnected
@@ -717,7 +718,7 @@ type:NodeDeleted
 path:/testwatch
 ----------------------------------------------------------------
 [t1]:
-watch -e /testwatch
+watch -b -e /testwatch
 [t2]:
 set /testwatch mydata666666666
 [t1]:

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperStarted.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperStarted.md
@@ -147,6 +147,7 @@ From the shell, type `help` to get a listing of commands that can be executed fr
 
 
     [zkshell: 0] help
+    
     ZooKeeper -server host:port cmd args
 	addauth scheme auth
 	close
@@ -175,7 +176,8 @@ From the shell, type `help` to get a listing of commands that can be executed fr
 	setquota -n|-b val path
 	stat [-w] path
 	sync path
-
+	version
+	watch [-d|-c|-e] path
 
 From here, you can try a few simple commands to get a feel for this simple command line interface.  First, start by issuing the list command, as
 in `ls`, yielding:

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperStarted.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperStarted.md
@@ -177,7 +177,7 @@ From the shell, type `help` to get a listing of commands that can be executed fr
 	stat [-w] path
 	sync path
 	version
-	watch [-d|-c|-e] path
+	watch [-b] [-d|-c|-e] path
 
 From here, you can try a few simple commands to get a feel for this simple command line interface.  First, start by issuing the list command, as
 in `ls`, yielding:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -63,6 +63,7 @@ import org.apache.zookeeper.cli.SetQuotaCommand;
 import org.apache.zookeeper.cli.StatCommand;
 import org.apache.zookeeper.cli.SyncCommand;
 import org.apache.zookeeper.cli.VersionCommand;
+import org.apache.zookeeper.cli.WatchCommand;
 import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.server.ExitCode;
 import org.slf4j.Logger;
@@ -123,6 +124,7 @@ public class ZooKeeperMain {
         new GetEphemeralsCommand().addToMap(commandMapCli);
         new GetAllChildrenNumberCommand().addToMap(commandMapCli);
         new VersionCommand().addToMap(commandMapCli);
+        new WatchCommand().addToMap(commandMapCli);
 
         // add all to commandMap
         for (Entry<String, CliCommand> entry : commandMapCli.entrySet()) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/WatchCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/WatchCommand.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.zookeeper.cli;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.Parser;
+import org.apache.commons.cli.PosixParser;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+
+/**
+ * watch command for CLI
+ */
+public class WatchCommand extends CliCommand {
+    private static Options options = new Options();
+    private String[] args;
+    private CommandLine cl;
+
+    public WatchCommand() {
+        super("watch", "[-d|-c|-e] path");
+
+        options.addOption(new Option("d", false, "data changed watch"));
+        options.addOption(new Option("c", false, "child changed watch"));
+        options.addOption(new Option("e", false, "exist watch"));
+    }
+
+    @Override
+    public CliCommand parse(String[] cmdArgs) throws CliParseException {
+        Parser parser = new PosixParser();
+        try {
+            cl = parser.parse(options, cmdArgs);
+        } catch (ParseException ex) {
+            throw new CliParseException(ex);
+        }
+        args = cl.getArgs();
+        if (args.length < 2) {
+            throw new CliParseException(getUsageStr());
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean exec() throws CliException {
+        try {
+            String path = args[1];
+            CountDownLatch latch = new CountDownLatch(1);
+            SimpleCLIWatcher cliWatcher = new SimpleCLIWatcher(latch);
+
+            if (cl.hasOption("d") || cl.getOptions().length == 0) {
+                zk.getData(path, cliWatcher, null);
+                latch.await();
+                WatchedEvent watchedEvent = cliWatcher.getEvent();
+                printWatchedEvent(watchedEvent);
+                if (!cliWatcher.isWatched()) {
+                    return false;
+                }
+                if (watchedEvent.getType().equals(Watcher.Event.EventType.NodeDataChanged)) {
+                    byte[] newData = zk.getData(path, false, null);
+                    out.println("new data:" + new String(newData));
+                }
+            } else if (cl.hasOption("c")) {
+                zk.getChildren(path, cliWatcher);
+                latch.await();
+                WatchedEvent watchedEvent = cliWatcher.getEvent();
+                printWatchedEvent(watchedEvent);
+                if (!cliWatcher.isWatched()) {
+                    return false;
+                }
+                if ((watchedEvent.getType().equals(Watcher.Event.EventType.NodeChildrenChanged))) {
+                    List<String> newChildList = zk.getChildren(path, false);
+                    out.println("new child list:" + newChildList.toString());
+                }
+            } else if (cl.hasOption("e")) {
+                zk.exists(path, cliWatcher);
+                latch.await();
+                WatchedEvent watchedEvent = cliWatcher.getEvent();
+                printWatchedEvent(watchedEvent);
+            }
+        } catch (KeeperException | InterruptedException ex) {
+            throw new CliWrapperException(ex);
+        }
+
+        return false;
+    }
+
+    private void printWatchedEvent(WatchedEvent watchedEvent) {
+        out.println("WatchedEvent state:" + watchedEvent.getState());
+        out.println("type:" + watchedEvent.getType());
+        out.println("path:" + watchedEvent.getPath());
+    }
+
+    private static class SimpleCLIWatcher implements Watcher {
+        private CountDownLatch latch;
+        private WatchedEvent event;
+        private boolean watched = false;
+
+        public SimpleCLIWatcher(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        public WatchedEvent getEvent() {
+            return event;
+        }
+
+        public boolean isWatched() {
+            return watched;
+        }
+
+        public void process(WatchedEvent e) {
+            if (e.getType() != Event.EventType.None
+                    && e.getState() == Event.KeeperState.SyncConnected) {
+                watched = true;
+            }
+            event = e;
+            latch.countDown();
+        }
+    }
+}


### PR DESCRIPTION
- it's a very useful CLI for users to use, test, debug the `watch` function.
- the `watch` cmd is one-off and it will be blocking until something has changed.
- Although we already have `ls -w /foo` to watch the child change, `get -w /foo` to watch the data change,this new cli is also valuable and user-fridendly in a perspective view of watch.
- In the further, we can add `-f` option: watch a node forever, add `-R` option to watch all the events under a dir.
- this CLI just calls the api about `watch` in the `zookeeper.java`,the correctness of function has been tested in the `WatcherFuncTest`,so add no UTs.But a very detailed test evidence has included in the[ jira](https://issues.apache.org/jira/browse/ZOOKEEPER-3281)