### PR TITLE
[ZOOKEEPER-3387] Use BufferedWriter instead of FileWriter

### DIFF
--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/CGenerator.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/CGenerator.java
@@ -64,7 +64,7 @@ class CGenerator {
         }
 
         try (BufferedWriter c = new BufferedWriter(new FileWriter(new File(outputDirectory, mName + ".c")));
-             BufferedWriter h = new BufferedWRiter(new FileWriter(new File(outputDirectory, mName + ".h")));
+             BufferedWriter h = new BufferedWriter(new FileWriter(new File(outputDirectory, mName + ".h")));
         ) {
 	
             h.write("/**\n");
@@ -121,7 +121,7 @@ class CGenerator {
 
             for (Iterator<JRecord> i = mRecList.iterator(); i.hasNext(); ) {
                 JRecord jr = i.next();
-                jr.genCCode(h, c);
+                jr.genCCode(new FileWriter(h), new FileWriter(c));
             }
 
             h.write("\n#ifdef __cplusplus\n}\n#endif\n\n");

--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/CGenerator.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/CGenerator.java
@@ -63,69 +63,71 @@ class CGenerator {
             }
         }
 
-        try (BufferedWriter c = new BufferedWriter(new FileWriter(new File(outputDirectory, mName + ".c")));
-             BufferedWriter h = new BufferedWriter(new FileWriter(new File(outputDirectory, mName + ".h")));
+        try (FileWriter c = new FileWriter(new File(outputDirectory, mName + ".c"));
+             FileWriter h = new FileWriter(new File(outputDirectory, mName + ".h"));
         ) {
-	
-            h.write("/**\n");
-            h.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
-            h.write("* or more contributor license agreements.  See the NOTICE file\n");
-            h.write("* distributed with this work for additional information\n");
-            h.write("* regarding copyright ownership.  The ASF licenses this file\n");
-            h.write("* to you under the Apache License, Version 2.0 (the\n");
-            h.write("* \"License\"); you may not use this file except in compliance\n");
-            h.write("* with the License.  You may obtain a copy of the License at\n");
-            h.write("*\n");
-            h.write("*     http://www.apache.org/licenses/LICENSE-2.0\n");
-            h.write("*\n");
-            h.write("* Unless required by applicable law or agreed to in writing, software\n");
-            h.write("* distributed under the License is distributed on an \"AS IS\" BASIS,\n");
-            h.write("* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n");
-            h.write("* See the License for the specific language governing permissions and\n");
-            h.write("* limitations under the License.\n");
-            h.write("*/\n");
-            h.write("\n");
+            BufferedWriter bwh = new BufferedWriter(h);
+	    BufferedWriter bwc = new BufferedWriter(c);
 
-            c.write("/**\n");
-            c.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
-            c.write("* or more contributor license agreements.  See the NOTICE file\n");
-            c.write("* distributed with this work for additional information\n");
-            c.write("* regarding copyright ownership.  The ASF licenses this file\n");
-            c.write("* to you under the Apache License, Version 2.0 (the\n");
-            c.write("* \"License\"); you may not use this file except in compliance\n");
-            c.write("* with the License.  You may obtain a copy of the License at\n");
-            c.write("*\n");
-            c.write("*     http://www.apache.org/licenses/LICENSE-2.0\n");
-            c.write("*\n");
-            c.write("* Unless required by applicable law or agreed to in writing, software\n");
-            c.write("* distributed under the License is distributed on an \"AS IS\" BASIS,\n");
-            c.write("* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n");
-            c.write("* See the License for the specific language governing permissions and\n");
-            c.write("* limitations under the License.\n");
-            c.write("*/\n");
-            c.write("\n");
+            bwh.write("/**\n");
+            bwh.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
+            bwh.write("* or more contributor license agreements.  See the NOTICE file\n");
+            bwh.write("* distributed with this work for additional information\n");
+            bwh.write("* regarding copyright ownership.  The ASF licenses this file\n");
+            bwh.write("* to you under the Apache License, Version 2.0 (the\n");
+            bwh.write("* \"License\"); you may not use this file except in compliance\n");
+            bwh.write("* with the License.  You may obtain a copy of the License at\n");
+            bwh.write("*\n");
+            bwh.write("*     http://www.apache.org/licenses/LICENSE-2.0\n");
+            bwh.write("*\n");
+            bwh.write("* Unless required by applicable law or agreed to in writing, software\n");
+            bwh.write("* distributed under the License is distributed on an \"AS IS\" BASIS,\n");
+            bwh.write("* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n");
+            bwh.write("* See the License for the specific language governing permissions and\n");
+            bwh.write("* limitations under the License.\n");
+            bwh.write("*/\n");
+            bwh.write("\n");
 
-            h.write("#ifndef __" + mName.toUpperCase().replace('.', '_') + "__\n");
-            h.write("#define __" + mName.toUpperCase().replace('.', '_') + "__\n");
+            bwc.write("/**\n");
+            bwc.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
+            bwc.write("* or more contributor license agreements.  See the NOTICE file\n");
+            bwc.write("* distributed with this work for additional information\n");
+            bwc.write("* regarding copyright ownership.  The ASF licenses this file\n");
+            bwc.write("* to you under the Apache License, Version 2.0 (the\n");
+            bwc.write("* \"License\"); you may not use this file except in compliance\n");
+            bwc.write("* with the License.  You may obtain a copy of the License at\n");
+            bwc.write("*\n");
+            bwc.write("*     http://www.apache.org/licenses/LICENSE-2.0\n");
+            bwc.write("*\n");
+            bwc.write("* Unless required by applicable law or agreed to in writing, software\n");
+            bwc.write("* distributed under the License is distributed on an \"AS IS\" BASIS,\n");
+            bwc.write("* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n");
+            bwc.write("* See the License for the specific language governing permissions and\n");
+            bwc.write("* limitations under the License.\n");
+            bwc.write("*/\n");
+            bwc.write("\n");
+
+            bwh.write("#ifndef __" + mName.toUpperCase().replace('.', '_') + "__\n");
+            bwh.write("#define __" + mName.toUpperCase().replace('.', '_') + "__\n");
 
             h.write("#include \"recordio.h\"\n");
             for (Iterator<JFile> i = mInclFiles.iterator(); i.hasNext(); ) {
                 JFile f = i.next();
-                h.write("#include \"" + f.getName() + ".h\"\n");
+                bwh.write("#include \"" + f.getName() + ".h\"\n");
             }
             // required for compilation from C++
-            h.write("\n#ifdef __cplusplus\nextern \"C\" {\n#endif\n\n");
+            bwh.write("\n#ifdef __cplusplus\nextern \"C\" {\n#endif\n\n");
 
-            c.write("#include <stdlib.h>\n"); // need it for calloc() & free()
-            c.write("#include \"" + mName + ".h\"\n\n");
+            bwc.write("#include <stdlib.h>\n"); // need it for calloc() & free()
+            bwc.write("#include \"" + mName + ".h\"\n\n");
 
             for (Iterator<JRecord> i = mRecList.iterator(); i.hasNext(); ) {
                 JRecord jr = i.next();
-                jr.genCCode(new FileWriter(h), new FileWriter(c));
+                jr.genCCode(h, c);
             }
 
-            h.write("\n#ifdef __cplusplus\n}\n#endif\n\n");
-            h.write("#endif //" + mName.toUpperCase().replace('.', '_') + "__\n");
+            bwh.write("\n#ifdef __cplusplus\n}\n#endif\n\n");
+            bwh.write("#endif //" + mName.toUpperCase().replace('.', '_') + "__\n");
         }
     }
 }

