### PR TITLE
[ZOOKEEPER-3472] Treat check request as a write request which needs to wait for the check txn commit from leader

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/CommitProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/CommitProcessor.java
@@ -155,6 +155,7 @@ public class CommitProcessor extends ZooKeeperCriticalThread implements
             case OpCode.reconfig:
             case OpCode.multi:
             case OpCode.setACL:
+            case OpCode.check:
                 return true;
             case OpCode.sync:
                 return matchSyncs;


### PR DESCRIPTION
Check op is usually used as a sub op in multi, but from the ZooKeeper server implementation it can also called separately, the learner will forward this request to leader, and the leader will check the version with the given version in the request, and generate a txn (error) in the quorum.
 
There is no explicit API exposed for check, but it could leave an issue there if the check API is exposed in the future.

Also because the check API is not exposed, we cannot write an E2E test for check here.