### PR TITLE
ZOOKEEPER-3291: Improve error message when JAVA_HOME is set to the wrong value

### DIFF
--- a/bin/zkEnv.cmd
+++ b/bin/zkEnv.cmd
@@ -42,7 +42,8 @@ if not defined JAVA_HOME (
 set JAVA_HOME=%JAVA_HOME:"=%
 
 if not exist "%JAVA_HOME%"\bin\java.exe (
-  echo Error: JAVA_HOME is incorrectly set.
+  echo Error: JAVA_HOME is incorrectly set: %JAVA_HOME%
+  echo Expected to find java.exe here: %JAVA_HOME%\bin\java.exe
   goto :eof
 )
 


### PR DESCRIPTION
This is small (Windows-based) developer usability improvement.

When the `JAVA_HOME` environment variable is set, but the value is wrong (so that `JAVA_HOME` + `/bin/java.exe` does not point correctly to `java.exe`), the startup script will simply fail with the message
```dos
Error: JAVA_HOME is incorrectly set.
```
which is a bummer. 😞 

With this tiny change, the error message will be much friendlier:
```dos
Error: JAVA_HOME is incorrectly set: C:\Program Files\Java\jre1.8.0_201\bin
Expected to find java.exe here: C:\Program Files\Java\jre1.8.0_201\bin\bin\java.exe
```
(in this case showing a situation where one has inadvertently included `/bin` in the `JAVA_HOME` environment variable).

This will also give a nicer error message in situations, where the JRE has been updated, and the one pointed to by `JAVA_HOME` has been uninstalled.