### PR TITLE
Exclude spotbugs annotations jar from the release

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -801,6 +801,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
         </fileset>
         <fileset dir="${ivy.lib}">
           <exclude name="**/jsr305*.jar" />
+          <exclude name="**/spotbugs-annotations*.jar" />
         </fileset>
       </copy>
 


### PR DESCRIPTION
Fix for 3.4.14-rc4: exclude `spotbugs-annotations` jar from the distribution.