### PR TITLE
ZOOKEEPER-3356: Implement advanced Netty flow control based on feedback from ZK

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -887,6 +887,12 @@ property, when available, is noted below.
     **New in 3.6.0:**
     The time (in milliseconds) the RequestThrottler waits for the request queue to drain during shutdown before it shuts down forcefully. The default is 10000.  
 
+* *advancedFlowControlEnabled* :
+    (Java system property: **zookeeper.netty.advancedFlowControl.enabled**)
+    Using accurate flow control in netty based on the status of ZooKeeper 
+    pipeline to avoid direct buffer OOM. It will disable the AUTO_READ in
+    Netty.
+
 <a name="sc_clusterOptions"></a>
 
 #### Cluster Options

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
@@ -225,6 +225,8 @@ public final class ServerMetrics {
         STALE_REQUESTS_DROPPED = metricsContext.getCounter("stale_requests_dropped");
         STALE_REPLIES = metricsContext.getCounter("stale_replies");
         REQUEST_THROTTLE_WAIT_COUNT = metricsContext.getCounter("request_throttle_wait_count");
+
+        NETTY_QUEUED_BUFFER = metricsContext.getSummary("netty_queued_buffer_capacity", DetailLevel.BASIC);
     }
 
     /**
@@ -423,6 +425,8 @@ public final class ServerMetrics {
     public final Counter STALE_REQUESTS_DROPPED;
     public final Counter STALE_REPLIES;
     public final Counter REQUEST_THROTTLE_WAIT_COUNT;
+
+    public final Summary NETTY_QUEUED_BUFFER;
 
     private final MetricsProvider metricsProvider;
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SSLAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SSLAuthTest.java
@@ -33,21 +33,40 @@ import org.junit.Test;
 public class SSLAuthTest extends ClientBase {
     
     private ClientX509Util clientX509Util;
-    
-    @Before
-    public void setUp() throws Exception {
-        clientX509Util = new ClientX509Util();
+
+    public static ClientX509Util setUpSecure() throws Exception{
+        ClientX509Util x509Util = new ClientX509Util();
         String testDataPath = System.getProperty("test.data.dir", "src/test/resources/data");
         System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY, "org.apache.zookeeper.server.NettyServerCnxnFactory");
         System.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET, "org.apache.zookeeper.ClientCnxnSocketNetty");
         System.setProperty(ZKClientConfig.SECURE_CLIENT, "true");
-        System.setProperty(clientX509Util.getSslAuthProviderProperty(), "x509");
-        System.setProperty(clientX509Util.getSslKeystoreLocationProperty(), testDataPath + "/ssl/testKeyStore.jks");
-        System.setProperty(clientX509Util.getSslKeystorePasswdProperty(), "testpass");
-        System.setProperty(clientX509Util.getSslTruststoreLocationProperty(), testDataPath + "/ssl/testTrustStore.jks");
-        System.setProperty(clientX509Util.getSslTruststorePasswdProperty(), "testpass");
+        System.setProperty(x509Util.getSslAuthProviderProperty(), "x509");
+        System.setProperty(x509Util.getSslKeystoreLocationProperty(), testDataPath + "/ssl/testKeyStore.jks");
+        System.setProperty(x509Util.getSslKeystorePasswdProperty(), "testpass");
+        System.setProperty(x509Util.getSslTruststoreLocationProperty(), testDataPath + "/ssl/testTrustStore.jks");
+        System.setProperty(x509Util.getSslTruststorePasswdProperty(), "testpass");
         System.setProperty("javax.net.debug", "ssl");
         System.setProperty("zookeeper.authProvider.x509", "org.apache.zookeeper.server.auth.X509AuthenticationProvider");
+        return x509Util;
+    }
+
+    public static void clearSecureSetting(ClientX509Util clientX509Util) {
+        System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
+        System.clearProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET);
+        System.clearProperty(ZKClientConfig.SECURE_CLIENT);
+        System.clearProperty(clientX509Util.getSslAuthProviderProperty());
+        System.clearProperty(clientX509Util.getSslKeystoreLocationProperty());
+        System.clearProperty(clientX509Util.getSslKeystorePasswdProperty());
+        System.clearProperty(clientX509Util.getSslTruststoreLocationProperty());
+        System.clearProperty(clientX509Util.getSslTruststorePasswdProperty());
+        System.clearProperty("javax.net.debug");
+        System.clearProperty("zookeeper.authProvider.x509");
+        clientX509Util.close();
+    }
+    
+    @Before
+    public void setUp() throws Exception {
+        clientX509Util = setUpSecure();
 
         String host = "localhost";
         int port = PortAssignment.unique();
@@ -61,17 +80,7 @@ public class SSLAuthTest extends ClientBase {
 
     @After
     public void teardown() throws Exception {
-        System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
-        System.clearProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET);
-        System.clearProperty(ZKClientConfig.SECURE_CLIENT);
-        System.clearProperty(clientX509Util.getSslAuthProviderProperty());
-        System.clearProperty(clientX509Util.getSslKeystoreLocationProperty());
-        System.clearProperty(clientX509Util.getSslKeystorePasswdProperty());
-        System.clearProperty(clientX509Util.getSslTruststoreLocationProperty());
-        System.clearProperty(clientX509Util.getSslTruststorePasswdProperty());
-        System.clearProperty("javax.net.debug");
-        System.clearProperty("zookeeper.authProvider.x509");
-        clientX509Util.close();
+        clearSecureSetting(clientX509Util);
     }
 
     @Test


### PR DESCRIPTION
The current implementation of enable/disable recv logic may cause the direct buffer OOM because we may enable read a large chunk and disabled again after consume a single ZK request.

This implementation disabled AUTO_READ and controls the READ depends on whether the SslHandler has issued a READ and what's the queuedBuffer status.

With this implementation, the max Netty queued buffer size (direct memory usage) will be 2 * recv_buffer size. It's not the per message size because in EPoll ET mode it will try to read until the socket is empty, and because of SslHandler will trigger another read when it's not a full encrypt packet and haven't issued any decrypt message.