### PR TITLE
ZOOKEEPER-3362 Create a simple checkstyle file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ cache:
   directories:
   - "$HOME/.m2"
 
+addons:
+  apt:
+    packages:
+    - libcppunit-dev
+
 script: mvn clean install -DskipTests spotbugs:check checkstyle:check -Pfull-build
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   directories:
   - "$HOME/.m2"
 
-script: mvn clean install -DskipTests spotbugs:check
+script: mvn clean install -DskipTests spotbugs:check checkstyle:check -Pfull-build
 
 branches:
   only:

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!-- This is a checkstyle configuration file. For descriptions of
+what the following rules do, please see the checkstyle configuration
+page at http://checkstyle.sourceforge.net/config.html -->
+
+<module name="Checker">
+
+    <!-- Prevent *Tests.java as tools may not pick them up -->
+    <module name="RegexpOnFilename">
+        <property name="fileNamePattern" value=".*Tests\.java$" />
+    </module>
+
+    <module name="SuppressionFilter">
+        <property name="file" value="${checkstyle.suppressions.file}" default="suppressions.xml" />
+    </module>
+
+    <!-- All Java AST specific tests live under TreeWalker module. -->
+    <module name="TreeWalker">
+
+        <!-- Allow use of comment to suppress javadocstyle -->
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+            <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+            <property name="checkFormat" value="$1"/>
+        </module>
+        <module name="TodoComment">
+            <!-- Checks that disallowed strings are not used in comments.  -->
+            <property name="format" value="(@author)" />
+        </module>
+
+
+        <module name="PackageName">
+            <!-- Validates identifiers for package names against the
+            supplied expression. -->
+            <!-- Here the default checkstyle rule restricts package name parts to
+              seven characters, this is not in line with common practice at Google.
+            -->
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$"/>
+            <property name="severity" value="error"/>
+        </module>
+
+    </module>
+</module>

--- a/checkstyleSuppressions.xml
+++ b/checkstyleSuppressions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <!-- suppress all checks in the generated directories -->
+    <suppress checks=".*" files=".+[\\/]generated[\\/].+\.java" />
+    <suppress checks=".*" files=".+[\\/]generated-sources[\\/].+\.java" />
+    <suppress checks=".*" files=".+[\\/]generated-test-sources[\\/].+\.java" />
+
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,7 @@
     <commons-lang.version>2.6</commons-lang.version>
     <dropwizard.version>3.2.5</dropwizard.version>
     <spotbugsannotations.version>3.1.9</spotbugsannotations.version>
+    <checkstyle.version>8.17</checkstyle.version>
   </properties>
 
   <dependencyManagement>
@@ -553,7 +554,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>8.17</version>
+              <version>${checkstyle.version}</version>
             </dependency>
           </dependencies>
           <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -545,6 +545,36 @@
           <artifactId>dependency-check-maven</artifactId>
           <version>4.0.2</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>3.0.0</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>8.17</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <configLocation>checkstyle.xml</configLocation>
+            <suppressionsLocation>checkstyleSuppressions.xml</suppressionsLocation>
+            <encoding>UTF-8</encoding>
+            <consoleOutput>true</consoleOutput>
+            <failOnViolation>true</failOnViolation>
+            <includeResources>false</includeResources>
+            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+          </configuration>
+          <executions>
+            <execution>
+              <id>checkstyle</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/zookeeper-assembly/src/main/assembly/source-package.xml
+++ b/zookeeper-assembly/src/main/assembly/source-package.xml
@@ -112,6 +112,8 @@
         <include>ivysettings.xml</include>
         <include>excludeFindBugsFilter.xml</include>
         <include>owaspSuppressions.xml</include>
+        <include>checktyle.xml</include>
+        <include>checktyleSuppressions.xml</include>
       </includes>
       <fileMode>${rw.file.permission}</fileMode>
     </fileSet>

--- a/zookeeper-client/zookeeper-client-c/pom.xml
+++ b/zookeeper-client/zookeeper-client-c/pom.xml
@@ -55,6 +55,8 @@
             <id>test-cppunit</id>
             <phase>test</phase>
             <configuration>
+              <!-- do not run cpp tests if tests are globally skipped -->
+              <skip>${skipTests}</skip> 
               <tasks>
                 <exec dir="${basedir}/target/c" executable="make" failonerror="true">
                   <env key="LD_LIBRARY_PATH" value="${env.LD_LIBRARY_PATH};/usr/lib" />

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/java/com/nitido/utils/toaster/Toaster.java
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/java/com/nitido/utils/toaster/Toaster.java
@@ -44,8 +44,6 @@ import javax.swing.border.*;
 /**
  * Class to show tosters in multiplatform
  *
- * @author daniele piras
- *
  */
 public class Toaster
 {
@@ -97,8 +95,6 @@ public class Toaster
 	/**
 	 * Constructor to initialized toaster component...
 	 *
-	 * @author daniele piras
-	 *
 	 */
 	public Toaster()
 	{
@@ -123,8 +119,6 @@ public class Toaster
 
 	/**
 	 * Class that rappresent a single toaster
-	 *
-	 * @author daniele piras
 	 *
 	 */
 	class SingleToaster extends javax.swing.JWindow


### PR DESCRIPTION
Create a basic checkstyle file, in order to cover the minimal check on @author tags.

This is needed in order to drop old ANT based precommit job (see ZOOKEEPER-3351)

We will not remove legacy checkstyle configuration file in zookeeper-server/src/test/resources/checkstyle.xml because it is referred by ANT build.xml files (even if we are not actually using that target).

This task won't add a complete checkstyle configuration with usual checks because it would imply almost a change at every .java in the codebase.