### PR TITLE
ZOOKEEPER-3405: Upgrade the version of Jackson-databind to address OWASP CVE

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -55,7 +55,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="javacc.version" value="5.0"/>
 
     <property name="jetty.version" value="9.4.15.v20190215"/>
-    <property name="jackson.version" value="2.9.8"/>
+    <property name="jackson.version" value="2.9.9"/>
     <property name="dependency-check-ant.version" value="4.0.2"/>
 
     <property name="commons-io.version" value="2.6"/>

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
     <commons-cli.version>1.2</commons-cli.version>
     <netty.version>4.1.29.Final</netty.version>
     <jetty.version>9.4.17.v20190418</jetty.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.9.9</jackson.version>
     <json.version>1.1.1</json.version>
     <jline.version>2.11</jline.version>
     <snappy.version>1.1.7</snappy.version>


### PR DESCRIPTION
Upgraded the library to the latest version.

Change-Id: I94743e7f7817202fff25c757730ba05fe0a9cc17