### PR TITLE
ZOOKEEPER-3443: Add support of PKCS12 trust/key stores

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1119,7 +1119,7 @@ encryption/authentication/authorization performed by the service.
 * *ssl.keyStore.type* and *ssl.quorum.keyStore.type* :
     (Java system properties: **zookeeper.ssl.keyStore.type** and **zookeeper.ssl.quorum.keyStore.type**)
     **New in 3.5.5:**
-    Specifies the file format of client and quorum keystores. Values: JKS, PEM or null (detect by filename).    
+    Specifies the file format of client and quorum keystores. Values: JKS, PEM, PKCS12 or null (detect by filename).    
     Default: null     
     
 * *ssl.trustStore.location* and *ssl.trustStore.password* and *ssl.quorum.trustStore.location* and *ssl.quorum.trustStore.password* :
@@ -1132,7 +1132,7 @@ encryption/authentication/authorization performed by the service.
 * *ssl.trustStore.type* and *ssl.quorum.trustStore.type* :
     (Java system properties: **zookeeper.ssl.trustStore.type** and **zookeeper.ssl.quorum.trustStore.type**)
     **New in 3.5.5:**
-    Specifies the file format of client and quorum trustStores. Values: JKS, PEM or null (detect by filename).    
+    Specifies the file format of client and quorum trustStores. Values: JKS, PEM, PKCS12 or null (detect by filename).    
     Default: null     
 
 * *ssl.protocol* and *ssl.quorum.protocol* :

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/FileKeyStoreLoaderBuilderProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/FileKeyStoreLoaderBuilderProvider.java
@@ -36,6 +36,8 @@ public class FileKeyStoreLoaderBuilderProvider {
                 return new JKSFileLoader.Builder();
             case PEM:
                 return new PEMFileLoader.Builder();
+            case PKCS12:
+                return new PKCS12FileLoader.Builder();
             default:
                 throw new AssertionError(
                         "Unexpected StoreFileType: " + type.name());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/KeyStoreFileType.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/KeyStoreFileType.java
@@ -20,11 +20,10 @@ package org.apache.zookeeper.common;
 
 /**
  * This enum represents the file type of a KeyStore or TrustStore.
- * Currently, JKS (java keystore) and PEM types are supported.
+ * Currently, JKS (Java keystore), PEM, and PKCS12 types are supported.
  */
 public enum KeyStoreFileType {
-    // TODO: consider adding support for PKCS12
-    JKS(".jks"), PEM(".pem");
+    JKS(".jks"), PEM(".pem"), PKCS12(".p12");
 
     private final String defaultFileExtension;
 
@@ -54,7 +53,7 @@ public enum KeyStoreFileType {
      * @return the KeyStoreFileType, or <code>null</code> if
      *         <code>propertyValue</code> is <code>null</code> or empty.
      * @throws IllegalArgumentException if <code>propertyValue</code> is not
-     *         one of "JKS", "PEM", or empty/null.
+     *         one of "JKS", "PEM", "PKCS12", or empty/null.
      */
     public static KeyStoreFileType fromPropertyValue(String propertyValue) {
         if (propertyValue == null || propertyValue.length() == 0) {
@@ -67,11 +66,12 @@ public enum KeyStoreFileType {
      * Detects the type of KeyStore / TrustStore file from the file extension.
      * If the file name ends with ".jks", returns <code>StoreFileType.JKS</code>.
      * If the file name ends with ".pem", returns <code>StoreFileType.PEM</code>.
+     * If the file name ends with ".p12", returns <code>StoreFileType.PKCS12</code>.
      * Otherwise, throws an IllegalArgumentException.
      * @param filename the filename of the key store or trust store file.
      * @return a KeyStoreFileType.
      * @throws IllegalArgumentException if the filename does not end with
-     *         ".jks" or ".pem".
+     *         ".jks", ".pem", or "p12".
      */
     public static KeyStoreFileType fromFilename(String filename) {
         int i = filename.lastIndexOf('.');
@@ -99,7 +99,7 @@ public enum KeyStoreFileType {
      *                 <code>propertyValue</code> is null or empty.
      * @return a KeyStoreFileType.
      * @throws IllegalArgumentException if <code>propertyValue</code> is not
-     *         one of "JKS", "PEM", or empty/null.
+     *         one of "JKS", "PEM", "PKCS12", or empty/null.
      * @throws IllegalArgumentException if <code>propertyValue</code>is empty
      *         or null and the type could not be determined from the file name.
      */

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/PKCS12FileLoader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/PKCS12FileLoader.java
@@ -22,25 +22,25 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 
 /**
- * Implementation of {@link FileKeyStoreLoader} that loads from JKS files.
+ * Implementation of {@link FileKeyStoreLoader} that loads from PKCS12 files.
  */
-class JKSFileLoader extends StandardTypeFileKeyStoreLoader {
-    private JKSFileLoader(String keyStorePath,
-                          String trustStorePath,
-                          String keyStorePassword,
-                          String trustStorePassword) {
+class PKCS12FileLoader extends StandardTypeFileKeyStoreLoader {
+    private PKCS12FileLoader(String keyStorePath,
+                             String trustStorePath,
+                             String keyStorePassword,
+                             String trustStorePassword) {
         super(keyStorePath, trustStorePath, keyStorePassword, trustStorePassword);
     }
 
     @Override
     protected KeyStore keyStoreInstance() throws KeyStoreException {
-        return KeyStore.getInstance("JKS");
+        return KeyStore.getInstance("PKCS12");
     }
 
-    static class Builder extends FileKeyStoreLoader.Builder<JKSFileLoader> {
+    static class Builder extends FileKeyStoreLoader.Builder<PKCS12FileLoader> {
         @Override
-        JKSFileLoader build() {
-            return new JKSFileLoader(keyStorePath, trustStorePath, keyStorePassword, trustStorePassword);
+        PKCS12FileLoader build() {
+            return new PKCS12FileLoader(keyStorePath, trustStorePath, keyStorePassword, trustStorePassword);
         }
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/StandardTypeFileKeyStoreLoader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/StandardTypeFileKeyStoreLoader.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.common;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+
+/**
+ * Base class for instances of {@link KeyStoreLoader} which load the key/trust
+ * stores from files on a filesystem using standard {@link KeyStore} types like
+ * JKS or PKCS12.
+ */
+abstract class StandardTypeFileKeyStoreLoader extends FileKeyStoreLoader {
+    private static final char[] EMPTY_CHAR_ARRAY = new char[0];
+
+    StandardTypeFileKeyStoreLoader(String keyStorePath,
+                                   String trustStorePath,
+                                   String keyStorePassword,
+                                   String trustStorePassword) {
+        super(keyStorePath, trustStorePath, keyStorePassword, trustStorePassword);
+    }
+
+    @Override
+    public KeyStore loadKeyStore() throws IOException, GeneralSecurityException {
+        try (InputStream inputStream = new FileInputStream(new File(keyStorePath))) {
+            KeyStore ks = keyStoreInstance();
+            ks.load(inputStream, passwordStringToCharArray(keyStorePassword));
+            return ks;
+        }
+    }
+
+    @Override
+    public KeyStore loadTrustStore() throws IOException, GeneralSecurityException {
+        try (InputStream inputStream = new FileInputStream(new File(trustStorePath))) {
+            KeyStore ts = keyStoreInstance();
+            ts.load(inputStream, passwordStringToCharArray(trustStorePassword));
+            return ts;
+        }
+    }
+
+    protected abstract KeyStore keyStoreInstance() throws KeyStoreException;
+
+    private static char[] passwordStringToCharArray(String password) {
+        return password == null ? EMPTY_CHAR_ARRAY : password.toCharArray();
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/FileKeyStoreLoaderBuilderProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/FileKeyStoreLoaderBuilderProviderTest.java
@@ -39,6 +39,14 @@ public class FileKeyStoreLoaderBuilderProviderTest extends ZKTestCase {
         Assert.assertTrue(builder instanceof PEMFileLoader.Builder);
     }
 
+    @Test
+    public void testGetBuilderForPKCS12FileType() {
+        FileKeyStoreLoader.Builder<?> builder =
+            FileKeyStoreLoaderBuilderProvider.getBuilderForKeyStoreFileType(
+                KeyStoreFileType.PKCS12);
+        Assert.assertTrue(builder instanceof PKCS12FileLoader.Builder);
+    }
+
     @Test(expected = NullPointerException.class)
     public void testGetBuilderForNullFileType() {
         FileKeyStoreLoaderBuilderProvider.getBuilderForKeyStoreFileType(null);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/KeyStoreFileTypeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/KeyStoreFileTypeTest.java
@@ -27,12 +27,14 @@ public class KeyStoreFileTypeTest extends ZKTestCase {
     public void testGetPropertyValue() {
         Assert.assertEquals("PEM", KeyStoreFileType.PEM.getPropertyValue());
         Assert.assertEquals("JKS", KeyStoreFileType.JKS.getPropertyValue());
+        Assert.assertEquals("PKCS12", KeyStoreFileType.PKCS12.getPropertyValue());
     }
 
     @Test
     public void testFromPropertyValue() {
         Assert.assertEquals(KeyStoreFileType.PEM, KeyStoreFileType.fromPropertyValue("PEM"));
         Assert.assertEquals(KeyStoreFileType.JKS, KeyStoreFileType.fromPropertyValue("JKS"));
+        Assert.assertEquals(KeyStoreFileType.PKCS12, KeyStoreFileType.fromPropertyValue("PKCS12"));
         Assert.assertNull(KeyStoreFileType.fromPropertyValue(""));
         Assert.assertNull(KeyStoreFileType.fromPropertyValue(null));
     }
@@ -41,6 +43,7 @@ public class KeyStoreFileTypeTest extends ZKTestCase {
     public void testFromPropertyValueIgnoresCase() {
         Assert.assertEquals(KeyStoreFileType.PEM, KeyStoreFileType.fromPropertyValue("pem"));
         Assert.assertEquals(KeyStoreFileType.JKS, KeyStoreFileType.fromPropertyValue("jks"));
+        Assert.assertEquals(KeyStoreFileType.PKCS12, KeyStoreFileType.fromPropertyValue("pkcs12"));
         Assert.assertNull(KeyStoreFileType.fromPropertyValue(""));
         Assert.assertNull(KeyStoreFileType.fromPropertyValue(null));
     }
@@ -60,6 +63,10 @@ public class KeyStoreFileTypeTest extends ZKTestCase {
                 KeyStoreFileType.fromFilename("mykey.pem"));
         Assert.assertEquals(KeyStoreFileType.PEM,
                 KeyStoreFileType.fromFilename("/path/to/key/dir/mykey.pem"));
+        Assert.assertEquals(KeyStoreFileType.PKCS12,
+            KeyStoreFileType.fromFilename("mykey.p12"));
+        Assert.assertEquals(KeyStoreFileType.PKCS12,
+            KeyStoreFileType.fromFilename("/path/to/key/dir/mykey.p12"));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -73,6 +80,12 @@ public class KeyStoreFileTypeTest extends ZKTestCase {
         Assert.assertEquals(KeyStoreFileType.JKS,
                 KeyStoreFileType.fromPropertyValueOrFileName(
                         "JKS", "prod.key"));
+        Assert.assertEquals(KeyStoreFileType.PEM,
+            KeyStoreFileType.fromPropertyValueOrFileName(
+                "PEM", "prod.key"));
+        Assert.assertEquals(KeyStoreFileType.PKCS12,
+            KeyStoreFileType.fromPropertyValueOrFileName(
+                "PKCS12", "prod.key"));
         // Falls back to filename detection if no property value
         Assert.assertEquals(KeyStoreFileType.JKS,
                 KeyStoreFileType.fromPropertyValueOrFileName("", "prod.jks"));

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/PKCS12FileLoaderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/PKCS12FileLoaderTest.java
@@ -1,0 +1,165 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.common;
+
+import java.io.IOException;
+import java.security.KeyStore;
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class PKCS12FileLoaderTest extends BaseX509ParameterizedTestCase {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> params() {
+        return BaseX509ParameterizedTestCase.defaultParams();
+    }
+
+    public PKCS12FileLoaderTest(
+        final X509KeyType caKeyType,
+        final X509KeyType certKeyType,
+        final String keyPassword,
+        final Integer paramIndex) {
+        super(paramIndex, () -> {
+            try {
+                return X509TestContext.newBuilder()
+                    .setTempDir(tempDir)
+                    .setKeyStorePassword(keyPassword)
+                    .setKeyStoreKeyType(certKeyType)
+                    .setTrustStorePassword(keyPassword)
+                    .setTrustStoreKeyType(caKeyType)
+                    .build();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void testLoadKeyStore() throws Exception {
+        String path = x509TestContext.getKeyStoreFile(KeyStoreFileType.PKCS12)
+            .getAbsolutePath();
+        KeyStore ks = new PKCS12FileLoader.Builder()
+            .setKeyStorePath(path)
+            .setKeyStorePassword(x509TestContext.getKeyStorePassword())
+            .build()
+            .loadKeyStore();
+        Assert.assertEquals(1, ks.size());
+    }
+
+    @Test(expected = Exception.class)
+    public void testLoadKeyStoreWithWrongPassword() throws Exception {
+        String path = x509TestContext.getKeyStoreFile(KeyStoreFileType.PKCS12)
+            .getAbsolutePath();
+        new PKCS12FileLoader.Builder()
+            .setKeyStorePath(path)
+            .setKeyStorePassword("wrong password")
+            .build()
+            .loadKeyStore();
+    }
+
+    @Test(expected = IOException.class)
+    public void testLoadKeyStoreWithWrongFilePath() throws Exception {
+        String path = x509TestContext.getKeyStoreFile(KeyStoreFileType.PKCS12)
+            .getAbsolutePath();
+        new PKCS12FileLoader.Builder()
+            .setKeyStorePath(path + ".does_not_exist")
+            .setKeyStorePassword(x509TestContext.getKeyStorePassword())
+            .build()
+            .loadKeyStore();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testLoadKeyStoreWithNullFilePath() throws Exception {
+        new PKCS12FileLoader.Builder()
+            .setKeyStorePassword(x509TestContext.getKeyStorePassword())
+            .build()
+            .loadKeyStore();
+    }
+
+    @Test(expected = IOException.class)
+    public void testLoadKeyStoreWithWrongFileType() throws Exception {
+        // Trying to load a PEM file with PKCS12 loader should fail
+        String path = x509TestContext.getKeyStoreFile(KeyStoreFileType.PEM)
+            .getAbsolutePath();
+        new PKCS12FileLoader.Builder()
+            .setKeyStorePath(path)
+            .setKeyStorePassword(x509TestContext.getKeyStorePassword())
+            .build()
+            .loadKeyStore();
+    }
+
+    @Test
+    public void testLoadTrustStore() throws Exception {
+        String path = x509TestContext.getTrustStoreFile(KeyStoreFileType.PKCS12)
+            .getAbsolutePath();
+        KeyStore ts = new PKCS12FileLoader.Builder()
+            .setTrustStorePath(path)
+            .setTrustStorePassword(x509TestContext.getTrustStorePassword())
+            .build()
+            .loadTrustStore();
+        Assert.assertEquals(1, ts.size());
+    }
+
+    @Test(expected = Exception.class)
+    public void testLoadTrustStoreWithWrongPassword() throws Exception {
+        String path = x509TestContext.getTrustStoreFile(KeyStoreFileType.PKCS12)
+            .getAbsolutePath();
+        new PKCS12FileLoader.Builder()
+            .setTrustStorePath(path)
+            .setTrustStorePassword("wrong password")
+            .build()
+            .loadTrustStore();
+    }
+
+    @Test(expected = IOException.class)
+    public void testLoadTrustStoreWithWrongFilePath() throws Exception {
+        String path = x509TestContext.getTrustStoreFile(KeyStoreFileType.PKCS12)
+            .getAbsolutePath();
+        new PKCS12FileLoader.Builder()
+            .setTrustStorePath(path + ".does_not_exist")
+            .setTrustStorePassword(x509TestContext.getTrustStorePassword())
+            .build()
+            .loadTrustStore();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testLoadTrustStoreWithNullFilePath() throws Exception {
+        new PKCS12FileLoader.Builder()
+            .setTrustStorePassword(x509TestContext.getTrustStorePassword())
+            .build()
+            .loadTrustStore();
+    }
+
+    @Test(expected = IOException.class)
+    public void testLoadTrustStoreWithWrongFileType() throws Exception {
+        // Trying to load a PEM file with PKCS12 loader should fail
+        String path = x509TestContext.getTrustStoreFile(KeyStoreFileType.PEM)
+            .getAbsolutePath();
+        new PKCS12FileLoader.Builder()
+            .setTrustStorePath(path)
+            .setTrustStorePassword(x509TestContext.getTrustStorePassword())
+            .build()
+            .loadTrustStore();
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509TestHelpers.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509TestHelpers.java
@@ -348,6 +348,30 @@ public class X509TestHelpers {
             X509Certificate cert,
             String keyPassword) throws IOException, GeneralSecurityException {
         KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        return certToTrustStoreBytes(cert, keyPassword, trustStore);
+    }
+
+    /**
+     * Encodes the given X509Certificate as a PKCS12 TrustStore, optionally protecting the cert with a password (though
+     * it's unclear why one would do this since certificates only contain public information and do not need to be
+     * kept secret). Returns the byte array encoding of the trust store, which may be written to a file and loaded to
+     * instantiate the trust store at a later point or in another process.
+     * @param cert the certificate to serialize.
+     * @param keyPassword an optional password to encrypt the trust store. If empty or null, the cert will not be encrypted.
+     * @return the serialized bytes of the PKCS12 trust store.
+     * @throws IOException
+     * @throws GeneralSecurityException
+     */
+    public static byte[] certToPKCS12TrustStoreBytes(
+            X509Certificate cert,
+            String keyPassword) throws IOException, GeneralSecurityException {
+        KeyStore trustStore = KeyStore.getInstance("PKCS12");
+        return certToTrustStoreBytes(cert, keyPassword, trustStore);
+    }
+
+    private static byte[] certToTrustStoreBytes(X509Certificate cert,
+                                                String keyPassword,
+                                                KeyStore trustStore) throws IOException, GeneralSecurityException {
         char[] keyPasswordChars = keyPassword == null ? new char[0] : keyPassword.toCharArray();
         trustStore.load(null, keyPasswordChars);
         trustStore.setCertificateEntry(cert.getSubjectDN().toString(), cert);
@@ -375,6 +399,33 @@ public class X509TestHelpers {
             PrivateKey privateKey,
             String keyPassword) throws IOException, GeneralSecurityException {
         KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        return certAndPrivateKeyToPKCS12Bytes(cert, privateKey, keyPassword, keyStore);
+    }
+
+    /**
+     * Encodes the given X509Certificate and private key as a PKCS12 KeyStore, optionally protecting the private key
+     * (and possibly the cert?) with a password. Returns the byte array encoding of the key store, which may be written
+     * to a file and loaded to instantiate the key store at a later point or in another process.
+     * @param cert the X509 certificate to serialize.
+     * @param privateKey the private key to serialize.
+     * @param keyPassword an optional key password. If empty or null, the private key will not be encrypted.
+     * @return the serialized bytes of the PKCS12 key store.
+     * @throws IOException
+     * @throws GeneralSecurityException
+     */
+    public static byte[] certAndPrivateKeyToPKCS12Bytes(
+            X509Certificate cert,
+            PrivateKey privateKey,
+            String keyPassword) throws IOException, GeneralSecurityException {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        return certAndPrivateKeyToPKCS12Bytes(cert, privateKey, keyPassword, keyStore);
+    }
+
+    private static byte[] certAndPrivateKeyToPKCS12Bytes(
+            X509Certificate cert,
+            PrivateKey privateKey,
+            String keyPassword,
+            KeyStore keyStore) throws IOException, GeneralSecurityException {
         char[] keyPasswordChars = keyPassword == null ? new char[0] : keyPassword.toCharArray();
         keyStore.load(null, keyPasswordChars);
         keyStore.setKeyEntry(

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
@@ -377,6 +377,100 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
     }
 
     @Test
+    public void testLoadPKCS12KeyStore() throws Exception {
+        // Make sure we can instantiate a key manager from the PKCS12 file on disk
+        X509KeyManager km = X509Util.createKeyManager(
+            x509TestContext.getKeyStoreFile(KeyStoreFileType.PKCS12).getAbsolutePath(),
+            x509TestContext.getKeyStorePassword(),
+            KeyStoreFileType.PKCS12.getPropertyValue());
+    }
+
+    @Test
+    public void testLoadPKCS12KeyStoreNullPassword() throws Exception {
+        if (!x509TestContext.getKeyStorePassword().isEmpty()) {
+            return;
+        }
+        // Make sure that empty password and null password are treated the same
+        X509KeyManager km = X509Util.createKeyManager(
+            x509TestContext.getKeyStoreFile(KeyStoreFileType.PKCS12).getAbsolutePath(),
+            null,
+            KeyStoreFileType.PKCS12.getPropertyValue());
+    }
+
+    @Test
+    public void testLoadPKCS12KeyStoreAutodetectStoreFileType() throws Exception {
+        // Make sure we can instantiate a key manager from the PKCS12 file on disk
+        X509KeyManager km = X509Util.createKeyManager(
+            x509TestContext.getKeyStoreFile(KeyStoreFileType.PKCS12).getAbsolutePath(),
+            x509TestContext.getKeyStorePassword(),
+            null /* null StoreFileType means 'autodetect from file extension' */);
+    }
+
+    @Test(expected = X509Exception.KeyManagerException.class)
+    public void testLoadPKCS12KeyStoreWithWrongPassword() throws Exception {
+        // Attempting to load with the wrong key password should fail
+        X509KeyManager km = X509Util.createKeyManager(
+            x509TestContext.getKeyStoreFile(KeyStoreFileType.PKCS12).getAbsolutePath(),
+            "wrong password",
+            KeyStoreFileType.PKCS12.getPropertyValue());
+    }
+
+    @Test
+    public void testLoadPKCS12TrustStore() throws Exception {
+        // Make sure we can instantiate a trust manager from the PKCS12 file on disk
+        X509TrustManager tm = X509Util.createTrustManager(
+            x509TestContext.getTrustStoreFile(KeyStoreFileType.PKCS12).getAbsolutePath(),
+            x509TestContext.getTrustStorePassword(),
+            KeyStoreFileType.PKCS12.getPropertyValue(),
+            true,
+            true,
+            true,
+            true);
+    }
+
+    @Test
+    public void testLoadPKCS12TrustStoreNullPassword() throws Exception {
+        if (!x509TestContext.getTrustStorePassword().isEmpty()) {
+            return;
+        }
+        // Make sure that empty password and null password are treated the same
+        X509TrustManager tm = X509Util.createTrustManager(
+            x509TestContext.getTrustStoreFile(KeyStoreFileType.PKCS12).getAbsolutePath(),
+            null,
+            KeyStoreFileType.PKCS12.getPropertyValue(),
+            false,
+            false,
+            true,
+            true);
+    }
+
+    @Test
+    public void testLoadPKCS12TrustStoreAutodetectStoreFileType() throws Exception {
+        // Make sure we can instantiate a trust manager from the PKCS12 file on disk
+        X509TrustManager tm = X509Util.createTrustManager(
+            x509TestContext.getTrustStoreFile(KeyStoreFileType.PKCS12).getAbsolutePath(),
+            x509TestContext.getTrustStorePassword(),
+            null,  // null StoreFileType means 'autodetect from file extension'
+            true,
+            true,
+            true,
+            true);
+    }
+
+    @Test(expected = X509Exception.TrustManagerException.class)
+    public void testLoadPKCS12TrustStoreWithWrongPassword() throws Exception {
+        // Attempting to load with the wrong key password should fail
+        X509TrustManager tm = X509Util.createTrustManager(
+            x509TestContext.getTrustStoreFile(KeyStoreFileType.PKCS12).getAbsolutePath(),
+            "wrong password",
+            KeyStoreFileType.PKCS12.getPropertyValue(),
+            true,
+            true,
+            true,
+            true);
+    }
+
+    @Test
     public void testGetSslHandshakeDetectionTimeoutMillisProperty() {
         Assert.assertEquals(
                 X509Util.DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS,


### PR DESCRIPTION
This commit adds support of PKCS12 trust store and key store type.
The existing mechanism for trust/key store types that support JKS and
PEM were extended with PKCS12.

The implementations of JKSFileLoader and PKCS12FileLoader were almost
identical so most of it were abstracted away in
StandardTypeFileKeyStoreLoader.