--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/CGenerator.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/CGenerator.java
@@ -20,6 +20,7 @@ package org.apache.jute.compiler;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -62,9 +63,10 @@ class CGenerator {
             }
         }
 
-        try (FileWriter c = new FileWriter(new File(outputDirectory, mName + ".c"));
-             FileWriter h = new FileWriter(new File(outputDirectory, mName + ".h"));
+        try (BufferedWriter c = new BufferedWriter(new FileWriter(new File(outputDirectory, mName + ".c")));
+             BufferedWriter h = new BufferedWRiter(new FileWriter(new File(outputDirectory, mName + ".h")));
         ) {
+	
             h.write("/**\n");
             h.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
             h.write("* or more contributor license agreements.  See the NOTICE file\n");

--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/CppGenerator.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/CppGenerator.java
@@ -20,6 +20,7 @@ package org.apache.jute.compiler;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -65,24 +66,25 @@ class CppGenerator {
         try (FileWriter cc = new FileWriter(new File(outputDirectory, mName + ".cc"));
              FileWriter hh = new FileWriter(new File(outputDirectory, mName + ".hh"));
         ) {
-            hh.write("/**\n");
-            hh.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
-            hh.write("* or more contributor license agreements.  See the NOTICE file\n");
-            hh.write("* distributed with this work for additional information\n");
-            hh.write("* regarding copyright ownership.  The ASF licenses this file\n");
-            hh.write("* to you under the Apache License, Version 2.0 (the\n");
-            hh.write("* \"License\"); you may not use this file except in compliance\n");
-            hh.write("* with the License.  You may obtain a copy of the License at\n");
-            hh.write("*\n");
-            hh.write("*     http://www.apache.org/licenses/LICENSE-2.0\n");
-            hh.write("*\n");
-            hh.write("* Unless required by applicable law or agreed to in writing, software\n");
-            hh.write("* distributed under the License is distributed on an \"AS IS\" BASIS,\n");
-            hh.write("* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n");
-            hh.write("* See the License for the specific language governing permissions and\n");
-            hh.write("* limitations under the License.\n");
-            hh.write("*/\n");
-            hh.write("\n");
+            BufferedWriter bwhh = new BufferedWriter(hh);
+            bwhh.write("/**\n");
+            bwhh.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
+            bwhh.write("* or more contributor license agreements.  See the NOTICE file\n");
+            bwhh.write("* distributed with this work for additional information\n");
+            bwhh.write("* regarding copyright ownership.  The ASF licenses this file\n");
+            bwhh.write("* to you under the Apache License, Version 2.0 (the\n");
+            bwhh.write("* \"License\"); you may not use this file except in compliance\n");
+            bwhh.write("* with the License.  You may obtain a copy of the License at\n");
+            bwhh.write("*\n");
+            bwhh.write("*     http://www.apache.org/licenses/LICENSE-2.0\n");
+            bwhh.write("*\n");
+            bwhh.write("* Unless required by applicable law or agreed to in writing, software\n");
+            bwhh.write("* distributed under the License is distributed on an \"AS IS\" BASIS,\n");
+            bwhh.write("* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n");
+            bwhh.write("* See the License for the specific language governing permissions and\n");
+            bwhh.write("* limitations under the License.\n");
+            bwhh.write("*/\n");
+            bwhh.write("\n");
 
             cc.write("/**\n");
             cc.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
@@ -103,13 +105,13 @@ class CppGenerator {
             cc.write("*/\n");
             cc.write("\n");
 
-            hh.write("#ifndef __" + mName.toUpperCase().replace('.', '_') + "__\n");
-            hh.write("#define __" + mName.toUpperCase().replace('.', '_') + "__\n");
+            bwhh.write("#ifndef __" + mName.toUpperCase().replace('.', '_') + "__\n");
+            bwhh.write("#define __" + mName.toUpperCase().replace('.', '_') + "__\n");
 
-            hh.write("#include \"recordio.hh\"\n");
+            bwhh.write("#include \"recordio.hh\"\n");
             for (Iterator<JFile> i = mInclFiles.iterator(); i.hasNext(); ) {
                 JFile f = i.next();
-                hh.write("#include \"" + f.getName() + ".hh\"\n");
+                bwhh.write("#include \"" + f.getName() + ".hh\"\n");
             }
             cc.write("#include \"" + mName + ".hh\"\n");
 
@@ -118,7 +120,7 @@ class CppGenerator {
                 jr.genCppCode(hh, cc);
             }
 
-            hh.write("#endif //" + mName.toUpperCase().replace('.', '_') + "__\n");
+            bwhh.write("#endif //" + mName.toUpperCase().replace('.', '_') + "__\n");
         }
     }
 }

--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/JRecord.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/JRecord.java
@@ -20,6 +20,7 @@ package org.apache.jute.compiler;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -143,6 +144,8 @@ public class JRecord extends JCompType {
 
     static Map<String, String> vectorStructs = new HashMap<String, String>();
     public void genCCode(FileWriter h, FileWriter c) throws IOException {
+	BufferedWriter bwh = new BufferedWriter(h);
+	BufferedWriter bwc = new BufferedWriter(c);
         for (JField f : mFields) {
             if (f.getType() instanceof JVector) {
                 JVector jv = (JVector) f.getType();
@@ -150,102 +153,102 @@ public class JRecord extends JCompType {
                 String struct_name = JVector.extractVectorName(jvType);
                 if (vectorStructs.get(struct_name) == null) {
                     vectorStructs.put(struct_name, struct_name);
-                    h.write("struct " + struct_name + " {\n    int32_t count;\n" + jv.getElementType().genCDecl("*data") + "\n};\n");
-                    h.write("int serialize_" + struct_name + "(struct oarchive *out, const char *tag, struct " + struct_name + " *v);\n");
-                    h.write("int deserialize_" + struct_name + "(struct iarchive *in, const char *tag, struct " + struct_name + " *v);\n");
-                    h.write("int allocate_" + struct_name + "(struct " + struct_name + " *v, int32_t len);\n");
-                    h.write("int deallocate_" + struct_name + "(struct " + struct_name + " *v);\n");
-                    c.write("int allocate_" + struct_name + "(struct " + struct_name + " *v, int32_t len) {\n");
-                    c.write("    if (!len) {\n");
-                    c.write("        v->count = 0;\n");
-                    c.write("        v->data = 0;\n");
-                    c.write("    } else {\n");
-                    c.write("        v->count = len;\n");
-                    c.write("        v->data = calloc(sizeof(*v->data), len);\n");
-                    c.write("    }\n");
-                    c.write("    return 0;\n");
-                    c.write("}\n");
-                    c.write("int deallocate_" + struct_name + "(struct " + struct_name + " *v) {\n");
-                    c.write("    if (v->data) {\n");
-                    c.write("        int32_t i;\n");
-                    c.write("        for(i=0;i<v->count; i++) {\n");
-                    c.write("            deallocate_" + JRecord.extractMethodSuffix(jvType) + "(&v->data[i]);\n");
-                    c.write("        }\n");
-                    c.write("        free(v->data);\n");
-                    c.write("        v->data = 0;\n");
-                    c.write("    }\n");
-                    c.write("    return 0;\n");
-                    c.write("}\n");
-                    c.write("int serialize_" + struct_name + "(struct oarchive *out, const char *tag, struct " + struct_name + " *v)\n");
-                    c.write("{\n");
-                    c.write("    int32_t count = v->count;\n");
-                    c.write("    int rc = 0;\n");
-                    c.write("    int32_t i;\n");
-                    c.write("    rc = out->start_vector(out, tag, &count);\n");
-                    c.write("    for(i=0;i<v->count;i++) {\n");
+                    bwh.write("struct " + struct_name + " {\n    int32_t count;\n" + jv.getElementType().genCDecl("*data") + "\n};\n");
+                    bwh.write("int serialize_" + struct_name + "(struct oarchive *out, const char *tag, struct " + struct_name + " *v);\n");
+                    bwh.write("int deserialize_" + struct_name + "(struct iarchive *in, const char *tag, struct " + struct_name + " *v);\n");
+                    bwh.write("int allocate_" + struct_name + "(struct " + struct_name + " *v, int32_t len);\n");
+                    bwh.write("int deallocate_" + struct_name + "(struct " + struct_name + " *v);\n");
+                    bwc.write("int allocate_" + struct_name + "(struct " + struct_name + " *v, int32_t len) {\n");
+                    bwc.write("    if (!len) {\n");
+                    bwc.write("        v->count = 0;\n");
+                    bwc.write("        v->data = 0;\n");
+                    bwc.write("    } else {\n");
+                    bwc.write("        v->count = len;\n");
+                    bwc.write("        v->data = calloc(sizeof(*v->data), len);\n");
+                    bwc.write("    }\n");
+                    bwc.write("    return 0;\n");
+                    bwc.write("}\n");
+                    bwc.write("int deallocate_" + struct_name + "(struct " + struct_name + " *v) {\n");
+                    bwc.write("    if (v->data) {\n");
+                    bwc.write("        int32_t i;\n");
+                    bwc.write("        for(i=0;i<v->count; i++) {\n");
+                    bwc.write("            deallocate_" + JRecord.extractMethodSuffix(jvType) + "(&v->data[i]);\n");
+                    bwc.write("        }\n");
+                    bwc.write("        free(v->data);\n");
+                    bwc.write("        v->data = 0;\n");
+                    bwc.write("    }\n");
+                    bwc.write("    return 0;\n");
+                    bwc.write("}\n");
+                    bwc.write("int serialize_" + struct_name + "(struct oarchive *out, const char *tag, struct " + struct_name + " *v)\n");
+                    bwc.write("{\n");
+                    bwc.write("    int32_t count = v->count;\n");
+                    bwc.write("    int rc = 0;\n");
+                    bwc.write("    int32_t i;\n");
+                    bwc.write("    rc = out->start_vector(out, tag, &count);\n");
+                    bwc.write("    for(i=0;i<v->count;i++) {\n");
                     genSerialize(c, jvType, "data", "data[i]");
-                    c.write("    }\n");
-                    c.write("    rc = rc ? rc : out->end_vector(out, tag);\n");
-                    c.write("    return rc;\n");
-                    c.write("}\n");
-                    c.write("int deserialize_" + struct_name + "(struct iarchive *in, const char *tag, struct " + struct_name + " *v)\n");
-                    c.write("{\n");
-                    c.write("    int rc = 0;\n");
-                    c.write("    int32_t i;\n");
-                    c.write("    rc = in->start_vector(in, tag, &v->count);\n");
-                    c.write("    v->data = calloc(v->count, sizeof(*v->data));\n");
-                    c.write("    for(i=0;i<v->count;i++) {\n");
+                    bwc.write("    }\n");
+                    bwc.write("    rc = rc ? rc : out->end_vector(out, tag);\n");
+                    bwc.write("    return rc;\n");
+                    bwc.write("}\n");
+                    bwc.write("int deserialize_" + struct_name + "(struct iarchive *in, const char *tag, struct " + struct_name + " *v)\n");
+                    bwc.write("{\n");
+                    bwc.write("    int rc = 0;\n");
+                    bwc.write("    int32_t i;\n");
+                    bwc.write("    rc = in->start_vector(in, tag, &v->count);\n");
+                    bwc.write("    v->data = calloc(v->count, sizeof(*v->data));\n");
+                    bwc.write("    for(i=0;i<v->count;i++) {\n");
                     genDeserialize(c, jvType, "value", "data[i]");
-                    c.write("    }\n");
-                    c.write("    rc = in->end_vector(in, tag);\n");
-                    c.write("    return rc;\n");
-                    c.write("}\n");
+                    bwc.write("    }\n");
+                    bwc.write("    rc = in->end_vector(in, tag);\n");
+                    bwc.write("    return rc;\n");
+                    bwc.write("}\n");
 
                 }
             }
         }
         String rec_name = getName();
-        h.write("struct " + rec_name + " {\n");
+        bwh.write("struct " + rec_name + " {\n");
         for (JField f : mFields) {
-            h.write(f.genCDecl());
+            bwh.write(f.genCDecl());
         }
-        h.write("};\n");
-        h.write("int serialize_" + rec_name + "(struct oarchive *out, const char *tag, struct " + rec_name + " *v);\n");
-        h.write("int deserialize_" + rec_name + "(struct iarchive *in, const char *tag, struct " + rec_name + "*v);\n");
-        h.write("void deallocate_" + rec_name + "(struct " + rec_name + "*);\n");
-        c.write("int serialize_" + rec_name + "(struct oarchive *out, const char *tag, struct " + rec_name + " *v)");
-        c.write("{\n");
-        c.write("    int rc;\n");
-        c.write("    rc = out->start_record(out, tag);\n");
+        bwh.write("};\n");
+        bwh.write("int serialize_" + rec_name + "(struct oarchive *out, const char *tag, struct " + rec_name + " *v);\n");
+        bwh.write("int deserialize_" + rec_name + "(struct iarchive *in, const char *tag, struct " + rec_name + "*v);\n");
+        bwh.write("void deallocate_" + rec_name + "(struct " + rec_name + "*);\n");
+        bwc.write("int serialize_" + rec_name + "(struct oarchive *out, const char *tag, struct " + rec_name + " *v)");
+        bwc.write("{\n");
+        bwc.write("    int rc;\n");
+        bwc.write("    rc = out->start_record(out, tag);\n");
         for (JField f : mFields) {
             genSerialize(c, f.getType(), f.getTag(), f.getName());
         }
-        c.write("    rc = rc ? rc : out->end_record(out, tag);\n");
-        c.write("    return rc;\n");
-        c.write("}\n");
-        c.write("int deserialize_" + rec_name + "(struct iarchive *in, const char *tag, struct " + rec_name + "*v)");
-        c.write("{\n");
-        c.write("    int rc;\n");
-        c.write("    rc = in->start_record(in, tag);\n");
+        bwc.write("    rc = rc ? rc : out->end_record(out, tag);\n");
+        bwc.write("    return rc;\n");
+        bwc.write("}\n");
+        bwc.write("int deserialize_" + rec_name + "(struct iarchive *in, const char *tag, struct " + rec_name + "*v)");
+        bwc.write("{\n");
+        bwc.write("    int rc;\n");
+        bwc.write("    rc = in->start_record(in, tag);\n");
         for (JField f : mFields) {
             genDeserialize(c, f.getType(), f.getTag(), f.getName());
         }
-        c.write("    rc = rc ? rc : in->end_record(in, tag);\n");
-        c.write("    return rc;\n");
-        c.write("}\n");
-        c.write("void deallocate_" + rec_name + "(struct " + rec_name + "*v)");
-        c.write("{\n");
+        bwc.write("    rc = rc ? rc : in->end_record(in, tag);\n");
+        bwc.write("    return rc;\n");
+        bwc.write("}\n");
+        bwc.write("void deallocate_" + rec_name + "(struct " + rec_name + "*v)");
+        bwc.write("{\n");
         for (JField f : mFields) {
             if (f.getType() instanceof JRecord) {
-                c.write("    deallocate_" + extractStructName(f.getType()) + "(&v->" + f.getName() + ");\n");
+                bwc.write("    deallocate_" + extractStructName(f.getType()) + "(&v->" + f.getName() + ");\n");
             } else if (f.getType() instanceof JVector) {
                 JVector vt = (JVector) f.getType();
-                c.write("    deallocate_" + JVector.extractVectorName(vt.getElementType()) + "(&v->" + f.getName() + ");\n");
+                bwc.write("    deallocate_" + JVector.extractVectorName(vt.getElementType()) + "(&v->" + f.getName() + ");\n");
             } else if (f.getType() instanceof JCompType) {
-                c.write("    deallocate_" + extractMethodSuffix(f.getType()) + "(&v->" + f.getName() + ");\n");
+                bwc.write("    deallocate_" + extractMethodSuffix(f.getType()) + "(&v->" + f.getName() + ");\n");
             }
         }
-        c.write("}\n");
+        bwc.write("}\n");
     }
 
     private void genSerialize(FileWriter c, JType type, String tag, String name) throws IOException {
@@ -283,113 +286,116 @@ public class JRecord extends JCompType {
 
     public void genCppCode(FileWriter hh, FileWriter cc)
         throws IOException {
+	BufferedWriter bwhh = new BufferedWriter(hh);
+	BufferedWriter bwcc = new BufferedWriterd(cc);
+	
         String[] ns = getCppNameSpace().split("::");
         for (int i = 0; i < ns.length; i++) {
             hh.write("namespace "+ns[i]+" {\n");
         }
 
-        hh.write("class "+getName()+" : public ::hadoop::Record {\n");
-        hh.write("private:\n");
+        bwhh.write("class "+getName()+" : public ::hadoop::Record {\n");
+        bwhh.write("private:\n");
 
         for (Iterator<JField> i = mFields.iterator(); i.hasNext();) {
             JField jf = i.next();
-            hh.write(jf.genCppDecl());
+            bwhh.write(jf.genCppDecl());
         }
-        hh.write("  mutable std::bitset<"+mFields.size()+"> bs_;\n");
-        hh.write("public:\n");
-        hh.write("  virtual void serialize(::hadoop::OArchive& a_, const char* tag) const;\n");
-        hh.write("  virtual void deserialize(::hadoop::IArchive& a_, const char* tag);\n");
-        hh.write("  virtual const ::std::string& type() const;\n");
-        hh.write("  virtual const ::std::string& signature() const;\n");
-        hh.write("  virtual bool validate() const;\n");
-        hh.write("  virtual bool operator<(const "+getName()+"& peer_) const;\n");
-        hh.write("  virtual bool operator==(const "+getName()+"& peer_) const;\n");
-        hh.write("  virtual ~"+getName()+"() {};\n");
+        bwhh.write("  mutable std::bitset<"+mFields.size()+"> bs_;\n");
+        bwhh.write("public:\n");
+        bwhh.write("  virtual void serialize(::hadoop::OArchive& a_, const char* tag) const;\n");
+        bwhh.write("  virtual void deserialize(::hadoop::IArchive& a_, const char* tag);\n");
+        bwhh.write("  virtual const ::std::string& type() const;\n");
+        bwhh.write("  virtual const ::std::string& signature() const;\n");
+        bwhh.write("  virtual bool validate() const;\n");
+        bwhh.write("  virtual bool operator<(const "+getName()+"& peer_) const;\n");
+        bwhh.write("  virtual bool operator==(const "+getName()+"& peer_) const;\n");
+        bwhh.write("  virtual ~"+getName()+"() {};\n");
         int fIdx = 0;
         for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
             JField jf = i.next();
-            hh.write(jf.genCppGetSet(fIdx));
+            bwhh.write(jf.genCppGetSet(fIdx));
         }
-        hh.write("}; // end record "+getName()+"\n");
+        bwhh.write("}; // end record "+getName()+"\n");
         for (int i=ns.length-1; i>=0; i--) {
-            hh.write("} // end namespace "+ns[i]+"\n");
+            bwhh.write("} // end namespace "+ns[i]+"\n");
         }
-        cc.write("void "+getCppFQName()+"::serialize(::hadoop::OArchive& a_, const char* tag) const {\n");
-        cc.write("  if (!validate()) throw new ::hadoop::IOException(\"All fields not set.\");\n");
-        cc.write("  a_.startRecord(*this,tag);\n");
+        bwcc.write("void "+getCppFQName()+"::serialize(::hadoop::OArchive& a_, const char* tag) const {\n");
+        bwcc.write("  if (!validate()) throw new ::hadoop::IOException(\"All fields not set.\");\n");
+        bwcc.write("  a_.startRecord(*this,tag);\n");
         fIdx = 0;
         for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
             JField jf = i.next();
             String name = jf.getName();
             if (jf.getType() instanceof JBuffer) {
-                cc.write("  a_.serialize(m"+name+",m"+name+".length(),\""+jf.getTag()+"\");\n");
+                bwcc.write("  a_.serialize(m"+name+",m"+name+".length(),\""+jf.getTag()+"\");\n");
             } else {
-                cc.write("  a_.serialize(m"+name+",\""+jf.getTag()+"\");\n");
+                bwcc.write("  a_.serialize(m"+name+",\""+jf.getTag()+"\");\n");
             }
-            cc.write("  bs_.reset("+fIdx+");\n");
+            bwcc.write("  bs_.reset("+fIdx+");\n");
         }
-        cc.write("  a_.endRecord(*this,tag);\n");
-        cc.write("  return;\n");
-        cc.write("}\n");
+        bwcc.write("  a_.endRecord(*this,tag);\n");
+        bwcc.write("  return;\n");
+        bwcc.write("}\n");
 
-        cc.write("void "+getCppFQName()+"::deserialize(::hadoop::IArchive& a_, const char* tag) {\n");
-        cc.write("  a_.startRecord(*this,tag);\n");
+        bwcc.write("void "+getCppFQName()+"::deserialize(::hadoop::IArchive& a_, const char* tag) {\n");
+        bwcc.write("  a_.startRecord(*this,tag);\n");
         fIdx = 0;
         for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
             JField jf = i.next();
             String name = jf.getName();
             if (jf.getType() instanceof JBuffer) {
-                cc.write("  { size_t len=0; a_.deserialize(m"+name+",len,\""+jf.getTag()+"\");}\n");
+                bwcc.write("  { size_t len=0; a_.deserialize(m"+name+",len,\""+jf.getTag()+"\");}\n");
             } else {
-                cc.write("  a_.deserialize(m"+name+",\""+jf.getTag()+"\");\n");
+                bwcc.write("  a_.deserialize(m"+name+",\""+jf.getTag()+"\");\n");
             }
-            cc.write("  bs_.set("+fIdx+");\n");
+            bwcc.write("  bs_.set("+fIdx+");\n");
         }
-        cc.write("  a_.endRecord(*this,tag);\n");
-        cc.write("  return;\n");
-        cc.write("}\n");
+        bwcc.write("  a_.endRecord(*this,tag);\n");
+        bwcc.write("  return;\n");
+        bwcc.write("}\n");
 
-        cc.write("bool "+getCppFQName()+"::validate() const {\n");
-        cc.write("  if (bs_.size() != bs_.count()) return false;\n");
+        bwcc.write("bool "+getCppFQName()+"::validate() const {\n");
+        bwcc.write("  if (bs_.size() != bs_.count()) return false;\n");
         for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
             JField jf = (JField) i.next();
             JType type = jf.getType();
             if (type instanceof JRecord) {
-                cc.write("  if (!m"+jf.getName()+".validate()) return false;\n");
+                bwcc.write("  if (!m"+jf.getName()+".validate()) return false;\n");
             }
         }
-        cc.write("  return true;\n");
-        cc.write("}\n");
+        bwcc.write("  return true;\n");
+        bwcc.write("}\n");
 
-        cc.write("bool "+getCppFQName()+"::operator< (const "+getCppFQName()+"& peer_) const {\n");
-        cc.write("  return (1\n");
+        bwcc.write("bool "+getCppFQName()+"::operator< (const "+getCppFQName()+"& peer_) const {\n");
+        bwcc.write("  return (1\n");
         for (Iterator<JField> i = mFields.iterator(); i.hasNext();) {
             JField jf = i.next();
             String name = jf.getName();
-            cc.write("    && (m"+name+" < peer_.m"+name+")\n");
+            bwcc.write("    && (m"+name+" < peer_.m"+name+")\n");
         }
-        cc.write("  );\n");
-        cc.write("}\n");
+        bwcc.write("  );\n");
+        bwcc.write("}\n");
 
-        cc.write("bool "+getCppFQName()+"::operator== (const "+getCppFQName()+"& peer_) const {\n");
-        cc.write("  return (1\n");
+        bwcc.write("bool "+getCppFQName()+"::operator== (const "+getCppFQName()+"& peer_) const {\n");
+        bwcc.write("  return (1\n");
         for (Iterator<JField> i = mFields.iterator(); i.hasNext();) {
             JField jf = i.next();
             String name = jf.getName();
-            cc.write("    && (m"+name+" == peer_.m"+name+")\n");
+            bwcc.write("    && (m"+name+" == peer_.m"+name+")\n");
         }
-        cc.write("  );\n");
-        cc.write("}\n");
+        bwcc.write("  );\n");
+        bwcc.write("}\n");
 
-        cc.write("const ::std::string&"+getCppFQName()+"::type() const {\n");
-        cc.write("  static const ::std::string type_(\""+mName+"\");\n");
-        cc.write("  return type_;\n");
-        cc.write("}\n");
+        bwcc.write("const ::std::string&"+getCppFQName()+"::type() const {\n");
+        bwcc.write("  static const ::std::string type_(\""+mName+"\");\n");
+        bwcc.write("  return type_;\n");
+        bwcc.write("}\n");
 
-        cc.write("const ::std::string&"+getCppFQName()+"::signature() const {\n");
-        cc.write("  static const ::std::string sig_(\""+getSignature()+"\");\n");
-        cc.write("  return sig_;\n");
-        cc.write("}\n");
+        bwcc.write("const ::std::string&"+getCppFQName()+"::signature() const {\n");
+        bwcc.write("  static const ::std::string sig_(\""+getSignature()+"\");\n");
+        bwcc.write("  return sig_;\n");
+        bwcc.write("}\n");
 
     }
 
@@ -406,108 +412,110 @@ public class JRecord extends JCompType {
             throw new IOException(pkgpath + " is not a directory.");
         }
         try (FileWriter jj = new FileWriter(new File(pkgdir, getName()+".java"))) {
-            jj.write("// File generated by hadoop record compiler. Do not edit.\n");
-            jj.write("/**\n");
-            jj.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
-            jj.write("* or more contributor license agreements.  See the NOTICE file\n");
-            jj.write("* distributed with this work for additional information\n");
-            jj.write("* regarding copyright ownership.  The ASF licenses this file\n");
-            jj.write("* to you under the Apache License, Version 2.0 (the\n");
-            jj.write("* \"License\"); you may not use this file except in compliance\n");
-            jj.write("* with the License.  You may obtain a copy of the License at\n");
-            jj.write("*\n");
-            jj.write("*     http://www.apache.org/licenses/LICENSE-2.0\n");
-            jj.write("*\n");
-            jj.write("* Unless required by applicable law or agreed to in writing, software\n");
-            jj.write("* distributed under the License is distributed on an \"AS IS\" BASIS,\n");
-            jj.write("* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n");
-            jj.write("* See the License for the specific language governing permissions and\n");
-            jj.write("* limitations under the License.\n");
-            jj.write("*/\n");
-            jj.write("\n");
-            jj.write("package " + getJavaPackage() + ";\n\n");
-            jj.write("import org.apache.jute.*;\n");
-            jj.write("import org.apache.yetus.audience.InterfaceAudience;\n");
-            jj.write("@InterfaceAudience.Public\n");
-            jj.write("public class " + getName() + " implements Record {\n");
+            BufferedWriter bwjj = new BufferedWriter(jj);
+
+            bwjj.write("// File generated by hadoop record compiler. Do not edit.\n");
+            bwjj.write("/**\n");
+            bwjj.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
+            bwjj.write("* or more contributor license agreements.  See the NOTICE file\n");
+            bwjj.write("* distributed with this work for additional information\n");
+            bwjj.write("* regarding copyright ownership.  The ASF licenses this file\n");
+            bwjj.write("* to you under the Apache License, Version 2.0 (the\n");
+            bwjj.write("* \"License\"); you may not use this file except in compliance\n");
+            bwjj.write("* with the License.  You may obtain a copy of the License at\n");
+            bwjj.write("*\n");
+            bwjj.write("*     http://www.apache.org/licenses/LICENSE-2.0\n");
+            bwjj.write("*\n");
+            bwjj.write("* Unless required by applicable law or agreed to in writing, software\n");
+            bwjj.write("* distributed under the License is distributed on an \"AS IS\" BASIS,\n");
+            bwjj.write("* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n");
+            bwjj.write("* See the License for the specific language governing permissions and\n");
+            bwjj.write("* limitations under the License.\n");
+            bwjj.write("*/\n");
+            bwjj.write("\n");
+            bwjj.write("package " + getJavaPackage() + ";\n\n");
+            bwjj.write("import org.apache.jute.*;\n");
+            bwjj.write("import org.apache.yetus.audience.InterfaceAudience;\n");
+            bwjj.write("@InterfaceAudience.Public\n");
+            bwjj.write("public class " + getName() + " implements Record {\n");
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); ) {
                 JField jf = i.next();
-                jj.write(jf.genJavaDecl());
+                bwjj.write(jf.genJavaDecl());
             }
-            jj.write("  public " + getName() + "() {\n");
-            jj.write("  }\n");
+            bwjj.write("  public " + getName() + "() {\n");
+            bwjj.write("  }\n");
 
-            jj.write("  public " + getName() + "(\n");
+            bwjj.write("  public " + getName() + "(\n");
             int fIdx = 0;
             int fLen = mFields.size();
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                jj.write(jf.genJavaConstructorParam(jf.getName()));
-                jj.write((fLen - 1 == fIdx) ? "" : ",\n");
+                bwjj.write(jf.genJavaConstructorParam(jf.getName()));
+                bwjj.write((fLen - 1 == fIdx) ? "" : ",\n");
             }
