### PR TITLE
ZOOKEEPER-3410:./zkTxnLogToolkit.sh will throw the NPE and stop the process of formatting txn logs due to the data's content is null

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
@@ -262,57 +262,63 @@ public class TxnLogToolkit implements Closeable {
         }
     }
 
-    private void printTxn(byte[] bytes) throws IOException {
+    private void printTxn(byte[] bytes) {
         printTxn(bytes, "");
     }
 
-    private void printTxn(byte[] bytes, String prefix) throws IOException {
-        TxnHeader hdr = new TxnHeader();
-        Record txn = SerializeUtils.deserializeTxn(bytes, hdr);
-        String txnStr = getDataStrFromTxn(txn);
-        String txns = String.format("%s session 0x%s cxid 0x%s zxid 0x%s %s %s",
-                DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.LONG).format(new Date(hdr.getTime())),
-                Long.toHexString(hdr.getClientId()),
-                Long.toHexString(hdr.getCxid()),
-                Long.toHexString(hdr.getZxid()),
-                TraceFormatter.op2String(hdr.getType()),
-                txnStr);
-        if (prefix != null && !"".equals(prefix.trim())) {
-            System.out.print(prefix + " - ");
-        }
-        if (txns.endsWith("\n")) {
-            System.out.print(txns);
-        } else {
-            System.out.println(txns);
+    private void printTxn(byte[] bytes, String prefix) {
+        try {
+            TxnHeader hdr = new TxnHeader();
+            Record txn = SerializeUtils.deserializeTxn(bytes, hdr);
+            String txnStr;
+
+            txnStr = getFormattedTxnStr(txn);
+            String txns = String.format("%s session 0x%s cxid 0x%s zxid 0x%s %s %s",
+                    DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.LONG).format(new Date(hdr.getTime())),
+                    Long.toHexString(hdr.getClientId()),
+                    Long.toHexString(hdr.getCxid()),
+                    Long.toHexString(hdr.getZxid()),
+                    TraceFormatter.op2String(hdr.getType()),
+                    txnStr);
+            if (prefix != null && !"".equals(prefix.trim())) {
+                System.out.print(prefix + " - ");
+            }
+            if (txns.endsWith("\n")) {
+                System.out.print(txns);
+            } else {
+                System.out.println(txns);
+            }
+        } catch (Exception e) {
+            System.err.println("unexpected exception happens when printing the Txn:" + e);
         }
     }
 
     /**
-     * get transaction log data string with node's data as a string
-     * @param txn
-     * @return
+     * get the formatted string from the txn.
+     * @param txn transaction log data
+     * @return the formatted string
      */
-    private static String getDataStrFromTxn(Record txn) {
+    private static String getFormattedTxnStr(Record txn) {
         StringBuilder txnData = new StringBuilder();
         if (txn == null) {
             return txnData.toString();
         }
         if (txn instanceof CreateTxn) {
             CreateTxn createTxn = ((CreateTxn) txn);
-            txnData.append(createTxn.getPath() + "," + new String(createTxn.getData()))
+            txnData.append(createTxn.getPath() + "," + checkNullToEmpty(createTxn.getData()))
                    .append("," + createTxn.getAcl() + "," + createTxn.getEphemeral())
                    .append("," + createTxn.getParentCVersion());
         } else if (txn instanceof SetDataTxn) {
             SetDataTxn setDataTxn = ((SetDataTxn) txn);
-            txnData.append(setDataTxn.getPath() + "," + new String(setDataTxn.getData()))
+            txnData.append(setDataTxn.getPath() + "," + checkNullToEmpty(setDataTxn.getData()))
                    .append("," + setDataTxn.getVersion());
         } else if (txn instanceof CreateContainerTxn) {
             CreateContainerTxn createContainerTxn = ((CreateContainerTxn) txn);
-            txnData.append(createContainerTxn.getPath() + "," + new String(createContainerTxn.getData()))
+            txnData.append(createContainerTxn.getPath() + "," + checkNullToEmpty(createContainerTxn.getData()))
                    .append("," + createContainerTxn.getAcl() + "," + createContainerTxn.getParentCVersion());
         } else if (txn instanceof CreateTTLTxn) {
             CreateTTLTxn createTTLTxn = ((CreateTTLTxn) txn);
-            txnData.append(createTTLTxn.getPath() + "," + new String(createTTLTxn.getData()))
+            txnData.append(createTTLTxn.getPath() + "," + checkNullToEmpty(createTTLTxn.getData()))
                    .append("," + createTTLTxn.getAcl() + "," + createTTLTxn.getParentCVersion())
                    .append("," + createTTLTxn.getTtl());
         } else if (txn instanceof MultiTxn) {
@@ -321,9 +327,9 @@ public class TxnLogToolkit implements Closeable {
             for (int i = 0; i < txnList.size(); i++ ) {
                 Txn t = txnList.get(i);
                 if (i == 0) {
-                    txnData.append(TraceFormatter.op2String(t.getType()) + ":" + new String(t.getData()));
+                    txnData.append(TraceFormatter.op2String(t.getType()) + ":" + checkNullToEmpty(t.getData()));
                 } else {
-                    txnData.append(";" + TraceFormatter.op2String(t.getType()) + ":" + new String(t.getData()));
+                    txnData.append(";" + TraceFormatter.op2String(t.getType()) + ":" + checkNullToEmpty(t.getData()));
                 }
             }
         } else {
@@ -332,7 +338,15 @@ public class TxnLogToolkit implements Closeable {
 
         return txnData.toString();
     }
-    
+
+    private static String checkNullToEmpty(byte[] data) {
+        if (data == null || data.length == 0) {
+            return "";
+        }
+
+        return new String(data);
+    }
+
     private void openTxnLogFile() throws FileNotFoundException {
         txnFis = new FileInputStream(txnLogFile);
         logStream = BinaryInputArchive.getArchive(txnFis);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
@@ -262,34 +262,28 @@ public class TxnLogToolkit implements Closeable {
         }
     }
 
-    private void printTxn(byte[] bytes) {
+    private void printTxn(byte[] bytes) throws IOException {
         printTxn(bytes, "");
     }
 
-    private void printTxn(byte[] bytes, String prefix) {
-        try {
-            TxnHeader hdr = new TxnHeader();
-            Record txn = SerializeUtils.deserializeTxn(bytes, hdr);
-            String txnStr;
-
-            txnStr = getFormattedTxnStr(txn);
-            String txns = String.format("%s session 0x%s cxid 0x%s zxid 0x%s %s %s",
-                    DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.LONG).format(new Date(hdr.getTime())),
-                    Long.toHexString(hdr.getClientId()),
-                    Long.toHexString(hdr.getCxid()),
-                    Long.toHexString(hdr.getZxid()),
-                    TraceFormatter.op2String(hdr.getType()),
-                    txnStr);
-            if (prefix != null && !"".equals(prefix.trim())) {
-                System.out.print(prefix + " - ");
-            }
-            if (txns.endsWith("\n")) {
-                System.out.print(txns);
-            } else {
-                System.out.println(txns);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
+    private void printTxn(byte[] bytes, String prefix) throws IOException {
+        TxnHeader hdr = new TxnHeader();
+        Record txn = SerializeUtils.deserializeTxn(bytes, hdr);
+        String txnStr = getFormattedTxnStr(txn);
+        String txns = String.format("%s session 0x%s cxid 0x%s zxid 0x%s %s %s",
+                DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.LONG).format(new Date(hdr.getTime())),
+                Long.toHexString(hdr.getClientId()),
+                Long.toHexString(hdr.getCxid()),
+                Long.toHexString(hdr.getZxid()),
+                TraceFormatter.op2String(hdr.getType()),
+                txnStr);
+        if (prefix != null && !"".equals(prefix.trim())) {
+            System.out.print(prefix + " - ");
+        }
+        if (txns.endsWith("\n")) {
+            System.out.print(txns);
+        } else {
+            System.out.println(txns);
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
@@ -289,7 +289,7 @@ public class TxnLogToolkit implements Closeable {
                 System.out.println(txns);
             }
         } catch (Exception e) {
-            System.err.println("unexpected exception happens when printing the Txn:" + e);
+            e.printStackTrace();
         }
     }
 
@@ -298,7 +298,7 @@ public class TxnLogToolkit implements Closeable {
      * @param txn transaction log data
      * @return the formatted string
      */
-    private static String getFormattedTxnStr(Record txn) {
+    private static String getFormattedTxnStr(Record txn) throws IOException {
         StringBuilder txnData = new StringBuilder();
         if (txn == null) {
             return txnData.toString();
@@ -339,12 +339,12 @@ public class TxnLogToolkit implements Closeable {
         return txnData.toString();
     }
 
-    private static String checkNullToEmpty(byte[] data) {
+    private static String checkNullToEmpty(byte[] data) throws IOException {
         if (data == null || data.length == 0) {
             return "";
         }
 
-        return new String(data);
+        return new String(data, "UTF8");
     }
 
     private void openTxnLogFile() throws FileNotFoundException {


### PR DESCRIPTION
- the data can be null,but the other fileds(`acl`,`version`,`ttl`)  cannot be `null`.  I also make the `printTxn` method more safer , surrounding it with `try-catch` in case of other unexpected NPEs.
- some test cases were included in the [JIRA](https://issues.apache.org/jira/browse/ZOOKEEPER-3410).
- more details in the [ZOOKEEPER-3410](https://issues.apache.org/jira/browse/ZOOKEEPER-3410)