### PR TITLE
ZOOKEEPER-3404. Downgrade BouncyCastle to 1.60

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -44,7 +44,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="checkstyle.version" value="7.1.2"/>
     <property name="commons-collections.version" value="3.2.2"/>
 
-    <property name="bouncycastle.version" value="1.61"/>
+    <property name="bouncycastle.version" value="1.60"/>
 
     <property name="jdiff.version" value="1.0.9"/>
     <property name="xerces.version" value="1.4.4"/>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
     <jline.version>2.11</jline.version>
     <snappy.version>1.1.7</snappy.version>
     <kerby.version>1.1.0</kerby.version>
-    <bouncycastle.version>1.61</bouncycastle.version>
+    <bouncycastle.version>1.60</bouncycastle.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-lang.version>2.6</commons-lang.version>
     <dropwizard.version>3.2.5</dropwizard.version>


### PR DESCRIPTION
I've seen a lot of test timeout errors with QuorumSSL tests since I upgraded master to BouncyCastle 1.61 due to a Java 9 warning. The warning has been reported by Enrico Olivelli which we tried to solve by the upgrade, but the warning message is still present so I don't see any harm in downgrading to the previous version. 

https://issues.apache.org/jira/browse/ZOOKEEPER-3404