### PR TITLE
ZOOKEEPER-2122 Impplement SSL support in the Zookeeper C client library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,17 @@ zookeeper-client/zookeeper-client-c/ltmain.sh
 zookeeper-client/zookeeper-client-c/missing
 zookeeper-server/src/main/java/org/apache/zookeeper/version/Info.java
 zookeeper-server/src/test/resources/
+zookeeper-client/zookeeper-client-c/.deps/
+zookeeper-client/zookeeper-client-c/.libs/
+zookeeper-client/zookeeper-client-c/Makefile
+zookeeper-client/zookeeper-client-c/cli_mt
+zookeeper-client/zookeeper-client-c/cli_st
+zookeeper-client/zookeeper-client-c/config.h
+zookeeper-client/zookeeper-client-c/config.status
+zookeeper-client/zookeeper-client-c/libtool
+zookeeper-client/zookeeper-client-c/load_gen
+zookeeper-client/zookeeper-client-c/stamp-h1
+zookeeper-client/zookeeper-client-c/build
 
 # Python
 *.py[cod]

--- a/zookeeper-client/zookeeper-client-c/CMakeLists.txt
+++ b/zookeeper-client/zookeeper-client-c/CMakeLists.txt
@@ -182,6 +182,14 @@ target_link_libraries(zookeeper PUBLIC
   $<$<PLATFORM_ID:Linux>:rt> # clock_gettime
   $<$<PLATFORM_ID:Windows>:ws2_32>) # Winsock 2.0
 
+option(WITH_OPENSSL "openssl directory" OFF)
+if(WITH_OPENSSL)
+  target_compile_definitions(zookeeper PUBLIC HAVE_OPENSSL_H)
+  include_directories(${WITH_OPENSSL}/include)
+  link_directories(${WITH_OPENSSL}/lib)
+  target_link_libraries(zookeeper PUBLIC ssl crypto)
+endif()
+
 if(WANT_SYNCAPI AND NOT WIN32)
   find_package(Threads REQUIRED)
   target_link_libraries(zookeeper PUBLIC Threads::Threads)
@@ -224,6 +232,7 @@ if(WANT_SYNCAPI)
 endif()
 
 if(WANT_CPPUNIT)
+  set (CMAKE_CXX_STANDARD 11)
   add_executable(zktest ${test_sources})
   target_include_directories(zktest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/zookeeper-client/zookeeper-client-c/Makefile.am
+++ b/zookeeper-client/zookeeper-client-c/Makefile.am
@@ -1,22 +1,29 @@
 # need this for Doxygen integration
 include $(top_srcdir)/aminclude.am
 
-AUTOMAKE_OPTIONS = serial-tests
+#Many of our build machines are running older automake
+#AUTOMAKE_OPTIONS = serial-tests
+
 if SOLARIS
   SOLARIS_CPPFLAGS = -D_POSIX_PTHREAD_SEMANTICS
   SOLARIS_LIB_LDFLAGS = -lnsl -lsocket
 endif
-AM_CPPFLAGS = -I${srcdir}/include -I${srcdir}/tests -I${srcdir}/generated $(SOLARIS_CPPFLAGS)
+
+if WANT_OPENSSL
+  OPENSSL_CPPFLAGS = -DHAVE_OPENSSL_H -I$(OPENSSL_DIR)
+  OPENSSL_LIB_LDFLAGS = -lssl -lcrypto
+endif
+
+AM_CPPFLAGS = -I${srcdir}/include -I${srcdir}/tests -I${srcdir}/generated $(SOLARIS_CPPFLAGS) $(OPENSSL_CPPFLAGS)
 AM_CFLAGS = -Wall -Werror -Wdeclaration-after-statement
 AM_CXXFLAGS = -Wall $(USEIPV6)
+LIB_LDFLAGS = -no-undefined -version-info 2 $(SOLARIS_LIB_LDFLAGS) $(OPENSSL_LIB_LDFLAGS)
 
 # Additional flags for coverage testing (if enabled)
 if ENABLEGCOV
   AM_CFLAGS += -fprofile-arcs -ftest-coverage
   AM_LDFLAGS = -lgcov
 endif
-
-LIB_LDFLAGS = -no-undefined -version-info 2 $(SOLARIS_LIB_LDFLAGS)
 
 pkginclude_HEADERS = include/zookeeper.h include/zookeeper_version.h include/zookeeper_log.h include/proto.h include/recordio.h generated/zookeeper.jute.h
 EXTRA_DIST=LICENSE
@@ -120,14 +127,14 @@ check_PROGRAMS = zktest-st
 TESTS_ENVIRONMENT = ZKROOT=${srcdir}/../.. \
                     CLASSPATH=$$CLASSPATH:$$CLOVER_HOME/lib/clover*.jar
 nodist_zktest_st_SOURCES = $(TEST_SOURCES)
-zktest_st_LDADD = libzkst.la libhashtable.la $(CPPUNIT_LIBS) -ldl
+zktest_st_LDADD = libzkst.la libhashtable.la $(CPPUNIT_LIBS) $(OPENSSL_LIB_LDFLAGS) -ldl
 zktest_st_CXXFLAGS = -DUSE_STATIC_LIB $(CPPUNIT_CFLAGS) $(USEIPV6) $(SOLARIS_CPPFLAGS)
 zktest_st_LDFLAGS = -shared $(SYMBOL_WRAPPERS) $(SOLARIS_LIB_LDFLAGS)
 
 if WANT_SYNCAPI
   check_PROGRAMS += zktest-mt
   nodist_zktest_mt_SOURCES = $(TEST_SOURCES) tests/PthreadMocks.cc
-  zktest_mt_LDADD = libzkmt.la libhashtable.la -lpthread $(CPPUNIT_LIBS) -ldl
+  zktest_mt_LDADD = libzkmt.la libhashtable.la -lpthread $(CPPUNIT_LIBS) $(OPENSSL_LIB_LDFLAGS) -ldl
   zktest_mt_CXXFLAGS = -DUSE_STATIC_LIB -DTHREADED $(CPPUNIT_CFLAGS) $(USEIPV6)
 if SOLARIS
   SHELL_SYMBOL_WRAPPERS_MT = cat ${srcdir}/tests/wrappers-mt.opt

--- a/zookeeper-client/zookeeper-client-c/Makefile.am
+++ b/zookeeper-client/zookeeper-client-c/Makefile.am
@@ -1,8 +1,7 @@
 # need this for Doxygen integration
 include $(top_srcdir)/aminclude.am
 
-#Many of our build machines are running older automake
-#AUTOMAKE_OPTIONS = serial-tests
+AUTOMAKE_OPTIONS = serial-tests
 
 if SOLARIS
   SOLARIS_CPPFLAGS = -D_POSIX_PTHREAD_SEMANTICS

--- a/zookeeper-client/zookeeper-client-c/configure.ac
+++ b/zookeeper-client/zookeeper-client-c/configure.ac
@@ -22,7 +22,20 @@ DX_PS_FEATURE(OFF)
 DX_INIT_DOXYGEN([zookeeper],[c-doc.Doxyfile],[docs])
 
 # initialize automake
-AM_INIT_AUTOMAKE([-Wall foreign])
+dnl Initialize automake.  automake < 1.12 didn't have serial-tests and
+dnl gives an error if it sees this, but for automake >= 1.13
+dnl serial-tests is required so we have to include it.  Solution is to
+dnl test for the version of automake (by running an external command)
+dnl and provide it if necessary.  Note we have to do this entirely using
+dnl m4 macros since automake queries this macro by running
+dnl 'autoconf --trace ...'.
+m4_define([serial_tests], [
+    m4_esyscmd([automake --version |
+                head -1 |
+                awk '{split ($NF,a,"."); if (a[1] == 1 && a[2] >= 12) { print "serial-tests" }}'
+    ])
+])
+AM_INIT_AUTOMAKE(-Wall foreign serial_tests) dnl NB: Do not [quote] this parameter.
 AC_CONFIG_HEADER([config.h])
 
 # Checks for programs.
@@ -36,6 +49,26 @@ if test "$with_cppunit" = "no" ; then
 else
    CHECK_CPPUNIT(1.10.2)
 fi
+
+AM_CONDITIONAL([WANT_OPENSSL],[test "x$with_openssl" != x])
+
+
+AC_ARG_WITH(openssl,
+  AS_HELP_STRING([--without-openssl],
+                 [Do not use Openssl. Default: auto-detect]), [
+case "$with_openssl" in
+  yes|no)
+    : # Nothing special to do here
+    ;;
+  *)
+    if test ! -d "$withval" ; then
+      AC_MSG_ERROR([--with-openssl path does not point to a directory])
+    fi
+       OPENSSL_DIR="$withval"
+    AC_SUBST(OPENSSL_DIR)
+  esac
+])
+AH_TEMPLATE(USE_OPENSSL,[Openssl support is available])
 
 if test "$CALLER" = "ANT" ; then
 CPPUNIT_CFLAGS="$CPPUNIT_CFLAGS -DZKSERVER_CMD=\"\\\"${base_dir}/zookeeper-client/zookeeper-client-c/tests/zkServer.sh\\\"\""
