### PR TITLE
ZOOKEEPER-3361: Add multi version of getChildren request

### DIFF
--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/JRecord.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/JRecord.java
@@ -271,6 +271,8 @@ public class JRecord extends JCompType {
     static String extractMethodSuffix(JType t) {
         if (t instanceof JRecord) {
             return extractStructName(t);
+        } else if (t instanceof JVector) {
+            return JVector.extractVectorName(((JVector)t).getElementType());
         }
         return t.getMethodSuffix();
     }

--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/JVector.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/JVector.java
@@ -38,7 +38,7 @@ public class JVector extends JCompType {
     /** Creates a new instance of JVector */
     public JVector(JType t) {
         super("struct " + extractVectorName(t), " ::std::vector<"+t.getCppType()+">", "System.Collections.Generic.List<" + t.getCsharpType() + ">", "java.util.List<" + t.getJavaType() + ">", "Vector",
-                "System.Collections.Generic.List<" + t.getCsharpType() + ">", "java.util.ArrayList<" + t.getJavaType() + ">");
+                "java.util.ArrayList<" + t.getJavaType() + ">", "System.Collections.Generic.List<" + t.getCsharpType() + ">");
         mElement = t;
     }
     
@@ -54,7 +54,7 @@ public class JVector extends JCompType {
     public String genJavaReadWrapper(String fname, String tag, boolean decl) {
         StringBuilder ret = new StringBuilder("");
         if (decl) {
-            ret.append("      java.util.List "+fname+";\n");
+            ret.append("      java.util.List "+fname+"=null;\n");
         }
         ret.append("    {\n");
         incrLevel();

--- a/zookeeper-jute/src/main/resources/zookeeper.jute
+++ b/zookeeper-jute/src/main/resources/zookeeper.jute
@@ -149,6 +149,10 @@ module org.apache.zookeeper.proto {
         ustring path;
         boolean watch;
     }
+    class GetChildrenListRequest {
+        vector<ustring> pathList;
+        boolean watch;
+    }
     class CheckVersionRequest {
         ustring path;
         int version;
@@ -215,6 +219,9 @@ module org.apache.zookeeper.proto {
     class GetChildren2Response {
         vector<ustring> children;
         org.apache.zookeeper.data.Stat stat;
+    }
+    class GetChildrenListResponse {
+        vector<vector<ustring>> children;
     }
     class GetACLResponse {
         vector<org.apache.zookeeper.data.ACL> acl;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooDefs.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooDefs.java
@@ -75,6 +75,8 @@ public class ZooDefs {
 
         public final int createTTL = 21;
 
+        public final int getChildrenList = 22;
+
         public final int auth = 100;
 
         public final int setWatches = 101;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooDefs.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooDefs.java
@@ -147,5 +147,6 @@ public class ZooDefs {
 
     final public static String[] opNames = { "notification", "create",
             "delete", "exists", "getData", "setData", "getACL", "setACL",
-            "getChildren", "getChildren2", "getMaxChildren", "setMaxChildren", "ping", "reconfig", "getConfig" };
+            "getChildren", "getChildren2" , "getChildrenList", "getMaxChildren",
+            "setMaxChildren", "ping", "reconfig", "getConfig" };
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
@@ -153,6 +153,7 @@ public class Request {
         case OpCode.getChildren:
         case OpCode.getAllChildrenNumber:
         case OpCode.getChildren2:
+        case OpCode.getChildrenList:
         case OpCode.getData:
         case OpCode.getEphemerals:
         case OpCode.multi:

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/GetChildrenListTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/GetChildrenListTest.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import java.io.IOException;
+import java.util.*;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.data.Stat;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GetChildrenListTest extends ClientBase {
+    private ZooKeeper zk;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        zk = createClient();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        zk.close();
+    }
+
+    @Test
+    public void testChild()
+            throws IOException, KeeperException, InterruptedException
+    {
+        String name = "/foo";
+        zk.create(name, name.getBytes(), Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+
+        String childname = name + "/bar";
+        zk.create(childname, childname.getBytes(), Ids.OPEN_ACL_UNSAFE,
+                CreateMode.EPHEMERAL);
+
+        Stat stat = new Stat();
+        List<String> s = zk.getChildren(name, false, stat);
+
+        Assert.assertEquals(stat.getCzxid(), stat.getMzxid());
+        Assert.assertEquals(stat.getCzxid() + 1, stat.getPzxid());
+        Assert.assertEquals(stat.getCtime(), stat.getMtime());
+        Assert.assertEquals(1, stat.getCversion());
+        Assert.assertEquals(0, stat.getVersion());
+        Assert.assertEquals(0, stat.getAversion());
+        Assert.assertEquals(0, stat.getEphemeralOwner());
+        Assert.assertEquals(name.length(), stat.getDataLength());
+        Assert.assertEquals(1, stat.getNumChildren());
+        Assert.assertEquals(s.size(), stat.getNumChildren());
+
+        s = zk.getChildren(childname, false, stat);
+
+        Assert.assertEquals(stat.getCzxid(), stat.getMzxid());
+        Assert.assertEquals(stat.getCzxid(), stat.getPzxid());
+        Assert.assertEquals(stat.getCtime(), stat.getMtime());
+        Assert.assertEquals(0, stat.getCversion());
+        Assert.assertEquals(0, stat.getVersion());
+        Assert.assertEquals(0, stat.getAversion());
+        Assert.assertEquals(zk.getSessionId(), stat.getEphemeralOwner());
+        Assert.assertEquals(childname.length(), stat.getDataLength());
+        Assert.assertEquals(0, stat.getNumChildren());
+        Assert.assertEquals(s.size(), stat.getNumChildren());
+    }
+
+    @Test
+    public void testChildrenList()
+            throws IOException, KeeperException, InterruptedException
+    {
+        List<String> topLevelNodes = new ArrayList<String>();
+        Map<String, List<String>> childrenNodes = new HashMap<String, List<String>>();
+        // Creating a database where '/fooX' nodes contains 'barXY' nodes
+        for (int i = 0; i < 10; i++) {
+            String name = "/foo" + i;
+            zk.create(name, name.getBytes(), Ids.OPEN_ACL_UNSAFE,
+                    CreateMode.PERSISTENT);
+            topLevelNodes.add(name);
+            childrenNodes.put(name, new ArrayList<>());
+            for (int j = 0; j < 10; j++) {
+                String childname = name + "/bar" + i + j;
+                String childname_s = "bar" + i + j;
+                zk.create(childname, childname.getBytes(), Ids.OPEN_ACL_UNSAFE,
+                        CreateMode.EPHEMERAL);
+                childrenNodes.get(name).add(childname_s);
+            }
+        }
+
+        List<List<String>> childrenList = zk.getChildren(topLevelNodes, false);
+        for (int i = 0; i < topLevelNodes.size(); i++) {
+            String nodeName = topLevelNodes.get(i);
+            // In general, we do not demand an order from the children list but to contain every child.
+            Assert.assertEquals(new TreeSet<String>(childrenList.get(i)),
+                                new TreeSet<String>(childrenNodes.get(nodeName)));
+
+            List<String> children = zk.getChildren(nodeName, false);
+            Assert.assertEquals(childrenList.get(i), children);
+        }
+    }
+}


### PR DESCRIPTION
Added an overloaded version of getChildren function to the client API and the request handling procedures to the server. Integration and unit tests added as well.
Rewritten the BFS based on the new functionality which - in some cases - can lead to significant improvement in performance (for more info, see the issue).