### PR TITLE
 ZOOKEEPER-3143 Pluggable metrics system for ZooKeeper - Data Collection on Server

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/Counter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/Counter.java
@@ -29,7 +29,7 @@ public interface Counter {
      * <p>This method is thread safe, The MetricsProvider will take care of synchronization.</p>
      */
     default void inc() {
-        inc(1);
+        add(1);
     }
 
     /**
@@ -38,7 +38,7 @@ public interface Counter {
      *
      * @param delta amount to increment, this cannot be a negative number.
      */
-    void inc(long delta);
+    void add(long delta);
 
     /**
      * Get the current value held by the counter.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/MetricsContext.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/MetricsContext.java
@@ -62,9 +62,27 @@ public interface MetricsContext {
 
     /**
      * Returns a summary.
+     * The returned Summary is expected to track
+     * only simple aggregated values, like min/max/avg.
+     * <p>If you get a Summary with this method you cannot
+     * request the same with {@link #getSummary(java.lang.String) }
      *
      * @param name
      * @return the summary identified by name in this context.
+     * @see #getSummary(java.lang.String)
+     */
+    Summary getBasicSummary(String name);
+    
+    /**
+     * Returns a summary. It is expected
+     * that the returned Summary performs expensive
+     * aggregations, like percentiles.
+     * <p>If you get a Summary with this method you cannot
+     * request the same with {@link #getBasicSummary(java.lang.String) }
+     *
+     * @param name
+     * @return the summary identified by name in this context.
+     * @see #getBasicSummary(java.lang.String)
      */
     Summary getSummary(String name);
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/MetricsProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/MetricsProvider.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.metrics;
 
 import java.util.Properties;
+import java.util.function.BiConsumer;
 
 /**
  * A MetricsProvider is a system which collects Metrics and publishes current values to external facilities.
@@ -61,4 +62,18 @@ public interface MetricsProvider {
      * This method can be called more than once.
      */
     void stop();
+
+    /**
+     * Dumps all metrics as a key-value pair.
+     * This method will be used in legacy monitor command.
+     * @param sink the receiver of all of the current values.
+     */
+    public void dump(BiConsumer<String, Object> sink);
+
+    /**
+     * Reset all values.
+     * This method is optional and can be noop, depending
+     * on the underlying implementation.
+     */
+    public void resetAllValues();
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/Summary.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/Summary.java
@@ -30,6 +30,6 @@ public interface Summary {
       *
       * @param value current value
       */
-     void registerValue(long value);
+     void add(long value);
 
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/impl/DefaultMetricsProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/impl/DefaultMetricsProvider.java
@@ -70,7 +70,7 @@ public class DefaultMetricsProvider implements MetricsProvider {
         rootMetricsContext.reset();
     }
 
-    private final class DefaultMetricsContext implements MetricsContext {
+    private static final class DefaultMetricsContext implements MetricsContext {
 
         private final ConcurrentMap<String, SimpleCounter> counters = new ConcurrentHashMap<>();
         private final ConcurrentMap<String, AvgMinMaxCounter> basicSummaries = new ConcurrentHashMap<>();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/impl/DefaultMetricsProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/impl/DefaultMetricsProvider.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.metrics.impl;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiConsumer;
+import org.apache.zookeeper.metrics.Counter;
+import org.apache.zookeeper.metrics.Gauge;
+import org.apache.zookeeper.metrics.MetricsContext;
+import org.apache.zookeeper.metrics.MetricsProvider;
+import org.apache.zookeeper.metrics.MetricsProviderLifeCycleException;
+import org.apache.zookeeper.metrics.Summary;
+import org.apache.zookeeper.server.metric.AvgMinMaxCounter;
+import org.apache.zookeeper.server.metric.AvgMinMaxPercentileCounter;
+import org.apache.zookeeper.server.metric.SimpleCounter;
+
+/**
+ * Default implementation of {@link MetricsProvider}.<br>
+ * It does not implement a real hierarchy of contexts, but metrics are
+ * flattened in a single namespace.<br>
+ * It is mostly useful to make the legacy 4 letter words interface work
+ * as expected.
+ */
+public class DefaultMetricsProvider implements MetricsProvider {
+
+    private final DefaultMetricsContext rootMetricsContext = new DefaultMetricsContext();
+
+    @Override
+    public void configure(Properties configuration) throws MetricsProviderLifeCycleException {
+    }
+
+    @Override
+    public void start() throws MetricsProviderLifeCycleException {
+    }
+
+    @Override
+    public MetricsContext getRootContext() {
+        return rootMetricsContext;
+    }
+
+    @Override
+    public void stop() {
+    }
+
+    @Override
+    public void dump(BiConsumer<String, Object> sink) {
+        rootMetricsContext.dump(sink);
+    }
+
+    @Override
+    public void resetAllValues() {
+        rootMetricsContext.reset();
+    }
+
+    private final class DefaultMetricsContext implements MetricsContext {
+
+        private final ConcurrentMap<String, SimpleCounter> counters = new ConcurrentHashMap<>();
+        private final ConcurrentMap<String, AvgMinMaxCounter> basicSummaries = new ConcurrentHashMap<>();
+        private final ConcurrentMap<String, AvgMinMaxPercentileCounter> summaries = new ConcurrentHashMap<>();
+
+        @Override
+        public MetricsContext getContext(String name) {
+            // no hierarchy
+            return this;
+        }
+
+        @Override
+        public Counter getCounter(String name) {
+            return counters.computeIfAbsent(name, (n) -> {
+                return new SimpleCounter(n);
+            });
+        }
+
+        @Override
+        public boolean registerGauge(String name, Gauge gauge) {
+            // Not supported
+            return false;
+        }
+
+        @Override
+        public Summary getSummary(String name) {
+            return summaries.computeIfAbsent(name, (n) -> {
+                if (basicSummaries.containsKey(n)) {
+                    throw new IllegalArgumentException("Already registered a basic summary as " + n);
+                }
+                return new AvgMinMaxPercentileCounter(name);
+            });
+        }
+
+        @Override
+        public Summary getBasicSummary(String name) {
+            return basicSummaries.computeIfAbsent(name, (n) -> {
+                if (summaries.containsKey(n)) {
+                    throw new IllegalArgumentException("Already registered a non basic summary as " + n);
+                }
+                return new AvgMinMaxCounter(name);
+            });
+        }
+
+        void dump(BiConsumer<String, Object> sink) {
+            counters.values().forEach(metric -> {
+                metric.values().forEach(sink);
+            });
+            basicSummaries.values().forEach(metric -> {
+                metric.values().forEach(sink);
+            });
+            summaries.values().forEach(metric -> {
+                metric.values().forEach(sink);
+            });
+        }
+
+        void reset() {
+            counters.values().forEach(metric -> {
+                metric.reset();
+            });
+            basicSummaries.values().forEach(metric -> {
+                metric.reset();
+            });
+            summaries.values().forEach(metric -> {
+                metric.reset();
+            });
+        }
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/impl/NullMetricsProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/impl/NullMetricsProvider.java
@@ -18,6 +18,7 @@
 package org.apache.zookeeper.metrics.impl;
 
 import java.util.Properties;
+import java.util.function.BiConsumer;
 import org.apache.zookeeper.metrics.Counter;
 import org.apache.zookeeper.metrics.Gauge;
 import org.apache.zookeeper.metrics.MetricsContext;
@@ -30,6 +31,11 @@ import org.apache.zookeeper.metrics.Summary;
  */
 public class NullMetricsProvider implements MetricsProvider {
 
+    /**
+     * Instance of NullMetricsProvider useful for tests.
+     */
+    public static final MetricsProvider INSTANCE = new NullMetricsProvider();
+
     @Override
     public void configure(Properties configuration) throws MetricsProviderLifeCycleException {
     }
@@ -41,6 +47,14 @@ public class NullMetricsProvider implements MetricsProvider {
     @Override
     public MetricsContext getRootContext() {
         return NullMetricsContext.INSTANCE;
+    }
+
+    @Override
+    public void dump(BiConsumer<String, Object> sink) {
+    }
+
+    @Override
+    public void resetAllValues() {
     }
 
     @Override
@@ -71,6 +85,12 @@ public class NullMetricsProvider implements MetricsProvider {
             return NullSummary.INSTANCE;
         }
 
+        @Override
+        public Summary getBasicSummary(String name) {
+            return NullSummary.INSTANCE;
+        }
+
+
     }
 
     private static final class NullCounter implements Counter {
@@ -78,7 +98,7 @@ public class NullMetricsProvider implements MetricsProvider {
         private static final NullCounter INSTANCE = new NullCounter();
 
         @Override
-        public void inc(long delta) {
+        public void add(long delta) {
         }
 
         @Override
@@ -93,7 +113,7 @@ public class NullMetricsProvider implements MetricsProvider {
         private static final NullSummary INSTANCE = new NullSummary();
 
         @Override
-        public void registerValue(long value) {
+        public void add(long value) {
         }
 
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
@@ -168,7 +168,7 @@ public class FinalRequestProcessor implements RequestProcessor {
              */
             long propagationLatency = Time.currentWallTime() - request.getHdr().getTime();
             if (propagationLatency > 0) {
-                ServerMetrics.PROPAGATION_LATENCY.add(propagationLatency);
+                this.zks.getServerMetrics().PROPAGATION_LATENCY.add(propagationLatency);
             }
         }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -362,7 +362,9 @@ public class NIOServerCnxn extends ServerCnxn {
             close();
         } catch (ClientCnxnLimitException e) {
             // Common case exception, print at debug level
-            ServerMetrics.CONNECTION_REJECTED.add(1);
+            if (zkServer != null) {
+                zkServer.getServerMetrics().CONNECTION_REJECTED.add(1);            
+            }
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Exception causing close of session 0x"
                           + Long.toHexString(sessionId) + ": " + e.getMessage());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxnFactory.java
@@ -310,7 +310,9 @@ public class NIOServerCnxnFactory extends ServerCnxnFactory {
                 acceptErrorLogger.flush();
             } catch (IOException e) {
                 // accept, maxClientCnxns, configureBlocking
-                ServerMetrics.CONNECTION_REJECTED.add(1);
+                if (zkServer != null) {
+                    zkServer.getServerMetrics().CONNECTION_REJECTED.add(1);
+                }
                 acceptErrorLogger.rateLimitLog(
                     "Error accepting new connection: " + e.getMessage());
                 fastCloseSock(sc);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -531,7 +531,9 @@ public class NettyServerCnxn extends ServerCnxn {
             close();
         } catch(ClientCnxnLimitException e) {
             // Common case exception, print at debug level
-            ServerMetrics.CONNECTION_REJECTED.add(1);
+            if (zkServer != null) {
+                zkServer.getServerMetrics().CONNECTION_REJECTED.add(1);
+            }
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Closing connection to " + getRemoteSocketAddress(), e);
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -109,7 +109,9 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
             InetAddress addr = ((InetSocketAddress) channel.remoteAddress())
                     .getAddress();
             if (maxClientCnxns > 0 && getClientCnxnCount(addr) >= maxClientCnxns) {
-                ServerMetrics.CONNECTION_REJECTED.add(1);
+                if (zkServer != null) {
+                    zkServer.getServerMetrics().CONNECTION_REJECTED.add(1);
+                }
                 LOG.warn("Too many connections from {} - max is {}", addr,
                         maxClientCnxns);
                 channel.close();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerCnxn.java
@@ -137,9 +137,13 @@ public abstract class ServerCnxn implements Stats, Watcher {
                     // Cache miss, serialize the response and put it in cache.
                     data = serializeRecord(r);
                     cache.put(cacheKey, data, stat);
-                    ServerMetrics.RESPONSE_PACKET_CACHE_MISSING.add(1);
+                    if (zkServer != null) {
+                        zkServer.getServerMetrics().RESPONSE_PACKET_CACHE_MISSING.add(1);
+                    }
                 } else {
-                    ServerMetrics.RESPONSE_PACKET_CACHE_HITS.add(1);
+                    if (zkServer != null) {
+                        zkServer.getServerMetrics().RESPONSE_PACKET_CACHE_HITS.add(1);
+                    }
                 }
             } else {
                 data = serializeRecord(r);
@@ -235,7 +239,9 @@ public abstract class ServerCnxn implements Stats, Watcher {
         if (serverStats != null) {
             serverStats().incrementPacketsReceived();
         }
-        ServerMetrics.BYTES_RECEIVED_COUNT.add(bytes);
+        if (zkServer != null) {
+            zkServer.getServerMetrics().BYTES_RECEIVED_COUNT.add(bytes);
+        }
     }
 
     protected void packetSent() {
@@ -247,6 +253,13 @@ public abstract class ServerCnxn implements Stats, Watcher {
     }
 
     protected abstract ServerStats serverStats();
+    
+    public final ServerMetrics getServerMetrics() {
+        if (zkServer == null) {
+            return ServerMetrics.NULL_METRICS;
+        }
+        return zkServer.getServerMetrics();
+    }  
 
     protected final Date established = new Date();
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerConfig.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.Properties;
 
 import org.apache.yetus.audience.InterfaceAudience;
-import org.apache.zookeeper.metrics.impl.NullMetricsProvider;
+import org.apache.zookeeper.metrics.impl.DefaultMetricsProvider;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig.ConfigException;
 
@@ -50,7 +50,7 @@ public class ServerConfig {
     protected int minSessionTimeout = -1;
     /** defaults to -1 if not set explicitly */
     protected int maxSessionTimeout = -1;
-    protected String metricsProviderClassName = NullMetricsProvider.class.getName();
+    protected String metricsProviderClassName = DefaultMetricsProvider.class.getName();
     protected Properties metricsProviderConfiguration = new Properties();
     /** defaults to -1 if not set explicitly */
     protected int listenBacklog = -1;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
@@ -73,6 +73,7 @@ public class ZKDatabase {
     protected DataTree dataTree;
     protected ConcurrentHashMap<Long, Integer> sessionsWithTimeouts;
     protected FileTxnSnapLog snapLog;
+    protected ServerMetrics serverMetrics;
     protected long minCommittedLog, maxCommittedLog;
 
     /**
@@ -94,10 +95,11 @@ public class ZKDatabase {
      * between a filetxnsnaplog and zkdatabase.
      * @param snapLog the FileTxnSnapLog mapping this zkdatabase
      */
-    public ZKDatabase(FileTxnSnapLog snapLog) {
+    public ZKDatabase(FileTxnSnapLog snapLog, ServerMetrics serverMetrics) {
         dataTree = createDataTree();
         sessionsWithTimeouts = new ConcurrentHashMap<Long, Integer>();
         this.snapLog = snapLog;
+        this.serverMetrics = serverMetrics;
 
         try {
             snapshotSizeFactor = Double.parseDouble(
@@ -249,7 +251,7 @@ public class ZKDatabase {
         long zxid = snapLog.restore(dataTree, sessionsWithTimeouts, commitProposalPlaybackListener);
         initialized = true;
         long loadTime = Time.currentElapsedTime() - startTime;
-        ServerMetrics.DB_INIT_TIME.add(loadTime);
+        serverMetrics.DB_INIT_TIME.add(loadTime);
         LOG.info("Snapshot loaded in " + loadTime + " ms");
         return zxid;
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
@@ -129,7 +129,7 @@ public class ZooKeeperServerMain {
                 throw new IOException("Cannot boot MetricsProvider "+config.getMetricsProviderClassName(),
                     error);
             }
-
+            ServerMetrics serverMetrics = new ServerMetrics(metricsProvider);
             // Note that this thread isn't going to be doing anything else,
             // so rather than spawning another thread, we will just call
             // run() in this thread.
@@ -137,8 +137,7 @@ public class ZooKeeperServerMain {
             txnLog = new FileTxnSnapLog(config.dataLogDir, config.dataDir);
             final ZooKeeperServer zkServer = new ZooKeeperServer(txnLog,
                     config.tickTime, config.minSessionTimeout, config.maxSessionTimeout,
-                    config.listenBacklog, null);
-            zkServer.setRootMetricsContext(metricsProvider.getRootContext());
+                    config.listenBacklog, null, serverMetrics);
             txnLog.setServerStats(zkServer.serverStats());
 
             // Registers shutdown handler which will be used to know the

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Commands.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Commands.java
@@ -391,9 +391,14 @@ public class Commands {
             if (zkServer instanceof ObserverZooKeeperServer) {
                 response.put("observer_master_id", ((ObserverZooKeeperServer)zkServer).getObserver().getLearnerMasterId());
             }
-
-            response.putAll(ServerMetrics.getAllValues());
-
+            
+            
+            zkServer.getServerMetrics()
+                    .getMetricsProvider()
+                    .dump(
+                    (metric, value) -> {
+                        response.put(metric, value);
+                    });
             return response;
 
         }}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/EnsembleAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/EnsembleAuthenticationProvider.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.jmx.ZKMBeanInfo;
 
 import javax.management.JMException;
+import org.apache.zookeeper.server.ServerStats;
 
 /**
  * This is not a true AuthenticationProvider in the strict sense. it does
@@ -83,19 +84,19 @@ public class EnsembleAuthenticationProvider implements AuthenticationProvider {
     handleAuthentication(ServerCnxn cnxn, byte[] authData)
     {
         if (authData == null || authData.length == 0) {
-            ServerMetrics.ENSEMBLE_AUTH_SKIP.add(1);
+            cnxn.getServerMetrics().ENSEMBLE_AUTH_SKIP.add(1);            
             return KeeperException.Code.OK;
         }
 
         String receivedEnsembleName = new String(authData);
 
         if (ensembleNames == null) {
-            ServerMetrics.ENSEMBLE_AUTH_SKIP.add(1);
+            cnxn.getServerMetrics().ENSEMBLE_AUTH_SKIP.add(1);
             return KeeperException.Code.OK;
         }
 
         if (ensembleNames.contains(receivedEnsembleName)) {
-            ServerMetrics.ENSEMBLE_AUTH_SUCCESS.add(1);
+            cnxn.getServerMetrics().ENSEMBLE_AUTH_SUCCESS.add(1);            
             return KeeperException.Code.OK;
         }
 
@@ -111,7 +112,8 @@ public class EnsembleAuthenticationProvider implements AuthenticationProvider {
          * we return an error, the client will get a fatal auth error and
          * shutdown.
          */
-        ServerMetrics.ENSEMBLE_AUTH_FAIL.add(1);
+        cnxn.getServerMetrics().ENSEMBLE_AUTH_FAIL.add(1);
+        
         cnxn.close();
         return KeeperException.Code.BADARGUMENTS;
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/metric/AvgMinMaxCounter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/metric/AvgMinMaxCounter.java
@@ -22,12 +22,14 @@ import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.zookeeper.metrics.Summary;
 
 /**
  * Generic long counter that keep track of min/max/avg. The counter is
  * thread-safe
  */
-public class AvgMinMaxCounter extends Metric {
+public class AvgMinMaxCounter extends Metric
+            implements Summary {
     private String name;
     private AtomicLong total = new AtomicLong();
     private AtomicLong min = new AtomicLong(Long.MAX_VALUE);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/metric/AvgMinMaxPercentileCounter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/metric/AvgMinMaxPercentileCounter.java
@@ -29,13 +29,15 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
+import org.apache.zookeeper.metrics.Summary;
 
 
 /**
  * Generic long counter that keep track of min/max/avg/percentiles.
  * The counter is thread-safe
  */
-public class AvgMinMaxPercentileCounter extends Metric  {
+public class AvgMinMaxPercentileCounter extends Metric 
+                implements Summary {
 
     private String name;
     private AvgMinMaxCounter counter;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/metric/SimpleCounter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/metric/SimpleCounter.java
@@ -22,8 +22,10 @@ import java.lang.Override;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.zookeeper.metrics.Counter;
 
-public class SimpleCounter extends Metric {
+public class SimpleCounter extends Metric
+                    implements Counter {
     private final String name;
     private final AtomicLong counter = new AtomicLong();
 
@@ -41,14 +43,14 @@ public class SimpleCounter extends Metric {
         counter.set(0);
     }
 
-    public long getCount() {
+    public long get() {
         return counter.get();
     }
 
     @Override
     public Map<String, Object> values() {
         Map<String, Object> m = new LinkedHashMap<String, Object>();
-        m.put(name, this.getCount());
+        m.put(name, this.get());
         return m;
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnLog.java
@@ -388,7 +388,9 @@ public class FileTxnLog implements TxnLog {
                             + "File size is " + channel.size() + " bytes. "
                             + "See the ZooKeeper troubleshooting guide");
                 }
-                ServerMetrics.FSYNC_TIME.add(syncElapsedMS);
+                if (serverStats != null) {
+                    serverStats.getServerMetrics().FSYNC_TIME.add(syncElapsedMS);
+                }
             }
         }
         while (streamsToFlush.size() > 1) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Follower.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Follower.java
@@ -70,7 +70,7 @@ public class Follower extends Learner{
         self.end_fle = Time.currentElapsedTime();
         long electionTimeTaken = self.end_fle - self.start_fle;
         self.setElectionTimeTaken(electionTimeTaken);
-        ServerMetrics.ELECTION_TIME.add(electionTimeTaken);
+        self.getActiveServer().getServerMetrics().ELECTION_TIME.add(electionTimeTaken);
         LOG.info("FOLLOWING - LEADER ELECTION TOOK - {} {}", electionTimeTaken,
                 QuorumPeer.FLE_TIME_UNIT);
         self.start_fle = 0;
@@ -96,7 +96,7 @@ public class Follower extends Learner{
                     syncWithLeader(newEpochZxid);
                 } finally {
                     long syncTime = Time.currentElapsedTime() - startTime;
-                    ServerMetrics.FOLLOWER_SYNC_TIME.add(syncTime);
+                    self.getActiveServer().getServerMetrics().FOLLOWER_SYNC_TIME.add(syncTime);
                 }
                 if (self.getObserverMasterPort() > 0) {
                     LOG.info("Starting ObserverMaster");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -428,7 +428,8 @@ public class Leader implements LearnerMaster {
 
                         BufferedInputStream is = new BufferedInputStream(
                                 s.getInputStream());
-                        LearnerHandler fh = new LearnerHandler(s, is, Leader.this);
+                        LearnerHandler fh = new LearnerHandler(s, is,
+                                Leader.this, self.getServerMetrics());
                         fh.start();
                     } catch (SocketException e) {
                         error = true;
@@ -502,7 +503,7 @@ public class Leader implements LearnerMaster {
         self.end_fle = Time.currentElapsedTime();
         long electionTimeTaken = self.end_fle - self.start_fle;
         self.setElectionTimeTaken(electionTimeTaken);
-        ServerMetrics.ELECTION_TIME.add(electionTimeTaken);
+        self.getServerMetrics().ELECTION_TIME.add(electionTimeTaken);
         LOG.info("LEADING - LEADER ELECTION TOOK - {} {}", electionTimeTaken,
                 QuorumPeer.FLE_TIME_UNIT);
         self.start_fle = 0;
@@ -1057,7 +1058,7 @@ public class Leader implements LearnerMaster {
         }
         QuorumPacket qp = new QuorumPacket(Leader.COMMIT, zxid, null, null);
         sendPacket(qp);
-        ServerMetrics.COMMIT_COUNT.add(1);
+        self.getServerMetrics().COMMIT_COUNT.add(1);
     }
 
     //commit and send some info

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
@@ -60,6 +60,7 @@ public class LearnerHandler extends ZooKeeperThread {
     private static final Logger LOG = LoggerFactory.getLogger(LearnerHandler.class);
 
     protected final Socket sock;
+    private final ServerMetrics serverMetrics;
 
     public Socket getSocket() {
         return sock;
@@ -184,8 +185,10 @@ public class LearnerHandler extends ZooKeeperThread {
      */
     private long leaderLastZxid;
 
-    LearnerHandler(Socket sock, BufferedInputStream bufferedInput, LearnerMaster learnerMaster) throws IOException {
+    LearnerHandler(Socket sock, BufferedInputStream bufferedInput,
+            LearnerMaster learnerMaster, ServerMetrics serverMetrics) throws IOException {
         super("LearnerHandler-" + sock.getRemoteSocketAddress());
+        this.serverMetrics = serverMetrics;
         this.sock = sock;
         this.learnerMaster = learnerMaster;
         this.bufferedInput = bufferedInput;
@@ -481,11 +484,11 @@ public class LearnerHandler extends ZooKeeperThread {
                     bufferedOutput.flush();
                 } finally {
                     snapshot.close();
-                    ServerMetrics.SNAP_COUNT.add(1);
+                    serverMetrics.SNAP_COUNT.add(1);
                 }
             }
             else {
-                ServerMetrics.DIFF_COUNT.add(1);
+                serverMetrics.DIFF_COUNT.add(1);
             }
 
             LOG.debug("Sending NEWLEADER message to " + sid);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
@@ -473,7 +473,7 @@ public class ObserverMaster implements LearnerMaster, Runnable {
                 // in LearnerHandler switch to the syncLimit
                 s.setSoTimeout(self.tickTime * self.initLimit);
                 BufferedInputStream is = new BufferedInputStream(s.getInputStream());
-                LearnerHandler lh = new LearnerHandler(s, is, this);
+                LearnerHandler lh = new LearnerHandler(s, is, this, self.getServerMetrics());
                 lh.start();
             } catch (Exception e) {
                 if (listenerRunning) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -56,7 +56,7 @@ import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
 import org.apache.zookeeper.server.util.VerifyingFileFactory;
 
 import static org.apache.zookeeper.common.NetUtils.formatInetAddr;
-import org.apache.zookeeper.metrics.impl.NullMetricsProvider;
+import org.apache.zookeeper.metrics.impl.DefaultMetricsProvider;
 
 @InterfaceAudience.Public
 public class QuorumPeerConfig {
@@ -83,7 +83,7 @@ public class QuorumPeerConfig {
     protected int minSessionTimeout = -1;
     /** defaults to -1 if not set explicitly */
     protected int maxSessionTimeout = -1;
-    protected String metricsProviderClassName = NullMetricsProvider.class.getName();
+    protected String metricsProviderClassName = DefaultMetricsProvider.class.getName();
     protected Properties metricsProviderConfiguration = new Properties();
     protected boolean localSessionsEnabled = false;
     protected boolean localSessionsUpgradingEnabled = false;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
@@ -34,6 +34,7 @@ import org.apache.zookeeper.server.ExitCode;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.DatadirCleanupManager;
+import org.apache.zookeeper.server.ServerMetrics;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.admin.AdminServer.AdminServerException;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
@@ -154,7 +155,7 @@ public class QuorumPeerMain {
                       error);
       }
       try {
-
+          final ServerMetrics serverMetrics = new ServerMetrics(metricsProvider);
           ServerCnxnFactory cnxnFactory = null;
           ServerCnxnFactory secureCnxnFactory = null;
 
@@ -173,7 +174,7 @@ public class QuorumPeerMain {
           }
 
           quorumPeer = getQuorumPeer();
-          quorumPeer.setRootMetricsContext(metricsProvider.getRootContext());
+          quorumPeer.setServerMetrics(serverMetrics);
           quorumPeer.setTxnFactory(new FileTxnSnapLog(
                       config.getDataLogDir(),
                       config.getDataDir()));
@@ -191,7 +192,7 @@ public class QuorumPeerMain {
           quorumPeer.setObserverMasterPort(config.getObserverMasterPort());
           quorumPeer.setConfigFileName(config.getConfigFilename());
           quorumPeer.setClientPortListenBacklog(config.getClientPortListenBacklog());
-          quorumPeer.setZKDatabase(new ZKDatabase(quorumPeer.getTxnFactory()));
+          quorumPeer.setZKDatabase(new ZKDatabase(quorumPeer.getTxnFactory(), serverMetrics));
           quorumPeer.setQuorumVerifier(config.getQuorumVerifier(), false);
           if (config.getLastSeenQuorumVerifier()!=null) {
               quorumPeer.setLastSeenQuorumVerifier(config.getLastSeenQuorumVerifier(), false);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
@@ -46,7 +46,8 @@ public abstract class QuorumZooKeeperServer extends ZooKeeperServer {
             int minSessionTimeout, int maxSessionTimeout, int listenBacklog,
             ZKDatabase zkDb, QuorumPeer self)
     {
-        super(logFactory, tickTime, minSessionTimeout, maxSessionTimeout, listenBacklog, zkDb);
+        super(logFactory, tickTime, minSessionTimeout, maxSessionTimeout, listenBacklog,
+                zkDb, self.getServerMetrics());
         this.self = self;
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyZooKeeperServer.java
@@ -46,7 +46,8 @@ public class ReadOnlyZooKeeperServer extends ZooKeeperServer {
     ReadOnlyZooKeeperServer(FileTxnSnapLog logFactory, QuorumPeer self,
                             ZKDatabase zkDb) {
         super(logFactory, self.tickTime, self.minSessionTimeout,
-              self.maxSessionTimeout, self.clientPortListenBacklog, zkDb);
+              self.maxSessionTimeout, self.clientPortListenBacklog, zkDb,
+              self.getServerMetrics());
         this.self = self;
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/IWatchManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/IWatchManager.java
@@ -22,6 +22,7 @@ import java.io.PrintWriter;
 
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.EventType;
+import org.apache.zookeeper.server.ServerMetrics;
 
 public interface IWatchManager {
 
@@ -131,4 +132,11 @@ public interface IWatchManager {
      * @return string representation of watches
      */
     public void dumpWatches(PrintWriter pwriter, boolean byPath);
+    
+    
+    /**
+     * Link the manager with the Metrics collector.
+     * @param serverMetrics 
+     */
+    public void setServerMetrics(ServerMetrics serverMetrics);
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/WatchManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/WatchManager.java
@@ -48,7 +48,9 @@ public class WatchManager implements IWatchManager {
 
     private final Map<Watcher, Set<String>> watch2Paths =
         new HashMap<Watcher, Set<String>>();
-
+    
+    private ServerMetrics serverMetrics = ServerMetrics.NULL_METRICS;
+    
     @Override
     public synchronized int size(){
         int result = 0;
@@ -142,19 +144,19 @@ public class WatchManager implements IWatchManager {
 
         switch (type) {
         case NodeCreated:
-            ServerMetrics.NODE_CREATED_WATCHER.add(watchers.size());
+            serverMetrics.NODE_CREATED_WATCHER.add(watchers.size());
             break;
 
         case NodeDeleted:
-            ServerMetrics.NODE_DELETED_WATCHER.add(watchers.size());
+            serverMetrics.NODE_DELETED_WATCHER.add(watchers.size());
             break;
 
         case NodeDataChanged:
-            ServerMetrics.NODE_CHANGED_WATCHER.add(watchers.size());
+            serverMetrics.NODE_CHANGED_WATCHER.add(watchers.size());
             break;
 
         case NodeChildrenChanged:
-            ServerMetrics.NODE_CHILDREN_WATCHER.add(watchers.size());
+            serverMetrics.NODE_CHILDREN_WATCHER.add(watchers.size());
             break;
         default:
             // Other types not logged.
@@ -267,4 +269,11 @@ public class WatchManager implements IWatchManager {
 
     @Override
     public void shutdown() { /* do nothing */ }
+
+    @Override
+    public void setServerMetrics(ServerMetrics serverMetrics) {
+        this.serverMetrics = serverMetrics;
+    }
+    
+    
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/WatchManagerOptimized.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/WatchManagerOptimized.java
@@ -68,6 +68,8 @@ public class WatchManagerOptimized
     private final WatcherCleaner watcherCleaner;
 
     private final ReentrantReadWriteLock addRemovePathRWLock = new ReentrantReadWriteLock();
+    
+    private ServerMetrics serverMetrics = ServerMetrics.NULL_METRICS;
 
     public WatchManagerOptimized() {
         watcherCleaner = new WatcherCleaner(this);
@@ -277,19 +279,19 @@ public class WatchManagerOptimized
     void updateMetrics(final EventType type, int size) {
         switch (type) {
         case NodeCreated:
-            ServerMetrics.NODE_CREATED_WATCHER.add(size);
+            serverMetrics.NODE_CREATED_WATCHER.add(size);
             break;
 
         case NodeDeleted:
-            ServerMetrics.NODE_DELETED_WATCHER.add(size);
+            serverMetrics.NODE_DELETED_WATCHER.add(size);
             break;
 
         case NodeDataChanged:
-            ServerMetrics.NODE_CHANGED_WATCHER.add(size);
+            serverMetrics.NODE_CHANGED_WATCHER.add(size);
             break;
 
         case NodeChildrenChanged:
-            ServerMetrics.NODE_CHILDREN_WATCHER.add(size);
+            serverMetrics.NODE_CHILDREN_WATCHER.add(size);
             break;
         default:
             // Other types not logged.
@@ -413,5 +415,11 @@ public class WatchManagerOptimized
             .append(pathSize()).append(" paths\n");
         sb.append("Total watches:").append(size());
         return sb.toString();
+    }
+
+    @Override
+    public void setServerMetrics(ServerMetrics serverMetrics) {
+        this.serverMetrics = serverMetrics;
+        watcherCleaner.setServerMetrics(serverMetrics);
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/WatcherCleaner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/WatcherCleaner.java
@@ -61,6 +61,7 @@ public class WatcherCleaner extends Thread {
     private final int watcherCleanIntervalInSeconds;
     private final int maxInProcessingDeadWatchers;
     private final AtomicInteger totalDeadWatchers = new AtomicInteger();
+    private ServerMetrics serverMetrics = ServerMetrics.NULL_METRICS;
 
     public WatcherCleaner(IDeadWatcherListener listener) {
         this(listener,
@@ -109,7 +110,7 @@ public class WatcherCleaner extends Thread {
                     processingCompletedEvent.wait(100);
                 }
                 long latency = Time.currentElapsedTime() - startTime;
-                ServerMetrics.ADD_DEAD_WATCHER_STALL_TIME.add(latency);
+                serverMetrics.ADD_DEAD_WATCHER_STALL_TIME.add(latency);
             } catch (InterruptedException e) {
                 LOG.info("Got interrupted while waiting for dead watches " +
                         "queue size");
@@ -119,7 +120,7 @@ public class WatcherCleaner extends Thread {
         synchronized (this) {
             if (deadWatchers.add(watcherBit)) {
                 totalDeadWatchers.incrementAndGet();
-                ServerMetrics.DEAD_WATCHERS_QUEUED.add(1);
+                serverMetrics.DEAD_WATCHERS_QUEUED.add(1);
                 if (deadWatchers.size() >= watcherCleanThreshold) {
                     synchronized (cleanEvent) {
                         cleanEvent.notifyAll();
@@ -169,8 +170,8 @@ public class WatcherCleaner extends Thread {
                         listener.processDeadWatchers(snapshot);
                         long latency = Time.currentElapsedTime() - startTime;
                         LOG.info("Takes {} to process {} watches", latency, total);
-                        ServerMetrics.DEAD_WATCHERS_CLEANER_LATENCY.add(latency);
-                        ServerMetrics.DEAD_WATCHERS_CLEARED.add(total);
+                        serverMetrics.DEAD_WATCHERS_CLEANER_LATENCY.add(latency);
+                        serverMetrics.DEAD_WATCHERS_CLEARED.add(total);
                         totalDeadWatchers.addAndGet(-total);
                         synchronized(processingCompletedEvent) {
                             processingCompletedEvent.notifyAll();
@@ -192,4 +193,9 @@ public class WatcherCleaner extends Thread {
         }
     }
 
+    public void setServerMetrics(ServerMetrics serverMetrics) {
+        this.serverMetrics = serverMetrics;
+    }
+
+    
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/metrics/BaseTestMetricsProvider.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/metrics/BaseTestMetricsProvider.java
@@ -17,9 +17,12 @@
  */
 package org.apache.zookeeper.metrics;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import org.apache.zookeeper.metrics.impl.NullMetricsProvider;
 
 /**
@@ -42,6 +45,14 @@ public abstract class BaseTestMetricsProvider implements MetricsProvider {
 
     @Override
     public void stop() {
+    }
+
+    @Override
+    public void dump(BiConsumer<String, Object> sink) {
+    }
+
+    @Override
+    public void resetAllValues() {
     }
 
     public static final class MetricsProviderCapturingLifecycle extends BaseTestMetricsProvider {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/MockServerCnxn.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/MockServerCnxn.java
@@ -97,7 +97,7 @@ public class MockServerCnxn extends ServerCnxn {
     }
 
     @Override
-    protected ServerStats serverStats() {
+    public ServerStats serverStats() {
         return null;
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ServerMetricsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ServerMetricsTest.java
@@ -99,7 +99,7 @@ public class ServerMetricsTest extends ZKTestCase {
         }
 
         long expectedCount = Arrays.stream(values).sum();
-        Assert.assertEquals(expectedCount, metric.getCount());
+        Assert.assertEquals(expectedCount, metric.get());
 
         final Map<String, Object> results = metric.values();
         Assert.assertEquals(expectedCount, (long)results.get("test"));

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ServerStatsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ServerStatsTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class ServerStatsTest extends ZKTestCase {
@@ -34,6 +35,8 @@ public class ServerStatsTest extends ZKTestCase {
     @Before
     public void setUp() {
         providerMock = mock(ServerStats.Provider.class);
+        when(providerMock.getServerMetrics())
+                .thenReturn(ServerMetrics.NULL_METRICS);
     }
 
     @Test

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerMainTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerMainTest.java
@@ -189,7 +189,8 @@ public class ZooKeeperServerMainTest extends ZKTestCase implements Watcher {
                 throw new IOException("Input/output error");
             }
         };
-        ZKDatabase newDB = new ZKDatabase(fileTxnSnapLogWithError);
+        ZKDatabase newDB = new ZKDatabase(fileTxnSnapLogWithError,
+                ServerMetrics.NULL_METRICS);
         zooKeeperServer.setZKDatabase(newDB);
 
         try {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/CommandsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/CommandsTest.java
@@ -193,8 +193,16 @@ public class CommandsTest extends ClientBase {
                 new Field("global_sessions", Long.class),
                 new Field("local_sessions", Long.class),
                 new Field("connection_drop_probability", Double.class)
-        ));
-        for (String metric : ServerMetrics.getAllValues().keySet()) {
+        ));        
+        Map<String, Object> metrics = new HashMap<>();
+                this.serverFactory
+                .getZooKeeperServer()
+                .getServerMetrics()
+                .getMetricsProvider()
+                .dump( (metric, value)-> {
+                    metrics.put(metric, value);
+                });
+        for (String metric : metrics.keySet()) {
             if (metric.startsWith("avg_")) {
                 fields.add(new Field(metric, Double.class));  
             } else {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/FuzzySnapshotRelatedTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/FuzzySnapshotRelatedTest.java
@@ -379,7 +379,7 @@ public class FuzzySnapshotRelatedTest extends QuorumPeerTestBase {
             return new QuorumPeer() {
                 @Override
                 public void setZKDatabase(ZKDatabase database) {
-                    super.setZKDatabase(new ZKDatabase(this.getTxnFactory()) {
+                    super.setZKDatabase(new ZKDatabase(this.getTxnFactory(), this.getServerMetrics()) {
                         @Override
                         public DataTree createDataTree() {
                             return new CustomDataTree();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
@@ -43,6 +43,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.zookeeper.server.ServerMetrics;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -82,7 +83,7 @@ public class LeaderBeanTest {
         File tmpDir = ClientBase.createEmptyTestDir();
         fileTxnSnapLog = new FileTxnSnapLog(new File(tmpDir, "data"),
                 new File(tmpDir, "data_txnlog"));
-        ZKDatabase zkDb = new ZKDatabase(fileTxnSnapLog);
+        ZKDatabase zkDb = new ZKDatabase(fileTxnSnapLog, ServerMetrics.NULL_METRICS);
 
         zks = new LeaderZooKeeperServer(fileTxnSnapLog, qp, zkDb);
         leader = new Leader(qp, zks);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerHandlerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerHandlerTest.java
@@ -34,6 +34,7 @@ import java.util.Queue;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.server.ServerMetrics;
 import org.apache.zookeeper.server.TxnLogProposalIterator;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
@@ -55,7 +56,8 @@ public class LearnerHandlerTest extends ZKTestCase {
         boolean threadStarted = false;
 
         MockLearnerHandler(Socket sock, Leader leader) throws IOException {
-            super(sock, new BufferedInputStream(sock.getInputStream()), leader);
+            super(sock, new BufferedInputStream(sock.getInputStream()),
+                    leader, ServerMetrics.NULL_METRICS);
         }
 
         protected void startSendingPackets() {
@@ -70,7 +72,7 @@ public class LearnerHandlerTest extends ZKTestCase {
         LinkedList<Proposal> txnLog = new LinkedList<Leader.Proposal>();
 
         public MockZKDatabase(FileTxnSnapLog snapLog) {
-            super(snapLog);
+            super(snapLog, ServerMetrics.NULL_METRICS);
         }
 
         public long getDataTreeLastProcessedZxid() {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerTest.java
@@ -33,6 +33,7 @@ import org.apache.jute.BinaryOutputArchive;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.server.ServerMetrics;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.test.TestUtils;
@@ -51,7 +52,8 @@ public class LearnerTest extends ZKTestCase {
 
         public SimpleLearnerZooKeeperServer(FileTxnSnapLog ftsl, QuorumPeer self)
                 throws IOException {
-            super(ftsl, 2000, 2000, 2000, -1, new ZKDatabase(ftsl), self);
+            super(ftsl, 2000, 2000, 2000, -1,
+                    new ZKDatabase(ftsl, self.getServerMetrics()), self);
         }
 
         @Override

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/WatchLeakTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/WatchLeakTest.java
@@ -61,6 +61,7 @@ import org.apache.zookeeper.server.MockSelectorThread;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.ZKParameterized;
+import org.apache.zookeeper.server.ServerMetrics;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -118,9 +119,10 @@ public class WatchLeakTest {
             }
         });
 
-        ZKDatabase database = new ZKDatabase(null);
+        ZKDatabase database = new ZKDatabase(null, ServerMetrics.NULL_METRICS);
         database.setlastProcessedZxid(2L);
         QuorumPeer quorumPeer = mock(QuorumPeer.class);
+        when(quorumPeer.getServerMetrics()).thenReturn(ServerMetrics.NULL_METRICS);
         FileTxnSnapLog logfactory = mock(FileTxnSnapLog.class);
         // Directories are not used but we need it to avoid NPE
         when(logfactory.getDataDir()).thenReturn(new File(""));

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ZabUtils.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ZabUtils.java
@@ -92,7 +92,7 @@ public class ZabUtils {
             throws IOException, NoSuchFieldException, IllegalAccessException {
         FileTxnSnapLog logFactory = new FileTxnSnapLog(tmpDir, tmpDir);
         peer.setTxnFactory(logFactory);
-        ZKDatabase zkDb = new ZKDatabase(logFactory);
+        ZKDatabase zkDb = new ZKDatabase(logFactory, peer.getServerMetrics());
         LeaderZooKeeperServer zk = new LeaderZooKeeperServer(logFactory, peer, zkDb);
         return zk;
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/watch/WatchManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/watch/WatchManagerTest.java
@@ -19,6 +19,7 @@ package org.apache.zookeeper.server.watch;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -34,9 +35,6 @@ import org.apache.zookeeper.server.ServerCnxn;
 
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.server.ServerMetrics;
-import org.apache.zookeeper.server.metric.AvgMinMaxCounter;
-import org.apache.zookeeper.server.metric.Metric;
-import org.eclipse.jetty.util.IO;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,6 +53,7 @@ public class WatchManagerTest extends ZKTestCase {
     private ConcurrentHashMap<Integer, DumbWatcher> watchers;
     private Random r;
     private String className;
+    private ServerMetrics serverMetrics = ServerMetrics.DEFAULT_METRICS_FOR_TESTS;
 
     public WatchManagerTest(String className) {
         this.className = className;
@@ -70,13 +69,16 @@ public class WatchManagerTest extends ZKTestCase {
 
     @Before
     public void setUp() {
+        serverMetrics.resetAll();
         watchers = new ConcurrentHashMap<Integer, DumbWatcher>();
         r = new Random(System.nanoTime());
     }
 
     public IWatchManager getWatchManager() throws IOException {
         System.setProperty(WatchManagerFactory.ZOOKEEPER_WATCH_MANAGER_NAME, className);
-        return WatchManagerFactory.createWatchManager();
+        IWatchManager res = WatchManagerFactory.createWatchManager();
+        res.setServerMetrics(serverMetrics);
+        return res;
     }
 
     public DumbWatcher createOrGetWatcher(int watcherId) {
@@ -409,7 +411,10 @@ public class WatchManagerTest extends ZKTestCase {
     }
 
     private void checkMetrics(String metricName, long min, long max, double avg, long cnt, long sum){
-        Map<String, Object> values = ServerMetrics.getAllValues();
+        Map<String, Object> values = new HashMap<>();
+        serverMetrics.getMetricsProvider().dump((metric, value) -> {
+            values.put(metric, value);
+        });
 
         Assert.assertEquals(min, values.get("min_" + metricName));
         Assert.assertEquals(max, values.get("max_" + metricName));
@@ -421,7 +426,7 @@ public class WatchManagerTest extends ZKTestCase {
     @Test
     public void testWatcherMetrics() throws IOException {
         IWatchManager manager = getWatchManager();
-        ServerMetrics.resetAll();
+        serverMetrics.resetAll();
 
         DumbWatcher watcher1 = new DumbWatcher(1);
         DumbWatcher watcher2 = new DumbWatcher(2);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/watch/WatcherCleanerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/watch/WatcherCleanerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.zookeeper.server.watch;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
@@ -134,6 +135,8 @@ public class WatcherCleanerTest extends ZKTestCase {
 
     @Test
     public void testDeadWatcherMetrics() {
+        ServerMetrics serverMetrics = ServerMetrics.DEFAULT_METRICS_FOR_TESTS;
+        serverMetrics.resetAll();
         MyDeadWatcherListener listener = new MyDeadWatcherListener();
         WatcherCleaner cleaner = new WatcherCleaner(listener, 1, 1, 1, 1);
         listener.setDelayMs(20);
@@ -146,9 +149,11 @@ public class WatcherCleanerTest extends ZKTestCase {
         cleaner.addDeadWatcher(3);
 
         Assert.assertTrue(listener.wait(5000));
-
-        Map<String, Object> values = ServerMetrics.getAllValues();
-
+        
+        Map<String, Object> values = new HashMap<>();
+        serverMetrics.getMetricsProvider().dump((metric, value) -> {
+            values.put(metric, value);
+        });
         Assert.assertThat("Adding dead watcher should be stalled twice",
                           (Long)values.get("add_dead_watcher_stall_time"),
                            greaterThan(0L));

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/watch/WatcherCleanerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/watch/WatcherCleanerTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.common.Time;
+import org.apache.zookeeper.metrics.impl.DefaultMetricsProvider;
 import org.apache.zookeeper.server.ServerMetrics;
 import org.junit.Test;
 import org.junit.Assert;
@@ -135,10 +136,10 @@ public class WatcherCleanerTest extends ZKTestCase {
 
     @Test
     public void testDeadWatcherMetrics() {
-        ServerMetrics serverMetrics = ServerMetrics.DEFAULT_METRICS_FOR_TESTS;
-        serverMetrics.resetAll();
+        ServerMetrics serverMetrics = new ServerMetrics(new DefaultMetricsProvider());
         MyDeadWatcherListener listener = new MyDeadWatcherListener();
         WatcherCleaner cleaner = new WatcherCleaner(listener, 1, 1, 1, 1);
+        cleaner.setServerMetrics(serverMetrics);
         listener.setDelayMs(20);
         cleaner.start();
         listener.setCountDownLatch(new CountDownLatch(3));

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/NonRecoverableErrorTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/NonRecoverableErrorTest.java
@@ -29,6 +29,7 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.server.ServerMetrics;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
@@ -105,7 +106,7 @@ public class NonRecoverableErrorTest extends QuorumPeerTestBase {
                 .getZKDatabase();
         long leaderCurrentEpoch = leader.getCurrentEpoch();
 
-        ZKDatabase newDB = new ZKDatabase(fileTxnSnapLogWithError);
+        ZKDatabase newDB = new ZKDatabase(fileTxnSnapLogWithError, ServerMetrics.NULL_METRICS);
         leader.getActiveServer().setZKDatabase(newDB);
 
         try {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ResponseCacheTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ResponseCacheTest.java
@@ -18,13 +18,13 @@
 
 package org.apache.zookeeper.test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
-import org.apache.zookeeper.server.ServerMetrics;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -48,13 +48,21 @@ public class ResponseCacheTest extends ClientBase {
     }
 
     private void checkCacheStatus(long expectedHits, long expectedMisses) {
-        Map<String, Object> metrics = ServerMetrics.getAllValues();
+        
+        Map<String, Object> metrics = new HashMap<>();
+                this.serverFactory
+                .getZooKeeperServer()
+                .getServerMetrics()
+                .getMetricsProvider()
+                .dump((metric, value)-> {
+                    metrics.put(metric, value);
+                });
         Assert.assertEquals(expectedHits, metrics.get("response_packet_cache_hits"));
         Assert.assertEquals(expectedMisses, metrics.get("response_packet_cache_misses"));
     }
 
     public void performCacheTest(ZooKeeper zk, String path, boolean useCache) throws Exception {
-        ServerMetrics.resetAll();
+        this.serverFactory.getZooKeeperServer().getServerMetrics().resetAll();
         Stat writeStat = new Stat();
         Stat readStat = new Stat();
         byte[] readData = null;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/TruncateTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/TruncateTest.java
@@ -34,6 +34,7 @@ import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ServerMetrics;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.persistence.FileTxnLog;
@@ -73,7 +74,7 @@ public class TruncateTest extends ZKTestCase {
     public void testTruncationStreamReset() throws Exception {
         File tmpdir = ClientBase.createTmpDir();
         FileTxnSnapLog snaplog = new FileTxnSnapLog(tmpdir, tmpdir);
-        ZKDatabase zkdb = new ZKDatabase(snaplog);
+        ZKDatabase zkdb = new ZKDatabase(snaplog, ServerMetrics.NULL_METRICS);
         // make sure to snapshot, so that we have something there when
         // truncateLog reloads the db
         snaplog.save(zkdb.getDataTree(), zkdb.getSessionWithTimeOuts(), false);
@@ -112,7 +113,7 @@ public class TruncateTest extends ZKTestCase {
     public void testTruncationNullLog() throws Exception {
         File tmpdir = ClientBase.createTmpDir();
         FileTxnSnapLog snaplog = new FileTxnSnapLog(tmpdir, tmpdir);
-        ZKDatabase zkdb = new ZKDatabase(snaplog);
+        ZKDatabase zkdb = new ZKDatabase(snaplog, ServerMetrics.NULL_METRICS);
 
         for (int i = 1; i <= 100; i++) {
             append(zkdb, i);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ZkDatabaseCorruptionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ZkDatabaseCorruptionTest.java
@@ -28,6 +28,7 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.server.ServerMetrics;
 import org.apache.zookeeper.server.SyncRequestProcessor;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
@@ -163,7 +164,7 @@ public class ZkDatabaseCorruptionTest extends ZKTestCase {
             public File findMostRecentSnapshot() throws IOException {
                 return null;
             }
-        });
+        }, ServerMetrics.NULL_METRICS);
         assertEquals(0, zkDatabase.calculateTxnLogSizeLimit());
     }
 


### PR DESCRIPTION
- Refactor ServerMetrics, make it a single instance.
- Make ServerMetrics use the MetricsProvider API.
- Introduce a DefaultMetricsProvider which uses builtin metrics classes.
- Clean up ServerMetrics boot code.
- Integrate MetricsProvider with four letter words interface (monitor and reset)
- Add getBasicSummary() API to MetricsProvider to make it possile to model AvgMinMaxCounter (Summary without percentiles)