@@ -91,6 +124,9 @@ AC_ARG_ENABLE(gcov, [AS_HELP_STRING([--enable-gcov],[enable coverage test])])
 AC_MSG_CHECKING([whether to enable gcov])
 AS_IF([test "x${enable_gcov}" = "xyes"],AC_MSG_RESULT([yes]),AC_MSG_RESULT([no]))
 AM_CONDITIONAL([ENABLEGCOV],[test "x${enable_gcov}" = "xyes"])
+
+
+CXXFLAGS="$CXXFLAGS -std=c++11"
 
 AC_ARG_WITH([syncapi],
  [AS_HELP_STRING([--with-syncapi],[build with support for SyncAPI [default=yes]])],

--- a/zookeeper-client/zookeeper-client-c/configure.ac
+++ b/zookeeper-client/zookeeper-client-c/configure.ac
@@ -22,20 +22,8 @@ DX_PS_FEATURE(OFF)
 DX_INIT_DOXYGEN([zookeeper],[c-doc.Doxyfile],[docs])
 
 # initialize automake
-dnl Initialize automake.  automake < 1.12 didn't have serial-tests and
-dnl gives an error if it sees this, but for automake >= 1.13
-dnl serial-tests is required so we have to include it.  Solution is to
-dnl test for the version of automake (by running an external command)
-dnl and provide it if necessary.  Note we have to do this entirely using
-dnl m4 macros since automake queries this macro by running
-dnl 'autoconf --trace ...'.
-m4_define([serial_tests], [
-    m4_esyscmd([automake --version |
-                head -1 |
-                awk '{split ($NF,a,"."); if (a[1] == 1 && a[2] >= 12) { print "serial-tests" }}'
-    ])
-])
-AM_INIT_AUTOMAKE(-Wall foreign serial_tests) dnl NB: Do not [quote] this parameter.
+AM_INIT_AUTOMAKE([-Wall foreign])
+
 AC_CONFIG_HEADER([config.h])
 
 # Checks for programs.

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper.h
@@ -32,6 +32,10 @@
 #include <ws2tcpip.h> /* for struct sock_addr and socklen_t */
 #endif
 
+#ifdef HAVE_OPENSSL_H
+#include <openssl/ossl_typ.h>
+#endif
+
 #include <stdio.h>
 #include <ctype.h>
 
@@ -106,6 +110,7 @@ enum ZOO_ERRORS {
   ZRECONFIGINPROGRESS = -14, /*!< Reconfiguration requested while another
                                   reconfiguration is currently in progress. This
                                   is currently not supported. Please retry. */
+  ZSSLCONNECTIONERROR = -15, /*!< The SSL connection Error */
 
   /** API errors.
    * This is never thrown by the server, it shouldn't be used other than
@@ -282,6 +287,34 @@ extern ZOOAPI const int ZOO_NOTWATCHING_EVENT;
  * \ref zookeeper_init.
  */
 typedef struct _zhandle zhandle_t;
+
+/**
+ * This structure represents the certificates to zookeeper.
+ */
+typedef struct _zcert {
+    char *certstr;
+    char *ca;
+    char *cert;
+    char *key;
+    char *passwd;
+} zcert_t;
+
+/**
+ * This structure represents the socket to zookeeper.
+ */
+typedef struct _zsock {
+#ifdef WIN32
+    SOCKET sock;
+#else
+    int sock;
+#endif
+    zcert_t *cert;
+#ifdef HAVE_OPENSSL_H
+    SSL *ssl_sock;
+    SSL_CTX *ssl_ctx;
+#endif
+} zsock_t;
+
 
 /**
  * \brief client id structure.
@@ -494,6 +527,13 @@ typedef void (*log_callback_fn)(const char *message);
  */
 ZOOAPI zhandle_t *zookeeper_init(const char *host, watcher_fn fn,
   int recv_timeout, const clientid_t *clientid, void *context, int flags);
+
+#ifdef HAVE_OPENSSL_H
+ZOOAPI zhandle_t *zookeeper_init_ssl(const char *host, const char *cert, watcher_fn fn,
+  int recv_timeout, const clientid_t *clientid, void *context, int flags);
+#endif
+
+ZOOAPI void close_zsock(zsock_t *zsock);
 
 /**
  * \brief create a handle to communicate with zookeeper.

--- a/zookeeper-client/zookeeper-client-c/pom.xml
+++ b/zookeeper-client/zookeeper-client-c/pom.xml
@@ -33,6 +33,20 @@
   <name>Apache ZooKeeper - Client - C</name>
   <description>ZooKeeper c client</description>
 
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12 -->
+    <dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-log4j12</artifactId>
+    <version>1.7.26</version>
+    <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>
@@ -109,6 +123,7 @@
                 <CALLER>ANT</CALLER>
               </environmentVariables>
               <arguments>
+                <argument>--with-openssl=/usr/include/openssl/</argument>
                 <argument>--prefix=${project.build.directory}/c</argument>
                 <argument>--enable-gcov</argument>
               </arguments>

--- a/zookeeper-client/zookeeper-client-c/pom.xml
+++ b/zookeeper-client/zookeeper-client-c/pom.xml
@@ -33,20 +33,6 @@
   <name>Apache ZooKeeper - Client - C</name>
   <description>ZooKeeper c client</description>
 
-  <dependencies>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12 -->
-    <dependency>
-    <groupId>org.slf4j</groupId>
-    <artifactId>slf4j-log4j12</artifactId>
-    <version>1.7.26</version>
-    <scope>test</scope>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/zookeeper-client/zookeeper-client-c/src/cli.c
+++ b/zookeeper-client/zookeeper-client-c/src/cli.c
@@ -45,6 +45,7 @@ int write(int _Filehandle, const void * _Buf, unsigned int _MaxCharCount);
 #include <time.h>
 #include <errno.h>
 #include <assert.h>
+#include <getopt.h>
 
 #ifdef YCA
 #include <yca/yca.h>
@@ -56,7 +57,8 @@ static zhandle_t *zh;
 static clientid_t myid;
 static const char *clientIdFile = 0;
 struct timeval startTime;
-static char cmd[1024];
+static char *cmd;
+static char *cert;
 static int batchMode=0;
 
 static int to_send=0;
@@ -741,6 +743,13 @@ int handleBatchMode(char* arg, char* buf, size_t maxlen) {
 }
 
 int main(int argc, char **argv) {
+    static struct option long_options[] = {
+            {"host",    required_argument, NULL, 'h'}, //hostPort
+            {"myid",    optional_argument, NULL, 'i'}, //myId
+            {"cmd",     optional_argument, NULL, 'c'}, //cmd
+            {"cert",    optional_argument, NULL, 's'}, //certificates files
+            {NULL,      0,                 NULL, 0},
+    };
 #ifndef THREADED
     fd_set rfds, wfds, efds;
     int processed=0;
@@ -752,45 +761,63 @@ int main(int argc, char **argv) {
     char appId[64];
 #endif
     int bufoff = 0;
-    int flags, i;
+    int flags;
     FILE *fh;
 
-    if (argc < 2) {
+    int opt;
+    int option_index = 0;
+
+    flags = 0;
+    while ((opt = getopt_long(argc, argv, "h:m::rc::s::", long_options, &option_index)) != -1) {
+        switch (opt) {
+            case 'h':
+                hostPort = strdup(optarg);
+                break;
+            case 'i':
+                clientIdFile = strdup(optarg);
+                fh = fopen(clientIdFile, "r");
+                if (fh) {
+                    if (fread(&myid, sizeof(myid), 1, fh) != sizeof(myid)) {
+                        memset(&myid, 0, sizeof(myid));
+                    }
+                    fclose(fh);
+                }
+                break;
+            case 'r':
+                flags = ZOO_READONLY;
+                break;
+            case 'c':
+                cmd = strdup(optarg);
+                batchMode = 1;
+                fprintf(stderr,"Batch mode: %s\n",cmd);
+                break;
+            case 's':
+                cert = strdup(optarg);
+                break;
+            case '?':
+                if (optopt == 'h') {
+                    fprintf (stderr, "Option -%c requires host list.\n", optopt);
+                } else if (isprint (optopt)) {
+                    fprintf (stderr, "Unknown option `-%c'.\n", optopt);
+                } else {
+                    fprintf (stderr,
+                             "Unknown option character `\\x%x'.\n",
+                             optopt);
+                    return 1;
+                }
+        }
+    }
+
+    if (!hostPort) {
         fprintf(stderr,
-                "USAGE %s zookeeper_host_list [clientid_file|cmd:(ls|ls2|create|create2|od|...)]\n", 
+                "USAGE %s -h zookeeper_host_list -i clientid_file -c (ls|ls2|create|create2|od|...) -s ca,cert,key,passwd \n",
                 argv[0]);
         fprintf(stderr,
-                "Version: ZooKeeper cli (c client) version %d.%d.%d\n", 
+                "Version: ZooKeeper cli (c client) version %d.%d.%d\n",
                 ZOO_MAJOR_VERSION,
                 ZOO_MINOR_VERSION,
                 ZOO_PATCH_VERSION);
         return 2;
-    }
-    if (argc > 2) {
-      int batchModeRes = handleBatchMode(argv[2], cmd, sizeof(cmd));
-      if (batchModeRes == -1) {
-          return 2;
-      } else if(batchModeRes == 1){                
-        batchMode=1;
-        fprintf(stderr,"Batch mode: '%s'\n",cmd);
-      }else{
-        clientIdFile = argv[2];
-        fh = fopen(clientIdFile, "r");
-        if (fh) {
-            if (fread(&myid, sizeof(myid), 1, fh) != sizeof(myid)) {
-                memset(&myid, 0, sizeof(myid));
-            }
-            fclose(fh);
-        }
-      }
-    }
-
-    flags = 0;
-    for (i = 1; i < argc; ++i) {
-      if (strcmp("-r", argv[i]) == 0) {
-        flags = ZOO_READONLY;
-        break;
-      }
     }
 
 #ifdef YCA
@@ -810,8 +837,17 @@ int main(int argc, char **argv) {
     verbose = 0;
     zoo_set_debug_level(ZOO_LOG_LEVEL_WARN);
     zoo_deterministic_conn_order(1); // enable deterministic order
-    hostPort = argv[1];
+
+#ifdef HAVE_OPENSSL_H
+    if (!cert) {
+        zh = zookeeper_init(hostPort, watcher, 30000, &myid, NULL, flags);
+    } else {
+        zh = zookeeper_init_ssl(hostPort, cert, watcher, 30000, &myid, NULL, flags);
+    }
+#else
     zh = zookeeper_init(hostPort, watcher, 30000, &myid, NULL, flags);
+#endif
+
     if (!zh) {
         return errno;
     }

--- a/zookeeper-client/zookeeper-client-c/src/st_adaptor.c
+++ b/zookeeper-client/zookeeper-client-c/src/st_adaptor.c
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#ifndef DLL_EXPORT
+#if !defined(DLL_EXPORT) && !defined(USE_STATIC_LIB)
 #  define USE_STATIC_LIB
 #endif
 

--- a/zookeeper-client/zookeeper-client-c/src/zk_adaptor.h
+++ b/zookeeper-client/zookeeper-client-c/src/zk_adaptor.h
@@ -43,6 +43,7 @@
 #define ASSOCIATING_STATE_DEF 2
 #define CONNECTED_STATE_DEF 3
 #define READONLY_STATE_DEF 5
+#define SSL_CONNECTING_STATE_DEF 7
 #define NOTCONNECTED_STATE_DEF 999
 
 /* zookeeper event type constants */
@@ -185,10 +186,9 @@ typedef struct _auth_list_head {
  * This structure represents the connection to zookeeper.
  */
 struct _zhandle {
+    zsock_t *fd;
 #ifdef WIN32
     SOCKET fd;                          // the descriptor used to talk to zookeeper
-#else
-    int fd;                             // the descriptor used to talk to zookeeper
 #endif
 
     // Hostlist and list of addresses

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -1312,6 +1312,7 @@ static zhandle_t *zookeeper_init_internal(const char *host, watcher_fn watcher,
 abort:
     errnosave=errno;
     destroy(zh);
+    free(zh->fd);
     free(zh);
     errno=errnosave;
     return 0;
@@ -3494,6 +3495,7 @@ int zookeeper_close(zhandle_t *zh)
 finish:
     destroy(zh);
     adaptor_destroy(zh);
+    free(zh->fd);
     free(zh);
 #ifdef _WIN32
     Win32WSACleanup();

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -79,9 +79,15 @@
 #include <pwd.h>
 #endif
 
+#ifdef HAVE_OPENSSL_H
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#endif
+
 #ifdef __MACH__ // OS X
 #include <mach/clock.h>
 #include <mach/mach.h>
+#include <netinet/tcp.h>
 #endif
 
 #ifdef WIN32
@@ -124,6 +130,7 @@ const int ZOO_CONNECTING_STATE = CONNECTING_STATE_DEF;
 const int ZOO_ASSOCIATING_STATE = ASSOCIATING_STATE_DEF;
 const int ZOO_CONNECTED_STATE = CONNECTED_STATE_DEF;
 const int ZOO_READONLY_STATE = READONLY_STATE_DEF;
+const int ZOO_SSL_CONNECTING_STATE = SSL_CONNECTING_STATE_DEF;
 const int ZOO_NOTCONNECTED_STATE = NOTCONNECTED_STATE_DEF;
 
 static __attribute__ ((unused)) const char* state2String(int state){
@@ -132,6 +139,8 @@ static __attribute__ ((unused)) const char* state2String(int state){
         return "ZOO_CLOSED_STATE";
     case CONNECTING_STATE_DEF:
         return "ZOO_CONNECTING_STATE";
+    case SSL_CONNECTING_STATE_DEF:
+        return "ZOO_SSL_CONNECTING_STATE";
     case ASSOCIATING_STATE_DEF:
         return "ZOO_ASSOCIATING_STATE";
     case CONNECTED_STATE_DEF:
@@ -273,6 +282,9 @@ static struct sockaddr_storage *addr_rw_server = 0;
 
 static void *SYNCHRONOUS_MARKER = (void*)&SYNCHRONOUS_MARKER;
 static int isValidPath(const char* path, const int mode);
+#ifdef HAVE_OPENSSL_H
+static int init_ssl(zhandle_t *zh);
+#endif
 
 static int aremove_watches(
     zhandle_t *zh, const char *path, ZooWatcherType wtype,
@@ -323,9 +335,22 @@ static void abort_singlethreaded(zhandle_t *zh)
     abort();
 }
 
-static sendsize_t zookeeper_send(socket_t s, const void* buf, size_t len)
+static ssize_t zookeeper_send(zsock_t *fd, const void* buf, size_t len)
 {
-    return send(s, buf, len, SEND_FLAGS);
+#ifdef HAVE_OPENSSL_H
+    if (fd->ssl_sock)
+        return (ssize_t)SSL_write(fd->ssl_sock, buf, (int)len);
+#endif
+    return send(fd->sock, buf, len, SEND_FLAGS);
+}
+
+static ssize_t zookeeper_recv(zsock_t *fd, void *buf, size_t len, int flags)
+{
+#ifdef HAVE_OPENSSL_H
+    if (fd->ssl_sock)
+        return (ssize_t)SSL_read(fd->ssl_sock, buf, (int)len);
+#endif
+    return recv(fd->sock, buf, len, flags);
 }
 
 /**
@@ -555,6 +580,22 @@ zk_hashtable *child_result_checker(zhandle_t *zh, int rc)
     return rc==ZOK ? zh->active_child_watchers : 0;
 }
 
+void close_zsock(zsock_t *fd)
+{
+    if (fd->sock != -1) {
+#ifdef HAVE_OPENSSL_H
+        if (fd->ssl_sock) {
+            SSL_free(fd->ssl_sock);
+            fd->ssl_sock = NULL;
+            SSL_CTX_free(fd->ssl_ctx);
+            fd->ssl_ctx = NULL;
+        }
+#endif
+        close(fd->sock);
+        fd->sock = -1;
+    }
+}
+
 /**
  * Frees and closes everything associated with a handle,
  * including the handle itself.
@@ -570,9 +611,8 @@ static void destroy(zhandle_t *zh)
         free(zh->hostname);
         zh->hostname = NULL;
     }
-    if (zh->fd != -1) {
-        close(zh->fd);
-        zh->fd = -1;
+    if (zh->fd->sock != -1) {
+        close_zsock(zh->fd);
         memset(&zh->addr_cur, 0, sizeof(zh->addr_cur));
         zh->state = 0;
     }
@@ -582,7 +622,13 @@ static void destroy(zhandle_t *zh)
         free(zh->chroot);
         zh->chroot = NULL;
     }
-
+#ifdef HAVE_OPENSSL_H
+    if (zh->fd->cert) {
+        free(zh->fd->cert->certstr);
+        free(zh->fd->cert);
+        zh->fd->cert = NULL;
+    }
+#endif
     free_auth_info(&zh->auth_h);
     destroy_zk_hashtable(zh->active_node_watchers);
     destroy_zk_hashtable(zh->active_exist_watchers);
@@ -1027,10 +1073,9 @@ int update_addrs(zhandle_t *zh)
     // If we need to do a reconfig and we're currently connected to a server,
     // then force close that connection so on next interest() call we'll make a
     // new connection
-    if (zh->reconfig == 1 && zh->fd != -1)
+    if (zh->reconfig == 1 && zh->fd->sock != -1)
     {
-        close(zh->fd);
-        zh->fd = -1;
+        close_zsock(zh->fd);
         zh->state = ZOO_NOTCONNECTED_STATE;
     }
 
@@ -1077,7 +1122,7 @@ struct sockaddr* zookeeper_get_connected_host(zhandle_t *zh,
     if (zh->state!=ZOO_CONNECTED_STATE) {
         return NULL;
     }
-    if (getpeername(zh->fd, addr, addr_len)==-1) {
+    if (getpeername(zh->fd->sock, addr, addr_len)==-1) {
         return NULL;
     }
     return addr;
@@ -1148,7 +1193,7 @@ static void log_env(zhandle_t *zh) {
  */
 static zhandle_t *zookeeper_init_internal(const char *host, watcher_fn watcher,
         int recv_timeout, const clientid_t *clientid, void *context, int flags,
-        log_callback_fn log_callback)
+        log_callback_fn log_callback, zcert_t *cert)
 {
     int errnosave = 0;
     zhandle_t *zh = NULL;
@@ -1165,6 +1210,13 @@ static zhandle_t *zookeeper_init_internal(const char *host, watcher_fn watcher,
 
     if (!(flags & ZOO_NO_LOG_CLIENTENV)) {
         log_env(zh);
+    }
+
+    zh->fd = calloc(1, sizeof(zsock_t));
+    zh->fd->sock = -1;
+    if (cert) {
+        zh->fd->cert = calloc(1, sizeof(zcert_t));
+        memcpy(zh->fd->cert, cert, sizeof(zcert_t));
     }
 
 #ifdef _WIN32
@@ -1185,7 +1237,6 @@ static zhandle_t *zookeeper_init_internal(const char *host, watcher_fn watcher,
               flags);
 
     zh->hostname = NULL;
-    zh->fd = -1;
     zh->state = ZOO_NOTCONNECTED_STATE;
     zh->context = context;
     zh->recv_timeout = recv_timeout;
@@ -1269,15 +1320,29 @@ abort:
 zhandle_t *zookeeper_init(const char *host, watcher_fn watcher,
         int recv_timeout, const clientid_t *clientid, void *context, int flags)
 {
-    return zookeeper_init_internal(host, watcher, recv_timeout, clientid, context, flags, NULL);
+    return zookeeper_init_internal(host, watcher, recv_timeout, clientid, context, flags, NULL, NULL);
 }
 
 zhandle_t *zookeeper_init2(const char *host, watcher_fn watcher,
         int recv_timeout, const clientid_t *clientid, void *context, int flags,
         log_callback_fn log_callback)
 {
-    return zookeeper_init_internal(host, watcher, recv_timeout, clientid, context, flags, log_callback);
+    return zookeeper_init_internal(host, watcher, recv_timeout, clientid, context, flags, log_callback, NULL);
 }
+
+#ifdef HAVE_OPENSSL_H
+zhandle_t *zookeeper_init_ssl(const char *host, const char *cert, watcher_fn watcher,
+        int recv_timeout, const clientid_t *clientid, void *context, int flags)
+{
+    zcert_t zcert;
+    zcert.certstr = strdup(cert);
+    zcert.ca = strtok(strdup(cert), ",");
+    zcert.cert = strtok(NULL, ",");
+    zcert.key = strtok(NULL, ",");
+    zcert.passwd = strtok(NULL, ",");       
+    return zookeeper_init_internal(host, watcher, recv_timeout, clientid, context, flags, NULL, &zcert);
+}
+#endif
 
 /**
  * Set a new list of zk servers to connect to.  Disconnect will occur if
@@ -1565,7 +1630,7 @@ static __attribute__ ((unused)) int get_queue_len(buffer_head_t *list)
  * 0 if send would block while sending the buffer (or a send was incomplete),
  * 1 if success
  */
-static int send_buffer(socket_t fd, buffer_list_t *buff)
+static int send_buffer(zhandle_t *zh, buffer_list_t *buff)
 {
     int len = buff->len;
     int off = buff->curr_offset;
@@ -1575,7 +1640,7 @@ static int send_buffer(socket_t fd, buffer_list_t *buff)
         /* we need to send the length at the beginning */
         int nlen = htonl(len);
         char *b = (char*)&nlen;
-        rc = zookeeper_send(fd, b + off, sizeof(nlen) - off);
+        rc = zookeeper_send(zh->fd, b + off, sizeof(nlen) - off);
         if (rc == -1) {
 #ifdef _WIN32
             if (WSAGetLastError() != WSAEWOULDBLOCK) {
@@ -1594,7 +1659,7 @@ static int send_buffer(socket_t fd, buffer_list_t *buff)
     if (off >= 4) {
         /* want off to now represent the offset into the buffer */
         off -= sizeof(buff->len);
-        rc = zookeeper_send(fd, buff->buffer + off, len - off);
+        rc = zookeeper_send(zh->fd, buff->buffer + off, len - off);
         if (rc == -1) {
 #ifdef _WIN32
             if (WSAGetLastError() != WSAEWOULDBLOCK) {
@@ -1623,7 +1688,7 @@ static int recv_buffer(zhandle_t *zh, buffer_list_t *buff)
     /* if buffer is less than 4, we are reading in the length */
     if (off < 4) {
         char *buffer = (char*)&(buff->len);
-        rc = recv(zh->fd, buffer+off, sizeof(int)-off, 0);
+        rc = zookeeper_recv(zh->fd, buffer+off, sizeof(int)-off, 0);
         switch (rc) {
         case 0:
             errno = EHOSTDOWN;
@@ -1649,7 +1714,7 @@ static int recv_buffer(zhandle_t *zh, buffer_list_t *buff)
         /* want off to now represent the offset into the buffer */
         off -= sizeof(buff->len);
 
-        rc = recv(zh->fd, buff->buffer+off, buff->len-off, 0);
+        rc = zookeeper_recv(zh->fd, buff->buffer+off, buff->len-off, 0);
 
         /* dirty hack to make new client work against old server
          * old server sends 40 bytes to finish connection handshake,
@@ -1769,7 +1834,7 @@ static int is_connected(zhandle_t* zh)
 
 static void cleanup(zhandle_t *zh,int rc)
 {
-    close(zh->fd);
+    close_zsock(zh->fd);
     if (is_unrecoverable(zh)) {
         LOG_DEBUG(LOGCALLBACK(zh), "Calling a watcher for a ZOO_SESSION_EVENT and the state=%s",
                 state2String(zh->state));
@@ -1779,7 +1844,6 @@ static void cleanup(zhandle_t *zh,int rc)
         PROCESS_SESSION_EVENT(zh, ZOO_CONNECTING_STATE);
     }
     cleanup_bufs(zh,1,rc);
-    zh->fd = -1;
 
     LOG_DEBUG(LOGCALLBACK(zh), "Previous connection=%s delay=%d", zoo_get_current_server(zh), zh->delay);
 
@@ -2035,6 +2099,11 @@ static int prime_connection(zhandle_t *zh)
     int len = sizeof(buffer_req);
     int hlen = 0;
     struct connect_req req;
+
+    if (zh->state == ZOO_SSL_CONNECTING_STATE) {
+       // The SSL connection is yet to happen.
+       return ZOK;
+    }
     req.protocolVersion = 0;
     req.sessionId = zh->seen_rw_server_before ? zh->client_id.client_id : 0;
     req.passwd_len = sizeof(req.passwd);
@@ -2142,7 +2211,7 @@ static int ping_rw_server(zhandle_t* zh)
         return 0;
     }
 
-    ssize = zookeeper_send(sock, "isro", 4);
+    ssize = zookeeper_send(zh->fd, "isro", 4);
     if (ssize < 0) {
         rc = 0;
         goto out;
@@ -2289,7 +2358,7 @@ int zookeeper_interest(zhandle_t *zh, socket_t *fd, int *interest,
         return api_epilog(zh, rc);
     }
 
-    *fd = zh->fd;
+    *fd = zh->fd->sock;
     *interest = 0;
     tv->tv_sec = 0;
     tv->tv_usec = 0;
@@ -2319,8 +2388,8 @@ int zookeeper_interest(zhandle_t *zh, socket_t *fd, int *interest,
                 // No need to delay -- grab the next server and attempt connection
                 zoo_cycle_next_server(zh);
             }
-            zh->fd = socket(zh->addr_cur.ss_family, sock_flags, 0);
-            if (zh->fd < 0) {
+            zh->fd->sock  = socket(zh->addr_cur.ss_family, sock_flags, 0);
+            if (zh->fd->sock < 0) {
               rc = handle_socket_error_msg(zh,
                                            __LINE__,
                                            ZSYSTEMERROR,
@@ -2328,17 +2397,21 @@ int zookeeper_interest(zhandle_t *zh, socket_t *fd, int *interest,
               return api_epilog(zh, rc);
             }
 
-            zookeeper_set_sock_nodelay(zh, zh->fd);
-            zookeeper_set_sock_noblock(zh, zh->fd);
+            zookeeper_set_sock_nodelay(zh, zh->fd->sock);
+            zookeeper_set_sock_noblock(zh, zh->fd->sock);
 
-            rc = zookeeper_connect(zh, &zh->addr_cur, zh->fd);
+            rc = zookeeper_connect(zh, &zh->addr_cur, zh->fd->sock);
 
             if (rc == -1) {
                 /* we are handling the non-blocking connect according to
                  * the description in section 16.3 "Non-blocking connect"
                  * in UNIX Network Programming vol 1, 3rd edition */
                 if (errno == EWOULDBLOCK || errno == EINPROGRESS) {
-                    zh->state = ZOO_CONNECTING_STATE;
+                    // For SSL, we first go to ZOO_SSL_CONNECTING_STATE
+                    if (zh->fd->cert != NULL)
+                        zh->state = ZOO_SSL_CONNECTING_STATE;
+                    else
+                        zh->state = ZOO_CONNECTING_STATE;
                 } else {
                     rc = handle_socket_error_msg(zh,
                                                  __LINE__,
@@ -2347,6 +2420,14 @@ int zookeeper_interest(zhandle_t *zh, socket_t *fd, int *interest,
                     return api_epilog(zh, rc);
                 }
             } else {
+#ifdef HAVE_OPENSSL_H
+                if (zh->fd->cert != NULL) {
+                    // We do SSL_connect() here
+                    if (init_ssl(zh) != ZOK) {
+                        return ZSSLCONNECTIONERROR;
+                    }
+                }
+#endif
                 rc = prime_connection(zh);
                 if (rc != 0) {
                     return api_epilog(zh,rc);
@@ -2358,7 +2439,7 @@ int zookeeper_interest(zhandle_t *zh, socket_t *fd, int *interest,
             }
             *tv = get_timeval(zh->recv_timeout/3);
         }
-        *fd = zh->fd;
+        *fd = zh->fd->sock;
         zh->last_recv = now;
         zh->last_send = now;
         zh->last_ping = now;
@@ -2366,13 +2447,13 @@ int zookeeper_interest(zhandle_t *zh, socket_t *fd, int *interest,
         zh->ping_rw_timeout = MIN_RW_TIMEOUT;
     }
 
-    if (zh->fd != -1) {
+    if (zh->fd->sock != -1) {
         int idle_recv = calculate_interval(&zh->last_recv, &now);
         int idle_send = calculate_interval(&zh->last_send, &now);
         int recv_to = zh->recv_timeout*2/3 - idle_recv;
         int send_to = zh->recv_timeout/3;
         // have we exceeded the receive timeout threshold?
-        if (recv_to <= 0) {
+        if (recv_to <= 0 && zh->state != ZOO_SSL_CONNECTING_STATE) {
             // We gotta cut our losses and connect to someone else
 #ifdef _WIN32
             errno = WSAETIMEDOUT;
@@ -2441,21 +2522,157 @@ int zookeeper_interest(zhandle_t *zh, socket_t *fd, int *interest,
         /* we are interested in a write if we are connected and have something
          * to send, or we are waiting for a connect to finish. */
         if ((zh->to_send.head && is_connected(zh))
-            || zh->state == ZOO_CONNECTING_STATE) {
+            || zh->state == ZOO_CONNECTING_STATE
+            || zh->state == ZOO_SSL_CONNECTING_STATE) {
             *interest |= ZOOKEEPER_WRITE;
         }
     }
     return api_epilog(zh,ZOK);
 }
 
+#ifdef HAVE_OPENSSL_H
+static int init_ssl(zhandle_t *zh)
+{
+    SSL_CTX **ctx;
+
+    if (!zh->fd->ssl_sock) {
+        const SSL_METHOD *method;
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+        OpenSSL_add_all_algorithms();
+        ERR_load_BIO_strings();
+        ERR_load_crypto_strings();
+        SSL_load_error_strings();
+        SSL_library_init();
+        method = SSLv23_client_method();
+#else
+        OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
+        method = TLS_client_method();
+#endif 
+        if (FIPS_mode() == 0) {
+            LOG_INFO(LOGCALLBACK(zh), "FIPS mode is OFF ");
+        } else {
+            LOG_INFO(LOGCALLBACK(zh), "FIPS mode is ON ");
+        }
+        zh->fd->ssl_ctx = SSL_CTX_new(method);
+        ctx = &zh->fd->ssl_ctx;
+        
+        SSL_CTX_set_verify(*ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, 0);
+        /*SERVER CA FILE*/
+        if (SSL_CTX_load_verify_locations(*ctx, zh->fd->cert->ca, 0) != 1) {
+            SSL_CTX_free(*ctx);
+            LOG_ERROR(LOGCALLBACK(zh), "Failed to load CA file %s", zh->fd->cert->ca);
+            errno = EINVAL;
+            return ZBADARGUMENTS;
+        }
+        if (SSL_CTX_set_default_verify_paths(*ctx) != 1) {
+            SSL_CTX_free(*ctx);
+            LOG_ERROR(LOGCALLBACK(zh), "Call to SSL_CTX_set_default_verify_paths failed");
+            errno = EINVAL;
+            return ZBADARGUMENTS;
+        }
+        /*CLIENT CA FILE (With Certificate Chain)*/
+        if (SSL_CTX_use_certificate_chain_file(*ctx, zh->fd->cert->cert) != 1) {
+            SSL_CTX_free(*ctx);
+            LOG_ERROR(LOGCALLBACK(zh), "Failed to load client certificate chain from %s", zh->fd->cert->cert);
+            errno = EINVAL;
+            return ZBADARGUMENTS;
+        }
+        /*CLIENT PRIVATE KEY*/
+        SSL_CTX_set_default_passwd_cb_userdata(*ctx, zh->fd->cert->passwd);
+        if (SSL_CTX_use_PrivateKey_file(*ctx, zh->fd->cert->key, SSL_FILETYPE_PEM) != 1) {
+            SSL_CTX_free(*ctx);
+            LOG_ERROR(LOGCALLBACK(zh), "Failed to load client private key from %s", zh->fd->cert->key);
+            errno = EINVAL;
+            return ZBADARGUMENTS;
+        }
+        /*CHECK*/
+        if (SSL_CTX_check_private_key(*ctx) != 1) {
+            SSL_CTX_free(*ctx);
+            LOG_ERROR(LOGCALLBACK(zh), "SSL_CTX_check_private_key failed");
+            errno = EINVAL;
+            return ZBADARGUMENTS;
+        }
+        /*MULTIPLE HANDSHAKE*/
+        SSL_CTX_set_mode(*ctx, SSL_MODE_AUTO_RETRY);
+
+        zh->fd->ssl_sock = SSL_new(*ctx);
+        if (zh->fd->ssl_sock == NULL) {
+            return handle_socket_error_msg(zh,__LINE__,ZSSLCONNECTIONERROR,
+                                           "error creating ssl context");
+        }
+        SSL_set_fd(zh->fd->ssl_sock, zh->fd->sock);
+    }
+    while(1) {
+        int rc;
+        int fd = zh->fd->sock;
+        struct timeval tv;
+        fd_set s_rfds, s_wfds;
+        tv.tv_sec = 1;
+        tv.tv_usec = 0;
+        FD_ZERO(&s_rfds);
+        FD_ZERO(&s_wfds);
+        rc = SSL_connect(zh->fd->ssl_sock);
+        if (rc == 1) {
+            // (SUCCESS) Now mark the ZOO_CONNECTING_STATE so that
+            // prime_connection() happen.
+            // prime_connection() only happens in ZOO_CONNECTING_STATE
+            zh->state = ZOO_CONNECTING_STATE;
+            return ZOK;
+        }
+        else
+        {
+            rc = SSL_get_error(zh->fd->ssl_sock, rc);
+            if (rc == SSL_ERROR_WANT_READ) {
+                FD_SET(fd, &s_rfds);
+                FD_CLR(fd, &s_wfds);
+            } else if (rc == SSL_ERROR_WANT_WRITE) {
+                FD_SET(fd, &s_wfds);
+                FD_CLR(fd, &s_rfds);
+            } else {
+                return handle_socket_error_msg(zh,__LINE__,ZSSLCONNECTIONERROR,
+                    "error in ssl connect");
+            }
+            rc = select(fd + 1, &s_rfds, &s_wfds, NULL, &tv);
+            if (rc == -1) {
+                return handle_socket_error_msg(zh,__LINE__,ZSSLCONNECTIONERROR,
+                    "error in ssl connect");
+            }
+        }
+    }
+}
+#endif
+
 static int check_events(zhandle_t *zh, int events)
 {
-    if (zh->fd == -1)
+    if (zh->fd->sock == -1)
         return ZINVALIDSTATE;
+
+#ifdef HAVE_OPENSSL_H
+    if ((events&ZOOKEEPER_WRITE) && (zh->state == ZOO_SSL_CONNECTING_STATE) && zh->fd->cert != NULL) {
+        int rc, error;
+        socklen_t len = sizeof(error);
+        rc = getsockopt(zh->fd->sock, SOL_SOCKET, SO_ERROR, &error, &len);
+        /* the description in section 16.4 "Non-blocking connect"
+         * in UNIX Network Programming vol 1, 3rd edition, points out
+         * that sometimes the error is in errno and sometimes in error */
+        if (rc < 0 || error) {
+            if (rc == 0)
+                errno = error;
+            return handle_socket_error_msg(zh, __LINE__,ZCONNECTIONLOSS,
+                "server refused to accept the client");
+        }
+        // We do SSL_connect() here
+        if (init_ssl(zh) != ZOK) {
+            return ZSSLCONNECTIONERROR;
+        }
+    }
+#endif
+
     if ((events&ZOOKEEPER_WRITE)&&(zh->state == ZOO_CONNECTING_STATE)) {
         int rc, error;
         socklen_t len = sizeof(error);
-        rc = getsockopt(zh->fd, SOL_SOCKET, SO_ERROR, &error, &len);
+        rc = getsockopt(zh->fd->sock, SOL_SOCKET, SO_ERROR, &error, &len);
         /* the description in section 16.4 "Non-blocking connect"
          * in UNIX Network Programming vol 1, 3rd edition, points out
          * that sometimes the error is in errno and sometimes in error */
@@ -2472,6 +2689,7 @@ static int check_events(zhandle_t *zh, int events)
         LOG_INFO(LOGCALLBACK(zh), "initiated connection to server %s", format_endpoint_info(&zh->addr_cur));
         return ZOK;
     }
+
     if (zh->to_send.head && (events&ZOOKEEPER_WRITE)) {
         /* make the flush call non-blocking by specifying a 0 timeout */
         int rc=flush_send_queue(zh,0);
@@ -2802,7 +3020,7 @@ static void isSocketReadable(zhandle_t* zh)
 {
 #ifndef _WIN32
     struct pollfd fds;
-    fds.fd = zh->fd;
+    fds.fd = zh->fd->sock;
     fds.events = POLLIN;
     if (poll(&fds,1,0)<=0) {
         // socket not readable -- no more responses to process
@@ -4341,7 +4559,7 @@ int flush_send_queue(zhandle_t*zh, int timeout)
             // Poll the socket
             rc = select((int)(zh->fd)+1, NULL,  &pollSet, NULL, &wait);
 #else
-            fds.fd = zh->fd;
+            fds.fd = zh->fd->sock;
             fds.events = POLLOUT;
             fds.revents = 0;
             rc = poll(&fds, 1, timeout-elapsed);
@@ -4353,7 +4571,7 @@ int flush_send_queue(zhandle_t*zh, int timeout)
             }
         }
 
-        rc = send_buffer(zh->fd, zh->to_send.head);
+        rc = send_buffer(zh, zh->to_send.head);
         if(rc==0 && timeout==0){
             /* send_buffer would block while sending this buffer */
             rc = ZOK;

--- a/zookeeper-client/zookeeper-client-c/ssl/gencerts.sh
+++ b/zookeeper-client/zookeeper-client-c/ssl/gencerts.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# Generate the root key
+openssl genrsa -out rootkey.pem 2048
+
+#Generate the root Cert
+openssl req -x509 -new -key rootkey.pem -out root.crt -config <(
+cat <<-EOF
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+
+[ dn ]
+C = US
+ST = California
+L = San Francisco
+O = Bookkeeper
+emailAddress = dev@bookkeeper.apache.org
+CN = bookkeeper.apache.org
+EOF
+)
+
+#Generate Client Key
+openssl genrsa -out clientkey.pem 2048
+
+#Generate Client Cert
+openssl req -new -key clientkey.pem -out client.csr -config <(
+cat <<-EOF
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+
+[ dn ]
+C = US
+ST = California
+L = San Francisco
+O = Bookkeeper
+emailAddress = dev@bookkeeper.apache.org
+CN = bookkeeper.apache.org
+EOF
+)
+openssl x509 -req -in client.csr -CA root.crt -CAkey rootkey.pem -CAcreateserial -days 3650 -out client.crt
+
+#Export in pkcs12 format
+openssl pkcs12 -export -in client.crt -inkey clientkey.pem -out client.pkcs12 -password pass:password
+
+# Import Keystore in JKS
+keytool -importkeystore -srckeystore client.pkcs12 -destkeystore client.jks -srcstoretype pkcs12 -srcstorepass password -deststorepass password
+
+############################################################
+
+#Generate Server key
+openssl genrsa -out serverkey.pem 2048
+
+#Generate Server Cert
+openssl req -new -key serverkey.pem -out server.csr -config <(
+cat <<-EOF
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+
+[ dn ]
+C = US
+ST = California
+L = San Francisco
+O = Bookkeeper
+emailAddress = dev@bookkeeper.apache.org
+CN = bookkeeper.apache.org
+EOF
+)
+openssl x509 -req -in server.csr -CA root.crt -CAkey rootkey.pem -CAcreateserial -days 3650 -out server.crt
+
+#Export in pkcs12 format
+openssl pkcs12 -export -in server.crt -inkey serverkey.pem -out server.pkcs12 -password pass:password
+
+# Import Keystore in JKS
+keytool -importkeystore -srckeystore server.pkcs12 -destkeystore server.jks -srcstoretype pkcs12 -srcstorepass password -deststorepass password
+
+
+keytool -importcert -keystore server.jks -file root.crt -storepass password -noprompt
+
+keytool -importcert -alias ca -file root.crt -keystore clienttrust.jks -storepass password -noprompt
+
+keytool -importcert -alias clientcert -file client.crt -keystore clienttrust.jks -storepass password -noprompt
+
+keytool -importcert -alias ca -file root.crt -keystore servertrust.jks -storepass password -noprompt
+keytool -importcert -alias servercert -file server.crt -keystore servertrust.jks -storepass password -noprompt

--- a/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
@@ -800,6 +800,7 @@ public:
 #ifdef HAVE_OPENSSL_H
     void testSSL() {
         watchctx_t ctx;
+        zoo_set_debug_level(ZOO_LOG_LEVEL_DEBUG);
         zhandle_t *zk = createSSLClient("127.0.0.1:22281", "/tmp/certs/server.crt,/tmp/certs/client.crt,/tmp/certs/clientkey.pem,password", &ctx);
         CPPUNIT_ASSERT(zk);
         int rc = 0;

--- a/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
@@ -208,7 +208,7 @@ class Zookeeper_simpleSystem : public CPPUNIT_NS::TestFixture
 #ifdef THREADED
     CPPUNIT_TEST(testNullData);
 #ifdef ZOO_IPV6_ENABLED
-    //CPPUNIT_TEST(testIPV6);
+    CPPUNIT_TEST(testIPV6);
 #endif
 #ifdef HAVE_OPENSSL_H
     CPPUNIT_TEST(testSSL);

--- a/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
@@ -208,7 +208,10 @@ class Zookeeper_simpleSystem : public CPPUNIT_NS::TestFixture
 #ifdef THREADED
     CPPUNIT_TEST(testNullData);
 #ifdef ZOO_IPV6_ENABLED
-    CPPUNIT_TEST(testIPV6);
+    //CPPUNIT_TEST(testIPV6);
+#endif
+#ifdef HAVE_OPENSSL_H
+    CPPUNIT_TEST(testSSL);
 #endif
     CPPUNIT_TEST(testCreate);
     CPPUNIT_TEST(testCreateContainer);
@@ -267,7 +270,16 @@ class Zookeeper_simpleSystem : public CPPUNIT_NS::TestFixture
         sleep(1);
         return zk;
     }
-    
+
+#ifdef HAVE_OPENSSL_H
+    zhandle_t *createSSLClient(const char *hp, const char *cert, watchctx_t *ctx) {
+        zhandle_t *zk = zookeeper_init_ssl(hp, cert, watcher, 30000, 0, ctx, 0);
+        ctx->zh = zk;
+        sleep(1);
+        return zk;
+    }
+#endif
+
     zhandle_t *createchClient(watchctx_t *ctx, const char* chroot) {
         zhandle_t *zk = zookeeper_init(chroot, watcher, 10000, 0, ctx, 0);
         ctx->zh = zk;
@@ -363,7 +375,7 @@ public:
         sleep(1);
         zh->io_count = 0;
         //close socket
-        close(zh->fd);
+        close_zsock(zh->fd);
         sleep(1);
         //Check that doIo isn't spinning
         CPPUNIT_ASSERT(zh->io_count < 2);
@@ -784,6 +796,18 @@ public:
                         &ZOO_OPEN_ACL_UNSAFE, 0, 0, 0);
         CPPUNIT_ASSERT_EQUAL((int) ZOK, rc);
     }
+
+#ifdef HAVE_OPENSSL_H
+    void testSSL() {
+        watchctx_t ctx;
+        zhandle_t *zk = createSSLClient("127.0.0.1:22281", "/tmp/certs/server.crt,/tmp/certs/client.crt,/tmp/certs/clientkey.pem,password", &ctx);
+        CPPUNIT_ASSERT(zk);
+        int rc = 0;
+        rc = zoo_create(zk, "/ssl", NULL, -1,
+                        &ZOO_OPEN_ACL_UNSAFE, 0, 0, 0);
+        CPPUNIT_ASSERT_EQUAL((int) ZOK, rc);
+    }
+#endif
 
     void testNullData() {
         watchctx_t ctx;

--- a/zookeeper-client/zookeeper-client-c/tests/TestMulti.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestMulti.cc
@@ -52,7 +52,6 @@ using namespace std;
         int interest;
         int events;
         struct timeval tv;
-        int rc;
         time_t expires = time(0) + seconds;
         time_t timeLeft = seconds;
         fd_set rfds, wfds, efds;
@@ -80,7 +79,7 @@ using namespace std;
             if (tv.tv_sec > timeLeft) {
                 tv.tv_sec = timeLeft;
             }
-            rc = select(fd+1, &rfds, &wfds, &efds, &tv);
+            select(fd+1, &rfds, &wfds, &efds, &tv);
             timeLeft = expires - time(0);
             events = 0;
             if (FD_ISSET(fd, &rfds)) {

--- a/zookeeper-client/zookeeper-client-c/tests/TestReadOnlyClient.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestReadOnlyClient.cc
@@ -30,7 +30,8 @@
 #ifdef THREADED
 class Zookeeper_readOnly : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST_SUITE(Zookeeper_readOnly);
-    CPPUNIT_TEST(testReadOnly);
+    // Disabling this test as it's flapping on Ubuntu
+    //CPPUNIT_TEST(testReadOnly);
     CPPUNIT_TEST_SUITE_END();
 
     static void watcher(zhandle_t* zh, int type, int state,

--- a/zookeeper-client/zookeeper-client-c/tests/TestReadOnlyClient.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestReadOnlyClient.cc
@@ -30,8 +30,7 @@
 #ifdef THREADED
 class Zookeeper_readOnly : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST_SUITE(Zookeeper_readOnly);
-    // Disabling this test as it's flapping on Ubuntu
-    //CPPUNIT_TEST(testReadOnly);
+    CPPUNIT_TEST(testReadOnly);
     CPPUNIT_TEST_SUITE_END();
 
     static void watcher(zhandle_t* zh, int type, int state,

--- a/zookeeper-client/zookeeper-client-c/tests/TestReconfig.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestReconfig.cc
@@ -265,7 +265,7 @@ public:
 
     void tearDown()
     {
-        for (int i = 0; i < clients.size(); i++)
+        for (unsigned int i = 0; i < clients.size(); i++)
         {
             clients.at(i).close();
         }
@@ -316,7 +316,7 @@ public:
 
         stringstream ss;
 
-        for (int i = start; i >= stop; i--, octet--)
+        for (uint32_t i = start; i >= stop; i--, octet--)
         {
             ss << "10.10.10." << octet << ":" << portOffset + octet;
 
@@ -573,8 +573,6 @@ public:
     {
         zoo_deterministic_conn_order(0);
 
-        int rc = ZOK;
-
         uint32_t numServers = 9;
         const string initial_hosts = createHostList(numServers); // 10.10.10.9:2009...10.10.10.1:2001
 
@@ -584,7 +582,7 @@ public:
             numClientsPerHost.at(client.getServerPort() - portOffset - 1)++;
         }
 
-        for (int i = 0; i < numServers; i++) {
+        for (uint32_t i = 0; i < numServers; i++) {
             CPPUNIT_ASSERT(numClientsPerHost.at(i) <= upperboundClientsPerServer(numClients, numServers));
             CPPUNIT_ASSERT(numClientsPerHost.at(i) >= lowerboundClientsPerServer(numClients, numServers));
             numClientsPerHost.at(i) = 0; // prepare for next test

--- a/zookeeper-client/zookeeper-client-c/tests/TestZookeeperClose.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestZookeeperClose.cc
@@ -110,7 +110,7 @@ public:
         zh=zookeeper_init("localhost:2121",watcher,10000,0,0,0);       
         CPPUNIT_ASSERT(zh!=0);
         // simulate connected state 
-        zh->fd=ZookeeperServer::FD;
+        zh->fd->sock=ZookeeperServer::FD;
         zh->state=ZOO_CONNECTED_STATE;
         Mock_flush_send_queue zkMock;
         // do not actually free the memory while in zookeeper_close()

--- a/zookeeper-client/zookeeper-client-c/tests/TestZookeeperInit.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestZookeeperInit.cc
@@ -102,7 +102,7 @@ public:
                 &cid,(void*)1,0);
 
         CPPUNIT_ASSERT(zh != NULL);
-        CPPUNIT_ASSERT(zh->fd == -1);
+        CPPUNIT_ASSERT(zh->fd->sock == -1);
         CPPUNIT_ASSERT(zh->hostname != NULL);
         CPPUNIT_ASSERT_EQUAL(EXPECTED_ADDRS_COUNT,zh->addrs.count);
         CPPUNIT_ASSERT_EQUAL(EXPECTED_HOST,string(zh->hostname));
@@ -143,7 +143,7 @@ public:
 
         CPPUNIT_ASSERT(zh!=0);
         CPPUNIT_ASSERT_EQUAL(EXPECTED_ADDRS_COUNT,zh->addrs.count);
-        for(int i=0;i<zh->addrs.count;i++){
+        for(unsigned int i=0;i<zh->addrs.count;i++){
             sockaddr_in* addr=(struct sockaddr_in*)&zh->addrs.data[i];
             CPPUNIT_ASSERT(memcmp(EXPECTED_IPS[i],&addr->sin_addr,sizeof(addr->sin_addr))==0);
             CPPUNIT_ASSERT_EQUAL(2121,(int)ntohs(addr->sin_port));
@@ -161,7 +161,7 @@ public:
         CPPUNIT_ASSERT(zh!=0);
         CPPUNIT_ASSERT_EQUAL(EXPECTED_ADDRS_COUNT,zh->addrs.count);
 
-        for(int i=0;i<zh->addrs.count;i++){
+        for(unsigned int i=0;i<zh->addrs.count;i++){
             sockaddr_in* addr=(struct sockaddr_in*)&zh->addrs.data[i];
             CPPUNIT_ASSERT(memcmp(EXPECTED_IPS[i],&addr->sin_addr,sizeof(addr->sin_addr))==0);
             if(i<1)
@@ -182,7 +182,7 @@ public:
         CPPUNIT_ASSERT(zh!=0);
         CPPUNIT_ASSERT_EQUAL(EXPECTED_ADDRS_COUNT,zh->addrs.count);
 
-        for(int i=0;i<zh->addrs.count;i++){
+        for(unsigned int i=0;i<zh->addrs.count;i++){
             sockaddr_in* addr=(struct sockaddr_in*)&zh->addrs.data[i];
             CPPUNIT_ASSERT(memcmp(EXPECTED_IPS[i],&addr->sin_addr,sizeof(addr->sin_addr))==0);
             if(i<1)
@@ -289,7 +289,7 @@ public:
         CPPUNIT_ASSERT_EQUAL(EXPECTED_ADDR_COUNT,zh->addrs.count);
         const string EXPECTED_SEQ("3210");
         char ACTUAL_SEQ[EXPECTED_ADDR_COUNT+1]; ACTUAL_SEQ[EXPECTED_ADDR_COUNT]=0;
-        for(int i=0;i<zh->addrs.count;i++){
+        for(unsigned int i=0;i<zh->addrs.count;i++){
             sockaddr_in* addr=(struct sockaddr_in*)&zh->addrs.data[i];
             // match the first byte of the EXPECTED and of the actual address
             ACTUAL_SEQ[i]=((char*)&addr->sin_addr)[0]+'0';

--- a/zookeeper-client/zookeeper-client-c/tests/WatchUtil.h
+++ b/zookeeper-client/zookeeper-client-c/tests/WatchUtil.h
@@ -42,7 +42,6 @@ using namespace Util;
         int interest;
         int events;
         struct timeval tv;
-        int rc;
         time_t expires = time(0) + seconds;
         time_t timeLeft = seconds;
         fd_set rfds, wfds, efds;
@@ -70,7 +69,7 @@ using namespace Util;
             if (tv.tv_sec > timeLeft) {
                 tv.tv_sec = timeLeft;
             }
-            rc = select(fd+1, &rfds, &wfds, &efds, &tv);
+            select(fd+1, &rfds, &wfds, &efds, &tv);
             timeLeft = expires - time(0);
             events = 0;
             if (FD_ISSET(fd, &rfds)) {

--- a/zookeeper-client/zookeeper-client-c/tests/ZKMocks.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/ZKMocks.cc
@@ -33,7 +33,7 @@ TestClientId testClientId;
 const char* TestClientId::PASSWD="1234567890123456";
 
 HandshakeRequest* HandshakeRequest::parse(const std::string& buf) {
-    auto_ptr<HandshakeRequest> req(new HandshakeRequest);
+    unique_ptr<HandshakeRequest> req(new HandshakeRequest);
 
     memcpy(&req->protocolVersion,buf.data(), sizeof(req->protocolVersion));
     req->protocolVersion = htonl(req->protocolVersion);
@@ -480,7 +480,7 @@ void ZookeeperServer::onMessageReceived(const RequestHeader& rh, iarchive* ia){
 void ZookeeperServer::notifyBufferSent(const std::string& buffer){
     if(HandshakeRequest::isValid(buffer)){
         // could be a connect request
-        auto_ptr<HandshakeRequest> req(HandshakeRequest::parse(buffer));
+        unique_ptr<HandshakeRequest> req(HandshakeRequest::parse(buffer));
         if(req.get()!=0){
             // handle the handshake
             int64_t sessId=sessionExpired?req->sessionId+1:req->sessionId;
@@ -528,7 +528,7 @@ void forceConnected(zhandle_t* zh){
     zh->state=ZOO_CONNECTED_STATE;
 
     // Simulate we're connected to the first host in our host list
-    zh->fd=ZookeeperServer::FD;
+    zh->fd->sock=ZookeeperServer::FD;
     assert(zh->addrs.count > 0);
     zh->addr_cur = zh->addrs.data[0];
     zh->addrs.next++;

--- a/zookeeper-client/zookeeper-client-c/tests/ZooKeeperQuorumServer.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/ZooKeeperQuorumServer.cc
@@ -121,7 +121,7 @@ createConfigFile(std::string config) {
     confFile << "initLimit=5\n";
     confFile << "syncLimit=2\n";
     confFile << "dataDir=" << getDataDirectory() << "\n";
-    for (int i = 0; i < numServers_; i++) {
+    for (uint32_t i = 0; i < numServers_; i++) {
         confFile << getServerString(i) << "\n";
     }
     // Append additional config, if any.
@@ -177,14 +177,14 @@ getDataDirectory() {
 std::vector<ZooKeeperQuorumServer*> ZooKeeperQuorumServer::
 getCluster(uint32_t numServers) {
     std::vector<ZooKeeperQuorumServer*> cluster;
-    for (int i = 0; i < numServers; i++) {
+    for (uint32_t i = 0; i < numServers; i++) {
         cluster.push_back(new ZooKeeperQuorumServer(i, numServers));
     }
 
     // Wait until all the servers start, and fail if they don't start within 10
     // seconds.
-    for (int i = 0; i < 10; i++) {
-        int j = 0;
+    for (uint32_t i = 0; i < 10; i++) {
+        uint32_t j = 0;
         for (; j < cluster.size(); j++) {
             if (cluster[j]->getMode() == "") {
                 // The server hasn't started.
@@ -207,14 +207,14 @@ getCluster(uint32_t numServers, ZooKeeperQuorumServer::tConfigPairs configs, std
         std::pair<std::string, std::string> pair = *iter;
         config += (pair.first + "=" + pair.second + "\n");
     }
-    for (int i = 0; i < numServers; i++) {
+    for (uint32_t i = 0; i < numServers; i++) {
         cluster.push_back(new ZooKeeperQuorumServer(i, numServers, config, env));
     }
 
     // Wait until all the servers start, and fail if they don't start within 10
     // seconds.
-    for (int i = 0; i < 10; i++) {
-        int j = 0;
+    for (uint32_t i = 0; i < 10; i++) {
+        uint32_t j = 0;
         for (; j < cluster.size(); j++) {
             if (cluster[j]->getMode() == "") {
                 // The server hasn't started.

--- a/zookeeper-client/zookeeper-client-c/tests/ZooKeeperQuorumServer.h
+++ b/zookeeper-client/zookeeper-client-c/tests/ZooKeeperQuorumServer.h
@@ -55,10 +55,10 @@ class ZooKeeperQuorumServer {
     static const uint32_t ELECTION_PORT_BASE = 3000;
     static const uint32_t CLIENT_PORT_BASE = 4000;
 
-    uint32_t numServers_;
     uint32_t id_;
-    std::string root_;
     std::string env_;
+    uint32_t numServers_;
+    std::string root_;
 };
 
 #endif  // ZOOKEEPER_QUORUM_SERVER_H

--- a/zookeeper-client/zookeeper-client-c/tests/zkServer.sh
+++ b/zookeeper-client/zookeeper-client-c/tests/zkServer.sh
@@ -124,7 +124,7 @@ start|startClean)
         ./gencerts.sh >/dev/null 2>/dev/null
         cd -
         sed "s#TMPDIR#${tmpdir}#g;s#CERTDIR#${certdir}#g" tests/zoo.cfg > "${tmpdir}/zoo.cfg"
-        java -cp "$CLASSPATH" org.apache.zookeeper.server.ZooKeeperServerMain ${tmpdir}/zoo.cfg  &> /tmp/zk.log &
+        java -cp "$CLASSPATH" $PROPERTIES org.apache.zookeeper.server.ZooKeeperServerMain $ZOOPORT /tmp/zkdata 3000 $ZKMAXCNXNS &> /tmp/zk.log &
         pid=$!
         echo -n $! > /tmp/zk.pid
     else
@@ -139,7 +139,7 @@ start|startClean)
 
         sed "s#TMPDIR#${tmpdir}#g;s#CERTDIR#${certdir}#g" ${base_dir}/zookeeper-client/zookeeper-client-c/tests/zoo.cfg > "${tmpdir}/zoo.cfg"
 
-        java -cp "$CLASSPATH" org.apache.zookeeper.server.ZooKeeperServerMain ${tmpdir}/zoo.cfg &> "${base_dir}/build/tmp/zk.log" &
+        java -cp "$CLASSPATH" $PROPERTIES org.apache.zookeeper.server.ZooKeeperServerMain $ZOOPORT "${base_dir}/build/tmp/zkdata" 3000 $ZKMAXCNXNS &> "${base_dir}/build/tmp/zk.log" &
         pid=$!
         echo -n $pid > "${base_dir}/build/tmp/zk.pid"
     fi

--- a/zookeeper-client/zookeeper-client-c/tests/zoo.cfg
+++ b/zookeeper-client/zookeeper-client-c/tests/zoo.cfg
@@ -1,0 +1,12 @@
+tickTime=500
+initLimit=10
+syncLimit=5
+dataDir=TMPDIR/zkdata
+
+clientPort=22181
+secureClientPort=22281
+serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
+ssl.keyStore.location=CERTDIR/server.jks
+ssl.keyStore.password=password
+ssl.trustStore.location=CERTDIR/servertrust.jks
+ssl.trustStore.password=password


### PR DESCRIPTION
ZOOKEEPER-2122
There is an original PR opened for this by @SHUOSHI and reviewed by @anmolnar -
#639
This PR picks up those changes and fixes following bugs and design issues:

1. OPENSSL 1.0.2 version support:
PR#639 doesn't take care of any version of openssl less than 1.1.1.
2. SSL connection on non-blocking socket is handled correctly.
PR#639 starts the ZK protocol(prime_connection()) before establishing the SSL connection.
This leads to the connection failures sometimes.
3. Certificate Chain:
With clients cert chain(the intermediate certs), PR#639 doesn't work.
4. Memory Leaks
5. Generated Test certs: PR#639 had pre-generated certs pushed inside the repo. This change generated the certs dynamically.
