### PR TITLE
ZOOKEEPER-3373:need change description for "Single System Image" guarantee in document

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperOver.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperOver.md
@@ -160,8 +160,10 @@ synchronization, it provides a set of guarantees. These are:
   in the order that they were sent.
 * Atomicity - Updates either succeed or fail. No partial
   results.
-* Single System Image - Once connected, a client will see the same 
-  view of the service even if it switches to another server.
+* Single System Image - A client will see the same view of the
+  service regardless of the server that it connects to. i.e., a
+  client will never see an older view of the system even if the
+  client fails over to a different server with the same session.
 * Reliability - Once an update has been applied, it will persist
   from that time forward until a client overwrites the update.
 * Timeliness - The clients view of the system is guaranteed to

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperOver.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperOver.md
@@ -160,8 +160,8 @@ synchronization, it provides a set of guarantees. These are:
   in the order that they were sent.
 * Atomicity - Updates either succeed or fail. No partial
   results.
-* Single System Image - A client will see the same view of the
-  service regardless of the server that it connects to.
+* Single System Image - Once connected, a client will see the same 
+  view of the service even if it switches to another server.
 * Reliability - Once an update has been applied, it will persist
   from that time forward until a client overwrites the update.
 * Timeliness - The clients view of the system is guaranteed to

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperProgrammers.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperProgrammers.md
@@ -1064,8 +1064,8 @@ guarantees:
     results.
 
 * *Single System Image* :
-    A client will see the same view of the service regardless of
-    the server that it connects to.
+    Once connected, a client will see the same view of the service even
+    if it switches to another server.
 
 * *Reliability* :
     Once an update has been applied, it will persist from that

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperProgrammers.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperProgrammers.md
@@ -1064,8 +1064,10 @@ guarantees:
     results.
 
 * *Single System Image* :
-    Once connected, a client will see the same view of the service even
-    if it switches to another server.
+    A client will see the same view of the service regardless of
+    the server that it connects to. i.e., a client will never see an
+    older view of the system even if the client fails over to a
+    different server with the same session.
 
 * *Reliability* :
     Once an update has been applied, it will persist from that


### PR DESCRIPTION
In website, "Single System Image" is "A client will see the same view of the service regardless of the server that it connects to."

I want to change it to "Once connected, a client will see the same view of the service even if it switchs to another server"

Because the old one is a little misleading, if cluster has a outdated follower and a normal follower, I do not think a client will see the same view of the service regardless of the server that it connects to at its first connection.