### PR TITLE
ZOOKEEPER-3344:write a new script:zkSnapShotToolkit.sh to encapsulate SnapshotFormatter and doc the usage

### DIFF
--- a/bin/zkSnapShotToolkit.cmd
+++ b/bin/zkSnapShotToolkit.cmd
@@ -1,0 +1,24 @@
+@echo off
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+
+setlocal
+call "%~dp0zkEnv.cmd"
+
+set ZOOMAIN=org.apache.zookeeper.server.SnapshotFormatter
+call %JAVA% -cp "%CLASSPATH%" %ZOOMAIN% %*
+
+endlocal
+

--- a/bin/zkSnapShotToolkit.sh
+++ b/bin/zkSnapShotToolkit.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# If this scripted is run out of /usr/bin or some other system bin directory
+# it should be linked to and not copied. Things like java jar files are found
+# relative to the canonical path of this script.
+#
+
+# use POSIX interface, symlink is followed automatically
+ZOOBIN="${BASH_SOURCE-$0}"
+ZOOBIN="$(dirname "${ZOOBIN}")"
+ZOOBINDIR="$(cd "${ZOOBIN}"; pwd)"
+
+if [ -e "$ZOOBIN/../libexec/zkEnv.sh" ]; then
+  . "$ZOOBINDIR"/../libexec/zkEnv.sh
+else
+  . "$ZOOBINDIR"/zkEnv.sh
+fi
+
+"$JAVA" -cp "$CLASSPATH" $JVMFLAGS \
+     org.apache.zookeeper.server.SnapshotFormatter "$@"
+
+

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperTools.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperTools.md
@@ -22,6 +22,7 @@ limitations under the License.
     * [zkEnv.sh](#zkEnv)
     * [zkCleanup.sh](#zkCleanup)
     * [zkTxnLogToolkit.sh](#zkTxnLogToolkit)
+    * [zkSnapShotToolkit.sh](#zkSnapShotToolkit)
     
 * [Testing](#Testing)
     * [Jepsen Test](#jepsen-test)
@@ -153,6 +154,52 @@ The default behaviour of recovery is to be silent: only entries with CRC error g
 One can turn on verbose mode with the `-v,--verbose` parameter to see all records.
 Interactive mode can be turned off with the `-y,--yes` parameter. In this case all CRC errors will be fixed
 in the new transaction file.
+
+<a name="zkSnapShotToolkit"></a>
+
+### zkSnapShotToolkit.sh
+Dump a snapshot file to stdout, showing the detailed information of the each zk-node.
+
+```bash
+# help
+./zkSnapShotToolkit.sh
+/usr/bin/java
+USAGE: SnapshotFormatter [-d|-json] snapshot_file
+       -d dump the data for each znode
+       -json dump znode info in json format
+
+# show the each zk-node info without data content
+./zkSnapShotToolkit.sh /data/zkdata/version-2/snapshot.fa01000186d
+/zk-latencies_4/session_946
+  cZxid = 0x00000f0003110b
+  ctime = Wed Sep 19 21:58:22 CST 2018
+  mZxid = 0x00000f0003110b
+  mtime = Wed Sep 19 21:58:22 CST 2018
+  pZxid = 0x00000f0003110b
+  cversion = 0
+  dataVersion = 0
+  aclVersion = 0
+  ephemeralOwner = 0x00000000000000
+  dataLength = 100
+
+# [-d] show the each zk-node info with data content
+./zkSnapShotToolkit.sh -d /data/zkdata/version-2/snapshot.fa01000186d
+/zk-latencies2/session_26229
+  cZxid = 0x00000900007ba0
+  ctime = Wed Aug 15 20:13:52 CST 2018
+  mZxid = 0x00000900007ba0
+  mtime = Wed Aug 15 20:13:52 CST 2018
+  pZxid = 0x00000900007ba0
+  cversion = 0
+  dataVersion = 0
+  aclVersion = 0
+  ephemeralOwner = 0x00000000000000
+  data = eHh4eHh4eHh4eHh4eA==
+
+# [-json] show the each zk-node info with json format
+./zkSnapShotToolkit.sh -json /data/zkdata/version-2/snapshot.fa01000186d
+[[1,0,{"progname":"SnapshotFormatter.java","progver":"0.01","timestamp":1559788148637},[{"name":"\/","asize":0,"dsize":0,"dev":0,"ino":1001},[{"name":"zookeeper","asize":0,"dsize":0,"dev":0,"ino":1002},{"name":"config","asize":0,"dsize":0,"dev":0,"ino":1003},[{"name":"quota","asize":0,"dsize":0,"dev":0,"ino":1004},[{"name":"test","asize":0,"dsize":0,"dev":0,"ino":1005},{"name":"zookeeper_limits","asize":52,"dsize":52,"dev":0,"ino":1006},{"name":"zookeeper_stats","asize":15,"dsize":15,"dev":0,"ino":1007}]]],{"name":"test","asize":0,"dsize":0,"dev":0,"ino":1008}]]
+```
 
 <a name="Testing"></a>
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/SnapshotFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/SnapshotFormatter.java
@@ -18,9 +18,7 @@
 
 package org.apache.zookeeper.server;
 
-import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Base64;
@@ -28,8 +26,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.zip.Adler32;
-import java.util.zip.CheckedInputStream;
 
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.InputArchive;
@@ -55,7 +51,7 @@ public class SnapshotFormatter {
     private static Integer INODE_IDX = 1000;
 
     /**
-     * USAGE: SnapshotFormatter snapshot_file
+     * USAGE: SnapshotFormatter snapshot_file or the ready-made script: zkSnapShotToolkit.sh
      */
     public static void main(String[] args) throws Exception {
         String snapshotFile = null;


### PR DESCRIPTION
- A test case about `zkSnapShotToolkit.cmd` in the `Windows` os was included in the [JIRA](https://issues.apache.org/jira/browse/ZOOKEEPER-3344)
- more details in [ZOOKEEPER-3344](https://issues.apache.org/jira/browse/ZOOKEEPER-3344)  