### PR TITLE
Fixed bug in Java_Home

### DIFF
--- a/bin/zkEnv.cmd
+++ b/bin/zkEnv.cmd
@@ -50,5 +50,5 @@ if not exist "%JAVA_HOME%"\bin\java.exe (
 REM strip off trailing \ from JAVA_HOME or java does not start
 if "%JAVA_HOME:~-1%" EQU "\" set "JAVA_HOME=%JAVA_HOME:~0,-1%"
  
-set JAVA="%JAVA_HOME%"\bin\java
+set JAVA="%JAVA_HOME%\bin\java"
 


### PR DESCRIPTION
from zookeeper logs: call "C:\Program Files\AdoptOpenJDK\jdk-8.0.202.08\"\bin\java "-Dzookeeper.log.dir=... showed error in path! the " in the middle was caused by java_home setting in zookeeper