### PR TITLE
ZOOKEEPER-3299:'setquota -n|-b val path' needs a brackets

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperStarted.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperStarted.md
@@ -166,7 +166,7 @@ From the shell, type `help` to get a listing of commands that can be executed fr
         addauth scheme auth
         delete path [version]
         deleteall path
-        setquota -n|-b val path
+        setquota [-n|-b] val path
 
 
 From here, you can try a few simple commands to get a feel for this simple command line interface.  First, start by issuing the list command, as

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetQuotaCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetQuotaCommand.java
@@ -36,7 +36,7 @@ public class SetQuotaCommand extends CliCommand {
     private CommandLine cl;
 
     public SetQuotaCommand() {
-        super("setquota", "-n|-b val path");
+        super("setquota", "[-n|-b] val path");
         
         OptionGroup og1 = new OptionGroup();
         og1.addOption(new Option("b", true, "bytes quota"));


### PR DESCRIPTION
Look at https://issues.apache.org/jira/browse/ZOOKEEPER-3299