### PR TITLE
ZOOKEEPER-1815. Tolerate incorrectly set system hostname in tests (3.4)

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/JMXEnv.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/JMXEnv.java
@@ -50,7 +50,7 @@ public class JMXEnv {
     public static void setUp() throws IOException {
         MBeanServer mbs = MBeanRegistry.getInstance().getPlatformMBeanServer();
         
-        JMXServiceURL url = new JMXServiceURL("service:jmx:rmi://");
+        JMXServiceURL url = new JMXServiceURL("service:jmx:rmi://127.0.0.1");
         cs = JMXConnectorServerFactory.newJMXConnectorServer(url, null, mbs);
         cs.start();
 


### PR DESCRIPTION
Inspired by the following commit: https://github.com/apache/zookeeper/commit/23852655a6d41f675b8a9cca66387fca9bfe4e12

in order to fix build problems on H31 Jenkins slave. Infra reported that nothing has been changed in name resolution, but the patch still looks reasonable and hopefully fix the JMX connection problem.

This "backport" is JMX-only and doesn't try to fully backport the original patch.
