### PR TITLE
ZOOKEEPER-3440 Fix Apache RAT check by excluding binary files (images)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     packages:
     - libcppunit-dev
 
-script: mvn clean install -DskipTests spotbugs:check checkstyle:check -Pfull-build
+script: mvn clean apache-rat:check install -DskipTests spotbugs:check checkstyle:check -Pfull-build
 
 branches:
   only:

--- a/pom.xml
+++ b/pom.xml
@@ -784,6 +784,7 @@
             <exclude>README_packaging.txt</exclude>
             <exclude>src/main/resources/markdown/skin/*</exclude>
             <exclude>src/main/resources/markdown/html/*</exclude>
+            <exclude>src/main/resources/markdown/images/*</exclude>
             <exclude>zookeeper-contrib/zookeeper-contrib-loggraph/src/main/resources/webapp/org/apache/zookeeper/graph/resources/*</exclude>
             <exclude>zookeeper-contrib/zookeeper-contrib-zooinspector/TODO</exclude>
             <exclude>zookeeper-contrib/zookeeper-contrib-zkperl/Changes</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -801,6 +801,7 @@
             <exclude>zookeeper-client-c/tests/wrappers-mt.opt</exclude>
             <exclude>**/c-doc.Doxyfile</exclude>
           </excludes>
+          <consoleOutput>true</consoleOutput>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -785,21 +785,23 @@
             <exclude>src/main/resources/markdown/skin/*</exclude>
             <exclude>src/main/resources/markdown/html/*</exclude>
             <exclude>src/main/resources/markdown/images/*</exclude>
-            <exclude>zookeeper-contrib/zookeeper-contrib-loggraph/src/main/resources/webapp/org/apache/zookeeper/graph/resources/*</exclude>
-            <exclude>zookeeper-contrib/zookeeper-contrib-zooinspector/TODO</exclude>
-            <exclude>zookeeper-contrib/zookeeper-contrib-zkperl/Changes</exclude>
-            <exclude>zookeeper-contrib/zookeeper-contrib-zkperl/MANIFEST</exclude>
-            <exclude>zookeeper-contrib/zookeeper-contrib-fatjar/src/main/resources/mainClasses</exclude>
-            <exclude>zookeeper-contrib/zookeeper-contrib-monitoring/JMX-RESOURCES</exclude>
-            <exclude>zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/java/com/nitido/utils/toaster/Toaster.java</exclude>
+            <!-- contrib -->
+            <exclude>zookeeper-contrib-monitoring/JMX-RESOURCES</exclude>
+            <exclude>zookeeper-contrib-fatjar/src/main/resources/mainClasses</exclude>
+            <exclude>zookeeper-contrib-zkperl/Changes</exclude>
+            <exclude>zookeeper-contrib-zkperl/MANIFEST</exclude>
+            <exclude>zookeeper-contrib-loggraph/src/main/resources/webapp/org/apache/zookeeper/graph/resources/*</exclude>
+            <exclude>src/main/resources/webapp/org/apache/zookeeper/graph/resources/*</exclude>
+            <exclude>src/main/java/com/nitido/utils/toaster/Toaster.java</exclude>
+            <exclude>TODO</exclude>
+            <!-- c client -->
             <exclude>**/acinclude.m4</exclude>
             <exclude>**/aminclude.am</exclude>
-            <exclude>zookeeper-client/zookeeper-client-c/src/hashtable/*</exclude>
-            <exclude>zookeeper-client/zookeeper-client-c/include/winconfig.h</exclude>
-            <exclude>zookeeper-client/zookeeper-client-c/autom4te.cache/*</exclude>
-            <exclude>zookeeper-client/zookeeper-client-c/tests/wrappers.opt</exclude>
-            <exclude>zookeeper-client/zookeeper-client-c/tests/quorum.cfg</exclude>
-            <exclude>zookeeper-client/zookeeper-client-c/tests/wrappers-mt.opt</exclude>
+            <exclude>src/hashtable/*</exclude>
+            <exclude>include/winconfig.h</exclude>
+            <exclude>tests/wrappers.opt</exclude>
+            <exclude>tests/quorum.cfg</exclude>
+            <exclude>tests/wrappers-mt.opt</exclude>
             <exclude>**/c-doc.Doxyfile</exclude>
           </excludes>
           <consoleOutput>true</consoleOutput>

--- a/pom.xml
+++ b/pom.xml
@@ -794,11 +794,12 @@
             <exclude>zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/java/com/nitido/utils/toaster/Toaster.java</exclude>
             <exclude>**/acinclude.m4</exclude>
             <exclude>**/aminclude.am</exclude>
-            <exclude>zookeeper-client-c/src/hashtable/*</exclude>
-            <exclude>zookeeper-client-c/include/winconfig.h</exclude>
-            <exclude>zookeeper-client-c/tests/wrappers.opt</exclude>
-            <exclude>zookeeper-client-c/tests/quorum.cfg</exclude>
-            <exclude>zookeeper-client-c/tests/wrappers-mt.opt</exclude>
+            <exclude>zookeeper-client/zookeeper-client-c/src/hashtable/*</exclude>
+            <exclude>zookeeper-client/zookeeper-client-c/include/winconfig.h</exclude>
+            <exclude>zookeeper-client/zookeeper-client-c/autom4te.cache/*</exclude>
+            <exclude>zookeeper-client/zookeeper-client-c/tests/wrappers.opt</exclude>
+            <exclude>zookeeper-client/zookeeper-client-c/tests/quorum.cfg</exclude>
+            <exclude>zookeeper-client/zookeeper-client-c/tests/wrappers-mt.opt</exclude>
             <exclude>**/c-doc.Doxyfile</exclude>
           </excludes>
           <consoleOutput>true</consoleOutput>


### PR DESCRIPTION
- Fix Apache Rat plugin configuration (make it pass against C client, docs and contrib module)
- Add apache-rat:check on Travis