### PR TITLE
zoo_sample.cfg: enable autopurge and change dataDir 

### DIFF
--- a/conf/zoo_prod_sample.cfg
+++ b/conf/zoo_prod_sample.cfg
@@ -1,0 +1,51 @@
+## https://zookeeper.apache.org/doc/current/zookeeperAdmin.html
+
+## The number of milliseconds of each tick
+tickTime=2000
+## The number of ticks that the initial
+## synchronization phase can take
+initLimit=30000
+## The number of ticks that can pass between
+## sending a request and getting an acknowledgement
+syncLimit=10
+
+maxClientCnxns=2000
+
+maxSessionTimeout=60000000
+## the directory where the snapshot is stored.
+dataDir=/var/lib/zookeeper/data
+## Place the dataLogDir to a separate physical disc for better performance
+dataLogDir=/var/lib/zookeeper/logs
+
+autopurge.snapRetainCount=10
+autopurge.purgeInterval=1
+
+
+## To avoid seeks ZooKeeper allocates space in the transaction log file in
+## blocks of preAllocSize kilobytes. The default block size is 64M. One reason
+## for changing the size of the blocks is to reduce the block size if snapshots
+## are taken more often. (Also, see snapCount).
+preAllocSize=131072
+
+## Clients can submit requests faster than ZooKeeper can process them,
+## especially if there are a lot of clients. To prevent ZooKeeper from running
+## out of memory due to queued requests, ZooKeeper will throttle clients so that
+## there is no more than globalOutstandingLimit outstanding requests in the
+## system. The default limit is 1,000.ZooKeeper logs transactions to a
+## transaction log. After snapCount transactions are written to a log file a
+## snapshot is started and a new transaction log file is started. The default
+## snapCount is 10,000.
+snapCount=3000000
+
+## If this option is defined, requests will be will logged to a trace file named
+## traceFile.year.month.day.
+##traceFile=
+
+## Leader accepts client connections. Default value is "yes". The leader machine
+## coordinates updates. For higher update throughput at thes slight expense of
+## read throughput the leader can be configured to not accept clients and focus
+## on coordination.
+leaderServes=yes
+
+standaloneEnabled=false
+dynamicConfigFile=/etc/zookeeper/conf/zoo.cfg.dynamic

--- a/conf/zoo_sample.cfg
+++ b/conf/zoo_sample.cfg
@@ -7,10 +7,9 @@ initLimit=10
 # sending a request and getting an acknowledgement
 syncLimit=5
 # the directory where the snapshot is stored.
-# do not use /tmp for storage!!!.
-dataDir=/var/lib/zookeeper/data
-# place the dataLogDir to a separate physical disc for better performance
-dataLogDir=/var/lib/zookeeper/log
+# do not use /tmp for storage, /tmp here is just
+# example sakes.
+dataDir=/tmp/zookeeper
 # the port at which the clients will connect
 clientPort=2181
 # the maximum number of client connections.
@@ -23,7 +22,7 @@ clientPort=2181
 # http://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_maintenance
 #
 # The number of snapshots to retain in dataDir
-autopurge.snapRetainCount=3
+#autopurge.snapRetainCount=3
 # Purge task interval in hours
 # Set to "0" to disable auto purge feature
-autopurge.purgeInterval=1
+#autopurge.purgeInterval=1

--- a/conf/zoo_sample.cfg
+++ b/conf/zoo_sample.cfg
@@ -1,28 +1,29 @@
 # The number of milliseconds of each tick
 tickTime=2000
-# The number of ticks that the initial 
+# The number of ticks that the initial
 # synchronization phase can take
 initLimit=10
-# The number of ticks that can pass between 
+# The number of ticks that can pass between
 # sending a request and getting an acknowledgement
 syncLimit=5
 # the directory where the snapshot is stored.
-# do not use /tmp for storage, /tmp here is just 
-# example sakes.
-dataDir=/tmp/zookeeper
+# do not use /tmp for storage!!!.
+dataDir=/var/lib/zookeeper/data
+# place the dataLogDir to a separate physical disc for better performance
+dataLogDir=/var/lib/zookeeper/log
 # the port at which the clients will connect
 clientPort=2181
 # the maximum number of client connections.
 # increase this if you need to handle more clients
 #maxClientCnxns=60
 #
-# Be sure to read the maintenance section of the 
+# Be sure to read the maintenance section of the
 # administrator guide before turning on autopurge.
 #
 # http://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_maintenance
 #
 # The number of snapshots to retain in dataDir
-#autopurge.snapRetainCount=3
+autopurge.snapRetainCount=3
 # Purge task interval in hours
 # Set to "0" to disable auto purge feature
-#autopurge.purgeInterval=1
+autopurge.purgeInterval=1


### PR DESCRIPTION
I think it's a very important changes, because I encountered a lot of production installations with "default" config. It's not joke, people don't read the comments in this file.