### PR TITLE
ZOOKEEPER-3364: Compile with strict options in order to check code quality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,6 +440,15 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.0</version>
+          <configuration>
+             <compilerArgs>
+               <compilerArg>-Werror</compilerArg>
+               <compilerArg>-Xlint:deprecation</compilerArg>
+               <compilerArg>-Xlint:unchecked</compilerArg>
+               <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->
+               <compilerArg>-Xpkginfo:always</compilerArg>
+              </compilerArgs>
+            </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/zookeeper-contrib/pom.xml
+++ b/zookeeper-contrib/pom.xml
@@ -49,9 +49,19 @@
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>3.1.9</version>
           <configuration>
-            <!-- No spotbugs for contri modules -->
+            <!-- No spotbugs for contrib modules -->
             <skip>true</skip>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+             <!-- no additional args for contrib -->
+             <compilerArgs>
+                 <compilerArg>-Xlint:none</compilerArg>
+             </compilerArgs>
+            </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/JUnit4ZKTestRunner.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/JUnit4ZKTestRunner.java
@@ -40,6 +40,7 @@ public class JUnit4ZKTestRunner extends BlockJUnit4ClassRunner {
         super(klass);
     }
 
+    @SuppressWarnings("unchecked")
     public static List<FrameworkMethod> computeTestMethodsForClass(final Class klass, final List<FrameworkMethod> defaultMethods) {
         List<FrameworkMethod> list = defaultMethods;
         String methodName = System.getProperty("test.method");

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ZKTestCase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ZKTestCase.java
@@ -21,8 +21,8 @@ package org.apache.zookeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.junit.Rule;
-import org.junit.rules.MethodRule;
-import org.junit.rules.TestWatchman;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.FrameworkMethod;
 
@@ -44,9 +44,10 @@ public class ZKTestCase {
     }
 
     @Rule
-    public MethodRule watchman = new TestWatchman() {
+    public TestWatcher watchman= new TestWatcher() {
+        
         @Override
-        public void starting(FrameworkMethod method) {
+        public void starting(Description method) {
             // By default, disable starting a JettyAdminServer in tests to avoid
             // accidentally attempting to start multiple admin servers on the
             // same port.
@@ -54,22 +55,22 @@ public class ZKTestCase {
             // ZOOKEEPER-2693 disables all 4lw by default.
             // Here we enable the 4lw which ZooKeeper tests depends.
             System.setProperty("zookeeper.4lw.commands.whitelist", "*");
-            testName = method.getName();
+            testName = method.getMethodName();
             LOG.info("STARTING " + testName);
         }
 
         @Override
-        public void finished(FrameworkMethod method) {
+        public void finished(Description method) {
             LOG.info("FINISHED " + testName);
         }
 
         @Override
-        public void succeeded(FrameworkMethod method) {
+        public void succeeded(Description method) {
             LOG.info("SUCCEEDED " + testName);
         }
 
         @Override
-        public void failed(Throwable e, FrameworkMethod method) {
+        public void failed(Throwable e, Description method) {
             LOG.info("FAILED " + testName, e);
         }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerMainTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerMainTest.java
@@ -994,7 +994,7 @@ public class QuorumPeerMainTest extends QuorumPeerTestBase {
 
         // make sure it has a chance to write it to disk
         int sleepTime = 0;
-        Long longLeader = new Long(leader);
+        Long longLeader = Long.valueOf(leader);
         while (!p.qvAcksetPairs.get(0).getAckset().contains(longLeader)) {
             if (sleepTime > 2000) {
                 Assert.fail("Transaction not synced to disk within 1 second " + p.qvAcksetPairs.get(0).getAckset()

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/MiniKdc.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/MiniKdc.java
@@ -17,7 +17,6 @@
  */
 
 package org.apache.zookeeper.server.quorum.auth;
-import org.apache.commons.io.Charsets;
 import org.apache.kerby.kerberos.kerb.KrbException;
 import org.apache.kerby.kerberos.kerb.server.KdcConfigKey;
 import org.apache.kerby.kerberos.kerb.server.SimpleKdcServer;
@@ -31,6 +30,7 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
@@ -102,7 +102,7 @@ public class MiniKdc {
         Properties userConf = new Properties();
         InputStreamReader r = null;
         try {
-            r = new InputStreamReader(new FileInputStream(file), Charsets.UTF_8);
+            r = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8);
             userConf.load(r);
         } finally {
             if (r != null) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumKerberosHostBasedAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumKerberosHostBasedAuthTest.java
@@ -34,10 +34,9 @@ import org.apache.zookeeper.test.ClientBase;
 import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import junit.framework.Assert;
 
 public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
     private static File keytabFile;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/CnxManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/CnxManagerTest.java
@@ -244,10 +244,10 @@ public class CnxManagerTest extends ZKTestCase {
         SocketChannel sc = SocketChannel.open();
         sc.socket().connect(peers.get(1L).electionAddr, 5000);
 
-        InetSocketAddress otherAddr = peers.get(new Long(2)).electionAddr;
+        InetSocketAddress otherAddr = peers.get(Long.valueOf(2)).electionAddr;
         DataOutputStream dout = new DataOutputStream(sc.socket().getOutputStream());
         dout.writeLong(QuorumCnxManager.PROTOCOL_VERSION);
-        dout.writeLong(new Long(2));
+        dout.writeLong(2);
         String addr = otherAddr.getHostString()+ ":" + otherAddr.getPort();
         byte[] addr_bytes = addr.getBytes();
         dout.writeInt(addr_bytes.length);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/FourLetterWordsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/FourLetterWordsTest.java
@@ -44,7 +44,7 @@ public class FourLetterWordsTest extends ClientBase {
         LoggerFactory.getLogger(FourLetterWordsTest.class);
 
     @Rule
-    public Timeout timeout = new Timeout(30000);
+    public Timeout timeout = Timeout.millis(30000);
 
     /** Test the various four letter words */
     @Test

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/InvalidSnapshotTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/InvalidSnapshotTest.java
@@ -25,7 +25,6 @@ import java.io.File;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.server.LogFormatter;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.SnapshotFormatter;
 import org.apache.zookeeper.server.SyncRequestProcessor;
@@ -46,12 +45,13 @@ public class InvalidSnapshotTest extends ZKTestCase{
     /**
      * Verify the LogFormatter by running it on a known file.
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testLogFormatter() throws Exception {
         File snapDir = new File(testData, "invalidsnap");
         File logfile = new File(new File(snapDir, "version-2"), "log.274");
         String[] args = {logfile.getCanonicalFile().toString()};
-        LogFormatter.main(args);
+        org.apache.zookeeper.server.LogFormatter.main(args);
     }
 
     /**

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/LENonTerminateTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/LENonTerminateTest.java
@@ -38,7 +38,6 @@ import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.quorum.Election;
 import org.apache.zookeeper.server.quorum.FLELostMessageTest;
-import org.apache.zookeeper.server.quorum.LeaderElection;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.server.quorum.Vote;
 import org.apache.zookeeper.server.quorum.QuorumPeer.LearnerType;
@@ -51,7 +50,10 @@ import org.junit.Test;
 
 @SuppressWarnings("deprecation")
 public class LENonTerminateTest extends ZKTestCase {
-    public static class MockLeaderElection extends LeaderElection {
+
+    @SuppressWarnings("deprecation")
+    public static class MockLeaderElection
+            extends org.apache.zookeeper.server.quorum.LeaderElection {
         public MockLeaderElection(QuorumPeer self) {
             super(self);
         }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/LETest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/LETest.java
@@ -43,7 +43,6 @@ public class LETest extends ZKTestCase {
     volatile long leader = -1;
     Random rand = new Random();
     class LEThread extends Thread {
-        @SuppressWarnings("deprecated")
         org.apache.zookeeper.server.quorum.LeaderElection le;
         int i;
         QuorumPeer peer;
@@ -107,14 +106,15 @@ public class LETest extends ZKTestCase {
             tmpdir[i] = ClientBase.createTmpDir();
             port[i] = PortAssignment.unique();
         }
-        LeaderElection le[] = new LeaderElection[count];
+        org.apache.zookeeper.server.quorum.LeaderElection le[]
+                = new org.apache.zookeeper.server.quorum.LeaderElection[count];
         leaderDies = true;
         boolean allowOneBadLeader = leaderDies;
         for(int i = 0; i < le.length; i++) {
             QuorumPeer peer = new QuorumPeer(peers, tmpdir[i], tmpdir[i],
                     port[i], 0, i, 1000, 2, 2);
             peer.startLeaderElection();
-            le[i] = new LeaderElection(peer);
+            le[i] = new org.apache.zookeeper.server.quorum.LeaderElection(peer);
             LEThread thread = new LEThread(le[i], peer, i);
             thread.start();
             threads.add(thread);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/LETest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/LETest.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZKTestCase;
-import org.apache.zookeeper.server.quorum.LeaderElection;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.server.quorum.Vote;
 import org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer;
@@ -44,10 +43,11 @@ public class LETest extends ZKTestCase {
     volatile long leader = -1;
     Random rand = new Random();
     class LEThread extends Thread {
-        LeaderElection le;
+        @SuppressWarnings("deprecated")
+        org.apache.zookeeper.server.quorum.LeaderElection le;
         int i;
         QuorumPeer peer;
-        LEThread(LeaderElection le, QuorumPeer peer, int i) {
+        LEThread(org.apache.zookeeper.server.quorum.LeaderElection le, QuorumPeer peer, int i) {
             this.le = le;
             this.i = i;
             this.peer = peer;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/LoadFromLogTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/LoadFromLogTest.java
@@ -179,7 +179,7 @@ public class LoadFromLogTest extends ClientBase {
         String[] tokens = lastPath.split("-");
         String expectedPath = "/invalidsnap/test-"
                 + String.format("%010d",
-                (new Integer(tokens[1])).intValue() + 1);
+                (Integer.parseInt(tokens[1])) + 1);
         ZooKeeperServer zks = getServer(serverFactory);
         long eZxid = zks.getZKDatabase().getDataTreeLastProcessedZxid();
         // force the zxid to be behind the content

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigMisconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigMisconfigTest.java
@@ -81,7 +81,7 @@ public class ReconfigMisconfigTest extends ZKTestCase {
             reconfigPort();
             Assert.fail(errorMsg);
         } catch (KeeperException e) {
-            Assert.assertTrue(e.getCode() == KeeperException.Code.NoAuth);
+            Assert.assertTrue(e.code() == KeeperException.Code.NOAUTH);
         }
 
         try {
@@ -89,7 +89,7 @@ public class ReconfigMisconfigTest extends ZKTestCase {
             reconfigPort();
             Assert.fail(errorMsg);
         } catch (KeeperException e) {
-            Assert.assertTrue(e.getCode() == KeeperException.Code.NoAuth);
+            Assert.assertTrue(e.code() == KeeperException.Code.NOAUTH);
         }
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
@@ -33,7 +33,6 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.AsyncCallback.DataCallback;
 import org.apache.zookeeper.data.Stat;
-import org.apache.zookeeper.jmx.CommonNames;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer;
 import org.apache.zookeeper.server.quorum.QuorumPeer.ServerState;
@@ -48,6 +47,7 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.jmx.CommonNames;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -917,7 +917,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         int leavingIndex = 1;
         int replica2 = 2;
         QuorumPeer peer2 = qu.getPeer(replica2).peer;
-        QuorumServer leavingQS2 = peer2.getView().get(new Long(leavingIndex));
+        QuorumServer leavingQS2 = peer2.getView().get(Long.valueOf(leavingIndex));        
         String remotePeerBean2 = CommonNames.DOMAIN
                 + ":name0=ReplicatedServer_id" + replica2 + ",name1=replica."
                 + leavingIndex;
@@ -926,7 +926,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         // assert remotePeerBean.1 of ReplicatedServer_3
         int replica3 = 3;
         QuorumPeer peer3 = qu.getPeer(replica3).peer;
-        QuorumServer leavingQS3 = peer3.getView().get(new Long(leavingIndex));
+        QuorumServer leavingQS3 = peer3.getView().get(Long.valueOf(leavingIndex));
         String remotePeerBean3 = CommonNames.DOMAIN
                 + ":name0=ReplicatedServer_id" + replica3 + ",name1=replica."
                 + leavingIndex;
@@ -967,11 +967,11 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         assertLocalPeerMXBeanAttributes(removedPeer, localPeerBean, true);
 
         // assert remotePeerBean.1 of ReplicatedServer_2
-        leavingQS2 = peer2.getView().get(new Long(leavingIndex));
+        leavingQS2 = peer2.getView().get(Long.valueOf(leavingIndex));
         assertRemotePeerMXBeanAttributes(leavingQS2, remotePeerBean2);
 
         // assert remotePeerBean.1 of ReplicatedServer_3
-        leavingQS3 = peer3.getView().get(new Long(leavingIndex));
+        leavingQS3 = peer3.getView().get(Long.valueOf(leavingIndex));
         assertRemotePeerMXBeanAttributes(leavingQS3, remotePeerBean3);
     }
 
@@ -995,7 +995,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         int changingIndex = 1;
         int replica2 = 2;
         QuorumPeer peer2 = qu.getPeer(replica2).peer;
-        QuorumServer changingQS2 = peer2.getView().get(new Long(changingIndex));
+        QuorumServer changingQS2 = peer2.getView().get(Long.valueOf(changingIndex));
         String remotePeerBean2 = CommonNames.DOMAIN
                 + ":name0=ReplicatedServer_id" + replica2 + ",name1=replica."
                 + changingIndex;
@@ -1004,7 +1004,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         // assert remotePeerBean.1 of ReplicatedServer_3
         int replica3 = 3;
         QuorumPeer peer3 = qu.getPeer(replica3).peer;
-        QuorumServer changingQS3 = peer3.getView().get(new Long(changingIndex));
+        QuorumServer changingQS3 = peer3.getView().get(Long.valueOf(changingIndex));
         String remotePeerBean3 = CommonNames.DOMAIN
                 + ":name0=ReplicatedServer_id" + replica3 + ",name1=replica."
                 + changingIndex;
@@ -1040,11 +1040,11 @@ public class ReconfigTest extends ZKTestCase implements DataCallback{
         assertLocalPeerMXBeanAttributes(qp, localPeerBeanName, true);
 
         // assert remotePeerBean.1 of ReplicatedServer_2
-        changingQS2 = peer2.getView().get(new Long(changingIndex));
+        changingQS2 = peer2.getView().get(Long.valueOf(changingIndex));
         assertRemotePeerMXBeanAttributes(changingQS2, remotePeerBean2);
 
         // assert remotePeerBean.1 of ReplicatedServer_3
-        changingQS3 = peer3.getView().get(new Long(changingIndex));
+        changingQS3 = peer3.getView().get(Long.valueOf(changingIndex));
         assertRemotePeerMXBeanAttributes(changingQS3, remotePeerBean3);
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SyncCallTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SyncCallTest.java
@@ -107,12 +107,14 @@ public class SyncCallTest extends ClientBase
     }
 
     @SuppressWarnings("unchecked")
+    @Override
     public void processResult(int rc, String path, Object ctx){
         ((List<Integer>) ctx).add(rc);    
         opsCount.countDown();
     
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void processResult(int rc, String path, Object ctx, String name,
         Stat stat) {


### PR DESCRIPTION
This is the port of ZOOKEEPER-3364 to branch-3.5

- Add extra compiler arguments in order to achieve better code quality.
- Fix some minor issues reported by javac
- Extra checks are not enabled in "contrib" module.

Author: Enrico Olivelli <eolivelli@apache.org>

Reviewers: andor@apache.org

Closes #910 from eolivelli/fix/ZOOKEEPER-3364-javac-strict and squashes the following commits:

9660aff82 [Enrico Olivelli] Fix tests and fix warnings on JDK12
52895ec9d [Enrico Olivelli] ZOOKEEPER-3364 Compile with strict options in order to check code quality