### PR TITLE
ZOOKEEPER-1425:add version command to the zookeeper client shell

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -40,6 +40,7 @@ import org.apache.zookeeper.cli.CommandNotFoundException;
 import org.apache.zookeeper.cli.GetAllChildrenNumberCommand;
 import org.apache.zookeeper.cli.GetEphemeralsCommand;
 import org.apache.zookeeper.cli.MalformedCommandException;
+import org.apache.zookeeper.cli.VersionCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.ZooDefs.Ids;
@@ -126,6 +127,7 @@ public class ZooKeeperMain {
         new RemoveWatchesCommand().addToMap(commandMapCli);
         new GetEphemeralsCommand().addToMap(commandMapCli);
         new GetAllChildrenNumberCommand().addToMap(commandMapCli);
+        new VersionCommand().addToMap(commandMapCli);
 
         // add all to commandMap
         for (Entry<String, CliCommand> entry : commandMapCli.entrySet()) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/VersionCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/VersionCommand.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.zookeeper.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.Parser;
+import org.apache.commons.cli.PosixParser;
+import org.apache.zookeeper.Version;
+
+/**
+ * version command for cli
+ */
+public class VersionCommand extends CliCommand {
+
+    private static Options options = new Options();
+    private String[] args;
+
+    public VersionCommand() {
+        super("version", "");
+    }
+
+    @Override
+    public CliCommand parse(String[] cmdArgs) throws CliParseException {
+        Parser parser = new PosixParser();
+        CommandLine cl;
+        try {
+            cl = parser.parse(options, cmdArgs);
+        } catch (ParseException ex) {
+            throw new CliParseException(ex);
+        }
+        args = cl.getArgs();
+        if (args.length > 1) {
+            throw new CliParseException(getUsageStr());
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean exec() throws CliException {
+        out.println("ZooKeeper CLI version: " + Version.getFullVersion());
+
+        return false;
+    }
+}


### PR DESCRIPTION
Original review history was included in [PR-913](https://github.com/apache/zookeeper/pull/913) 
more details in [ZOOKEEPER-1425](https://issues.apache.org/jira/browse/ZOOKEEPER-1425) 