### PR TITLE
ZOOKEEPER-3234: Add Travis-CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: java
+sudo: false
+jdk:
+  - openjdk8
+  - openjdk11
+
+cache:
+  directories:
+  - "$HOME/.m2"
+
+script: mvn clean install -DskipTests spotbugs:check
+
+branches:
+  only:
+  - master
+  - branch-3.5
+  - branch-3.4


### PR DESCRIPTION
Use Travis-CI in order to build ZooKeeper on multiple JDKs and run spotbugs on every supported JDK