### PR TITLE
ZOOKEEPER-3406: Update website for new mailing lists

### DIFF
--- a/src/main/resources/markdown/lists.md
+++ b/src/main/resources/markdown/lists.md
@@ -34,7 +34,7 @@ In order to post to the list, it is necessary to first subscribe to it.
 
 If you'd like to contribute to ZooKeeper, please subscribe to the ZooKeeper developer mailing list.
 
-This mailing list is for general chat and announcements. All notifications are sent to other mailing lists (see below). The only exception are new Jira issues which will still be sent to this list.
+This mailing list is for general developer chat and announcements. All notifications are sent to other mailing lists (see below). The only exception are new Jira issues which will still be sent to this list.
 
 The ZooKeeper developer mailing list is : [dev@zookeeper.apache.org](mailto:dev@zookeeper.apache.org)
 

--- a/src/main/resources/markdown/lists.md
+++ b/src/main/resources/markdown/lists.md
@@ -23,6 +23,7 @@ The ZooKeeper user mailing list is: [user@zookeeper.apache.org](mailto:user@zook
 * [Subscribe to List](mailto:user-subscribe@zookeeper.apache.org)
 * [Unsubscribe from List](mailto:user-unsubscribe@zookeeper.apache.org)
 * [Archives](https://mail-archives.apache.org/mod_mbox/zookeeper-user/)
+* [Alternative Archives](https://lists.apache.org/list.html?user@zookeeper.apache.org)
 * [Older Archives (Hadoop, pre-TLP)](https://mail-archives.apache.org/mod_mbox/hadoop-zookeeper-user/)
 
 Note
@@ -38,6 +39,7 @@ The ZooKeeper developer mailing list is : [dev@zookeeper.apache.org](mailto:dev@
 * [Subscribe to List](mailto:dev-subscribe@zookeeper.apache.org)
 * [Unsubscribe from List](mailto:dev-unsubscribe@zookeeper.apache.org)
 * [Archives](https://mail-archives.apache.org/mod_mbox/zookeeper-dev/)
+* [Alternative Archives](https://lists.apache.org/list.html?dev@zookeeper.apache.org)
 * [Older Archives (Hadoop, pre-TLP)](https://mail-archives.apache.org/mod_mbox/hadoop-zookeeper-dev/)
 
 Note
@@ -50,4 +52,23 @@ If you'd like to see changes made in ZooKeeper's version control system then sub
 * [Subscribe to List](mailto:commits-subscribe@zookeeper.apache.org)
 * [Unsubscribe from List](mailto:commits-unsubscribe@zookeeper.apache.org)
 * [Archives](https://mail-archives.apache.org/mod_mbox/zookeeper-commits/)
+* [Alternative Archives](https://lists.apache.org/list.html?commits@zookeeper.apache.org)
 * [Older Archives (Hadoop, pre-TLP)](https://mail-archives.apache.org/mod_mbox/hadoop-zookeeper-commits/)
+
+## Jira Notifications
+
+If you'd like to see notifications mails for all changes made to Jira tickets then subscribe to the ZooKeeper issues mailing list.
+
+* [Subscribe to List](mailto:issues-subscribe@zookeeper.apache.org)
+* [Unsubscribe from List](mailto:issues-unsubscribe@zookeeper.apache.org)
+* [Archives](https://lists.apache.org/list.html?issues@zookeeper.apache.org)
+* [Alternative Archives](https://mail-archives.apache.org/mod_mbox/zookeeper-issues/)
+
+## Git Notifications
+
+If you'd like to see notifications mails for all non-commit related Git things (e.g. Pull Request comments) then subscribe to the ZooKeeper notifications mailing list.
+
+* [Subscribe to List](mailto:notifications-subscribe@zookeeper.apache.org)
+* [Unsubscribe from List](mailto:notifications-unsubscribe@zookeeper.apache.org)
+* [Archives](https://lists.apache.org/list.html?notifications@zookeeper.apache.org)
+* [Alternative Archives](https://mail-archives.apache.org/mod_mbox/zookeeper-notifications/)

--- a/src/main/resources/markdown/lists.md
+++ b/src/main/resources/markdown/lists.md
@@ -34,6 +34,8 @@ In order to post to the list, it is necessary to first subscribe to it.
 
 If you'd like to contribute to ZooKeeper, please subscribe to the ZooKeeper developer mailing list.
 
+This mailing list is for general chat and announcements. All notifications are sent to other mailing lists (see below). The only exception are new Jira issues which will still be sent to this list.
+
 The ZooKeeper developer mailing list is : [dev@zookeeper.apache.org](mailto:dev@zookeeper.apache.org)
 
 * [Subscribe to List](mailto:dev-subscribe@zookeeper.apache.org)
@@ -58,6 +60,8 @@ If you'd like to see changes made in ZooKeeper's version control system then sub
 ## Jira Notifications
 
 If you'd like to see notifications mails for all changes made to Jira tickets then subscribe to the ZooKeeper issues mailing list.
+
+*Note:* Notifications for the creation of new issues will _also_ be sent to the `dev` mailing list.
 
 * [Subscribe to List](mailto:issues-subscribe@zookeeper.apache.org)
 * [Unsubscribe from List](mailto:issues-unsubscribe@zookeeper.apache.org)


### PR DESCRIPTION
This updates the website with the new mailing lists.
Probably makes sense to wait with merging until INFRA has completed the changes.

Whoever merges this probably needs to follow the remaining steps here as well: https://cwiki.apache.org/confluence/display/ZOOKEEPER/WebSiteSetup