### PR TITLE
ZOOKEEPER-3342: Use StandardCharsets

### DIFF
--- a/zookeeper-recipes/zookeeper-recipes-queue/src/test/java/org/apache/zookeeper/recipes/queue/DistributedQueueTest.java
+++ b/zookeeper-recipes/zookeeper-recipes-queue/src/test/java/org/apache/zookeeper/recipes/queue/DistributedQueueTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,9 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.zookeeper.recipes.queue;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -28,9 +28,6 @@ import org.apache.zookeeper.test.ClientBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for {@link DistributedQueue}.
- */
 public class DistributedQueueTest extends ClientBase {
 
     @AfterEach
@@ -38,232 +35,287 @@ public class DistributedQueueTest extends ClientBase {
         super.tearDown();
     }
 
+
     @Test
     public void testOffer1() throws Exception {
         String dir = "/testOffer1";
         String testString = "Hello World";
-        final int numClients = 1;
-        ZooKeeper[] clients = new ZooKeeper[numClients];
-        DistributedQueue[] queueHandles = new DistributedQueue[numClients];
-        for (int i = 0; i < clients.length; i++) {
+        final int num_clients = 1;
+        ZooKeeper[] clients = new ZooKeeper[num_clients];
+        DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
+        for(int i=0; i < clients.length; i++){
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
 
-        queueHandles[0].offer(testString.getBytes());
+        queueHandles[0].offer(testString.getBytes(UTF_8));
 
         byte[] dequeuedBytes = queueHandles[0].remove();
+<<<<<<< HEAD
         assertEquals(new String(dequeuedBytes), testString);
+=======
+        Assert.assertEquals(new String(dequeuedBytes, UTF_8), testString);
+>>>>>>> ZOOKEEPER-3342: Use StandardCharsets
     }
 
     @Test
     public void testOffer2() throws Exception {
         String dir = "/testOffer2";
         String testString = "Hello World";
-        final int numClients = 2;
-        ZooKeeper[] clients = new ZooKeeper[numClients];
-        DistributedQueue[] queueHandles = new DistributedQueue[numClients];
-        for (int i = 0; i < clients.length; i++) {
+        final int num_clients = 2;
+        ZooKeeper[] clients = new ZooKeeper[num_clients];
+        DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
+        for(int i=0; i < clients.length; i++){
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
 
-        queueHandles[0].offer(testString.getBytes());
+        queueHandles[0].offer(testString.getBytes(UTF_8));
 
         byte[] dequeuedBytes = queueHandles[1].remove();
+<<<<<<< HEAD
         assertEquals(new String(dequeuedBytes), testString);
+=======
+        Assert.assertEquals(new String(dequeuedBytes, UTF_8), testString);
+>>>>>>> ZOOKEEPER-3342: Use StandardCharsets
     }
 
     @Test
     public void testTake1() throws Exception {
         String dir = "/testTake1";
         String testString = "Hello World";
-        final int numClients = 1;
-        ZooKeeper[] clients = new ZooKeeper[numClients];
-        DistributedQueue[] queueHandles = new DistributedQueue[numClients];
-        for (int i = 0; i < clients.length; i++) {
+        final int num_clients = 1;
+        ZooKeeper[] clients = new ZooKeeper[num_clients];
+        DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
+        for(int i=0; i < clients.length; i++){
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
 
-        queueHandles[0].offer(testString.getBytes());
+        queueHandles[0].offer(testString.getBytes(UTF_8));
 
         byte[] dequeuedBytes = queueHandles[0].take();
+<<<<<<< HEAD
         assertEquals(new String(dequeuedBytes), testString);
+=======
+        Assert.assertEquals(new String(dequeuedBytes, UTF_8), testString);
+>>>>>>> ZOOKEEPER-3342: Use StandardCharsets
     }
+
+
 
     @Test
-    public void testRemove1() throws Exception {
+    public void testRemove1() throws Exception{
         String dir = "/testRemove1";
-        final int numClients = 1;
-        ZooKeeper[] clients = new ZooKeeper[numClients];
-        DistributedQueue[] queueHandles = new DistributedQueue[numClients];
-        for (int i = 0; i < clients.length; i++) {
+        String testString = "Hello World";
+        final int num_clients = 1;
+        ZooKeeper[] clients = new ZooKeeper[num_clients];
+        DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
+        for(int i=0; i < clients.length; i++){
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
 
-        try {
+        try{
             queueHandles[0].remove();
-        } catch (NoSuchElementException e) {
+        }catch(NoSuchElementException e){
             return;
         }
+<<<<<<< HEAD
 
         fail();
+=======
+        Assert.assertTrue(false);
+>>>>>>> ZOOKEEPER-3342: Use StandardCharsets
     }
 
-    public void createNremoveMtest(String dir, int n, int m) throws Exception {
+    public void createNremoveMtest(String dir,int n,int m) throws Exception{
         String testString = "Hello World";
-        final int numClients = 2;
-        ZooKeeper[] clients = new ZooKeeper[numClients];
-        DistributedQueue[] queueHandles = new DistributedQueue[numClients];
-        for (int i = 0; i < clients.length; i++) {
+        final int num_clients = 2;
+        ZooKeeper[] clients = new ZooKeeper[num_clients];
+        DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
+        for(int i=0; i < clients.length; i++){
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
 
-        for (int i = 0; i < n; i++) {
+        for(int i=0; i< n; i++){
             String offerString = testString + i;
-            queueHandles[0].offer(offerString.getBytes());
+            queueHandles[0].offer(offerString.getBytes(UTF_8));
         }
 
         byte[] data = null;
-        for (int i = 0; i < m; i++) {
-            data = queueHandles[1].remove();
+        for(int i=0; i<m; i++){
+            data=queueHandles[1].remove();
         }
+<<<<<<< HEAD
 
         assertNotNull(data);
         assertEquals(new String(data), testString + (m - 1));
+=======
+        Assert.assertEquals(new String(data, UTF_8), testString+(m-1));
+>>>>>>> ZOOKEEPER-3342: Use StandardCharsets
     }
 
     @Test
-    public void testRemove2() throws Exception {
-        createNremoveMtest("/testRemove2", 10, 2);
+    public void testRemove2() throws Exception{
+        createNremoveMtest("/testRemove2",10,2);
     }
     @Test
-    public void testRemove3() throws Exception {
-        createNremoveMtest("/testRemove3", 1000, 1000);
+    public void testRemove3() throws Exception{
+        createNremoveMtest("/testRemove3",1000,1000);
     }
 
     public void createNremoveMelementTest(String dir, int n, int m) throws Exception {
         String testString = "Hello World";
-        final int numClients = 2;
-        ZooKeeper[] clients = new ZooKeeper[numClients];
-        DistributedQueue[] queueHandles = new DistributedQueue[numClients];
-        for (int i = 0; i < clients.length; i++) {
+        final int num_clients = 2;
+        ZooKeeper[] clients = new ZooKeeper[num_clients];
+        DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
+        for(int i=0; i < clients.length; i++){
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
 
-        for (int i = 0; i < n; i++) {
+        for(int i=0; i< n; i++){
             String offerString = testString + i;
-            queueHandles[0].offer(offerString.getBytes());
+            queueHandles[0].offer(offerString.getBytes(UTF_8));
         }
 
-        for (int i = 0; i < m; i++) {
-            queueHandles[1].remove();
+        byte[] data = null;
+        for(int i=0; i<m; i++){
+            data=queueHandles[1].remove();
         }
+<<<<<<< HEAD
         assertEquals(new String(queueHandles[1].element()), testString + m);
+=======
+        Assert.assertEquals(new String(queueHandles[1].element(), UTF_8), testString+m);
+>>>>>>> ZOOKEEPER-3342: Use StandardCharsets
     }
 
     @Test
     public void testElement1() throws Exception {
-        createNremoveMelementTest("/testElement1", 1, 0);
+        createNremoveMelementTest("/testElement1",1,0);
     }
 
     @Test
     public void testElement2() throws Exception {
-        createNremoveMelementTest("/testElement2", 10, 2);
+        createNremoveMelementTest("/testElement2",10,2);
     }
 
     @Test
     public void testElement3() throws Exception {
-        createNremoveMelementTest("/testElement3", 1000, 500);
+        createNremoveMelementTest("/testElement3",1000,500);
     }
 
     @Test
     public void testElement4() throws Exception {
-        createNremoveMelementTest("/testElement4", 1000, 1000 - 1);
+        createNremoveMelementTest("/testElement4",1000,1000-1);
     }
 
     @Test
-    public void testTakeWait1() throws Exception {
+    public void testTakeWait1() throws Exception{
         String dir = "/testTakeWait1";
         final String testString = "Hello World";
-        final int numClients = 1;
-        final ZooKeeper[] clients = new ZooKeeper[numClients];
-        final DistributedQueue[] queueHandles = new DistributedQueue[numClients];
-        for (int i = 0; i < clients.length; i++) {
+        final int num_clients = 1;
+        final ZooKeeper[] clients = new ZooKeeper[num_clients];
+        final DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
+        for(int i=0; i < clients.length; i++){
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
 
-        final byte[][] takeResult = new byte[1][];
-        Thread takeThread = new Thread(() -> {
-            try {
-                takeResult[0] = queueHandles[0].take();
-            } catch (KeeperException | InterruptedException ignore) {
-                // no op
+        final byte[] takeResult[] = new byte[1][];
+        Thread takeThread = new Thread(){
+            public void run(){
+                try{
+                    takeResult[0] = queueHandles[0].take();
+                }catch(KeeperException e){
+
+                }catch(InterruptedException e){
+
+                }
             }
-        });
+        };
         takeThread.start();
 
         Thread.sleep(1000);
-        Thread offerThread = new Thread(() -> {
-            try {
-                queueHandles[0].offer(testString.getBytes());
-            } catch (KeeperException | InterruptedException ignore) {
-                // no op
+        Thread offerThread= new Thread() {
+            public void run(){
+                try {
+                    queueHandles[0].offer(testString.getBytes(UTF_8));
+                } catch (KeeperException e) {
+
+                } catch (InterruptedException e) {
+
+                }
             }
-        });
+        };
         offerThread.start();
         offerThread.join();
 
         takeThread.join();
 
+<<<<<<< HEAD
         assertNotNull(takeResult[0]);
         assertEquals(new String(takeResult[0]), testString);
+=======
+        Assert.assertTrue(takeResult[0] != null);
+        Assert.assertEquals(new String(takeResult[0], UTF_8), testString);
+>>>>>>> ZOOKEEPER-3342: Use StandardCharsets
     }
 
     @Test
-    public void testTakeWait2() throws Exception {
+    public void testTakeWait2() throws Exception{
         String dir = "/testTakeWait2";
         final String testString = "Hello World";
-        final int numClients = 1;
-        final ZooKeeper[] clients = new ZooKeeper[numClients];
-        final DistributedQueue[] queueHandles = new DistributedQueue[numClients];
-        for (int i = 0; i < clients.length; i++) {
+        final int num_clients = 1;
+        final ZooKeeper[] clients = new ZooKeeper[num_clients];
+        final DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
+        for(int i=0; i < clients.length; i++){
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
-        int numAttempts = 2;
-        for (int i = 0; i < numAttempts; i++) {
-            final byte[][] takeResult = new byte[1][];
+        int num_attempts =2;
+        for(int i=0; i< num_attempts; i++){
+            final byte[] takeResult[] = new byte[1][];
             final String threadTestString = testString + i;
-            Thread takeThread = new Thread(() -> {
-                try {
-                    takeResult[0] = queueHandles[0].take();
-                } catch (KeeperException | InterruptedException ignore) {
-                    // no op
+            Thread takeThread = new Thread(){
+                public void run(){
+                    try{
+                        takeResult[0] = queueHandles[0].take();
+                    }catch(KeeperException e){
+
+                    }catch(InterruptedException e){
+
+                    }
                 }
-            });
+            };
             takeThread.start();
 
             Thread.sleep(1000);
-            Thread offerThread = new Thread(() -> {
-                try {
-                    queueHandles[0].offer(threadTestString.getBytes());
-                } catch (KeeperException | InterruptedException ignore) {
-                    // no op
+            Thread offerThread= new Thread() {
+                public void run(){
+                    try {
+                        queueHandles[0].offer(threadTestString.getBytes(UTF_8));
+                    } catch (KeeperException e) {
+
+                    } catch (InterruptedException e) {
+
+                    }
                 }
-            });
+            };
             offerThread.start();
             offerThread.join();
 
             takeThread.join();
 
+<<<<<<< HEAD
             assertNotNull(takeResult[0]);
             assertEquals(new String(takeResult[0]), threadTestString);
+=======
+            Assert.assertTrue(takeResult[0] != null);
+            Assert.assertEquals(new String(takeResult[0], UTF_8), threadTestString);
+>>>>>>> ZOOKEEPER-3342: Use StandardCharsets
         }
     }
 

--- a/zookeeper-recipes/zookeeper-recipes-queue/src/test/java/org/apache/zookeeper/recipes/queue/DistributedQueueTest.java
+++ b/zookeeper-recipes/zookeeper-recipes-queue/src/test/java/org/apache/zookeeper/recipes/queue/DistributedQueueTest.java
@@ -29,6 +29,9 @@ import org.apache.zookeeper.test.ClientBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests for {@link DistributedQueue}.
+ */
 public class DistributedQueueTest extends ClientBase {
 
     @AfterEach
@@ -36,15 +39,14 @@ public class DistributedQueueTest extends ClientBase {
         super.tearDown();
     }
 
-
     @Test
     public void testOffer1() throws Exception {
         String dir = "/testOffer1";
         String testString = "Hello World";
-        final int num_clients = 1;
-        ZooKeeper[] clients = new ZooKeeper[num_clients];
-        DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
-        for(int i=0; i < clients.length; i++){
+        final int numClients = 1;
+        ZooKeeper[] clients = new ZooKeeper[numClients];
+        DistributedQueue[] queueHandles = new DistributedQueue[numClients];
+        for (int i = 0; i < clients.length; i++) {
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
@@ -59,10 +61,10 @@ public class DistributedQueueTest extends ClientBase {
     public void testOffer2() throws Exception {
         String dir = "/testOffer2";
         String testString = "Hello World";
-        final int num_clients = 2;
-        ZooKeeper[] clients = new ZooKeeper[num_clients];
-        DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
-        for(int i=0; i < clients.length; i++){
+        final int numClients = 2;
+        ZooKeeper[] clients = new ZooKeeper[numClients];
+        DistributedQueue[] queueHandles = new DistributedQueue[numClients];
+        for (int i = 0; i < clients.length; i++) {
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
@@ -77,10 +79,10 @@ public class DistributedQueueTest extends ClientBase {
     public void testTake1() throws Exception {
         String dir = "/testTake1";
         String testString = "Hello World";
-        final int num_clients = 1;
-        ZooKeeper[] clients = new ZooKeeper[num_clients];
-        DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
-        for(int i=0; i < clients.length; i++){
+        final int numClients = 1;
+        ZooKeeper[] clients = new ZooKeeper[numClients];
+        DistributedQueue[] queueHandles = new DistributedQueue[numClients];
+        for (int i = 0; i < clients.length; i++) {
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
@@ -91,140 +93,130 @@ public class DistributedQueueTest extends ClientBase {
         assertEquals(new String(dequeuedBytes, UTF_8), testString);
     }
 
-
-
     @Test
-    public void testRemove1() throws Exception{
+    public void testRemove1() throws Exception {
         String dir = "/testRemove1";
-        String testString = "Hello World";
-        final int num_clients = 1;
-        ZooKeeper[] clients = new ZooKeeper[num_clients];
-        DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
-        for(int i=0; i < clients.length; i++){
+        final int numClients = 1;
+        ZooKeeper[] clients = new ZooKeeper[numClients];
+        DistributedQueue[] queueHandles = new DistributedQueue[numClients];
+        for (int i = 0; i < clients.length; i++) {
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
 
-        try{
+        try {
             queueHandles[0].remove();
-        }catch(NoSuchElementException e){
+        } catch (NoSuchElementException e) {
             return;
         }
+
         fail();
     }
 
-    public void createNremoveMtest(String dir,int n,int m) throws Exception{
+    public void createNremoveMtest(String dir, int n, int m) throws Exception {
         String testString = "Hello World";
-        final int num_clients = 2;
-        ZooKeeper[] clients = new ZooKeeper[num_clients];
-        DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
-        for(int i=0; i < clients.length; i++){
+        final int numClients = 2;
+        ZooKeeper[] clients = new ZooKeeper[numClients];
+        DistributedQueue[] queueHandles = new DistributedQueue[numClients];
+        for (int i = 0; i < clients.length; i++) {
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
 
-        for(int i=0; i< n; i++){
+        for (int i = 0; i < n; i++) {
             String offerString = testString + i;
             queueHandles[0].offer(offerString.getBytes(UTF_8));
         }
 
         byte[] data = null;
-        for(int i=0; i<m; i++){
-            data=queueHandles[1].remove();
+        for (int i = 0; i < m; i++) {
+            data = queueHandles[1].remove();
         }
+
         assertNotNull(data);
         assertEquals(new String(data, UTF_8), testString + (m - 1));
     }
 
     @Test
-    public void testRemove2() throws Exception{
-        createNremoveMtest("/testRemove2",10,2);
+    public void testRemove2() throws Exception {
+        createNremoveMtest("/testRemove2", 10, 2);
     }
     @Test
-    public void testRemove3() throws Exception{
-        createNremoveMtest("/testRemove3",1000,1000);
+    public void testRemove3() throws Exception {
+        createNremoveMtest("/testRemove3", 1000, 1000);
     }
 
     public void createNremoveMelementTest(String dir, int n, int m) throws Exception {
         String testString = "Hello World";
-        final int num_clients = 2;
-        ZooKeeper[] clients = new ZooKeeper[num_clients];
-        DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
-        for(int i=0; i < clients.length; i++){
+        final int numClients = 2;
+        ZooKeeper[] clients = new ZooKeeper[numClients];
+        DistributedQueue[] queueHandles = new DistributedQueue[numClients];
+        for (int i = 0; i < clients.length; i++) {
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
 
-        for(int i=0; i< n; i++){
+        for (int i = 0; i < n; i++) {
             String offerString = testString + i;
             queueHandles[0].offer(offerString.getBytes(UTF_8));
         }
 
-        byte[] data = null;
-        for(int i=0; i<m; i++){
-            data=queueHandles[1].remove();
+        for (int i = 0; i < m; i++) {
+            queueHandles[1].remove();
         }
         assertEquals(new String(queueHandles[1].element(), UTF_8), testString + m);
     }
 
     @Test
     public void testElement1() throws Exception {
-        createNremoveMelementTest("/testElement1",1,0);
+        createNremoveMelementTest("/testElement1", 1, 0);
     }
 
     @Test
     public void testElement2() throws Exception {
-        createNremoveMelementTest("/testElement2",10,2);
+        createNremoveMelementTest("/testElement2", 10, 2);
     }
 
     @Test
     public void testElement3() throws Exception {
-        createNremoveMelementTest("/testElement3",1000,500);
+        createNremoveMelementTest("/testElement3", 1000, 500);
     }
 
     @Test
     public void testElement4() throws Exception {
-        createNremoveMelementTest("/testElement4",1000,1000-1);
+        createNremoveMelementTest("/testElement4", 1000, 1000 - 1);
     }
 
     @Test
-    public void testTakeWait1() throws Exception{
+    public void testTakeWait1() throws Exception {
         String dir = "/testTakeWait1";
         final String testString = "Hello World";
-        final int num_clients = 1;
-        final ZooKeeper[] clients = new ZooKeeper[num_clients];
-        final DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
-        for(int i=0; i < clients.length; i++){
+        final int numClients = 1;
+        final ZooKeeper[] clients = new ZooKeeper[numClients];
+        final DistributedQueue[] queueHandles = new DistributedQueue[numClients];
+        for (int i = 0; i < clients.length; i++) {
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
 
-        final byte[] takeResult[] = new byte[1][];
-        Thread takeThread = new Thread(){
-            public void run(){
-                try{
-                    takeResult[0] = queueHandles[0].take();
-                }catch(KeeperException e){
-
-                }catch(InterruptedException e){
-
-                }
+        final byte[][] takeResult = new byte[1][];
+        Thread takeThread = new Thread(() -> {
+            try {
+                takeResult[0] = queueHandles[0].take();
+            } catch (KeeperException | InterruptedException ignore) {
+                // no op
             }
-        };
+        });
         takeThread.start();
 
         Thread.sleep(1000);
-        Thread offerThread= new Thread() {
-            public void run(){
-                try {
-                    queueHandles[0].offer(testString.getBytes(UTF_8));
-                } catch (KeeperException e) {
-
-                } catch (InterruptedException e) {
-
-                }
+        Thread offerThread = new Thread(() -> {
+            try {
+                queueHandles[0].offer(testString.getBytes(UTF_8)));
+            } catch (KeeperException | InterruptedException ignore) {
+                // no op
             }
-        };
+        });
         offerThread.start();
         offerThread.join();
 
@@ -235,45 +227,37 @@ public class DistributedQueueTest extends ClientBase {
     }
 
     @Test
-    public void testTakeWait2() throws Exception{
+    public void testTakeWait2() throws Exception {
         String dir = "/testTakeWait2";
         final String testString = "Hello World";
-        final int num_clients = 1;
-        final ZooKeeper[] clients = new ZooKeeper[num_clients];
-        final DistributedQueue[] queueHandles = new DistributedQueue[num_clients];
-        for(int i=0; i < clients.length; i++){
+        final int numClients = 1;
+        final ZooKeeper[] clients = new ZooKeeper[numClients];
+        final DistributedQueue[] queueHandles = new DistributedQueue[numClients];
+        for (int i = 0; i < clients.length; i++) {
             clients[i] = createClient();
             queueHandles[i] = new DistributedQueue(clients[i], dir, null);
         }
-        int num_attempts =2;
-        for(int i=0; i< num_attempts; i++){
-            final byte[] takeResult[] = new byte[1][];
+        int numAttempts = 2;
+        for (int i = 0; i < numAttempts; i++) {
+            final byte[][] takeResult = new byte[1][];
             final String threadTestString = testString + i;
-            Thread takeThread = new Thread(){
-                public void run(){
-                    try{
-                        takeResult[0] = queueHandles[0].take();
-                    }catch(KeeperException e){
-
-                    }catch(InterruptedException e){
-
-                    }
+            Thread takeThread = new Thread(() -> {
+                try {
+                    takeResult[0] = queueHandles[0].take();
+                } catch (KeeperException | InterruptedException ignore) {
+                    // no op
                 }
-            };
+            });
             takeThread.start();
 
             Thread.sleep(1000);
-            Thread offerThread= new Thread() {
-                public void run(){
-                    try {
-                        queueHandles[0].offer(threadTestString.getBytes(UTF_8));
-                    } catch (KeeperException e) {
-
-                    } catch (InterruptedException e) {
-
-                    }
+            Thread offerThread = new Thread(() -> {
+                try {
+                    queueHandles[0].offer(threadTestString.getBytes(UTF_8)));
+                } catch (KeeperException | InterruptedException ignore) {
+                    // no op
                 }
-            };
+            });
             offerThread.start();
             offerThread.join();
 

--- a/zookeeper-recipes/zookeeper-recipes-queue/src/test/java/org/apache/zookeeper/recipes/queue/DistributedQueueTest.java
+++ b/zookeeper-recipes/zookeeper-recipes-queue/src/test/java/org/apache/zookeeper/recipes/queue/DistributedQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.zookeeper.recipes.queue;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/zookeeper-recipes/zookeeper-recipes-queue/src/test/java/org/apache/zookeeper/recipes/queue/DistributedQueueTest.java
+++ b/zookeeper-recipes/zookeeper-recipes-queue/src/test/java/org/apache/zookeeper/recipes/queue/DistributedQueueTest.java
@@ -51,11 +51,7 @@ public class DistributedQueueTest extends ClientBase {
         queueHandles[0].offer(testString.getBytes(UTF_8));
 
         byte[] dequeuedBytes = queueHandles[0].remove();
-<<<<<<< HEAD
-        assertEquals(new String(dequeuedBytes), testString);
-=======
-        Assert.assertEquals(new String(dequeuedBytes, UTF_8), testString);
->>>>>>> ZOOKEEPER-3342: Use StandardCharsets
+        assertEquals(new String(dequeuedBytes, UTF_8), testString);
     }
 
     @Test
@@ -73,11 +69,7 @@ public class DistributedQueueTest extends ClientBase {
         queueHandles[0].offer(testString.getBytes(UTF_8));
 
         byte[] dequeuedBytes = queueHandles[1].remove();
-<<<<<<< HEAD
-        assertEquals(new String(dequeuedBytes), testString);
-=======
-        Assert.assertEquals(new String(dequeuedBytes, UTF_8), testString);
->>>>>>> ZOOKEEPER-3342: Use StandardCharsets
+        assertEquals(new String(dequeuedBytes, UTF_8), testString);
     }
 
     @Test
@@ -95,11 +87,7 @@ public class DistributedQueueTest extends ClientBase {
         queueHandles[0].offer(testString.getBytes(UTF_8));
 
         byte[] dequeuedBytes = queueHandles[0].take();
-<<<<<<< HEAD
-        assertEquals(new String(dequeuedBytes), testString);
-=======
-        Assert.assertEquals(new String(dequeuedBytes, UTF_8), testString);
->>>>>>> ZOOKEEPER-3342: Use StandardCharsets
+        assertEquals(new String(dequeuedBytes, UTF_8), testString);
     }
 
 
@@ -121,12 +109,7 @@ public class DistributedQueueTest extends ClientBase {
         }catch(NoSuchElementException e){
             return;
         }
-<<<<<<< HEAD
-
         fail();
-=======
-        Assert.assertTrue(false);
->>>>>>> ZOOKEEPER-3342: Use StandardCharsets
     }
 
     public void createNremoveMtest(String dir,int n,int m) throws Exception{
@@ -148,13 +131,8 @@ public class DistributedQueueTest extends ClientBase {
         for(int i=0; i<m; i++){
             data=queueHandles[1].remove();
         }
-<<<<<<< HEAD
-
         assertNotNull(data);
-        assertEquals(new String(data), testString + (m - 1));
-=======
-        Assert.assertEquals(new String(data, UTF_8), testString+(m-1));
->>>>>>> ZOOKEEPER-3342: Use StandardCharsets
+        assertEquals(new String(data, UTF_8), testString + (m - 1));
     }
 
     @Test
@@ -185,11 +163,7 @@ public class DistributedQueueTest extends ClientBase {
         for(int i=0; i<m; i++){
             data=queueHandles[1].remove();
         }
-<<<<<<< HEAD
-        assertEquals(new String(queueHandles[1].element()), testString + m);
-=======
-        Assert.assertEquals(new String(queueHandles[1].element(), UTF_8), testString+m);
->>>>>>> ZOOKEEPER-3342: Use StandardCharsets
+        assertEquals(new String(queueHandles[1].element(), UTF_8), testString + m);
     }
 
     @Test
@@ -255,13 +229,8 @@ public class DistributedQueueTest extends ClientBase {
 
         takeThread.join();
 
-<<<<<<< HEAD
         assertNotNull(takeResult[0]);
-        assertEquals(new String(takeResult[0]), testString);
-=======
-        Assert.assertTrue(takeResult[0] != null);
-        Assert.assertEquals(new String(takeResult[0], UTF_8), testString);
->>>>>>> ZOOKEEPER-3342: Use StandardCharsets
+        assertEquals(new String(takeResult[0], UTF_8), testString);
     }
 
     @Test
@@ -309,13 +278,8 @@ public class DistributedQueueTest extends ClientBase {
 
             takeThread.join();
 
-<<<<<<< HEAD
             assertNotNull(takeResult[0]);
-            assertEquals(new String(takeResult[0]), threadTestString);
-=======
-            Assert.assertTrue(takeResult[0] != null);
-            Assert.assertEquals(new String(takeResult[0], UTF_8), threadTestString);
->>>>>>> ZOOKEEPER-3342: Use StandardCharsets
+            assertEquals(new String(takeResult[0], UTF_8), threadTestString);
         }
     }
 

--- a/zookeeper-recipes/zookeeper-recipes-queue/src/test/java/org/apache/zookeeper/recipes/queue/DistributedQueueTest.java
+++ b/zookeeper-recipes/zookeeper-recipes-queue/src/test/java/org/apache/zookeeper/recipes/queue/DistributedQueueTest.java
@@ -212,7 +212,7 @@ public class DistributedQueueTest extends ClientBase {
         Thread.sleep(1000);
         Thread offerThread = new Thread(() -> {
             try {
-                queueHandles[0].offer(testString.getBytes(UTF_8)));
+                queueHandles[0].offer(testString.getBytes(UTF_8));
             } catch (KeeperException | InterruptedException ignore) {
                 // no op
             }
@@ -253,7 +253,7 @@ public class DistributedQueueTest extends ClientBase {
             Thread.sleep(1000);
             Thread offerThread = new Thread(() -> {
                 try {
-                    queueHandles[0].offer(threadTestString.getBytes(UTF_8)));
+                    queueHandles[0].offer(threadTestString.getBytes(UTF_8));
                 } catch (KeeperException | InterruptedException ignore) {
                     // no op
                 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ServerAdminClient.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ServerAdminClient.java
@@ -24,6 +24,7 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +53,7 @@ public class ServerAdminClient {
             byte[] resBytes = new byte[4];
 
             int rc = is.read(resBytes);
-            String retv = new String(resBytes);
+            String retv = new String(resBytes, StandardCharsets.UTF_8);
             System.out.println("rc=" + rc + " retv=" + retv);
         } catch (IOException e) {
             LOG.warn("Unexpected exception", e);
@@ -86,7 +87,7 @@ public class ServerAdminClient {
             byte[] resBytes = new byte[1024];
 
             int rc = is.read(resBytes);
-            String retv = new String(resBytes);
+            String retv = new String(resBytes, StandardCharsets.UTF_8);
             System.out.println("rc=" + rc + " retv=" + retv);
         } catch (IOException e) {
             LOG.warn("Unexpected exception", e);
@@ -120,7 +121,7 @@ public class ServerAdminClient {
             byte[] resBytes = new byte[1024];
 
             int rc = is.read(resBytes);
-            String retv = new String(resBytes);
+            String retv = new String(resBytes, StandardCharsets.UTF_8);
             System.out.println("rc=" + rc + " retv=" + retv);
         } catch (IOException e) {
             LOG.warn("Unexpected exception", e);
@@ -153,7 +154,7 @@ public class ServerAdminClient {
             byte[] resBytes = new byte[4];
 
             int rc = is.read(resBytes);
-            String retv = new String(resBytes);
+            String retv = new String(resBytes, StandardCharsets.UTF_8);
             System.out.println("rc=" + rc + " retv=" + retv);
         } catch (IOException e) {
             LOG.warn("Unexpected exception", e);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ServerAdminClient.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ServerAdminClient.java
@@ -18,13 +18,13 @@
 
 package org.apache.zookeeper;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +53,7 @@ public class ServerAdminClient {
             byte[] resBytes = new byte[4];
 
             int rc = is.read(resBytes);
-            String retv = new String(resBytes, StandardCharsets.UTF_8);
+            String retv = new String(resBytes, UTF_8);
             System.out.println("rc=" + rc + " retv=" + retv);
         } catch (IOException e) {
             LOG.warn("Unexpected exception", e);
@@ -87,7 +87,7 @@ public class ServerAdminClient {
             byte[] resBytes = new byte[1024];
 
             int rc = is.read(resBytes);
-            String retv = new String(resBytes, StandardCharsets.UTF_8);
+            String retv = new String(resBytes, UTF_8);
             System.out.println("rc=" + rc + " retv=" + retv);
         } catch (IOException e) {
             LOG.warn("Unexpected exception", e);
@@ -121,7 +121,7 @@ public class ServerAdminClient {
             byte[] resBytes = new byte[1024];
 
             int rc = is.read(resBytes);
-            String retv = new String(resBytes, StandardCharsets.UTF_8);
+            String retv = new String(resBytes, UTF_8);
             System.out.println("rc=" + rc + " retv=" + retv);
         } catch (IOException e) {
             LOG.warn("Unexpected exception", e);
@@ -154,7 +154,7 @@ public class ServerAdminClient {
             byte[] resBytes = new byte[4];
 
             int rc = is.read(resBytes);
-            String retv = new String(resBytes, StandardCharsets.UTF_8);
+            String retv = new String(resBytes, UTF_8);
             System.out.println("rc=" + rc + " retv=" + retv);
         } catch (IOException e) {
             LOG.warn("Unexpected exception", e);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/AddAuthCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/AddAuthCommand.java
@@ -18,7 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
-import java.nio.charset.StandardCharsets;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -58,7 +58,7 @@ public class AddAuthCommand extends CliCommand {
     public boolean exec() throws CliException {
         byte[] b = null;
         if (args.length >= 3) {
-            b = args[2].getBytes(StandardCharsets.UTF_8);
+            b = args[2].getBytes(UTF_8);
         }
 
         zk.addAuthInfo(args[1], b);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/AddAuthCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/AddAuthCommand.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -57,7 +58,7 @@ public class AddAuthCommand extends CliCommand {
     public boolean exec() throws CliException {
         byte[] b = null;
         if (args.length >= 3) {
-            b = args[2].getBytes();
+            b = args[2].getBytes(StandardCharsets.UTF_8);
         }
 
         zk.addAuthInfo(args[1], b);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CreateCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CreateCommand.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -112,7 +113,7 @@ public class CreateCommand extends CliCommand {
         String path = args[1];
         byte[] data = null;
         if (args.length > 2) {
-            data = args[2].getBytes();
+            data = args[2].getBytes(StandardCharsets.UTF_8);
         }
         List<ACL> acl = ZooDefs.Ids.OPEN_ACL_UNSAFE;
         if (args.length > 3) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CreateCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CreateCommand.java
@@ -18,7 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
-import java.nio.charset.StandardCharsets;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -113,7 +113,7 @@ public class CreateCommand extends CliCommand {
         String path = args[1];
         byte[] data = null;
         if (args.length > 2) {
-            data = args[2].getBytes(StandardCharsets.UTF_8);
+            data = args[2].getBytes(UTF_8);
         }
         List<ACL> acl = ZooDefs.Ids.OPEN_ACL_UNSAFE;
         if (args.length > 3) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/DelQuotaCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/DelQuotaCommand.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
@@ -119,13 +120,13 @@ public class DelQuotaCommand extends CliCommand {
             System.err.println("quota does not exist for " + path);
             return true;
         }
-        StatsTrack strack = new StatsTrack(new String(data));
+        StatsTrack strack = new StatsTrack(new String(data, UTF_8));
         if (bytes && !numNodes) {
             strack.setBytes(-1L);
-            zk.setData(quotaPath, strack.toString().getBytes(), -1);
+            zk.setData(quotaPath, strack.toString().getBytes(UTF_8), -1);
         } else if (!bytes && numNodes) {
             strack.setCount(-1);
-            zk.setData(quotaPath, strack.toString().getBytes(), -1);
+            zk.setData(quotaPath, strack.toString().getBytes(UTF_8), -1);
         } else if (bytes && numNodes) {
             // delete till you can find a node with more than
             // one child

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
@@ -18,7 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
-import java.nio.charset.StandardCharsets;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -93,7 +93,7 @@ public class GetCommand extends CliCommand {
             throw new CliException(ex);
         }
         data = (data == null) ? "null".getBytes() : data;
-        out.println(new String(data, StandardCharsets.UTF_8));
+        out.println(new String(data, UTF_8));
         if (cl.hasOption("s")) {
             new StatPrinter(out).print(stat);
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -92,7 +93,7 @@ public class GetCommand extends CliCommand {
             throw new CliException(ex);
         }
         data = (data == null) ? "null".getBytes() : data;
-        out.println(new String(data));
+        out.println(new String(data, StandardCharsets.UTF_8));
         if (cl.hasOption("s")) {
             new StatPrinter(out).print(stat);
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetConfigCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetConfigCommand.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -72,11 +73,11 @@ public class GetConfigCommand extends CliCommand {
         } catch (KeeperException | InterruptedException ex) {
             throw new CliWrapperException(ex);
         }
-        data = (data == null) ? "null".getBytes() : data;
+        data = (data == null) ? "null".getBytes(UTF_8) : data;
         if (cl.hasOption("c")) {
-            out.println(ConfigUtils.getClientConfigStr(new String(data)));
+            out.println(ConfigUtils.getClientConfigStr(new String(data, UTF_8)));
         } else {
-            out.println(new String(data));
+            out.println(new String(data, UTF_8));
         }
 
         if (cl.hasOption("s")) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ListQuotaCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ListQuotaCommand.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -64,11 +65,11 @@ public class ListQuotaCommand extends CliCommand {
             err.println("absolute path is " + absolutePath);
             Stat stat = new Stat();
             byte[] data = zk.getData(absolutePath, false, stat);
-            StatsTrack st = new StatsTrack(new String(data));
-            out.println("Output quota for " + path + " " + st.toString());
+            StatsTrack st = new StatsTrack(new String(data, UTF_8));
+            out.println("Output quota for " + path + " " + st);
 
             data = zk.getData(Quotas.quotaZookeeper + path + "/" + Quotas.statNode, false, stat);
-            out.println("Output stat for " + path + " " + new StatsTrack(new String(data)).toString());
+            out.println("Output stat for " + path + " " + new StatsTrack(new String(data, UTF_8)));
         } catch (IllegalArgumentException ex) {
             throw new MalformedPathException(ex.getMessage());
         } catch (KeeperException.NoNodeException ne) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ReconfigCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ReconfigCommand.java
@@ -18,8 +18,8 @@
 
 package org.apache.zookeeper.cli;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.FileInputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -152,7 +152,7 @@ public class ReconfigCommand extends CliCommand {
             }
 
             byte[] curConfig = ((ZooKeeperAdmin) zk).reconfigure(joining, leaving, members, version, stat);
-            out.println("Committed new configuration:\n" + new String(curConfig, StandardCharsets.UTF_8));
+            out.println("Committed new configuration:\n" + new String(curConfig, UTF_8));
 
             if (cl.hasOption("s")) {
                 new StatPrinter(out).print(stat);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ReconfigCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ReconfigCommand.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.cli;
 
 import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -151,7 +152,7 @@ public class ReconfigCommand extends CliCommand {
             }
 
             byte[] curConfig = ((ZooKeeperAdmin) zk).reconfigure(joining, leaving, members, version, stat);
-            out.println("Committed new configuration:\n" + new String(curConfig));
+            out.println("Committed new configuration:\n" + new String(curConfig, StandardCharsets.UTF_8));
 
             if (cl.hasOption("s")) {
                 new StatPrinter(out).print(stat);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
@@ -18,7 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
-import java.nio.charset.StandardCharsets;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -63,7 +63,7 @@ public class SetCommand extends CliCommand {
     @Override
     public boolean exec() throws CliException {
         String path = args[1];
-        byte[] data = args[2].getBytes(StandardCharsets.UTF_8);
+        byte[] data = args[2].getBytes(UTF_8);
         int version;
         if (cl.hasOption("v")) {
             version = Integer.parseInt(cl.getOptionValue("v"));

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -62,7 +63,7 @@ public class SetCommand extends CliCommand {
     @Override
     public boolean exec() throws CliException {
         String path = args[1];
-        byte[] data = args[2].getBytes();
+        byte[] data = args[2].getBytes(StandardCharsets.UTF_8);
         int version;
         if (cl.hasOption("v")) {
             version = Integer.parseInt(cl.getOptionValue("v"));

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetQuotaCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetQuotaCommand.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
@@ -169,21 +170,21 @@ public class SetQuotaCommand extends CliCommand {
         strack.setBytes(bytes);
         strack.setCount(numNodes);
         try {
-            zk.create(quotaPath, strack.toString().getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            zk.create(quotaPath, strack.toString().getBytes(UTF_8), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             StatsTrack stats = new StatsTrack(null);
             stats.setBytes(0L);
             stats.setCount(0);
-            zk.create(statPath, stats.toString().getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            zk.create(statPath, stats.toString().getBytes(UTF_8), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         } catch (KeeperException.NodeExistsException ne) {
             byte[] data = zk.getData(quotaPath, false, new Stat());
-            StatsTrack strackC = new StatsTrack(new String(data));
+            StatsTrack strackC = new StatsTrack(new String(data, UTF_8));
             if (bytes != -1L) {
                 strackC.setBytes(bytes);
             }
             if (numNodes != -1) {
                 strackC.setCount(numNodes);
             }
-            zk.setData(quotaPath, strackC.toString().getBytes(), -1);
+            zk.setData(quotaPath, strackC.toString().getBytes(UTF_8), -1);
         }
         return true;
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/FourLetterWordMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/FourLetterWordMain.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.client;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -26,7 +27,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
-import java.nio.charset.StandardCharsets;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -114,7 +114,7 @@ public class FourLetterWordMain {
         BufferedReader reader = null;
         try {
             OutputStream outstream = sock.getOutputStream();
-            outstream.write(cmd.getBytes(StandardCharsets.UTF_8));
+            outstream.write(cmd.getBytes(UTF_8));
             outstream.flush();
 
             // this replicates NC - close the output stream before reading

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/FourLetterWordMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/FourLetterWordMain.java
@@ -26,6 +26,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -113,7 +114,7 @@ public class FourLetterWordMain {
         BufferedReader reader = null;
         try {
             OutputStream outstream = sock.getOutputStream();
-            outstream.write(cmd.getBytes());
+            outstream.write(cmd.getBytes(StandardCharsets.UTF_8));
             outstream.flush();
 
             // this replicates NC - close the output stream before reading

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ContainerManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ContainerManager.java
@@ -18,8 +18,8 @@
 
 package org.apache.zookeeper.server;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -129,7 +129,7 @@ public class ContainerManager {
         for (String containerPath : getCandidates()) {
             long startMs = Time.currentElapsedTime();
 
-            ByteBuffer path = ByteBuffer.wrap(containerPath.getBytes(StandardCharsets.UTF_8));
+            ByteBuffer path = ByteBuffer.wrap(containerPath.getBytes(UTF_8));
             Request request = new Request(null, 0, 0, ZooDefs.OpCode.deleteContainer, path, null);
             try {
                 LOG.info("Attempting to delete candidate container: {}", containerPath);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ContainerManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ContainerManager.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -128,7 +129,7 @@ public class ContainerManager {
         for (String containerPath : getCandidates()) {
             long startMs = Time.currentElapsedTime();
 
-            ByteBuffer path = ByteBuffer.wrap(containerPath.getBytes());
+            ByteBuffer path = ByteBuffer.wrap(containerPath.getBytes(StandardCharsets.UTF_8));
             Request request = new Request(null, 0, 0, ZooDefs.OpCode.deleteContainer, path, null);
             try {
                 LOG.info("Attempting to delete candidate container: {}", containerPath);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -18,11 +18,11 @@
 
 package org.apache.zookeeper.server;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -392,10 +392,10 @@ public class DataTree {
             return;
         }
         synchronized (node) {
-            updatedStat = new StatsTrack(new String(node.data, StandardCharsets.UTF_8));
+            updatedStat = new StatsTrack(new String(node.data, UTF_8));
             updatedStat.setCount(updatedStat.getCount() + countDiff);
             updatedStat.setBytes(updatedStat.getBytes() + bytesDiff);
-            node.data = updatedStat.toString().getBytes(StandardCharsets.UTF_8);
+            node.data = updatedStat.toString().getBytes(UTF_8);
         }
         // now check if the counts match the quota
         String quotaNode = Quotas.quotaPath(lastPrefix);
@@ -407,7 +407,7 @@ public class DataTree {
             return;
         }
         synchronized (node) {
-            thisStats = new StatsTrack(new String(node.data, StandardCharsets.UTF_8));
+            thisStats = new StatsTrack(new String(node.data, UTF_8));
         }
         if (thisStats.getCount() > -1 && (thisStats.getCount() < updatedStat.getCount())) {
             LOG.warn(
@@ -1261,7 +1261,7 @@ public class DataTree {
         }
         synchronized (node) {
             nodes.preChange(statPath, node);
-            node.data = strack.toString().getBytes(StandardCharsets.UTF_8);
+            node.data = strack.toString().getBytes(UTF_8);
             nodes.postChange(statPath, node);
         }
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -22,6 +22,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -391,10 +392,10 @@ public class DataTree {
             return;
         }
         synchronized (node) {
-            updatedStat = new StatsTrack(new String(node.data));
+            updatedStat = new StatsTrack(new String(node.data, StandardCharsets.UTF_8));
             updatedStat.setCount(updatedStat.getCount() + countDiff);
             updatedStat.setBytes(updatedStat.getBytes() + bytesDiff);
-            node.data = updatedStat.toString().getBytes();
+            node.data = updatedStat.toString().getBytes(StandardCharsets.UTF_8);
         }
         // now check if the counts match the quota
         String quotaNode = Quotas.quotaPath(lastPrefix);
@@ -406,7 +407,7 @@ public class DataTree {
             return;
         }
         synchronized (node) {
-            thisStats = new StatsTrack(new String(node.data));
+            thisStats = new StatsTrack(new String(node.data, StandardCharsets.UTF_8));
         }
         if (thisStats.getCount() > -1 && (thisStats.getCount() < updatedStat.getCount())) {
             LOG.warn(
@@ -1260,7 +1261,7 @@ public class DataTree {
         }
         synchronized (node) {
             nodes.preChange(statPath, node);
-            node.data = strack.toString().getBytes();
+            node.data = strack.toString().getBytes(StandardCharsets.UTF_8);
             nodes.postChange(statPath, node);
         }
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.server;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -329,7 +330,7 @@ public class FinalRequestProcessor implements RequestProcessor {
             case OpCode.reconfig: {
                 lastOp = "RECO";
                 rsp = new GetDataResponse(
-                    ((QuorumZooKeeperServer) zks).self.getQuorumVerifier().toString().getBytes(),
+                    ((QuorumZooKeeperServer) zks).self.getQuorumVerifier().toString().getBytes(StandardCharsets.UTF_8),
                     rc.stat);
                 err = Code.get(rc.err);
                 break;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
@@ -18,9 +18,9 @@
 
 package org.apache.zookeeper.server;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -330,7 +330,7 @@ public class FinalRequestProcessor implements RequestProcessor {
             case OpCode.reconfig: {
                 lastOp = "RECO";
                 rsp = new GetDataResponse(
-                    ((QuorumZooKeeperServer) zks).self.getQuorumVerifier().toString().getBytes(StandardCharsets.UTF_8),
+                    ((QuorumZooKeeperServer) zks).self.getQuorumVerifier().toString().getBytes(UTF_8),
                     rc.stat);
                 err = Code.get(rc.err);
                 break;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -28,7 +29,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.CancelledKeyException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
-import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -443,7 +443,7 @@ public class NIOServerCnxn extends ServerCnxn {
          */
         private void checkFlush(boolean force) {
             if ((force && sb.length() > 0) || sb.length() > 2048) {
-                sendBufferSync(ByteBuffer.wrap(sb.toString().getBytes(StandardCharsets.UTF_8)));
+                sendBufferSync(ByteBuffer.wrap(sb.toString().getBytes(UTF_8)));
                 // clear our internal buffer
                 sb.setLength(0);
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -28,6 +28,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.CancelledKeyException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -442,7 +443,7 @@ public class NIOServerCnxn extends ServerCnxn {
          */
         private void checkFlush(boolean force) {
             if ((force && sb.length() > 0) || sb.length() > 2048) {
-                sendBufferSync(ByteBuffer.wrap(sb.toString().getBytes()));
+                sendBufferSync(ByteBuffer.wrap(sb.toString().getBytes(StandardCharsets.UTF_8)));
                 // clear our internal buffer
                 sb.setLength(0);
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.CompositeByteBuf;
@@ -35,7 +36,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
-import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -234,7 +234,7 @@ public class NettyServerCnxn extends ServerCnxn {
          */
         private void checkFlush(boolean force) {
             if ((force && sb.length() > 0) || sb.length() > 2048) {
-                sendBuffer(ByteBuffer.wrap(sb.toString().getBytes(StandardCharsets.UTF_8)));
+                sendBuffer(ByteBuffer.wrap(sb.toString().getBytes(UTF_8)));
                 // clear our internal buffer
                 sb.setLength(0);
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -35,6 +35,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -233,7 +234,7 @@ public class NettyServerCnxn extends ServerCnxn {
          */
         private void checkFlush(boolean force) {
             if ((force && sb.length() > 0) || sb.length() > 2048) {
-                sendBuffer(ByteBuffer.wrap(sb.toString().getBytes()));
+                sendBuffer(ByteBuffer.wrap(sb.toString().getBytes(StandardCharsets.UTF_8)));
                 // clear our internal buffer
                 sb.setLength(0);
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -18,11 +18,11 @@
 
 package org.apache.zookeeper.server;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -332,7 +332,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             break;
         }
         case OpCode.deleteContainer: {
-            String path = new String(request.request.array(), StandardCharsets.UTF_8);
+            String path = new String(request.request.array(), UTF_8);
             String parentPath = getParentPathAndValidate(path);
             ChangeRecord nodeRecord = getRecordForPath(path);
             if (nodeRecord.childCount > 0) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -331,7 +332,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             break;
         }
         case OpCode.deleteContainer: {
-            String path = new String(request.request.array());
+            String path = new String(request.request.array(), StandardCharsets.UTF_8);
             String parentPath = getParentPathAndValidate(path);
             ChangeRecord nodeRecord = getRecordForPath(path);
             if (nodeRecord.childCount > 0) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
@@ -18,8 +18,8 @@
 
 package org.apache.zookeeper.server;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.apache.jute.Record;
 import org.apache.zookeeper.KeeperException;
@@ -409,7 +409,7 @@ public class Request {
                 if (pathLen >= 0 && pathLen < 4096 && rbuf.remaining() >= pathLen) {
                     byte[] b = new byte[pathLen];
                     rbuf.get(b);
-                    path = new String(b, StandardCharsets.UTF_8);
+                    path = new String(b, UTF_8);
                 }
             } catch (Exception e) {
                 // ignore - can't find the path, will output "n/a" instead

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.apache.jute.Record;
 import org.apache.zookeeper.KeeperException;
@@ -408,7 +409,7 @@ public class Request {
                 if (pathLen >= 0 && pathLen < 4096 && rbuf.remaining() >= pathLen) {
                     byte[] b = new byte[pathLen];
                     rbuf.get(b);
-                    path = new String(b);
+                    path = new String(b, StandardCharsets.UTF_8);
                 }
             } catch (Exception e) {
                 // ignore - can't find the path, will output "n/a" instead

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
@@ -18,10 +18,10 @@
 
 package org.apache.zookeeper.server;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -678,7 +678,7 @@ public class ZKDatabase {
             }
             this.dataTree.setData(
                 ZooDefs.CONFIG_NODE,
-                qv.toString().getBytes(StandardCharsets.UTF_8),
+                qv.toString().getBytes(UTF_8),
                 -1,
                 qv.getVersion(),
                 Time.currentWallTime());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.server;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -677,7 +678,7 @@ public class ZKDatabase {
             }
             this.dataTree.setData(
                 ZooDefs.CONFIG_NODE,
-                qv.toString().getBytes(),
+                qv.toString().getBytes(StandardCharsets.UTF_8),
                 -1,
                 qv.getVersion(),
                 Time.currentWallTime());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
@@ -18,7 +18,7 @@
 
 package org.apache.zookeeper.server.auth;
 
-import java.nio.charset.StandardCharsets;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.apache.zookeeper.KeeperException;
@@ -89,7 +89,7 @@ public class DigestAuthenticationProvider implements AuthenticationProvider {
 
     public static String generateDigest(String idPassword) throws NoSuchAlgorithmException {
         String[] parts = idPassword.split(":", 2);
-        byte[] digest = MessageDigest.getInstance("SHA1").digest(idPassword.getBytes(StandardCharsets.UTF_8));
+        byte[] digest = MessageDigest.getInstance("SHA1").digest(idPassword.getBytes(UTF_8));
         return parts[0] + ":" + base64Encode(digest);
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server.auth;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.apache.zookeeper.KeeperException;
@@ -88,7 +89,7 @@ public class DigestAuthenticationProvider implements AuthenticationProvider {
 
     public static String generateDigest(String idPassword) throws NoSuchAlgorithmException {
         String[] parts = idPassword.split(":", 2);
-        byte[] digest = MessageDigest.getInstance("SHA1").digest(idPassword.getBytes());
+        byte[] digest = MessageDigest.getInstance("SHA1").digest(idPassword.getBytes(StandardCharsets.UTF_8));
         return parts[0] + ":" + base64Encode(digest);
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/EnsembleAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/EnsembleAuthenticationProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server.auth;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.zookeeper.KeeperException;
@@ -76,7 +77,7 @@ public class EnsembleAuthenticationProvider implements AuthenticationProvider {
             return KeeperException.Code.OK;
         }
 
-        String receivedEnsembleName = new String(authData);
+        String receivedEnsembleName = new String(authData, StandardCharsets.UTF_8);
 
         if (ensembleNames == null) {
             ServerMetrics.getMetrics().ENSEMBLE_AUTH_SKIP.add(1);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/KeyAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/KeyAuthenticationProvider.java
@@ -18,7 +18,7 @@
 
 package org.apache.zookeeper.server.auth;
 
-import java.nio.charset.StandardCharsets;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.apache.zookeeper.data.Id;
@@ -75,8 +75,8 @@ public class KeyAuthenticationProvider extends ServerAuthenticationProvider {
     private boolean validate(byte[] key, byte[] auth) {
         // perform arbitrary function (auth is a multiple of key)
         try {
-            String keyStr = new String(key, StandardCharsets.UTF_8);
-            String authStr = new String(auth, StandardCharsets.UTF_8);
+            String keyStr = new String(key, UTF_8);
+            String authStr = new String(auth, UTF_8);
             int keyVal = Integer.parseInt(keyStr);
             int authVal = Integer.parseInt(authStr);
             if (keyVal != 0 && ((authVal % keyVal) != 0)) {
@@ -92,11 +92,11 @@ public class KeyAuthenticationProvider extends ServerAuthenticationProvider {
     @Override
     public KeeperException.Code handleAuthentication(ServerObjs serverObjs, byte[] authData) {
         byte[] key = getKey(serverObjs.getZks());
-        String authStr = new String(authData, StandardCharsets.UTF_8);
+        String authStr = new String(authData, UTF_8);
         String keyStr = "";
         if (key != null) {
             if (!validate(key, authData)) {
-                keyStr = new String(key, StandardCharsets.UTF_8);
+                keyStr = new String(key, UTF_8);
                 LOG.debug("KeyAuthenticationProvider handleAuthentication ({}, {}) -> FAIL.\n", keyStr, authStr);
                 return KeeperException.Code.AUTHFAILED;
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/KeyAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/KeyAuthenticationProvider.java
@@ -92,22 +92,11 @@ public class KeyAuthenticationProvider extends ServerAuthenticationProvider {
     @Override
     public KeeperException.Code handleAuthentication(ServerObjs serverObjs, byte[] authData) {
         byte[] key = getKey(serverObjs.getZks());
-        String authStr = "";
+        String authStr = new String(authData, StandardCharsets.UTF_8);
         String keyStr = "";
-        try {
-            authStr = new String(authData, StandardCharsets.UTF_8);
-        } catch (Exception e) {
-            LOG.error("UTF-8", e);
-        }
         if (key != null) {
             if (!validate(key, authData)) {
-                try {
-                    keyStr = new String(key, StandardCharsets.UTF_8);
-                } catch (Exception e) {
-                    LOG.error("UTF-8", e);
-                    // empty key
-                    keyStr = authStr;
-                }
+                keyStr = new String(key, StandardCharsets.UTF_8);
                 LOG.debug("KeyAuthenticationProvider handleAuthentication ({}, {}) -> FAIL.\n", keyStr, authStr);
                 return KeeperException.Code.AUTHFAILED;
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FastLeaderElection.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FastLeaderElection.java
@@ -18,10 +18,10 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -302,7 +302,7 @@ public class FastLeaderElection implements Election {
 
                                 synchronized (self) {
                                     try {
-                                        rqv = self.configFromString(new String(b, StandardCharsets.UTF_8));
+                                        rqv = self.configFromString(new String(b, UTF_8));
                                         QuorumVerifier curQV = self.getQuorumVerifier();
                                         if (rqv.getVersion() > curQV.getVersion()) {
                                             LOG.info("{} Received version: {} my version: {}",
@@ -350,7 +350,7 @@ public class FastLeaderElection implements Election {
                                 self.getPeerState(),
                                 response.sid,
                                 current.getPeerEpoch(),
-                                qv.toString().getBytes(StandardCharsets.UTF_8));
+                                qv.toString().getBytes(UTF_8));
 
                             sendqueue.offer(notmsg);
                         } else {
@@ -698,7 +698,7 @@ public class FastLeaderElection implements Election {
                 QuorumPeer.ServerState.LOOKING,
                 sid,
                 proposedEpoch,
-                qv.toString().getBytes(StandardCharsets.UTF_8));
+                qv.toString().getBytes(UTF_8));
 
             LOG.debug(
                 "Sending Notification: {} (n.leader), 0x{} (n.zxid), 0x{} (n.round), {} (recipient),"
@@ -709,6 +709,7 @@ public class FastLeaderElection implements Election {
                 sid,
                 self.getId(),
                 Long.toHexString(proposedEpoch));
+
             sendqueue.offer(notmsg);
         }
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FastLeaderElection.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FastLeaderElection.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.server.quorum;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -301,7 +302,7 @@ public class FastLeaderElection implements Election {
 
                                 synchronized (self) {
                                     try {
-                                        rqv = self.configFromString(new String(b));
+                                        rqv = self.configFromString(new String(b, StandardCharsets.UTF_8));
                                         QuorumVerifier curQV = self.getQuorumVerifier();
                                         if (rqv.getVersion() > curQV.getVersion()) {
                                             LOG.info("{} Received version: {} my version: {}",
@@ -349,7 +350,7 @@ public class FastLeaderElection implements Election {
                                 self.getPeerState(),
                                 response.sid,
                                 current.getPeerEpoch(),
-                                qv.toString().getBytes());
+                                qv.toString().getBytes(StandardCharsets.UTF_8));
 
                             sendqueue.offer(notmsg);
                         } else {
@@ -697,7 +698,7 @@ public class FastLeaderElection implements Election {
                 QuorumPeer.ServerState.LOOKING,
                 sid,
                 proposedEpoch,
-                qv.toString().getBytes());
+                qv.toString().getBytes(StandardCharsets.UTF_8));
 
             LOG.debug(
                 "Sending Notification: {} (n.leader), 0x{} (n.zxid), 0x{} (n.round), {} (recipient),"
@@ -708,7 +709,6 @@ public class FastLeaderElection implements Election {
                 sid,
                 self.getId(),
                 Long.toHexString(proposedEpoch));
-
             sendqueue.offer(notmsg);
         }
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Follower.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Follower.java
@@ -18,9 +18,9 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.jute.Record;
@@ -177,7 +177,7 @@ public class Follower extends Learner {
 
             if (hdr.getType() == OpCode.reconfig) {
                 SetDataTxn setDataTxn = (SetDataTxn) txn;
-                QuorumVerifier qv = self.configFromString(new String(setDataTxn.getData(), StandardCharsets.UTF_8));
+                QuorumVerifier qv = self.configFromString(new String(setDataTxn.getData(), UTF_8));
                 self.setLastSeenQuorumVerifier(qv, true);
             }
 
@@ -214,7 +214,7 @@ public class Follower extends Learner {
             // get the new configuration from the request
             Request request = fzk.pendingTxns.element();
             SetDataTxn setDataTxn = (SetDataTxn) request.getTxn();
-            QuorumVerifier qv = self.configFromString(new String(setDataTxn.getData(), StandardCharsets.UTF_8));
+            QuorumVerifier qv = self.configFromString(new String(setDataTxn.getData(), UTF_8));
 
             // get new designated leader from (current) leader's message
             ByteBuffer buffer = ByteBuffer.wrap(qp.getData());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Follower.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Follower.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.server.quorum;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.jute.Record;
@@ -176,7 +177,7 @@ public class Follower extends Learner {
 
             if (hdr.getType() == OpCode.reconfig) {
                 SetDataTxn setDataTxn = (SetDataTxn) txn;
-                QuorumVerifier qv = self.configFromString(new String(setDataTxn.getData()));
+                QuorumVerifier qv = self.configFromString(new String(setDataTxn.getData(), StandardCharsets.UTF_8));
                 self.setLastSeenQuorumVerifier(qv, true);
             }
 
@@ -213,7 +214,7 @@ public class Follower extends Learner {
             // get the new configuration from the request
             Request request = fzk.pendingTxns.element();
             SetDataTxn setDataTxn = (SetDataTxn) request.getTxn();
-            QuorumVerifier qv = self.configFromString(new String(setDataTxn.getData()));
+            QuorumVerifier qv = self.configFromString(new String(setDataTxn.getData(), StandardCharsets.UTF_8));
 
             // get new designated leader from (current) leader's message
             ByteBuffer buffer = ByteBuffer.wrap(qp.getData());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -30,6 +30,7 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1693,7 +1694,7 @@ public class Leader extends LearnerMaster {
 
     @Override
     public byte[] getQuorumVerifierBytes() {
-        return self.getLastSeenQuorumVerifier().toString().getBytes();
+        return self.getLastSeenQuorumVerifier().toString().getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -30,7 +31,6 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1694,7 +1694,7 @@ public class Leader extends LearnerMaster {
 
     @Override
     public byte[] getQuorumVerifierBytes() {
-        return self.getLastSeenQuorumVerifier().toString().getBytes(StandardCharsets.UTF_8);
+        return self.getLastSeenQuorumVerifier().toString().getBytes(UTF_8);
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
@@ -28,7 +29,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Map;
@@ -635,7 +635,7 @@ public class Learner {
 
                     if (pif.hdr.getType() == OpCode.reconfig) {
                         SetDataTxn setDataTxn = (SetDataTxn) pif.rec;
-                        QuorumVerifier qv = self.configFromString(new String(setDataTxn.getData(), StandardCharsets.UTF_8));
+                        QuorumVerifier qv = self.configFromString(new String(setDataTxn.getData(), UTF_8));
                         self.setLastSeenQuorumVerifier(qv, true);
                     }
 
@@ -645,7 +645,7 @@ public class Learner {
                 case Leader.COMMITANDACTIVATE:
                     pif = packetsNotCommitted.peekFirst();
                     if (pif.hdr.getZxid() == qp.getZxid() && qp.getType() == Leader.COMMITANDACTIVATE) {
-                        QuorumVerifier qv = self.configFromString(new String(((SetDataTxn) pif.rec).getData(), StandardCharsets.UTF_8));
+                        QuorumVerifier qv = self.configFromString(new String(((SetDataTxn) pif.rec).getData(), UTF_8));
                         boolean majorChange = self.processReconfig(
                             qv,
                             ByteBuffer.wrap(qp.getData()).getLong(), qp.getZxid(),
@@ -681,7 +681,7 @@ public class Learner {
                         packet.hdr = logEntry.getHeader();
                         packet.rec = logEntry.getTxn();
                         packet.digest = logEntry.getDigest();
-                        QuorumVerifier qv = self.configFromString(new String(((SetDataTxn) packet.rec).getData(), StandardCharsets.UTF_8));
+                        QuorumVerifier qv = self.configFromString(new String(((SetDataTxn) packet.rec).getData(), UTF_8));
                         boolean majorChange = self.processReconfig(qv, suggestedLeaderId, qp.getZxid(), true);
                         if (majorChange) {
                             throw new Exception("changes proposed in reconfig");
@@ -729,7 +729,7 @@ public class Learner {
                     LOG.info("Learner received NEWLEADER message");
                     if (qp.getData() != null && qp.getData().length > 1) {
                         try {
-                            QuorumVerifier qv = self.configFromString(new String(qp.getData(), StandardCharsets.UTF_8));
+                            QuorumVerifier qv = self.configFromString(new String(qp.getData(), UTF_8));
                             self.setLastSeenQuorumVerifier(qv, true);
                             newLeaderQV = qv;
                         } catch (Exception e) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Map;
@@ -634,7 +635,7 @@ public class Learner {
 
                     if (pif.hdr.getType() == OpCode.reconfig) {
                         SetDataTxn setDataTxn = (SetDataTxn) pif.rec;
-                        QuorumVerifier qv = self.configFromString(new String(setDataTxn.getData()));
+                        QuorumVerifier qv = self.configFromString(new String(setDataTxn.getData(), StandardCharsets.UTF_8));
                         self.setLastSeenQuorumVerifier(qv, true);
                     }
 
@@ -644,7 +645,7 @@ public class Learner {
                 case Leader.COMMITANDACTIVATE:
                     pif = packetsNotCommitted.peekFirst();
                     if (pif.hdr.getZxid() == qp.getZxid() && qp.getType() == Leader.COMMITANDACTIVATE) {
-                        QuorumVerifier qv = self.configFromString(new String(((SetDataTxn) pif.rec).getData()));
+                        QuorumVerifier qv = self.configFromString(new String(((SetDataTxn) pif.rec).getData(), StandardCharsets.UTF_8));
                         boolean majorChange = self.processReconfig(
                             qv,
                             ByteBuffer.wrap(qp.getData()).getLong(), qp.getZxid(),
@@ -680,7 +681,7 @@ public class Learner {
                         packet.hdr = logEntry.getHeader();
                         packet.rec = logEntry.getTxn();
                         packet.digest = logEntry.getDigest();
-                        QuorumVerifier qv = self.configFromString(new String(((SetDataTxn) packet.rec).getData()));
+                        QuorumVerifier qv = self.configFromString(new String(((SetDataTxn) packet.rec).getData(), StandardCharsets.UTF_8));
                         boolean majorChange = self.processReconfig(qv, suggestedLeaderId, qp.getZxid(), true);
                         if (majorChange) {
                             throw new Exception("changes proposed in reconfig");
@@ -728,7 +729,7 @@ public class Learner {
                     LOG.info("Learner received NEWLEADER message");
                     if (qp.getData() != null && qp.getData().length > 1) {
                         try {
-                            QuorumVerifier qv = self.configFromString(new String(qp.getData()));
+                            QuorumVerifier qv = self.configFromString(new String(qp.getData(), StandardCharsets.UTF_8));
                             self.setLastSeenQuorumVerifier(qv, true);
                             newLeaderQV = qv;
                         } catch (Exception e) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Observer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Observer.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server.quorum;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.jute.Record;
 import org.apache.zookeeper.server.ObserverBean;
@@ -212,11 +213,12 @@ public class Observer extends Learner {
 
             byte[] remainingdata = new byte[buffer.remaining()];
             buffer.get(remainingdata);
+
             logEntry = SerializeUtils.deserializeTxn(remainingdata);
             hdr = logEntry.getHeader();
             txn = logEntry.getTxn();
             digest = logEntry.getDigest();
-            QuorumVerifier qv = self.configFromString(new String(((SetDataTxn) txn).getData()));
+            QuorumVerifier qv = self.configFromString(new String(((SetDataTxn) txn).getData(), StandardCharsets.UTF_8));
 
             request = new Request(hdr.getClientId(), hdr.getCxid(), hdr.getType(), hdr, txn, 0);
             request.setTxnDigest(digest);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Observer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Observer.java
@@ -18,8 +18,8 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.jute.Record;
 import org.apache.zookeeper.server.ObserverBean;
@@ -218,7 +218,7 @@ public class Observer extends Learner {
             hdr = logEntry.getHeader();
             txn = logEntry.getTxn();
             digest = logEntry.getDigest();
-            QuorumVerifier qv = self.configFromString(new String(((SetDataTxn) txn).getData(), StandardCharsets.UTF_8));
+            QuorumVerifier qv = self.configFromString(new String(((SetDataTxn) txn).getData(), UTF_8));
 
             request = new Request(hdr.getClientId(), hdr.getCxid(), hdr.getType(), hdr, txn, 0);
             request.setTxnDigest(digest);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Observer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Observer.java
@@ -213,7 +213,6 @@ public class Observer extends Learner {
 
             byte[] remainingdata = new byte[buffer.remaining()];
             buffer.get(remainingdata);
-
             logEntry = SerializeUtils.deserializeTxn(remainingdata);
             hdr = logEntry.getHeader();
             txn = logEntry.getTxn();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import static java.nio.charset.UTF_8;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -26,7 +27,6 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -344,7 +344,7 @@ public class ObserverMaster extends LearnerMaster implements Runnable {
 
     @Override
     public byte[] getQuorumVerifierBytes() {
-        return self.getLastSeenQuorumVerifier().toString().getBytes(StandardCharsets.UTF_8);
+        return self.getLastSeenQuorumVerifier().toString().getBytes(UTF_8);
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
@@ -18,7 +18,7 @@
 
 package org.apache.zookeeper.server.quorum;
 
-import static java.nio.charset.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
@@ -26,6 +26,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -343,7 +344,7 @@ public class ObserverMaster extends LearnerMaster implements Runnable {
 
     @Override
     public byte[] getQuorumVerifierBytes() {
-        return self.getLastSeenQuorumVerifier().toString().getBytes();
+        return self.getLastSeenQuorumVerifier().toString().getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -259,6 +259,7 @@ public class QuorumCnxManager {
             String[] addressStrings = new String(b, UTF_8).split("\\|");
             List<InetSocketAddress> addresses = new ArrayList<>(addressStrings.length);
             for (String addr : addressStrings) {
+
                 String[] host_port;
                 try {
                     host_port = ConfigUtils.getHostAndPort(addr);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -35,6 +35,7 @@ import java.net.UnknownHostException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.channels.UnresolvedAddressException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -255,10 +256,9 @@ public class QuorumCnxManager {
 
             // in PROTOCOL_VERSION_V1 we expect to get a single address here represented as a 'host:port' string
             // in PROTOCOL_VERSION_V2 we expect to get multiple addresses like: 'host1:port1|host2:port2|...'
-            String[] addressStrings = new String(b).split("\\|");
+            String[] addressStrings = new String(b, StandardCharsets.UTF_8).split("\\|");
             List<InetSocketAddress> addresses = new ArrayList<>(addressStrings.length);
             for (String addr : addressStrings) {
-
                 String[] host_port;
                 try {
                     host_port = ConfigUtils.getHostAndPort(addr);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.zookeeper.common.NetUtils.formatInetAddr;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -35,7 +36,6 @@ import java.net.UnknownHostException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.channels.UnresolvedAddressException;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -256,7 +256,7 @@ public class QuorumCnxManager {
 
             // in PROTOCOL_VERSION_V1 we expect to get a single address here represented as a 'host:port' string
             // in PROTOCOL_VERSION_V2 we expect to get multiple addresses like: 'host1:port1|host2:port2|...'
-            String[] addressStrings = new String(b, StandardCharsets.UTF_8).split("\\|");
+            String[] addressStrings = new String(b, UTF_8).split("\\|");
             List<InetSocketAddress> addresses = new ArrayList<>(addressStrings.length);
             for (String addr : addressStrings) {
                 String[] host_port;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
@@ -186,7 +186,7 @@ public abstract class QuorumZooKeeperServer extends ZooKeeperServer {
         pwriter.print("peerType=");
         pwriter.println(self.getLearnerType().ordinal());
         pwriter.println("membership: ");
-        pwriter.print(new String(self.getQuorumVerifier().toString().getBytes()));
+        pwriter.print(self.getQuorumVerifier().toString());
     }
 
     @Override

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/AtomicFileWritingIdiomTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/AtomicFileWritingIdiomTest.java
@@ -27,6 +27,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.common.AtomicFileWritingIdiom.OutputStreamStatement;
@@ -335,7 +336,7 @@ public class AtomicFileWritingIdiomTest extends ZKTestCase {
         assertFalse(target.exists(), "file should not exist");
     }
 
-    private String getContent(File file, String encoding) throws IOException {
+    private String getContent(File file, Charset encoding) throws IOException {
         StringBuilder result = new StringBuilder();
         FileInputStream fis = new FileInputStream(file);
         byte[] b = new byte[20];
@@ -348,7 +349,7 @@ public class AtomicFileWritingIdiomTest extends ZKTestCase {
     }
 
     private String getContent(File file) throws IOException {
-        return getContent(file, "ASCII");
+        return getContent(file, StandardCharsets.US_ASCII);
     }
 
     private void createFile(File file, String content) throws IOException {


### PR DESCRIPTION
> Encodes this String into a sequence of bytes using the platform's default charset, storing the result into a new byte array.  The behavior of this method when this string cannot be encoded in the default charset is unspecified.

https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#getBytes--

1.  Since this is a distributed system, it is always possible that different nodes have different default charsets defined.  I think it's most safe to specify it explicitly across all nodes for safety sake.  You could for example see a situation where an upgrade JVM uses a different default and during a rolling upgrade of the JVM, different nodes now have a different default.
2.  The default charset is usually "ISO-8859-1".  UTF-8 covers more of our international friends.
3. Explicitly specifying the CharSet yields slight performance gains 
4. Explicitly specifying the CharSet removes the need for try/catch blocks of UnsupportedEncodingException

https://blog.codecentric.de/en/2014/04/faster-cleaner-code-since-java-7/