-            jj.write(") {\n");
+            bwjj.write(") {\n");
             fIdx = 0;
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                jj.write(jf.genJavaConstructorSet(jf.getName()));
+                bwjj.write(jf.genJavaConstructorSet(jf.getName()));
             }
-            jj.write("  }\n");
+            bwjj.write("  }\n");
             fIdx = 0;
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                jj.write(jf.genJavaGetSet(fIdx));
+                bwjj.write(jf.genJavaGetSet(fIdx));
             }
-            jj.write("  public void serialize(OutputArchive a_, String tag) throws java.io.IOException {\n");
-            jj.write("    a_.startRecord(this,tag);\n");
+            bwjj.write("  public void serialize(OutputArchive a_, String tag) throws java.io.IOException {\n");
+            bwjj.write("    a_.startRecord(this,tag);\n");
             fIdx = 0;
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                jj.write(jf.genJavaWriteMethodName());
+                bwjj.write(jf.genJavaWriteMethodName());
             }
-            jj.write("    a_.endRecord(this,tag);\n");
-            jj.write("  }\n");
+            bwjj.write("    a_.endRecord(this,tag);\n");
+            bwjj.write("  }\n");
 
-            jj.write("  public void deserialize(InputArchive a_, String tag) throws java.io.IOException {\n");
-            jj.write("    a_.startRecord(tag);\n");
+            bwjj.write("  public void deserialize(InputArchive a_, String tag) throws java.io.IOException {\n");
+            bwjj.write("    a_.startRecord(tag);\n");
             fIdx = 0;
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                jj.write(jf.genJavaReadMethodName());
+                bwjj.write(jf.genJavaReadMethodName());
             }
