### PR TITLE
ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814

### DIFF
--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -35,4 +35,10 @@
            False positive on Netty 4.x-->
       <cve>CVE-2018-12056</cve>
    </suppress>
+   <suppress>
+      <!-- ZOOKEEPER-3441
+           we do not have jdom in our classpath
+           https://nvd.nist.gov/vuln/detail/CVE-2019-12814 -->
+      <cve>CVE-2019-12814</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
We are not affected by https://nvd.nist.gov/vuln/detail/CVE-2019-12814 as we do not have jdom in our classpath, so we can add a suppression.
We cannot upgrade jaskson as we are already using the latest and greatest version.

See more details in https://issues.apache.org/jira/browse/ZOOKEEPER-3441