### PR TITLE
ZOOKEEPER-3091 Prometheus.io Metrics Provider

### DIFF
--- a/conf/zoo_sample.cfg
+++ b/conf/zoo_sample.cfg
@@ -26,3 +26,11 @@ clientPort=2181
 # Purge task interval in hours
 # Set to "0" to disable auto purge feature
 #autopurge.purgeInterval=1
+
+## Metrics Providers
+#
+# https://prometheus.io Metrics Exporter
+#metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider
+#metricsProvider.httpPort=7000
+#metricsProvider.exportJvmInfo=true
+

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <module>zookeeper-docs</module>
     <module>zookeeper-jute</module>
     <module>zookeeper-server</module>
+    <module>zookeeper-metrics-providers</module>
     <module>zookeeper-client</module>
     <module>zookeeper-recipes</module>
     <module>zookeeper-assembly</module>

--- a/zookeeper-assembly/pom.xml
+++ b/zookeeper-assembly/pom.xml
@@ -62,6 +62,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper-prometheus-metrics</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-recipes</artifactId>
       <version>${project.version}</version>
       <type>pom</type>

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1407,6 +1407,29 @@ options are used to configure the [AdminServer](#sc_adminserver).
     The URL for listing and issuing commands relative to the
     root URL.  Defaults to "/commands".
 
+### Metrics Providers
+
+**New in 3.6.0:** The following options are used to configure metrics. 
+
+ By default ZooKeeper server exposes useful metrics using the [AdminServer](#sc_adminserver).
+ and [Four Letter Words](#sc_4lw) interface.
+
+ Since 3.6.0 you can configure a different Metrics Provider, that exports metrics
+ to your favourite system.
+
+ Since 3.6.0 ZooKeeper binary package bundles an integration with [Prometheus.io](https://prometheus.io)
+
+* *metricsProvider.className* :
+    Set to "org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider" to
+    enable Prometheus.io exporter.
+
+* *metricsProvider.httpPort* :
+    Prometheus.io exporter will start a Jetty server and bind to this port, it default to 7000.
+    Prometheus end point will be http://hostname:httPort/metrics.
+
+* *metricsProvider.exportJvmInfo* :
+    If this property is set to **true** Prometheus.io will export useful metrics about the JVM.
+    The default is true.
 
 <a name="Communication+using+the+Netty+framework"></a>
 

--- a/zookeeper-metrics-providers/pom.xml
+++ b/zookeeper-metrics-providers/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <!--
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements.  See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership.  The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License.  You may obtain a copy of the License at
+   *
+   *     http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+  -->
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.zookeeper</groupId>
+    <artifactId>parent</artifactId>
+    <version>3.6.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <groupId>org.apache.zookeeper</groupId>
+  <artifactId>zookeeper-metrics-providers</artifactId>
+  <packaging>pom</packaging>
+  <name>Apache ZooKeeper - Metrics Providers</name>
+  <description>ZooKeeper Metrics Providers</description>
+  
+  <modules>
+    <module>zookeeper-prometheus-metrics</module>
+  </modules>
+
+</project>

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/pom.xml
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <!--
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements.  See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership.  The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License.  You may obtain a copy of the License at
+   *
+   *     http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+  -->
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.zookeeper</groupId>
+    <artifactId>zookeeper-metrics-providers</artifactId>
+    <version>3.6.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <groupId>org.apache.zookeeper</groupId>
+  <artifactId>zookeeper-prometheus-metrics</artifactId>
+  <packaging>jar</packaging>
+  <name>Apache ZooKeeper - Prometheus.io Metrics Provider</name>
+  <description>ZooKeeper Prometheus.io Metrics Provider implementation</description>
+
+  <properties>
+      <prometheus.version>0.6.0</prometheus.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <!-- we can create a metrics-providers-api package
+           once we get rid of ant based build
+           https://issues.apache.org/jira/browse/ZOOKEEPER-3376
+      -->
+      <artifactId>zookeeper</artifactId>
+      <version>${project.version}</version>
+    </dependency>    
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+      <version>${prometheus.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_hotspot</artifactId>
+      <version>${prometheus.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_servlet</artifactId>
+      <version>${prometheus.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/main/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProvider.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/main/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProvider.java
@@ -1,0 +1,412 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.metrics.prometheus;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.MetricsServlet;
+import io.prometheus.client.hotspot.DefaultExports;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiConsumer;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.zookeeper.metrics.Counter;
+import org.apache.zookeeper.metrics.Gauge;
+import org.apache.zookeeper.metrics.MetricsContext;
+import org.apache.zookeeper.metrics.MetricsProvider;
+import org.apache.zookeeper.metrics.MetricsProviderLifeCycleException;
+import org.apache.zookeeper.metrics.Summary;
+import org.apache.zookeeper.metrics.SummarySet;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A Metrics Provider implementation based on https://prometheus.io.
+ *
+ * @since 3.6.0
+ */
+public class PrometheusMetricsProvider implements MetricsProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PrometheusMetricsProvider.class);
+    private static final String LABEL = "key";
+    private static final String[] LABELS = {LABEL};
+    /**
+     * We are using the 'defaultRegistry'.
+     * <p>
+     * When you are running ZooKeeper (server or client) together with other
+     * libraries every metrics will be expected as a single view.
+     *
+     */
+    private final CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry;
+    private int port = 7000;
+    private boolean exportJvmInfo = true;
+    private Server server;
+    private final MetricsServletImpl servlet = new MetricsServletImpl();
+    private final Context rootContext = new Context();
+
+    @Override
+    public void configure(Properties configuration) throws MetricsProviderLifeCycleException {
+        LOG.info("Initializing metrics, configuration: {}", configuration);
+        this.port = Integer.parseInt(configuration.getProperty("httpPort", "7000"));
+        this.exportJvmInfo = Boolean.parseBoolean(configuration.getProperty("exportJvmInfo", "true"));
+    }
+
+    @Override
+    public void start() throws MetricsProviderLifeCycleException {
+        try {
+            LOG.info("Starting /metrics HTTP endpoint at port {} exportJvmInfo: {}", port, exportJvmInfo);
+            if (exportJvmInfo) {
+                DefaultExports.initialize();
+            }
+            server = new Server(port);
+            ServletContextHandler context = new ServletContextHandler();
+            context.setContextPath("/");
+            server.setHandler(context);
+            context.addServlet(new ServletHolder(servlet), "/metrics");
+            server.start();
+        } catch (Exception err) {
+            LOG.error("Cannot start /metrics server", err);
+            if (server != null) {
+                try {
+                    server.stop();
+                } catch (Exception suppressed) {
+                    err.addSuppressed(suppressed);
+                } finally {
+                    server = null;
+                }
+            }
+            throw new MetricsProviderLifeCycleException(err);
+        }
+    }
+
+    // for tests
+    MetricsServletImpl getServlet() {
+        return servlet;
+    }
+
+    @Override
+    public MetricsContext getRootContext() {
+        return rootContext;
+    }
+
+    @Override
+    public void stop() {
+        if (server != null) {
+            try {
+                server.stop();
+            } catch (Exception err) {
+                LOG.error("Cannot safely stop Jetty server", err);
+            } finally {
+                server = null;
+            }
+        }
+    }
+
+    /**
+     * Dump all values to the 4lw interface and to the Admin server.
+     * <p>
+     * This method is not expected to be used to serve metrics to Prometheus. We
+     * are using the MetricsServlet provided by Prometheus for that, leaving the
+     * real representation to the Prometheus Java client.
+     *
+     * @param sink the receiver of data (4lw interface, Admin server or tests)
+     */
+    @Override
+    public void dump(BiConsumer<String, Object> sink) {
+        sampleGauges();
+        Enumeration<Collector.MetricFamilySamples> samplesFamilies = collectorRegistry.metricFamilySamples();
+        while (samplesFamilies.hasMoreElements()) {
+            Collector.MetricFamilySamples samples = samplesFamilies.nextElement();
+            samples.samples.forEach(sample -> {
+                String key = buildKeyForDump(sample);
+                sink.accept(key, sample.value);
+            });
+        }
+    }
+
+    private static String buildKeyForDump(Collector.MetricFamilySamples.Sample sample) {
+        StringBuilder keyBuilder = new StringBuilder();
+        keyBuilder.append(sample.name);
+        if (sample.labelNames.size() > 0) {
+            keyBuilder.append('{');
+            for (int i = 0; i < sample.labelNames.size(); ++i) {
+                if (i > 0) {
+                    keyBuilder.append(',');
+                }
+                keyBuilder.append(sample.labelNames.get(i));
+                keyBuilder.append("=\"");
+                keyBuilder.append(sample.labelValues.get(i));
+                keyBuilder.append('"');
+            }
+            keyBuilder.append('}');
+        }
+        return keyBuilder.toString();
+    }
+
+    /**
+     * Update Gauges. In ZooKeeper Metrics API Gauges are callbacks served by
+     * internal components and the value is not held by Prometheus structures.
+     */
+    private void sampleGauges() {
+        rootContext.gauges.values()
+                .forEach(PrometheusGaugeWrapper::sample);
+    }
+
+    @Override
+    public void resetAllValues() {
+        // not supported on Prometheus
+    }
+
+    private class Context implements MetricsContext {
+
+        private final ConcurrentMap<String, PrometheusGaugeWrapper> gauges = new ConcurrentHashMap<>();
+        private final ConcurrentMap<String, PrometheusCounter> counters = new ConcurrentHashMap<>();
+        private final ConcurrentMap<String, PrometheusSummary> basicSummaries = new ConcurrentHashMap<>();
+        private final ConcurrentMap<String, PrometheusSummary> summaries = new ConcurrentHashMap<>();
+        private final ConcurrentMap<String, PrometheusLabelledSummary> basicSummarySets = new ConcurrentHashMap<>();
+        private final ConcurrentMap<String, PrometheusLabelledSummary> summarySets = new ConcurrentHashMap<>();
+
+        @Override
+        public MetricsContext getContext(String name) {
+            // no hierarchy yet
+            return this;
+        }
+
+        @Override
+        public Counter getCounter(String name) {
+            return counters.computeIfAbsent(name, (n) -> {
+                return new PrometheusCounter(n);
+            });
+        }
+
+        /**
+         * Gauges may go up and down, in ZooKeeper they are a way to export
+         * internal values with a callback.
+         *
+         * @param name the name of the gauge
+         * @param gauge the callback
+         */
+        @Override
+        public void registerGauge(String name, Gauge gauge) {
+            Objects.requireNonNull(name);
+            gauges.compute(name, (id, prev) -> {
+                return new PrometheusGaugeWrapper(id, gauge,
+                        prev != null ? prev.inner : null);
+            });
+        }
+
+        @Override
+        public void unregisterGauge(String name) {
+            PrometheusGaugeWrapper existing = gauges.remove(name);
+            if (existing != null) {
+                existing.unregister();
+            }
+        }
+
+        @Override
+        public Summary getSummary(String name, DetailLevel detailLevel) {
+            if (detailLevel == DetailLevel.BASIC) {
+                return basicSummaries.computeIfAbsent(name, (n) -> {
+                    if (summaries.containsKey(n)) {
+                        throw new IllegalArgumentException("Already registered a non basic summary as " + n);
+                    }
+                    return new PrometheusSummary(name, detailLevel);
+                });
+            } else {
+                return summaries.computeIfAbsent(name, (n) -> {
+                    if (basicSummaries.containsKey(n)) {
+                        throw new IllegalArgumentException("Already registered a basic summary as " + n);
+                    }
+                    return new PrometheusSummary(name, detailLevel);
+                });
+            }
+        }
+
+        @Override
+        public SummarySet getSummarySet(String name, DetailLevel detailLevel) {
+            if (detailLevel == DetailLevel.BASIC) {
+                return basicSummarySets.computeIfAbsent(name, (n) -> {
+                    if (summarySets.containsKey(n)) {
+                        throw new IllegalArgumentException("Already registered a non basic summary set as " + n);
+                    }
+                    return new PrometheusLabelledSummary(name, detailLevel);
+                });
+            } else {
+                return summarySets.computeIfAbsent(name, (n) -> {
+                    if (basicSummarySets.containsKey(n)) {
+                        throw new IllegalArgumentException("Already registered a basic summary set as " + n);
+                    }
+                    return new PrometheusLabelledSummary(name, detailLevel);
+                });
+            }
+        }
+
+    }
+
+    private class PrometheusCounter implements Counter {
+
+        private final io.prometheus.client.Counter inner;
+        private final String name;
+
+        public PrometheusCounter(String name) {
+            this.name = name;
+            this.inner = io.prometheus.client.Counter
+                    .build(name, name)
+                    .register(collectorRegistry);
+        }
+
+        @Override
+        public void add(long delta) {
+            try {
+                inner.inc(delta);
+            } catch (IllegalArgumentException err) {
+                LOG.error("invalid delta " + delta + " for metric " + name, err);
+            }
+        }
+
+        @Override
+        public long get() {
+            // this method is used only for tests
+            // Prometheus returns a "double"
+            // it is safe to fine to a long
+            // we are never setting non-integer values
+            return (long) inner.get();
+        }
+
+    }
+
+    private class PrometheusGaugeWrapper {
+
+        private final io.prometheus.client.Gauge inner;
+        private final Gauge gauge;
+        private final String name;
+
+        public PrometheusGaugeWrapper(String name, Gauge gauge, io.prometheus.client.Gauge prev) {
+            this.name = name;
+            this.gauge = gauge;
+            this.inner = prev != null ? prev
+                    : io.prometheus.client.Gauge
+                            .build(name, name)
+                            .register(collectorRegistry);
+        }
+
+        /**
+         * Call the callack and update Prometheus Gauge. This method is called
+         * when the server is polling for a value.
+         */
+        private void sample() {
+            Number value = gauge.get();
+            this.inner.set(value != null ? value.doubleValue() : 0);
+        }
+
+        private void unregister() {
+            collectorRegistry.unregister(inner);
+        }
+
+    }
+
+    private class PrometheusSummary implements Summary {
+
+        private final io.prometheus.client.Summary inner;
+        private final String name;
+
+        public PrometheusSummary(String name, MetricsContext.DetailLevel level) {
+            this.name = name;
+            if (level == MetricsContext.DetailLevel.ADVANCED) {
+                this.inner = io.prometheus.client.Summary
+                        .build(name, name)
+                        .quantile(0.5, 0.05) // Add 50th percentile (= median) with 5% tolerated error
+                        .quantile(0.9, 0.01) // Add 90th percentile with 1% tolerated error
+                        .quantile(0.99, 0.001) // Add 99th percentile with 0.1% tolerated error
+                        .register(collectorRegistry);
+            } else {
+                this.inner = io.prometheus.client.Summary
+                        .build(name, name)
+                        .quantile(0.5, 0.05) // Add 50th percentile (= median) with 5% tolerated error
+                        .register(collectorRegistry);
+            }
+        }
+
+        @Override
+        public void add(long delta) {
+            try {
+                inner.observe(delta);
+            } catch (IllegalArgumentException err) {
+                LOG.error("invalid delta " + delta + " for metric " + name, err);
+            }
+        }
+
+    }
+
+    private class PrometheusLabelledSummary implements SummarySet {
+
+        private final io.prometheus.client.Summary inner;
+        private final String name;
+
+        public PrometheusLabelledSummary(String name, MetricsContext.DetailLevel level) {
+            this.name = name;
+            if (level == MetricsContext.DetailLevel.ADVANCED) {
+                this.inner = io.prometheus.client.Summary
+                        .build(name, name)
+                        .labelNames(LABELS)
+                        .quantile(0.5, 0.05) // Add 50th percentile (= median) with 5% tolerated error
+                        .quantile(0.9, 0.01) // Add 90th percentile with 1% tolerated error
+                        .quantile(0.99, 0.001) // Add 99th percentile with 0.1% tolerated error
+                        .register(collectorRegistry);
+            } else {
+                this.inner = io.prometheus.client.Summary
+                        .build(name, name)
+                        .labelNames(LABELS)
+                        .quantile(0.5, 0.05) // Add 50th percentile (= median) with 5% tolerated error
+                        .register(collectorRegistry);
+            }
+        }
+
+        @Override
+        public void add(String key, long value) {
+            try {
+                inner.labels(key).observe(value);
+            } catch (IllegalArgumentException err) {
+                LOG.error("invalid value " + value + " for metric " + name + " with key " + key, err);
+            }
+        }
+
+    }
+
+    class MetricsServletImpl extends MetricsServlet {
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            // little trick: update the Gauges before serving data
+            // from Prometheus CollectorRegistry
+            sampleGauges();
+            // serve data using Prometheus built in client.
+            super.doGet(req, resp);
+        }
+    }
+}

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/ExportJvmInfoTest.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/ExportJvmInfoTest.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.metrics.prometheus;
+
+import io.prometheus.client.CollectorRegistry;
+import java.util.Properties;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ * Tests about Prometheus Metrics Provider. Please note that we are not testing
+ * Prometheus but our integration.
+ */
+public class ExportJvmInfoTest {
+
+    @Test
+    public void exportInfo() throws Exception {
+        runTest(true);
+    }
+
+    @Test
+    public void doNotExportInfo() throws Exception {
+        runTest(false);
+    }
+
+    private void runTest(boolean exportJvmInfo) throws Exception {
+        CollectorRegistry.defaultRegistry.clear();
+        PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
+        try {
+            Properties configuration = new Properties();
+            configuration.setProperty("httpPort", "0"); // ephemeral port
+            configuration.setProperty("exportJvmInfo", exportJvmInfo + "");
+            provider.configure(configuration);
+            provider.start();
+            boolean[] found = {false};
+            provider.dump((k, v) -> {
+                found[0] = found[0] || k.contains("heap");
+            });
+            assertEquals(exportJvmInfo, found[0]);
+        } finally {
+            provider.stop();
+        }
+    }
+
+}

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderTest.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderTest.java
@@ -1,0 +1,295 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.metrics.prometheus;
+
+import io.prometheus.client.CollectorRegistry;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Properties;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.zookeeper.metrics.Counter;
+import org.apache.zookeeper.metrics.Gauge;
+import org.apache.zookeeper.metrics.MetricsContext;
+import org.apache.zookeeper.metrics.Summary;
+import org.hamcrest.CoreMatchers;
+import static org.hamcrest.CoreMatchers.containsString;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests about Prometheus Metrics Provider. Please note that we are not testing
+ * Prometheus but only our integration.
+ */
+public class PrometheusMetricsProviderTest {
+
+    private PrometheusMetricsProvider provider;
+
+    @Before
+    public void setup() throws Exception {
+        CollectorRegistry.defaultRegistry.clear();
+        provider = new PrometheusMetricsProvider();
+        Properties configuration = new Properties();
+        configuration.setProperty("httpPort", "0"); // ephemeral port
+        configuration.setProperty("exportJvmInfo", "false");
+        provider.configure(configuration);
+        provider.start();
+    }
+
+    @After
+    public void tearDown() {
+        if (provider != null) {
+            provider.stop();
+        }
+        CollectorRegistry.defaultRegistry.clear();
+    }
+
+    @Test
+    public void testCounters() throws Exception {
+        Counter counter = provider.getRootContext().getCounter("cc");
+        counter.add(10);
+        int[] count = {0};
+        provider.dump((k, v) -> {
+            assertEquals("cc", k);
+            assertEquals(10, ((Number) v).intValue());
+            count[0]++;
+        }
+        );
+        assertEquals(1, count[0]);
+        count[0] = 0;
+
+        // this is not allowed but it must not throw errors
+        counter.add(-1);
+
+        provider.dump((k, v) -> {
+            assertEquals("cc", k);
+            assertEquals(10, ((Number) v).intValue());
+            count[0]++;
+        }
+        );
+        assertEquals(1, count[0]);
+
+        // we always must get the same object
+        assertSame(counter, provider.getRootContext().getCounter("cc"));
+
+        String res = callServlet();
+        assertThat(res, CoreMatchers.containsString("# TYPE cc counter"));
+        assertThat(res, CoreMatchers.containsString("cc 10.0"));
+    }
+
+    @Test
+    public void testGauge() throws Exception {
+        int[] values = {78, -89};
+        int[] callCounts = {0, 0};
+        Gauge gauge0 = () -> {
+            callCounts[0]++;
+            return values[0];
+        };
+        Gauge gauge1 = () -> {
+            callCounts[1]++;
+            return values[1];
+        };
+        provider.getRootContext().registerGauge("gg", gauge0);
+
+        int[] count = {0};
+        provider.dump((k, v) -> {
+            assertEquals("gg", k);
+            assertEquals(values[0], ((Number) v).intValue());
+            count[0]++;
+        }
+        );
+        assertEquals(1, callCounts[0]);
+        assertEquals(0, callCounts[1]);
+        assertEquals(1, count[0]);
+        count[0] = 0;
+        String res2 = callServlet();
+        assertThat(res2, CoreMatchers.containsString("# TYPE gg gauge"));
+        assertThat(res2, CoreMatchers.containsString("gg 78.0"));
+
+        provider.getRootContext().unregisterGauge("gg");
+        provider.dump((k, v) -> {
+            count[0]++;
+        }
+        );
+        assertEquals(2, callCounts[0]);
+        assertEquals(0, callCounts[1]);
+        assertEquals(0, count[0]);
+        String res3 = callServlet();
+        assertTrue(res3.isEmpty());
+
+        provider.getRootContext().registerGauge("gg", gauge1);
+
+        provider.dump((k, v) -> {
+            assertEquals("gg", k);
+            assertEquals(values[1], ((Number) v).intValue());
+            count[0]++;
+        }
+        );
+        assertEquals(2, callCounts[0]);
+        assertEquals(1, callCounts[1]);
+        assertEquals(1, count[0]);
+        count[0] = 0;
+
+        String res4 = callServlet();
+        assertThat(res4, CoreMatchers.containsString("# TYPE gg gauge"));
+        assertThat(res4, CoreMatchers.containsString("gg -89.0"));
+        assertEquals(2, callCounts[0]);
+        // the servlet must sample the value again (from gauge1)
+        assertEquals(2, callCounts[1]);
+
+        // override gauge, without unregister
+        provider.getRootContext().registerGauge("gg", gauge0);
+
+        provider.dump((k, v) -> {
+            count[0]++;
+        }
+        );
+        assertEquals(1, count[0]);
+        assertEquals(3, callCounts[0]);
+        assertEquals(2, callCounts[1]);
+    }
+
+    @Test
+    public void testBasicSummary() throws Exception {
+        Summary summary = provider.getRootContext()
+                .getSummary("cc", MetricsContext.DetailLevel.BASIC);
+        summary.add(10);
+        summary.add(10);
+        int[] count = {0};
+        provider.dump((k, v) -> {
+            count[0]++;
+            int value = ((Number) v).intValue();
+
+            switch (k) {
+                case "cc{quantile=\"0.5\"}":
+                    assertEquals(10, value);
+                    break;
+                case "cc_count":
+                    assertEquals(2, value);
+                    break;
+                case "cc_sum":
+                    assertEquals(20, value);
+                    break;
+                default:
+                    fail("unespected key " + k);
+                    break;
+            }
+        }
+        );
+        assertEquals(3, count[0]);
+        count[0] = 0;
+
+        // we always must get the same object
+        assertSame(summary, provider.getRootContext()
+                .getSummary("cc", MetricsContext.DetailLevel.BASIC));
+
+        try {
+            provider.getRootContext()
+                    .getSummary("cc", MetricsContext.DetailLevel.ADVANCED);
+            fail("Can't get the same summary with a different DetailLevel");
+        } catch (IllegalArgumentException err) {
+            assertThat(err.getMessage(), containsString("Already registered"));
+        }
+
+        String res = callServlet();
+        assertThat(res, containsString("# TYPE cc summary"));
+        assertThat(res, CoreMatchers.containsString("cc_sum 20.0"));
+        assertThat(res, CoreMatchers.containsString("cc_count 2.0"));
+        assertThat(res, CoreMatchers.containsString("cc{quantile=\"0.5\",} 10.0"));
+    }
+
+    @Test
+    public void testAdvancedSummary() throws Exception {
+        Summary summary = provider.getRootContext()
+                .getSummary("cc", MetricsContext.DetailLevel.ADVANCED);
+        summary.add(10);
+        summary.add(10);
+        int[] count = {0};
+        provider.dump((k, v) -> {
+            count[0]++;
+            int value = ((Number) v).intValue();
+
+            switch (k) {
+                case "cc{quantile=\"0.5\"}":
+                    assertEquals(10, value);
+                    break;
+                case "cc{quantile=\"0.9\"}":
+                    assertEquals(10, value);
+                    break;
+                case "cc{quantile=\"0.99\"}":
+                    assertEquals(10, value);
+                    break;
+                case "cc_count":
+                    assertEquals(2, value);
+                    break;
+                case "cc_sum":
+                    assertEquals(20, value);
+                    break;
+                default:
+                    fail("unespected key " + k);
+                    break;
+            }
+        }
+        );
+        assertEquals(5, count[0]);
+        count[0] = 0;
+
+        // we always must get the same object
+        assertSame(summary, provider.getRootContext()
+                .getSummary("cc", MetricsContext.DetailLevel.ADVANCED));
+
+        try {
+            provider.getRootContext()
+                    .getSummary("cc", MetricsContext.DetailLevel.BASIC);
+            fail("Can't get the same summary with a different DetailLevel");
+        } catch (IllegalArgumentException err) {
+            assertThat(err.getMessage(), containsString("Already registered"));
+        }
+
+        String res = callServlet();
+        assertThat(res, containsString("# TYPE cc summary"));
+        assertThat(res, CoreMatchers.containsString("cc_sum 20.0"));
+        assertThat(res, CoreMatchers.containsString("cc_count 2.0"));
+        assertThat(res, CoreMatchers.containsString("cc{quantile=\"0.5\",} 10.0"));
+        assertThat(res, CoreMatchers.containsString("cc{quantile=\"0.9\",} 10.0"));
+        assertThat(res, CoreMatchers.containsString("cc{quantile=\"0.99\",} 10.0"));
+    }
+
+    private String callServlet() throws ServletException, IOException {
+        // we are not performing an HTTP request
+        // but we are calling directly the servlet
+        StringWriter writer = new StringWriter();
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(response.getWriter()).thenReturn(new PrintWriter(writer));
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        provider.getServlet().doGet(req, response);
+        String res = writer.toString();
+        return res;
+    }
+
+}

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/resources/log4j.properties
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/resources/log4j.properties
@@ -1,0 +1,65 @@
+# Copyright 2012 The Apache Software Foundation
+# 
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define some default values that can be overridden by system properties
+zookeeper.root.logger=INFO, CONSOLE
+
+zookeeper.console.threshold=INFO
+
+zookeeper.log.dir=.
+zookeeper.log.file=zookeeper.log
+zookeeper.log.threshold=INFO
+zookeeper.log.maxfilesize=256MB
+zookeeper.log.maxbackupindex=20
+
+zookeeper.tracelog.dir=${zookeeper.log.dir}
+zookeeper.tracelog.file=zookeeper_trace.log
+
+log4j.rootLogger=${zookeeper.root.logger}
+
+#
+# console
+# Add "console" to rootlogger above if you want to use this 
+#
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.Threshold=${zookeeper.console.threshold}
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+
+#
+# Add ROLLINGFILE to rootLogger to get log file output
+#
+log4j.appender.ROLLINGFILE=org.apache.log4j.RollingFileAppender
+log4j.appender.ROLLINGFILE.Threshold=${zookeeper.log.threshold}
+log4j.appender.ROLLINGFILE.File=${zookeeper.log.dir}/${zookeeper.log.file}
+log4j.appender.ROLLINGFILE.MaxFileSize=${zookeeper.log.maxfilesize}
+log4j.appender.ROLLINGFILE.MaxBackupIndex=${zookeeper.log.maxbackupindex}
+log4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+
+#
+# Add TRACEFILE to rootLogger to get log file output
+#    Log TRACE level and above messages to a log file
+#
+log4j.appender.TRACEFILE=org.apache.log4j.FileAppender
+log4j.appender.TRACEFILE.Threshold=TRACE
+log4j.appender.TRACEFILE.File=${zookeeper.tracelog.dir}/${zookeeper.tracelog.file}
+
+log4j.appender.TRACEFILE.layout=org.apache.log4j.PatternLayout
+### Notice we are including log4j's NDC here (%x)
+log4j.appender.TRACEFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L][%x] - %m%n

--- a/zookeeper-server/src/main/resources/lib/simpleclient-0.6.0.LICENSE.txt
+++ b/zookeeper-server/src/main/resources/lib/simpleclient-0.6.0.LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 1999-2005 The Apache Software Foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/zookeeper-server/src/main/resources/lib/simpleclient_common-0.6.0_LICENSE.txt
+++ b/zookeeper-server/src/main/resources/lib/simpleclient_common-0.6.0_LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 1999-2005 The Apache Software Foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/zookeeper-server/src/main/resources/lib/simpleclient_hotspot-0.6.0_LICENSE.txt
+++ b/zookeeper-server/src/main/resources/lib/simpleclient_hotspot-0.6.0_LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 1999-2005 The Apache Software Foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/zookeeper-server/src/main/resources/lib/simpleclient_servlet-0.6.0_LICENSE.txt
+++ b/zookeeper-server/src/main/resources/lib/simpleclient_servlet-0.6.0_LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 1999-2005 The Apache Software Foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Implement a MetricsProvider that exports data to Prometheus.io.
- introduce a new Maven module zookeeper-metrics-providers
- introduce an implementation of the MetricProvider that uses the Java library provided by Prometheus.io
- add the Provider to the binary tar ball
- add LICENSE files for Prometheus.io jars (it is ASL 2.0)
- add docs about configuration parameters
- change zoo_sample.cfg with the available configuration options (commented out by default)