### PR TITLE
ZOOKEEPER-3290: Throw detailed KeeperException when multi-op failed

### DIFF
--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/JCompType.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/JCompType.java
@@ -54,7 +54,7 @@ abstract class JCompType extends JType {
     }
 
     String genJavaEquals(String fname, String peer) {
-        return "    ret = " + fname + ".equals(" + peer + ");\n";
+        return "    ret = java.util.Objects.equals(" + fname + ", " + peer + ");\n";
     }
 
     String genJavaHashCode(String fname) {

--- a/zookeeper-jute/src/main/resources/zookeeper.jute
+++ b/zookeeper-jute/src/main/resources/zookeeper.jute
@@ -72,7 +72,7 @@ module org.apache.zookeeper.proto {
         vector<ustring>dataWatches;
         vector<ustring>existWatches;
         vector<ustring>childWatches;
-    }        
+    }
     class RequestHeader {
         int xid;
         int type;
@@ -92,12 +92,12 @@ module org.apache.zookeeper.proto {
         long zxid;
         int err;
     }
-    
-    class GetDataRequest {       
+
+    class GetDataRequest {
         ustring path;
         boolean watch;
     }
-    
+
     class SetDataRequest {
         ustring path;
         buffer data;
@@ -187,6 +187,7 @@ module org.apache.zookeeper.proto {
     }
     class ErrorResponse {
         int err;
+        ustring path;
     }
     class CreateResponse {
         ustring path;
@@ -325,6 +326,7 @@ module org.apache.zookeeper.txn {
     }
     class ErrorTxn {
         int err;
+        ustring path;
     }
     class Txn {
         int type;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/CreateMode.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/CreateMode.java
@@ -135,7 +135,7 @@ public enum CreateMode {
         default:
             String errMsg = "Received an invalid flag value: " + flag + " to convert to a CreateMode";
             LOG.error(errMsg);
-            throw new KeeperException.BadArgumentsException();
+            throw new KeeperException.BadArgumentsException(errMsg);
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/CreateMode.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/CreateMode.java
@@ -135,7 +135,7 @@ public enum CreateMode {
         default:
             String errMsg = "Received an invalid flag value: " + flag + " to convert to a CreateMode";
             LOG.error(errMsg);
-            throw new KeeperException.BadArgumentsException(errMsg);
+            throw new KeeperException.BadArgumentsException();
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/MultiResponse.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/MultiResponse.java
@@ -89,7 +89,8 @@ public class MultiResponse implements Record, Iterable<OpResult> {
                     .serialize(archive, tag);
                 break;
             case ZooDefs.OpCode.error:
-                new ErrorResponse(((OpResult.ErrorResult) result).getErr()).serialize(archive, tag);
+                OpResult.ErrorResult errorResult = (OpResult.ErrorResult) result;
+                new ErrorResponse(errorResult.getErr(), errorResult.getPath()).serialize(archive, tag);
                 break;
             default:
                 throw new IOException("Invalid type " + result.getType() + " in MultiResponse");
@@ -101,7 +102,7 @@ public class MultiResponse implements Record, Iterable<OpResult> {
 
     @Override
     public void deserialize(InputArchive archive, String tag) throws IOException {
-        results = new ArrayList<OpResult>();
+        results = new ArrayList<>();
 
         archive.startRecord(tag);
         MultiHeader h = new MultiHeader();
@@ -150,7 +151,7 @@ public class MultiResponse implements Record, Iterable<OpResult> {
                 // TODO: need way to more cleanly serialize/deserialize exceptions
                 ErrorResponse er = new ErrorResponse();
                 er.deserialize(archive, tag);
-                results.add(new OpResult.ErrorResult(er.getErr()));
+                results.add(new OpResult.ErrorResult(er.getErr(), er.getPath()));
                 break;
 
             default:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/OpResult.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/OpResult.java
@@ -19,6 +19,7 @@ package org.apache.zookeeper;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import org.apache.zookeeper.data.Stat;
 
 /**
@@ -282,15 +283,25 @@ public abstract class OpResult {
      */
     public static class ErrorResult extends OpResult {
 
-        private int err;
+        private final int err;
+        private final String path;
 
         public ErrorResult(int err) {
+            this(err, null);
+        }
+
+        public ErrorResult(int err, String path) {
             super(ZooDefs.OpCode.error);
             this.err = err;
+            this.path = path;
         }
 
         public int getErr() {
             return err;
+        }
+
+        public String getPath() {
+            return path;
         }
 
         @Override
@@ -298,17 +309,16 @@ public abstract class OpResult {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof ErrorResult)) {
+            if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-
-            ErrorResult other = (ErrorResult) o;
-            return getType() == other.getType() && err == other.getErr();
+            ErrorResult that = (ErrorResult) o;
+            return err == that.err && Objects.equals(path, that.path);
         }
 
         @Override
         public int hashCode() {
-            return getType() * 35 + err;
+            return Objects.hash(err, path);
         }
 
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/OpResult.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/OpResult.java
@@ -309,9 +309,11 @@ public abstract class OpResult {
             if (this == o) {
                 return true;
             }
-            if (o == null || getClass() != o.getClass()) {
+
+            if (!(o instanceof ErrorResult)) {
                 return false;
             }
+
             ErrorResult that = (ErrorResult) o;
             return err == that.err && Objects.equals(path, that.path);
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
@@ -1932,18 +1932,18 @@ public class ZooKeeper implements AutoCloseable {
                 op.validate();
             } catch (IllegalArgumentException iae) {
                 LOG.error("IllegalArgumentException: " + iae.getMessage());
-                ErrorResult err = new ErrorResult(KeeperException.Code.BADARGUMENTS.intValue());
+                ErrorResult err = new ErrorResult(KeeperException.Code.BADARGUMENTS.intValue(), op.getPath());
                 results.add(err);
                 error = true;
                 continue;
             } catch (KeeperException ke) {
                 LOG.error("KeeperException: " + ke.getMessage());
-                ErrorResult err = new ErrorResult(ke.code().intValue());
+                ErrorResult err = new ErrorResult(ke.code().intValue(), op.getPath());
                 results.add(err);
                 error = true;
                 continue;
             }
-            ErrorResult err = new ErrorResult(KeeperException.Code.RUNTIMEINCONSISTENCY.intValue());
+            ErrorResult err = new ErrorResult(KeeperException.Code.RUNTIMEINCONSISTENCY.intValue(), op.getPath());
             results.add(err);
         }
         if (!error) {
@@ -2026,7 +2026,9 @@ public class ZooKeeper implements AutoCloseable {
         }
 
         if (fatalError != null) {
-            KeeperException ex = KeeperException.create(KeeperException.Code.get(fatalError.getErr()));
+            KeeperException ex = KeeperException.create(
+                KeeperException.Code.get(fatalError.getErr()),
+                fatalError.getPath());
             ex.setMultiResults(results);
             throw ex;
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -944,6 +944,7 @@ public class DataTree {
             case OpCode.error:
                 ErrorTxn errTxn = (ErrorTxn) txn;
                 rc.err = errTxn.getErr();
+                rc.path = errTxn.getPath();
                 break;
             case OpCode.check:
                 CheckVersionTxn checkTxn = (CheckVersionTxn) txn;
@@ -952,7 +953,7 @@ public class DataTree {
             case OpCode.multi:
                 MultiTxn multiTxn = (MultiTxn) txn;
                 List<Txn> txns = multiTxn.getTxns();
-                rc.multiResult = new ArrayList<ProcessTxnResult>();
+                rc.multiResult = new ArrayList<>();
                 boolean failed = false;
                 for (Txn subtxn : txns) {
                     if (subtxn.getType() == OpCode.error) {
@@ -1000,7 +1001,9 @@ public class DataTree {
                         int ec = post_failed ? Code.RUNTIMEINCONSISTENCY.intValue() : Code.OK.intValue();
 
                         subtxn.setType(OpCode.error);
-                        record = new ErrorTxn(ec);
+
+                        // failed due to previous op, this path is irrelevant
+                        record = new ErrorTxn(ec, null);
                     }
 
                     assert !failed || (subtxn.getType() == OpCode.error);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -735,7 +735,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                      */
                     if (ke != null) {
                         type = OpCode.error;
-                        txn = new ErrorTxn(Code.RUNTIMEINCONSISTENCY.intValue());
+                        txn = new ErrorTxn(Code.RUNTIMEINCONSISTENCY.intValue(), null);
                     } else {
                         /* Prep the request and convert to a Txn */
                         try {
@@ -745,7 +745,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                         } catch (KeeperException e) {
                             ke = e;
                             type = OpCode.error;
-                            txn = new ErrorTxn(e.code().intValue());
+                            txn = new ErrorTxn(e.code().intValue(), e.getPath());
 
                             if (e.code().intValue() > Code.APIERROR.intValue()) {
                                 LOG.info("Got user-level KeeperException when processing {} aborting"
@@ -809,7 +809,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
         } catch (KeeperException e) {
             if (request.getHdr() != null) {
                 request.getHdr().setType(OpCode.error);
-                request.setTxn(new ErrorTxn(e.code().intValue()));
+                request.setTxn(new ErrorTxn(e.code().intValue(), e.getPath()));
             }
 
             if (e.code().intValue() > Code.APIERROR.intValue()) {
@@ -838,7 +838,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             LOG.error("Dumping request buffer: 0x" + sb.toString());
             if (request.getHdr() != null) {
                 request.getHdr().setType(OpCode.error);
-                request.setTxn(new ErrorTxn(Code.MARSHALLINGERROR.intValue()));
+                request.setTxn(new ErrorTxn(Code.MARSHALLINGERROR.intValue(), null));
             }
         }
         request.zxid = zks.getZxid();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerRequestProcessor.java
@@ -128,7 +128,7 @@ public class FollowerRequestProcessor extends ZooKeeperCriticalThread implements
                 } catch (KeeperException ke) {
                     if (request.getHdr() != null) {
                         request.getHdr().setType(OpCode.error);
-                        request.setTxn(new ErrorTxn(ke.code().intValue()));
+                        request.setTxn(new ErrorTxn(ke.code().intValue(), ke.getPath()));
                     }
                     request.setException(ke);
                     LOG.info("Error creating upgrade request", ke);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderRequestProcessor.java
@@ -60,7 +60,7 @@ public class LeaderRequestProcessor implements RequestProcessor {
             if (request.getHdr() != null) {
                 LOG.debug("Updating header");
                 request.getHdr().setType(OpCode.error);
-                request.setTxn(new ErrorTxn(ke.code().intValue()));
+                request.setTxn(new ErrorTxn(ke.code().intValue(), ke.getPath()));
             }
             request.setException(ke);
             LOG.info("Error creating upgrade request " + ke.getMessage());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverRequestProcessor.java
@@ -131,7 +131,7 @@ public class ObserverRequestProcessor extends ZooKeeperCriticalThread implements
             } catch (KeeperException ke) {
                 if (request.getHdr() != null) {
                     request.getHdr().setType(OpCode.error);
-                    request.setTxn(new ErrorTxn(ke.code().intValue()));
+                    request.setTxn(new ErrorTxn(ke.code().intValue(), ke.getPath()));
                 }
                 request.setException(ke);
                 LOG.info("Error creating upgrade request", ke);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/PrepRequestProcessorTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/PrepRequestProcessorTest.java
@@ -98,7 +98,9 @@ public class PrepRequestProcessorTest extends ClientBase {
         Request foo = new Request(null, 1L, 1, OpCode.create, ByteBuffer.allocate(3), null);
         processor.pRequest(foo);
 
-        assertEquals("Request should have marshalling error", new ErrorTxn(KeeperException.Code.MARSHALLINGERROR.intValue()), outcome.getTxn());
+        assertEquals("Request should have marshalling error",
+                     new ErrorTxn(KeeperException.Code.MARSHALLINGERROR.intValue(), null),
+                     outcome.getTxn());
         assertTrue("request hasn't been processed in chain", pLatch.await(5, TimeUnit.SECONDS));
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
@@ -1196,7 +1196,13 @@ public class Zab1_0Test extends ZKTestCase {
             version2.mkdir();
             logFactory.save(new DataTree(), new ConcurrentHashMap<Long, Integer>(), false);
             long zxid = ZxidUtils.makeZxid(3, 3);
-            logFactory.append(new Request(1, 1, ZooDefs.OpCode.error, new TxnHeader(1, 1, zxid, 1, ZooDefs.OpCode.error), new ErrorTxn(1), zxid));
+            logFactory.append(new Request(
+                1,
+                1,
+                ZooDefs.OpCode.error,
+                new TxnHeader(1, 1, zxid, 1, ZooDefs.OpCode.error),
+                new ErrorTxn(1, null),
+                zxid));
             logFactory.commit();
             ZKDatabase zkDb = new ZKDatabase(logFactory);
             QuorumPeer peer = QuorumPeer.testingQuorumPeer();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/MultiOperationTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/MultiOperationTest.java
@@ -337,7 +337,7 @@ public class MultiOperationTest extends ClientBase {
                 Op.create("/multi1", new byte[0], Ids.OPEN_ACL_UNSAFE, createModeFlag),
                 Op.create("/multi2", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT));
 
-        // TODO ZOOKEEPER-
+        // TODO ZOOKEEPER-3520
         String hackyPath = "Received an invalid flag value: 6789 to convert to a CreateMode";
         String expectedErr = KeeperException.create(KeeperException.Code.BADARGUMENTS, hackyPath).getMessage();
         multiHavingErrors(zk, opList, expectedResultCodes, expectedErr);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/MultiOperationTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/MultiOperationTest.java
@@ -336,7 +336,10 @@ public class MultiOperationTest extends ClientBase {
                 Op.create("/multi0", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT),
                 Op.create("/multi1", new byte[0], Ids.OPEN_ACL_UNSAFE, createModeFlag),
                 Op.create("/multi2", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT));
-        String expectedErr = KeeperException.create(KeeperException.Code.BADARGUMENTS).getMessage();
+
+        // TODO ZOOKEEPER-
+        String hackyPath = "Received an invalid flag value: 6789 to convert to a CreateMode";
+        String expectedErr = KeeperException.create(KeeperException.Code.BADARGUMENTS, hackyPath).getMessage();
         multiHavingErrors(zk, opList, expectedResultCodes, expectedErr);
     }
 


### PR DESCRIPTION
Assume we execute the follow statements

```java
ZooKeeper zk = ...;
zk.multi(Arrays.asList(
  Op.check(path1, -1),
  Op.delete(path2, -1)));
```

If path1 or path2 didn't exist, we got an exception KeeperException.NoNodeException without which of them doesn't exist.

The reason is when we executed PrepRequestProccessor#pRequest in PrepRequestProccessor#L804, it processed KeeperException.NoNodeException which contained path info.

However, we generated ErrorTxn which only contains err field represented error code and lost path info. I try a resolution that extend ErrorTxn to contain path info.