### PR TITLE
ZOOKEEPER-3372 Cleanup pom.xml in order to let Maven clients import as few dependencies as possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 sudo: false
 jdk:
   - openjdk8
-  - openjdk11
+  - oraclejdk11
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -277,11 +277,12 @@
     <mockito.version>1.8.5</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>
     <commons-cli.version>1.2</commons-cli.version>
-    <jetty.version>9.4.15.v20190215</jetty.version>
+    <jetty.version>9.4.17.v20190418</jetty.version>
     <jackson.version>2.9.8</jackson.version>
     <netty.version>4.1.29.Final</netty.version>
     <json.version>1.1.1</json.version>
     <jline.version>2.11</jline.version>
+    <snappy.version>1.1.7</snappy.version>
     <kerby.version>1.1.0</kerby.version>
     <bouncycastle.version>1.60</bouncycastle.version>
     <commons-collections.version>3.2.2</commons-collections.version>
@@ -412,6 +413,12 @@
         <groupId>com.googlecode.json-simple</groupId>
         <artifactId>json-simple</artifactId>
         <version>${json.version}</version>
+        <exclusions>
+          <exclusion>
+              <groupId>junit</groupId>
+              <artifactId>junit</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>jline</groupId>
@@ -419,12 +426,17 @@
         <version>${jline.version}</version>
       </dependency>
       <dependency>
-         <groupId>com.github.spotbugs</groupId>
-         <artifactId>spotbugs-annotations</artifactId>
-         <version>${spotbugsannotations.version}</version>
-         <scope>provided</scope>
-         <optional>true</optional>
-        </dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>${spotbugsannotations.version}</version>
+        <scope>provided</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>${snappy.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/zookeeper-assembly/pom.xml
+++ b/zookeeper-assembly/pom.xml
@@ -66,6 +66,32 @@
       <version>${project.version}</version>
       <type>pom</type>
     </dependency>
+    <!-- list here all the jars we want to put in "lib"
+         and are in scope 'provided' -->
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jline</groupId>
+      <artifactId>jline</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zookeeper-assembly/src/main/assembly/bin-package.xml
+++ b/zookeeper-assembly/src/main/assembly/bin-package.xml
@@ -29,29 +29,24 @@
     <componentDescriptor>src/main/assembly/components.xml</componentDescriptor>
   </componentDescriptors>
 
-  <moduleSets>
-    <!-- ZooKeeper jars (excluding pom projects) including 3rd party dependencies -->
-    <moduleSet>
-      <useAllReactorProjects>true</useAllReactorProjects>
+  <dependencySets>
+    <dependencySet>
       <includes>
-        <include>org.apache.zookeeper:zookeeper</include>
+        <include>*:*</include>
       </includes>
-
-      <binaries>
-        <outputDirectory>lib</outputDirectory>
-        <unpack>false</unpack>
-        <dependencySets>
-          <dependencySet>
-            <excludes>
-              <exclude>org.apache.zookeeper:zookeeper-recipes</exclude>
-              <exclude>org.apache.zookeeper:zookeeper-client</exclude>
-              <exclude>org.apache.zookeeper:zookeeper-docs</exclude>
-            </excludes>
-          </dependencySet>
-        </dependencySets>
-      </binaries>
-    </moduleSet>
-  </moduleSets>
+      <excludes>
+        <exclude>org.apache.zookeeper:zookeeper-recipes</exclude>
+        <exclude>org.apache.zookeeper:zookeeper-client</exclude>
+        <exclude>org.apache.zookeeper:zookeeper-docs</exclude>
+      </excludes>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useTransitiveDependencies>true</useTransitiveDependencies>
+      <outputDirectory>lib</outputDirectory>
+      <fileMode>${rw.file.permission}</fileMode>
+      <directoryMode>${rwx.file.permission}</directoryMode>
+      <useStrictFiltering>true</useStrictFiltering>
+    </dependencySet>
+  </dependencySets>
 
   <fileSets>
     <fileSet>

--- a/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-jute</artifactId>
-      <version>3.5.6-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.5.6-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zookeeper-contrib/zookeeper-contrib-rest/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-rest/pom.xml
@@ -56,12 +56,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.5.6-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.5.6-SNAPSHOT</version>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.5.6-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zookeeper-docs/pom.xml
+++ b/zookeeper-docs/pom.xml
@@ -29,7 +29,6 @@
 
   <groupId>org.apache.zookeeper</groupId>
   <artifactId>zookeeper-docs</artifactId>
-  <version>3.5.6-SNAPSHOT</version>
   <name>Apache ZooKeeper - Documentation</name>
   <description>Documentation</description>
 

--- a/zookeeper-recipes/pom.xml
+++ b/zookeeper-recipes/pom.xml
@@ -62,6 +62,32 @@
     <module>zookeeper-recipes-queue</module>
   </modules>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/zookeeper-recipes/zookeeper-recipes-election/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-election/pom.xml
@@ -34,21 +34,6 @@
     This election interface recipe implements the leader election recipe
   </description>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
-      <version>3.5.6-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
-      <version>3.5.6-SNAPSHOT</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/zookeeper-recipes/zookeeper-recipes-lock/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-lock/pom.xml
@@ -34,28 +34,6 @@
     This lock interface recipe implements the lock recipe
   </description>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
-      <version>3.5.6-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <version>3.1.9</version>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
-      <version>3.5.6-SNAPSHOT</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/zookeeper-recipes/zookeeper-recipes-queue/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-queue/pom.xml
@@ -39,21 +39,6 @@
     It will only work correctly once ZOOKEEPER-22 https://issues.apache.org/jira/browse/ZOOKEEPER-22 is resolved.
   </description>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
-      <version>3.5.6-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
-      <version>3.5.6-SNAPSHOT</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -53,11 +53,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-jute</artifactId>
-      <version>3.5.6-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.yetus</groupId>
@@ -78,18 +79,22 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -104,6 +109,7 @@
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>


### PR DESCRIPTION
- mark as 'provided' all of the dependencies not needed by java clients
- rework assembly project in order to build correctly the 'lib' directory
- update jetty to latest version
- use project.version in order to refer to the current version
- fix references to junit in recipes and in contrib