### PR TITLE
ZOOKEEPER-3399: Remove logging in getGlobalOutstandingLimit for optimal performance.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
@@ -136,7 +136,6 @@ public class FollowerZooKeeperServer extends LearnerZooKeeperServer {
     public int getGlobalOutstandingLimit() {
         int divisor = self.getQuorumSize() > 2 ? self.getQuorumSize() - 1 : 1;
         int globalOutstandingLimit = super.getGlobalOutstandingLimit() / divisor;
-        LOG.info("Override {} to {}", GLOBAL_OUTSTANDING_LIMIT, globalOutstandingLimit);
         return globalOutstandingLimit;
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderZooKeeperServer.java
@@ -108,7 +108,6 @@ public class LeaderZooKeeperServer extends QuorumZooKeeperServer {
     public int getGlobalOutstandingLimit() {
         int divisor = self.getQuorumSize() > 2 ? self.getQuorumSize() - 1 : 1;
         int globalOutstandingLimit = super.getGlobalOutstandingLimit() / divisor;
-        LOG.info("Override {} to {}", GLOBAL_OUTSTANDING_LIMIT, globalOutstandingLimit);
         return globalOutstandingLimit;
     }
 


### PR DESCRIPTION
Please refer https://issues.apache.org/jira/browse/ZOOKEEPER-3399 for detailed description. This PR removes the LOG statement which was the state of the code path before ZOOKEEPER-3177. The original patch of ZOOKEEPER-3177 had the LOG statement in right place, but that was changed in the second pull request (711) that reverted part of the original patch due to a find bug warning.