### PR TITLE
ZOOKEEPER-3286: xid wrap-around causes connection loss/segfault when hitting predefined XIDs

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/mt_adaptor.c
+++ b/zookeeper-client/zookeeper-client-c/src/mt_adaptor.c
@@ -502,13 +502,13 @@ int32_t fetch_and_add(volatile int32_t* operand, int incr)
 }
 
 // make sure the static xid is initialized before any threads started
-__attribute__((constructor)) int32_t get_xid()
+int32_t get_xid()
 {
-    static int32_t xid = -1;
-    if (xid == -1) {
-        xid = time(0);
-    }
-    return fetch_and_add(&xid,1);
+    static int32_t xid = 1;
+
+    // The XID returned should not be negative to avoid collisions
+    // with reserved XIDs, such as AUTH_XID or SET_WATCHES_XID.
+    return fetch_and_add(&xid,1) & ~(1<<31);
 }
 
 int lock_reconfig(struct _zhandle *zh)

--- a/zookeeper-client/zookeeper-client-c/src/st_adaptor.c
+++ b/zookeeper-client/zookeeper-client-c/src/st_adaptor.c
@@ -77,11 +77,11 @@ int32_t inc_ref_counter(zhandle_t* zh,int i)
 
 int32_t get_xid()
 {
-    static int32_t xid = -1;
-    if (xid == -1) {
-        xid = time(0);
-    }
-    return xid++;
+    static int32_t xid = 1;
+
+    // The XID returned should not be negative to avoid collisions
+    // with reserved XIDs, such as AUTH_XID or SET_WATCHES_XID.
+    return xid++ & ~(1<<31);
 }
 
 int lock_reconfig(struct _zhandle *zh)


### PR DESCRIPTION
I just saw ZOOKEEPER-3253, which seems to fix the issue for the Java client.
This fixes the issue for the C client, by avoiding returning negative XIDs.

