### PR TITLE
ZOOKEEPER-3445 ReferenceCountedACLCache.aclIndex should be volatile

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ReferenceCountedACLCache.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ReferenceCountedACLCache.java
@@ -51,7 +51,7 @@ public class ReferenceCountedACLCache {
     /**
      * these are the number of acls that we have in the datatree
      */
-    long aclIndex = 0;
+    volatile long aclIndex = 0;
 
     /**
      * converts the list of acls to a long.


### PR DESCRIPTION
This commit marks `ReferenceCountedACLCache.aclIndex` as volatile since it appears to be read by multiple threads. I didn't have any good ideas on how to exercise this in a unit test, but am happy to do so if you have any suggestions.