-            jj.write("    a_.endRecord(tag);\n");
-            jj.write("}\n");
+            bwjj.write("    a_.endRecord(tag);\n");
+            bwjj.write("}\n");
 
-            jj.write("  public String toString() {\n");
-            jj.write("    try {\n");
-            jj.write("      java.io.ByteArrayOutputStream s =\n");
-            jj.write("        new java.io.ByteArrayOutputStream();\n");
-            jj.write("      CsvOutputArchive a_ = \n");
-            jj.write("        new CsvOutputArchive(s);\n");
-            jj.write("      a_.startRecord(this,\"\");\n");
+            bwjj.write("  public String toString() {\n");
+            bwjj.write("    try {\n");
+            bwjj.write("      java.io.ByteArrayOutputStream s =\n");
+            bwjj.write("        new java.io.ByteArrayOutputStream();\n");
+            bwjj.write("      CsvOutputArchive a_ = \n");
+            bwjj.write("        new CsvOutputArchive(s);\n");
+            bwjj.write("      a_.startRecord(this,\"\");\n");
             fIdx = 0;
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                jj.write(jf.genJavaWriteMethodName());
+                bwjj.write(jf.genJavaWriteMethodName());
             }
-            jj.write("      a_.endRecord(this,\"\");\n");
-            jj.write("      return new String(s.toByteArray(), \"UTF-8\");\n");
-            jj.write("    } catch (Throwable ex) {\n");
-            jj.write("      ex.printStackTrace();\n");
-            jj.write("    }\n");
-            jj.write("    return \"ERROR\";\n");
-            jj.write("  }\n");
+            bwjj.write("      a_.endRecord(this,\"\");\n");
+            bwjj.write("      return new String(s.toByteArray(), \"UTF-8\");\n");
+            bwjj.write("    } catch (Throwable ex) {\n");
+            bwjj.write("      ex.printStackTrace();\n");
+            bwjj.write("    }\n");
+            bwjj.write("    return \"ERROR\";\n");
+            bwjj.write("  }\n");
 
