### PR TITLE
ZOOKEEPER-3314: Document the possibility of MultiCallback receiving a null pointer

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/AsyncCallback.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/AsyncCallback.java
@@ -326,9 +326,9 @@ public interface AsyncCallback {
          * <p/>
          * On failure, rc is a failure code in
          * {@link org.apache.zookeeper.KeeperException.Code}.
-         * All opResults are
+         * Either opResults is null, or all opResults are
          * {@link org.apache.zookeeper.OpResult.ErrorResult}.
-         * All operations will be rollback-ed even if operations
+         * All operations will be rolled back even if operations
          * before the failing one were successful.
          *
          * @param rc   The return code or the result of the call.


### PR DESCRIPTION
I have tried to get set up to verify that tests pass, but I am still seeing numerous test failures when running `ant test` against the unmodified `master` branch, so I cannot validate that this does not cause failures. Since this particular change is only in documentation, it seems unlikely, so I'm raising a PR anyway.