### PR TITLE
ZOOKEEPER-3122 - Only deploy zk-server and zk-jute to maven repo

### DIFF
--- a/zookeeper-assembly/pom.xml
+++ b/zookeeper-assembly/pom.xml
@@ -99,6 +99,14 @@
             <skip>true</skip>
         </configuration>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <!-- this module isn't to be deployed to Maven Central -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/zookeeper-client/pom.xml
+++ b/zookeeper-client/pom.xml
@@ -47,5 +47,15 @@
       <modules />
     </profile>
   </profiles>
-
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <!-- this module isn't to be deployed to Maven Central -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/zookeeper-docs/pom.xml
+++ b/zookeeper-docs/pom.xml
@@ -53,7 +53,13 @@
           <copyDirectories>images,skin</copyDirectories>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <!-- this module isn't to be deployed to Maven Central -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
-
 </project>

--- a/zookeeper-recipes/pom.xml
+++ b/zookeeper-recipes/pom.xml
@@ -62,4 +62,16 @@
     <module>zookeeper-recipes-queue</module>
   </modules>
 
+  <build>
+    <plugins>
+      <plugin>
+       <artifactId>maven-deploy-plugin</artifactId>
+       <configuration>
+         <!-- this module isn't to be deployed to Maven Central -->
+         <skip>true</skip>
+       </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
Skip Maven deploy plugin for modules which are not to be deployed:
- assembly
- clients (C binding)
- documentation
- recipes