### PR TITLE
ZOOKEEPER-3413:add a serialVersionUID for ClientCnxnLimitException to make compile no warning

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ClientCnxnLimitException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ClientCnxnLimitException.java
@@ -22,6 +22,8 @@ package org.apache.zookeeper.server;
  * Indicates that the number of client connections has exceeded some limit.
  */
 public class ClientCnxnLimitException extends Exception {
+    private static final long serialVersionUID = -8655587505476768446L;
+
     public ClientCnxnLimitException() {
         super("Connection throttle rejected connection");
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/LogFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/LogFormatter.java
@@ -40,6 +40,7 @@ import org.apache.zookeeper.txn.TxnHeader;
 /**
  * @deprecated deprecated in 3.5.5, use @see TxnLogToolkit instead
  */
+@Deprecated
 @InterfaceAudience.Public
 public class LogFormatter {
     private static final Logger LOG = LoggerFactory.getLogger(LogFormatter.class);


### PR DESCRIPTION
- the complier complains about these two warning recently.Look at [here](https://builds.apache.org/job/PreCommit-ZOOKEEPER-github-pr-build/3987/artifact/patchprocess/patchJavadocWarnings.txt)

> compile:
    [javac] Compiling 316 source files to /home/jenkins/jenkins-slave/workspace/PreCommit-ZOOKEEPER-github-pr-build@2/build/classes
    [javac] /home/jenkins/jenkins-slave/workspace/PreCommit-ZOOKEEPER-github-pr-build@2/zookeeper-server/src/main/java/org/apache/zookeeper/server/ClientCnxnLimitException.java:24: warning: [serial] serializable class ClientCnxnLimitException has no definition of serialVersionUID
    [javac] public class ClientCnxnLimitException extends Exception {
    [javac]        ^
    [javac] /home/jenkins/jenkins-slave/workspace/PreCommit-ZOOKEEPER-github-pr-build@2/zookeeper-server/src/main/java/org/apache/zookeeper/server/LogFormatter.java:44: warning: [dep-ann] deprecated item is not annotated with @Deprecated
    [javac] public class LogFormatter {
    [javac]        ^
    [javac] 2 warnings

- more details in the [ZOOKEEPER-3413](https://issues.apache.org/jira/browse/ZOOKEEPER-3413) 