-            jj.write("  public void write(java.io.DataOutput out) throws java.io.IOException {\n");
-            jj.write("    BinaryOutputArchive archive = new BinaryOutputArchive(out);\n");
-            jj.write("    serialize(archive, \"\");\n");
-            jj.write("  }\n");
+            bwjj.write("  public void write(java.io.DataOutput out) throws java.io.IOException {\n");
+            bwjj.write("    BinaryOutputArchive archive = new BinaryOutputArchive(out);\n");
+            bwjj.write("    serialize(archive, \"\");\n");
+            bwjj.write("  }\n");
 
-            jj.write("  public void readFields(java.io.DataInput in) throws java.io.IOException {\n");
-            jj.write("    BinaryInputArchive archive = new BinaryInputArchive(in);\n");
-            jj.write("    deserialize(archive, \"\");\n");
-            jj.write("  }\n");
+            bwjj.write("  public void readFields(java.io.DataInput in) throws java.io.IOException {\n");
+            bwjj.write("    BinaryInputArchive archive = new BinaryInputArchive(in);\n");
+            bwjj.write("    deserialize(archive, \"\");\n");
+            bwjj.write("  }\n");
 
-            jj.write("  public int compareTo (Object peer_) throws ClassCastException {\n");
+            bwjj.write("  public int compareTo (Object peer_) throws ClassCastException {\n");
             boolean unimplemented = false;
             for (JField f : mFields) {
                 if ((f.getType() instanceof JMap)
@@ -516,55 +524,55 @@ public class JRecord extends JCompType {
                 }
             }
             if (unimplemented) {
-                jj.write("    throw new UnsupportedOperationException(\"comparing "
+                bwjj.write("    throw new UnsupportedOperationException(\"comparing "
                         + getName() + " is unimplemented\");\n");
             } else {
-                jj.write("    if (!(peer_ instanceof " + getName() + ")) {\n");
-                jj.write("      throw new ClassCastException(\"Comparing different types of records.\");\n");
-                jj.write("    }\n");
-                jj.write("    " + getName() + " peer = (" + getName() + ") peer_;\n");
-                jj.write("    int ret = 0;\n");
+                bwjj.write("    if (!(peer_ instanceof " + getName() + ")) {\n");
+                bwjj.write("      throw new ClassCastException(\"Comparing different types of records.\");\n");
+                bwjj.write("    }\n");
+                bwjj.write("    " + getName() + " peer = (" + getName() + ") peer_;\n");
+                bwjj.write("    int ret = 0;\n");
                 for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                     JField jf = i.next();
-                    jj.write(jf.genJavaCompareTo());
-                    jj.write("    if (ret != 0) return ret;\n");
+                    bwjj.write(jf.genJavaCompareTo());
+                    bwjj.write("    if (ret != 0) return ret;\n");
                 }
-                jj.write("     return ret;\n");
+                bwjj.write("     return ret;\n");
             }
-            jj.write("  }\n");
+            bwjj.write("  }\n");
 
-            jj.write("  public boolean equals(Object peer_) {\n");
-            jj.write("    if (!(peer_ instanceof " + getName() + ")) {\n");
-            jj.write("      return false;\n");
-            jj.write("    }\n");
-            jj.write("    if (peer_ == this) {\n");
-            jj.write("      return true;\n");
-            jj.write("    }\n");
-            jj.write("    " + getName() + " peer = (" + getName() + ") peer_;\n");
-            jj.write("    boolean ret = false;\n");
+            bwjj.write("  public boolean equals(Object peer_) {\n");
+            bwjj.write("    if (!(peer_ instanceof " + getName() + ")) {\n");
+            bwjj.write("      return false;\n");
+            bwjj.write("    }\n");
+            bwjj.write("    if (peer_ == this) {\n");
+            bwjj.write("      return true;\n");
+            bwjj.write("    }\n");
+            bwjj.write("    " + getName() + " peer = (" + getName() + ") peer_;\n");
+            bwjj.write("    boolean ret = false;\n");
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                jj.write(jf.genJavaEquals());
-                jj.write("    if (!ret) return ret;\n");
+                bwjj.write(jf.genJavaEquals());
+                bwjj.write("    if (!ret) return ret;\n");
             }
