### PR TITLE
ZOOKEEPER-3361: Add multi version of getChildren request

### DIFF
--- a/zookeeper-jute/src/main/resources/zookeeper.jute
+++ b/zookeeper-jute/src/main/resources/zookeeper.jute
@@ -323,6 +323,10 @@ module org.apache.zookeeper.txn {
     class CreateSessionTxn {
         int timeOut;
     }
+    class GetChildrenTxn {
+        ustring path;
+        boolean watch;
+    }
     class ErrorTxn {
         int err;
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/MultiResponse.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/MultiResponse.java
@@ -22,6 +22,7 @@ import org.apache.jute.OutputArchive;
 import org.apache.jute.Record;
 import org.apache.zookeeper.proto.Create2Response;
 import org.apache.zookeeper.proto.CreateResponse;
+import org.apache.zookeeper.proto.GetChildrenResponse;
 import org.apache.zookeeper.proto.MultiHeader;
 import org.apache.zookeeper.proto.SetDataResponse;
 import org.apache.zookeeper.proto.ErrorResponse;
@@ -78,6 +79,9 @@ public class MultiResponse implements Record, Iterable<OpResult> {
                 case ZooDefs.OpCode.setData:
                     new SetDataResponse(((OpResult.SetDataResult) result).getStat()).serialize(archive, tag);
                     break;
+                case ZooDefs.OpCode.getChildren:
+                    new GetChildrenResponse(((OpResult.GetChildrenResult) result).getChildren()).serialize(archive, tag);
+                    break;
                 case ZooDefs.OpCode.error:
                     new ErrorResponse(((OpResult.ErrorResult) result).getErr()).serialize(archive, tag);
                     break;
@@ -122,6 +126,12 @@ public class MultiResponse implements Record, Iterable<OpResult> {
 
                 case ZooDefs.OpCode.check:
                     results.add(new OpResult.CheckResult());
+                    break;
+
+                case ZooDefs.OpCode.getChildren:
+                    GetChildrenResponse gcr = new GetChildrenResponse();
+                    gcr.deserialize(archive, tag);
+                    results.add(new OpResult.GetChildrenResult(gcr.getChildren()));
                     break;
 
                 case ZooDefs.OpCode.error:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/MultiTransactionRecord.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/MultiTransactionRecord.java
@@ -73,6 +73,7 @@ public class MultiTransactionRecord implements Record, Iterable<Op> {
                 case ZooDefs.OpCode.delete:
                 case ZooDefs.OpCode.setData:
                 case ZooDefs.OpCode.check:
+                case ZooDefs.OpCode.getChildren:
                     op.toRequestRecord().serialize(archive, tag);
                     break;
                 default:
@@ -117,6 +118,11 @@ public class MultiTransactionRecord implements Record, Iterable<Op> {
                     CheckVersionRequest cvr = new CheckVersionRequest();
                     cvr.deserialize(archive, tag);
                     add(Op.check(cvr.getPath(), cvr.getVersion()));
+                    break;
+                case ZooDefs.OpCode.getChildren:
+                    GetChildrenRequest gcr = new GetChildrenRequest();
+                    gcr.deserialize(archive, tag);
+                    add(Op.getChildren(gcr.getPath()));
                     break;
                 default:
                     throw new IOException("Invalid type of op");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/OpResult.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/OpResult.java
@@ -191,7 +191,7 @@ public abstract class OpResult {
             if (!(o instanceof GetChildrenResult)) return false;
 
             GetChildrenResult other = (GetChildrenResult) o;
-            return getType() == other.getType();
+            return getType() == other.getType() && children.equals(other.children);
         }
 
         @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/OpResult.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/OpResult.java
@@ -20,6 +20,8 @@ package org.apache.zookeeper;
 
 import org.apache.zookeeper.data.Stat;
 
+import java.util.List;
+
 /**
  * Encodes the result of a single part of a multiple operation commit.
  */
@@ -161,6 +163,34 @@ public abstract class OpResult {
             if (!(o instanceof CheckResult)) return false;
 
             CheckResult other = (CheckResult) o;
+            return getType() == other.getType();
+        }
+
+        @Override
+        public int hashCode() {
+            return getType();
+        }
+    }
+
+    /**
+     * A result from a getChildren operation. This provides access to a list containing
+     * the names of the children of the given node.
+     */
+    public static class GetChildrenResult extends OpResult {
+        private List<String> children;
+        public GetChildrenResult(List<String> children) {
+            super(ZooDefs.OpCode.getChildren);
+            this.children = children;
+        }
+
+        public List<String> getChildren() { return children; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof GetChildrenResult)) return false;
+
+            GetChildrenResult other = (GetChildrenResult) o;
             return getType() == other.getType();
         }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Transaction.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Transaction.java
@@ -59,6 +59,11 @@ public class Transaction {
         ops.add(Op.setData(path, data, version));
         return this;
     }
+    // Note: getChildren is a read-only function, will not change the state.
+    public Transaction getChildren(String path, boolean watch) {
+        ops.add(Op.getChildren(path));
+        return this;
+    }
 
     public List<OpResult> commit() throws InterruptedException, KeeperException {
         return zk.multi(ops);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -974,8 +974,9 @@ public class DataTree {
 
                         ByteBufferInputStream.byteBuffer2Record(bb, record);
 
+                        // For getChildren requests we'd like to the see the results of
+                        // requests which was made before the error in the multi operation.
                         if (failed && subtxn.getType() != OpCode.error &&
-                            // Before the error, the return values of getter methods are valid.
                             (post_failed || subtxn.getType() != OpCode.getChildren)) {
                             int ec = post_failed ? Code.RUNTIMEINCONSISTENCY.intValue()
                                                  : Code.OK.intValue();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
@@ -38,6 +38,7 @@ import org.apache.zookeeper.OpResult.CheckResult;
 import org.apache.zookeeper.OpResult.CreateResult;
 import org.apache.zookeeper.OpResult.DeleteResult;
 import org.apache.zookeeper.OpResult.ErrorResult;
+import org.apache.zookeeper.OpResult.GetChildrenResult;
 import org.apache.zookeeper.OpResult.SetDataResult;
 import org.apache.zookeeper.Watcher.WatcherType;
 import org.apache.zookeeper.ZooDefs;
@@ -255,6 +256,10 @@ public class FinalRequestProcessor implements RequestProcessor {
                         case OpCode.setData:
                             subResult = new SetDataResult(subTxnResult.stat);
                             break;
+                        case OpCode.getChildren: {
+                            subResult = new GetChildrenResult(subTxnResult.children);
+                            break;
+                        }
                         case OpCode.error:
                             subResult = new ErrorResult(subTxnResult.err) ;
                             if (subTxnResult.err == Code.SESSIONMOVED.intValue()) {


### PR DESCRIPTION
I have checked whether the `getChildren` query fits into a multi operation based on the issue [ZOOKEEPER-1407](https://issues.apache.org/jira/browse/ZOOKEEPER-1407). (Note: haven't checked `getData`) It was possible to make it work but it raises some questions about the implementation: 
The main similarity between the operations supported by multi that they are transitions which change the state of the zookeeper server and this fact is heavily used by the implementation. However, `getChildren` is a read-only query so somehow we need to find a workaround to that. What this patch introduces that we create a non-state-changing transaction for the getChildren operation only when used in a multi operation. This adds a bit antisymmetric workflow for the `getChildren` operation, however, this way we can ensure that the original queries stay efficient and the workflow for processing a multi operation is preserved.
Note: this patch does not support adding watchers to the children. It requires some update mainly on the client side but it can be added as a follow-up patch.