### PR TITLE
ZOOKEEPER-3122 - Rename zookeeper-server to zookeeper 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <!-- no parent resolution -->
   </parent>
   <groupId>org.apache.zookeeper</groupId>
-  <artifactId>zookeeper</artifactId>
+  <artifactId>parent</artifactId>
   <packaging>pom</packaging>
   <!-- to change version: mvn -\-batch-mode release:update-versions -DdevelopmentVersion=3.6.0-SNAPSHOT -->
   <version>3.6.0-SNAPSHOT</version>

--- a/zookeeper-assembly/pom.xml
+++ b/zookeeper-assembly/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.zookeeper</groupId>
-    <artifactId>zookeeper</artifactId>
+    <artifactId>parent</artifactId>
     <version>3.6.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper-server</artifactId>
+      <artifactId>zookeeper</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/zookeeper-assembly/src/main/assembly/bin-package.xml
+++ b/zookeeper-assembly/src/main/assembly/bin-package.xml
@@ -34,7 +34,7 @@
     <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
       <includes>
-        <include>org.apache.zookeeper:zookeeper-server</include>
+        <include>org.apache.zookeeper:zookeeper</include>
         <include>org.apache.zookeeper:zookeeper-recipes-election</include>
         <include>org.apache.zookeeper:zookeeper-recipes-lock</include>
         <include>org.apache.zookeeper:zookeeper-recipes-queue</include>

--- a/zookeeper-client/pom.xml
+++ b/zookeeper-client/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.zookeeper</groupId>
-    <artifactId>zookeeper</artifactId>
+    <artifactId>parent</artifactId>
     <version>3.6.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>

--- a/zookeeper-contrib/pom.xml
+++ b/zookeeper-contrib/pom.xml
@@ -23,7 +23,7 @@
 
   <parent>
     <groupId>org.apache.zookeeper</groupId>
-    <artifactId>zookeeper</artifactId>
+    <artifactId>parent</artifactId>
     <version>3.6.0-SNAPSHOT</version>
   </parent>
 

--- a/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper-server</artifactId>
+      <artifactId>zookeeper</artifactId>
       <version>3.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>

--- a/zookeeper-contrib/zookeeper-contrib-rest/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-rest/pom.xml
@@ -55,12 +55,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper-server</artifactId>
+      <artifactId>zookeeper</artifactId>
       <version>3.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper-server</artifactId>
+      <artifactId>zookeeper</artifactId>
       <version>3.6.0-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
@@ -43,7 +43,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper-server</artifactId>
+      <artifactId>zookeeper</artifactId>
       <version>3.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>

--- a/zookeeper-docs/pom.xml
+++ b/zookeeper-docs/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.zookeeper</groupId>
-    <artifactId>zookeeper</artifactId>
+    <artifactId>parent</artifactId>
     <version>3.6.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>

--- a/zookeeper-jute/pom.xml
+++ b/zookeeper-jute/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.zookeeper</groupId>
-    <artifactId>zookeeper</artifactId>
+    <artifactId>parent</artifactId>
     <version>3.6.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>

--- a/zookeeper-recipes/pom.xml
+++ b/zookeeper-recipes/pom.xml
@@ -23,7 +23,7 @@
 
   <parent>
     <groupId>org.apache.zookeeper</groupId>
-    <artifactId>zookeeper</artifactId>
+    <artifactId>parent</artifactId>
     <version>3.6.0-SNAPSHOT</version>
   </parent>
 

--- a/zookeeper-recipes/zookeeper-recipes-election/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-election/pom.xml
@@ -37,12 +37,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper-server</artifactId>
+      <artifactId>zookeeper</artifactId>
       <version>3.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper-server</artifactId>
+      <artifactId>zookeeper</artifactId>
       <version>3.6.0-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/zookeeper-recipes/zookeeper-recipes-lock/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-lock/pom.xml
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper-server</artifactId>
+      <artifactId>zookeeper</artifactId>
       <version>3.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper-server</artifactId>
+      <artifactId>zookeeper</artifactId>
       <version>3.6.0-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/zookeeper-recipes/zookeeper-recipes-queue/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-queue/pom.xml
@@ -42,12 +42,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper-server</artifactId>
+      <artifactId>zookeeper</artifactId>
       <version>3.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper-server</artifactId>
+      <artifactId>zookeeper</artifactId>
       <version>3.6.0-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -22,13 +22,13 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.zookeeper</groupId>
-    <artifactId>zookeeper</artifactId>
+    <artifactId>parent</artifactId>
     <version>3.6.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
-  <artifactId>zookeeper-server</artifactId>
+  <artifactId>zookeeper</artifactId>
   <packaging>jar</packaging>
   <name>Apache ZooKeeper - Server</name>
   <description>ZooKeeper server</description>


### PR DESCRIPTION
To stay backward compatible and make dependency management less confusing, everyone using ZooKeeper can stay on "zookeeper" as artifactid. 
When java client is separated from server code, we can think on the module names to make sense.