### PR TITLE
ZOOKEEPER-3463. Enable warning messages in maven compiler plugin (3.5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -454,10 +454,13 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.0</version>
           <configuration>
-             <compilerArgs>
+            <showWarnings>true</showWarnings>
+            <compilerArgs>
                <compilerArg>-Werror</compilerArg>
                <compilerArg>-Xlint:deprecation</compilerArg>
                <compilerArg>-Xlint:unchecked</compilerArg>
+               <compilerArg>-Xlint:-options</compilerArg>
+               <compilerArg>-Xdoclint:-missing</compilerArg>
                <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->
                <compilerArg>-Xpkginfo:always</compilerArg>
               </compilerArgs>


### PR DESCRIPTION
Backported changes from #1016 

@eolivelli ptal.