### PR TITLE
ZOOKEEPER-3396: Flaky test in RestoreCommittedLogTest

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -636,8 +636,10 @@ property, when available, is noted below.
     from taking a snapshot at the same time, each ZooKeeper server
     will take a snapshot when the size in bytes of the set of transactions in the
     transaction log reaches a runtime generated random value in the \[snapSize/2+1, snapSize]
-    range. The default snapSizeLimitInKb is 4,194,304 (4GB). A non-positive
-    value will disable the feature.
+    range. Each file system has a minimum standard file size and in order
+    to for valid functioning of this feature, the number chosen must be larger
+    than that value. The default snapSizeLimitInKb is 4,194,304 (4GB).
+    A non-positive value will disable the feature.
 
 * *txnLogSizeLimitInKb* :
     (Java system property: **zookeeper.txnLogSizeLimitInKb**)

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/RestoreCommittedLogTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/RestoreCommittedLogTest.java
@@ -53,7 +53,7 @@ public class RestoreCommittedLogTest extends ZKTestCase{
     @Test
     public void testRestoreCommittedLogWithSnapSize() throws Exception {
         final int minExpectedSnapshots = 5;
-        final int minTxnsToSnap = 40;
+        final int minTxnsToSnap = 256;
         final int numTransactions = minExpectedSnapshots * minTxnsToSnap;
         final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < 4*1024; i++) {
@@ -61,7 +61,10 @@ public class RestoreCommittedLogTest extends ZKTestCase{
         }
         final byte[] data = sb.toString().getBytes();
 
-        SyncRequestProcessor.setSnapCount(numTransactions * 1000);
+        SyncRequestProcessor.setSnapCount(numTransactions * 1000 /* just some high number */);
+        // The test breaks if this number is less than the smallest size file
+        // created on the system, as revealed through File::length.
+        // Setting to about 1 Mb.
         SyncRequestProcessor.setSnapSizeInBytes(minTxnsToSnap * data.length);
 
         testRestoreCommittedLog(numTransactions, data, minExpectedSnapshots);


### PR DESCRIPTION
Adjusting parameters of RestoreCommittedLogTest to avoid failures caused by threshold configured to be below the minimum allowed file size