### PR TITLE
ZOOKEEPER-3122 - fix some maven release related issues

### DIFF
--- a/zookeeper-assembly/src/main/assembly/bin-package.xml
+++ b/zookeeper-assembly/src/main/assembly/bin-package.xml
@@ -83,13 +83,6 @@
       </includes>
     </fileSet>
     <fileSet>
-      <directory>${project.basedir}/../zookeeper-jute/target</directory>
-      <outputDirectory>lib</outputDirectory>
-      <includes>
-        <include>zookeeper-*-sources.jar</include>
-      </includes>
-    </fileSet>
-    <fileSet>
       <directory>${project.basedir}/../zookeeper-recipes/zookeeper-recipes-election/target</directory>
       <outputDirectory>lib</outputDirectory>
       <includes>
@@ -116,11 +109,6 @@
     <file>
       <source>${project.basedir}/../zookeeper-server/src/main/resources/lib/cobertura/README.txt</source>
       <outputDirectory>lib/cobertura</outputDirectory>
-      <fileMode>${rw.file.permission}</fileMode>
-    </file>
-    <file>
-      <source>${project.basedir}/../zookeeper-server/src/main/resources/lib/jdiff/zookeeper_3.1.1.xml</source>
-      <outputDirectory>lib/jdiff</outputDirectory>
       <fileMode>${rw.file.permission}</fileMode>
     </file>
   </files>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -98,10 +98,12 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>jline</groupId>

--- a/zookeeper-server/src/main/resources/lib/json-simple-1.1.1.LICENSE.txt
+++ b/zookeeper-server/src/main/resources/lib/json-simple-1.1.1.LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 1999-2005 The Apache Software Foundation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -200,25 +200,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-
-This distribution bundles javacc, which is available under the
-3-clause BSD License. For details, see a copy of the license in
-lib/javacc.LICENSE.txt
-
-This distribution bundles jline 2.11, which is available under the
-2-clause BSD License. For details, see a copy of the license in
-lib/jline-2.11.LICENSE.txt
-
-This distribution bundles SLF4J 1.7.5, which is available under the MIT
-License. For details, see a copy of the license in
-lib/slf4j-1.7.5.LICENSE.txt
-
-This distribution bundles json-simple v1.1.1, which is available under the
-Apache Software License, Version 2.0. For details, see a copy of the license in
-lib/json-simple-1.1.1.LICENSE.txt
-
-This distribution bundles a modified version of 'JZLib' as part of
-Netty-3.7.0, which is available under the 3-clause BSD licence. For
-details, see a copy of the licence in META-INF/license/LICENSE-jzlib.txt
-as part of the Netty jar in lib/netty-3.7.0.Final.jar.


### PR DESCRIPTION
Some problems found in maven release procedure on branch-3.5 also applicable to master (missing license file, dependency scope)