### PR TITLE
Fix typo in error log message, added missing space

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerCnxnFactory.java
@@ -268,7 +268,7 @@ public abstract class ServerCnxnFactory {
             if (securityException != null && (loginContextName != null || jaasFile != null)) {
                 String errorMessage = "No JAAS configuration section named '" + serverSection +  "' was found";
                 if (jaasFile != null) {
-                    errorMessage += "in '" + jaasFile + "'.";
+                    errorMessage += " in '" + jaasFile + "'.";
                 }
                 if (loginContextName != null) {
                     errorMessage += " But " + ZooKeeperSaslServer.LOGIN_CONTEXT_NAME_KEY + " was set.";


### PR DESCRIPTION
Fix typo in error log message, added missing space