-            jj.write("     return ret;\n");
-            jj.write("  }\n");
+            bwjj.write("     return ret;\n");
+            bwjj.write("  }\n");
 
-            jj.write("  public int hashCode() {\n");
-            jj.write("    int result = 17;\n");
-            jj.write("    int ret;\n");
+            bwjj.write("  public int hashCode() {\n");
+            bwjj.write("    int result = 17;\n");
+            bwjj.write("    int ret;\n");
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                jj.write(jf.genJavaHashCode());
-                jj.write("    result = 37*result + ret;\n");
+                bwjj.write(jf.genJavaHashCode());
+                bwjj.write("    result = 37*result + ret;\n");
             }
-            jj.write("    return result;\n");
-            jj.write("  }\n");
-            jj.write("  public static String signature() {\n");
-            jj.write("    return \"" + getSignature() + "\";\n");
-            jj.write("  }\n");
+            bwjj.write("    return result;\n");
+            bwjj.write("  }\n");
+            bwjj.write("  public static String signature() {\n");
+            bwjj.write("    return \"" + getSignature() + "\";\n");
+            bwjj.write("  }\n");
 
-            jj.write("}\n");
+            bwjj.write("}\n");
         }
     }
 
@@ -579,111 +587,112 @@ public class JRecord extends JCompType {
         }
 
         try (FileWriter cs = new FileWriter(new File(outputDirectory, getName() + ".cs"));) {
-            cs.write("// File generated by hadoop record compiler. Do not edit.\n");
-            cs.write("/**\n");
-            cs.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
-            cs.write("* or more contributor license agreements.  See the NOTICE file\n");
-            cs.write("* distributed with this work for additional information\n");
-            cs.write("* regarding copyright ownership.  The ASF licenses this file\n");
-            cs.write("* to you under the Apache License, Version 2.0 (the\n");
-            cs.write("* \"License\"); you may not use this file except in compliance\n");
-            cs.write("* with the License.  You may obtain a copy of the License at\n");
-            cs.write("*\n");
-            cs.write("*     http://www.apache.org/licenses/LICENSE-2.0\n");
-            cs.write("*\n");
-            cs.write("* Unless required by applicable law or agreed to in writing, software\n");
-            cs.write("* distributed under the License is distributed on an \"AS IS\" BASIS,\n");
-            cs.write("* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n");
-            cs.write("* See the License for the specific language governing permissions and\n");
-            cs.write("* limitations under the License.\n");
-            cs.write("*/\n");
-            cs.write("\n");
-            cs.write("using System;\n");
-            cs.write("using Org.Apache.Jute;\n");
-            cs.write("\n");
-            cs.write("namespace " + getCsharpNameSpace() + "\n");
-            cs.write("{\n");
+            BufferedWriter bwcs = new BufferedWriter(cs);
+            bwcs.write("// File generated by hadoop record compiler. Do not edit.\n");
+            bwcs.write("/**\n");
+            bwcs.write("* Licensed to the Apache Software Foundation (ASF) under one\n");
+            bwcs.write("* or more contributor license agreements.  See the NOTICE file\n");
+            bwcs.write("* distributed with this work for additional information\n");
+            bwcs.write("* regarding copyright ownership.  The ASF licenses this file\n");
+            bwcs.write("* to you under the Apache License, Version 2.0 (the\n");
+            bwcs.write("* \"License\"); you may not use this file except in compliance\n");
+            bwcs.write("* with the License.  You may obtain a copy of the License at\n");
+            bwcs.write("*\n");
+            bwcs.write("*     http://www.apache.org/licenses/LICENSE-2.0\n");
+            bwcs.write("*\n");
+            bwcs.write("* Unless required by applicable law or agreed to in writing, software\n");
+            bwcs.write("* distributed under the License is distributed on an \"AS IS\" BASIS,\n");
+            bwcs.write("* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n");
+            bwcs.write("* See the License for the specific language governing permissions and\n");
+            bwcs.write("* limitations under the License.\n");
+            bwcs.write("*/\n");
+            bwcs.write("\n");
+            bwcs.write("using System;\n");
+            bwcs.write("using Org.Apache.Jute;\n");
+            bwcs.write("\n");
+            bwcs.write("namespace " + getCsharpNameSpace() + "\n");
+            bwcs.write("{\n");
 
             String className = getCsharpName();
-            cs.write("public class " + className + " : IRecord, IComparable \n");
-            cs.write("{\n");
-            cs.write("  public " + className + "() {\n");
-            cs.write("  }\n");
+            bwcs.write("public class " + className + " : IRecord, IComparable \n");
+            bwcs.write("{\n");
+            bwcs.write("  public " + className + "() {\n");
+            bwcs.write("  }\n");
 
-            cs.write("  public " + className + "(\n");
+            bwcs.write("  public " + className + "(\n");
             int fIdx = 0;
             int fLen = mFields.size();
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                cs.write(jf.genCsharpConstructorParam(jf.getCsharpName()));
-                cs.write((fLen - 1 == fIdx) ? "" : ",\n");
+                bwcs.write(jf.genCsharpConstructorParam(jf.getCsharpName()));
+                bwcs.write((fLen - 1 == fIdx) ? "" : ",\n");
             }
