### PR TITLE
ZOOKEEPER-3304 Maven build of "loggraph" is broken on branch-3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,16 +383,6 @@
         <version>${netty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.googlecode.json-simple</groupId>
         <artifactId>json-simple</artifactId>
         <version>${json.version}</version>

--- a/zookeeper-contrib/zookeeper-contrib-loggraph/ivy.xml
+++ b/zookeeper-contrib/zookeeper-contrib-loggraph/ivy.xml
@@ -36,8 +36,8 @@
   
     <!-- transitive false turns off dependency checking, log4j deps seem borked -->
     <dependency org="log4j" name="log4j" rev="1.2.15" transitive="false"/>
-    <dependency org="org.eclipse.jetty" name="jetty-server" rev="7.0.1.v20091125" />
-    <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="7.0.1.v20091125" />
+    <dependency org="org.eclipse.jetty" name="jetty-server" rev="9.4.15.v20190215" />
+    <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="9.4.15.v20190215" />
     <dependency org="com.googlecode.json-simple" name="json-simple" rev="1.1" />
   </dependencies>
 

--- a/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
@@ -33,6 +33,9 @@
   <description>
     LogGraph is an application for viewing and filtering zookeeper logs. It can handle transaction logs and message logs.
   </description>
+  <properties>
+    <jetty.version>9.4.14.v20181114</jetty.version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -72,10 +75,12 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>

--- a/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
@@ -34,7 +34,7 @@
     LogGraph is an application for viewing and filtering zookeeper logs. It can handle transaction logs and message logs.
   </description>
   <properties>
-    <jetty.version>9.4.14.v20181114</jetty.version>
+    <jetty.version>9.4.15.v20190215</jetty.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Fix Jetty dependency.
Move it only to loggraph package.
It won't be subject to global dependecyManagement because it is not used by core zookeeper-server module