-            cs.write(") {\n");
+            bwcs.write(") {\n");
             fIdx = 0;
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                cs.write(jf.genCsharpConstructorSet(jf.getCsharpName()));
+                bwcs.write(jf.genCsharpConstructorSet(jf.getCsharpName()));
             }
-            cs.write("  }\n");
+            bwcs.write("  }\n");
             fIdx = 0;
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                cs.write(jf.genCsharpGetSet(fIdx));
-                cs.write("\n");
+                bwcs.write(jf.genCsharpGetSet(fIdx));
+                bwcs.write("\n");
             }
-            cs.write("  public void Serialize(IOutputArchive a_, String tag) {\n");
-            cs.write("    a_.StartRecord(this,tag);\n");
+            bwcs.write("  public void Serialize(IOutputArchive a_, String tag) {\n");
+            bwcs.write("    a_.StartRecord(this,tag);\n");
             fIdx = 0;
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                cs.write(jf.genCsharpWriteMethodName());
+                bwcs.write(jf.genCsharpWriteMethodName());
             }
-            cs.write("    a_.EndRecord(this,tag);\n");
-            cs.write("  }\n");
+            bwcs.write("    a_.EndRecord(this,tag);\n");
+            bwcs.write("  }\n");
 
-            cs.write("  public void Deserialize(IInputArchive a_, String tag) {\n");
-            cs.write("    a_.StartRecord(tag);\n");
+            bwcs.write("  public void Deserialize(IInputArchive a_, String tag) {\n");
+            bwcs.write("    a_.StartRecord(tag);\n");
             fIdx = 0;
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                cs.write(jf.genCsharpReadMethodName());
+                bwcs.write(jf.genCsharpReadMethodName());
             }
-            cs.write("    a_.EndRecord(tag);\n");
-            cs.write("}\n");
+            bwcs.write("    a_.EndRecord(tag);\n");
+            bwcs.write("}\n");
 
-            cs.write("  public override String ToString() {\n");
-            cs.write("    try {\n");
-            cs.write("      System.IO.MemoryStream ms = new System.IO.MemoryStream();\n");
-            cs.write("      MiscUtil.IO.EndianBinaryWriter writer =\n");
-            cs.write("        new MiscUtil.IO.EndianBinaryWriter(MiscUtil.Conversion.EndianBitConverter.Big, ms, System.Text.Encoding.UTF8);\n");
-            cs.write("      BinaryOutputArchive a_ = \n");
-            cs.write("        new BinaryOutputArchive(writer);\n");
-            cs.write("      a_.StartRecord(this,\"\");\n");
+            bwcs.write("  public override String ToString() {\n");
+            bwcs.write("    try {\n");
+            bwcs.write("      System.IO.MemoryStream ms = new System.IO.MemoryStream();\n");
+            bwcs.write("      MiscUtil.IO.EndianBinaryWriter writer =\n");
+            bwcs.write("        new MiscUtil.IO.EndianBinaryWriter(MiscUtil.Conversion.EndianBitConverter.Big, ms, System.Text.Encoding.UTF8);\n");
+            bwcs.write("      BinaryOutputArchive a_ = \n");
+            bwcs.write("        new BinaryOutputArchive(writer);\n");
+            bwcs.write("      a_.StartRecord(this,\"\");\n");
             fIdx = 0;
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                cs.write(jf.genCsharpWriteMethodName());
+                bwcs.write(jf.genCsharpWriteMethodName());
             }
-            cs.write("      a_.EndRecord(this,\"\");\n");
-            cs.write("      ms.Position = 0;\n");
-            cs.write("      return System.Text.Encoding.UTF8.GetString(ms.ToArray());\n");
-            cs.write("    } catch (Exception ex) {\n");
-            cs.write("      Console.WriteLine(ex.StackTrace);\n");
-            cs.write("    }\n");
-            cs.write("    return \"ERROR\";\n");
-            cs.write("  }\n");
+            bwcs.write("      a_.EndRecord(this,\"\");\n");
+            bwcs.write("      ms.Position = 0;\n");
+            bwcs.write("      return System.Text.Encoding.UTF8.GetString(ms.ToArray());\n");
+            bwcs.write("    } catch (Exception ex) {\n");
+            bwcs.write("      Console.WriteLine(ex.StackTrace);\n");
+            bwcs.write("    }\n");
+            bwcs.write("    return \"ERROR\";\n");
+            bwcs.write("  }\n");
 
-            cs.write("  public void Write(MiscUtil.IO.EndianBinaryWriter writer) {\n");
-            cs.write("    BinaryOutputArchive archive = new BinaryOutputArchive(writer);\n");
-            cs.write("    Serialize(archive, \"\");\n");
-            cs.write("  }\n");
+            bwcs.write("  public void Write(MiscUtil.IO.EndianBinaryWriter writer) {\n");
+            bwcs.write("    BinaryOutputArchive archive = new BinaryOutputArchive(writer);\n");
+            bwcs.write("    Serialize(archive, \"\");\n");
+            bwcs.write("  }\n");
 
-            cs.write("  public void ReadFields(MiscUtil.IO.EndianBinaryReader reader) {\n");
-            cs.write("    BinaryInputArchive archive = new BinaryInputArchive(reader);\n");
-            cs.write("    Deserialize(archive, \"\");\n");
-            cs.write("  }\n");
+            bwcs.write("  public void ReadFields(MiscUtil.IO.EndianBinaryReader reader) {\n");
+            bwcs.write("    BinaryInputArchive archive = new BinaryInputArchive(reader);\n");
+            bwcs.write("    Deserialize(archive, \"\");\n");
+            bwcs.write("  }\n");
 
-            cs.write("  public int CompareTo (object peer_) {\n");
+            bwcs.write("  public int CompareTo (object peer_) {\n");
             boolean unimplemented = false;
             for (JField f : mFields) {
                 if ((f.getType() instanceof JMap)
@@ -692,58 +701,58 @@ public class JRecord extends JCompType {
                 }
             }
             if (unimplemented) {
-                cs.write("    throw new InvalidOperationException(\"comparing "
+                bwcs.write("    throw new InvalidOperationException(\"comparing "
                         + getCsharpName() + " is unimplemented\");\n");
             } else {
-                cs.write("    if (!(peer_ is " + getCsharpName() + ")) {\n");
-                cs.write("      throw new InvalidOperationException(\"Comparing different types of records.\");\n");
-                cs.write("    }\n");
-                cs.write("    " + getCsharpName() + " peer = (" + getCsharpName() + ") peer_;\n");
-                cs.write("    int ret = 0;\n");
+                bwcs.write("    if (!(peer_ is " + getCsharpName() + ")) {\n");
+                bwcs.write("      throw new InvalidOperationException(\"Comparing different types of records.\");\n");
+                bwcs.write("    }\n");
+                bwcs.write("    " + getCsharpName() + " peer = (" + getCsharpName() + ") peer_;\n");
+                bwcs.write("    int ret = 0;\n");
                 for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                     JField jf = i.next();
-                    cs.write(jf.genCsharpCompareTo());
-                    cs.write("    if (ret != 0) return ret;\n");
+                    bwcs.write(jf.genCsharpCompareTo());
+                    bwcs.write("    if (ret != 0) return ret;\n");
                 }
-                cs.write("     return ret;\n");
+                bwcs.write("     return ret;\n");
             }
-            cs.write("  }\n");
+            bwcs.write("  }\n");
 
-            cs.write("  public override bool Equals(object peer_) {\n");
-            cs.write("    if (!(peer_ is " + getCsharpName() + ")) {\n");
-            cs.write("      return false;\n");
-            cs.write("    }\n");
-            cs.write("    if (peer_ == this) {\n");
-            cs.write("      return true;\n");
-            cs.write("    }\n");
-            cs.write("    bool ret = false;\n");
-            cs.write("    " + getCsharpName() + " peer = (" + getCsharpName() + ")peer_;\n");
+            bwcs.write("  public override bool Equals(object peer_) {\n");
+            bwcs.write("    if (!(peer_ is " + getCsharpName() + ")) {\n");
+            bwcs.write("      return false;\n");
+            bwcs.write("    }\n");
+            bwcs.write("    if (peer_ == this) {\n");
+            bwcs.write("      return true;\n");
+            bwcs.write("    }\n");
+            bwcs.write("    bool ret = false;\n");
+            bwcs.write("    " + getCsharpName() + " peer = (" + getCsharpName() + ")peer_;\n");
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                cs.write(jf.genCsharpEquals());
-                cs.write("    if (!ret) return ret;\n");
+                bwcs.write(jf.genCsharpEquals());
+                bwcs.write("    if (!ret) return ret;\n");
             }
-            cs.write("     return ret;\n");
-            cs.write("  }\n");
+            bwcs.write("     return ret;\n");
+            bwcs.write("  }\n");
 
-            cs.write("  public override int GetHashCode() {\n");
-            cs.write("    int result = 17;\n");
-            cs.write("    int ret;\n");
+            bwcs.write("  public override int GetHashCode() {\n");
+            bwcs.write("    int result = 17;\n");
+            bwcs.write("    int ret;\n");
             for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
                 JField jf = i.next();
-                cs.write(jf.genCsharpHashCode());
-                cs.write("    result = 37*result + ret;\n");
+                bwcs.write(jf.genCsharpHashCode());
+                bwcs.write("    result = 37*result + ret;\n");
             }
-            cs.write("    return result;\n");
-            cs.write("  }\n");
-            cs.write("  public static string Signature() {\n");
-            cs.write("    return \"" + getSignature() + "\";\n");
-            cs.write("  }\n");
+            bwcs.write("    return result;\n");
+            bwcs.write("  }\n");
+            bwcs.write("  public static string Signature() {\n");
+            bwcs.write("    return \"" + getSignature() + "\";\n");
+            bwcs.write("  }\n");
 
-            cs.write("}\n");
-            cs.write("}\n");
+            bwcs.write("}\n");
+            bwcs.write("}\n");
 
-            cs.close();
+            bwcs.close();
         }
     }
 

--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/JRecord.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/JRecord.java
@@ -287,7 +287,7 @@ public class JRecord extends JCompType {
     public void genCppCode(FileWriter hh, FileWriter cc)
         throws IOException {
 	BufferedWriter bwhh = new BufferedWriter(hh);
-	BufferedWriter bwcc = new BufferedWriterd(cc);
+	BufferedWriter bwcc = new BufferedWriter(cc);
 	
         String[] ns = getCppNameSpace().split("::");
         for (int i = 0; i < ns.length; i++) {


### PR DESCRIPTION
[ZOOKEEPER-3387](https://issues.apache.org/jira/browse/ZOOKEEPER-3387) When FileWriter is used intensively within a loop, BufferedWriter can be used to improve performance by reducing IO operations.