### PR TITLE
[ZOOKEEPER-3473] Improving successful TLS handshake throughput with concurrent control

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -988,6 +988,14 @@ property, when available, is noted below.
     **New in 3.6.0:**
     The size threshold after which a request is considered a large request. If it is -1, then all requests are considered small, effectively turning off large request throttling. The default is -1.
 
+* *outstandingHandshake.limit* 
+    (Jave system property only: **zookeeper.netty.server.outstandingHandshake.limit**)
+    The maximum in-flight TLS handshake connections could have in ZooKeeper, 
+    the connections exceed this limit will be rejected before starting handshake. 
+    This setting doesn't limit the max TLS concurrency, but helps avoid herd 
+    effect due to TLS handshake timeout when there are too many in-flight TLS 
+    handshakes. Set it to something like 250 is good enough to avoid herd effect.
+
 <a name="sc_clusterOptions"></a>
 
 #### Cluster Options

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -70,6 +70,14 @@ public class NettyServerCnxn extends ServerCnxn {
 
     public int readIssuedAfterReadComplete;
 
+    private volatile HandshakeState handshakeState = HandshakeState.NONE;
+
+    public enum HandshakeState {
+        NONE,
+        STARTED,
+        FINISHED
+    }
+
     NettyServerCnxn(Channel channel, ZooKeeperServer zks, NettyServerCnxnFactory factory) {
         super(zks);
         this.channel = channel;
@@ -629,4 +637,11 @@ public class NettyServerCnxn extends ServerCnxn {
         return 0;
     }
 
+    public void setHandshakeState(HandshakeState state) {
+        this.handshakeState = state;
+    }
+
+    public HandshakeState getHandshakeState() {
+        return this.handshakeState;
+    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
@@ -228,6 +228,7 @@ public final class ServerMetrics {
         NETTY_QUEUED_BUFFER = metricsContext.getSummary("netty_queued_buffer_capacity", DetailLevel.BASIC);
 
         DIGEST_MISMATCHES_COUNT = metricsContext.getCounter("digest_mismatches_count");
+        TLS_HANDSHAKE_EXCEEDED = metricsContext.getCounter("tls_handshake_exceeded");
     }
 
     /**
@@ -433,6 +434,8 @@ public final class ServerMetrics {
     // Total number of digest mismatches that are observed when applying
     // txns to data tree.
     public final Counter DIGEST_MISMATCHES_COUNT;
+
+    public final Counter TLS_HANDSHAKE_EXCEEDED;
 
     private final MetricsProvider metricsProvider;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -1801,6 +1801,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         rootContext.registerGauge("max_client_response_size", stats.getClientResponseStats()::getMaxBufferSize);
         rootContext.registerGauge("min_client_response_size", stats.getClientResponseStats()::getMinBufferSize);
 
+        rootContext.registerGauge("outstanding_tls_handshake", this::getOutstandingHandshakeNum);
     }
 
     protected void unregisterMetrics() {
@@ -2060,4 +2061,11 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         return rv;
     }
 
+    public int getOutstandingHandshakeNum() {
+        if (serverCnxnFactory instanceof NettyServerCnxnFactory) {
+            return ((NettyServerCnxnFactory) serverCnxnFactory).getOutstandingHandshakeNum();
+        } else {
+            return 0;
+        }
+    }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/NettyServerCnxnFactoryTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/NettyServerCnxnFactoryTest.java
@@ -18,29 +18,25 @@
 
 package org.apache.zookeeper.server;
 
-import org.apache.zookeeper.PortAssignment;
-import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.WatchedEvent;
-import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.common.ClientX509Util;
-import org.apache.zookeeper.server.metric.SimpleCounter;
-import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.SSLAuthTest;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.common.ClientX509Util;
+import org.apache.zookeeper.server.metric.SimpleCounter;
+import org.apache.zookeeper.test.ClientBase;
+import org.apache.zookeeper.test.SSLAuthTest;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.greaterThan;
 
 public class NettyServerCnxnFactoryTest extends ClientBase {
 
@@ -143,20 +139,20 @@ public class NettyServerCnxnFactoryTest extends ClientBase {
             cnxnWorker[i].start();
         }
 
-        Assert.assertThat(latch.await(3, TimeUnit.SECONDS), is(true));
+        Assert.assertThat(latch.await(3, TimeUnit.SECONDS), Matchers.is(true));
         LOG.info("created {} connections", threadNum * cnxnPerThread);
 
         // Assert throttling not 0
         long handshakeThrottledNum = tlsHandshakeExceeded.get();
         LOG.info("TLS_HANDSHAKE_EXCEEDED: {}", handshakeThrottledNum);
-        Assert.assertThat("The number of handshake throttled should be " +
-                "greater than 0", handshakeThrottledNum, greaterThan(0L));
+        Assert.assertThat("The number of handshake throttled should be "
+                + "greater than 0", handshakeThrottledNum, Matchers.greaterThan(0L));
 
         // Assert there is no outstanding handshake anymore
         int outstandingHandshakeNum = factory.getOutstandingHandshakeNum();
         LOG.info("outstanding handshake is {}", outstandingHandshakeNum);
-        Assert.assertThat("The outstanding handshake number should be 0 " +
-                "after all cnxns established", outstandingHandshakeNum, is(0));
+        Assert.assertThat("The outstanding handshake number should be 0 "
+                + "after all cnxns established", outstandingHandshakeNum, Matchers.is(0));
 
     }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/NettyServerCnxnFactoryTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/NettyServerCnxnFactoryTest.java
@@ -53,6 +53,7 @@ public class NettyServerCnxnFactoryTest extends ClientBase {
 
     @Override
     public void tearDown() throws Exception {
+        System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
         super.tearDown();
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/NettyServerCnxnFactoryTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/NettyServerCnxnFactoryTest.java
@@ -18,12 +18,43 @@
 
 package org.apache.zookeeper.server;
 
-import java.net.InetSocketAddress;
 import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.common.ClientX509Util;
+import org.apache.zookeeper.server.metric.SimpleCounter;
+import org.apache.zookeeper.test.ClientBase;
+import org.apache.zookeeper.test.SSLAuthTest;
+
 import org.junit.Assert;
 import org.junit.Test;
 
-public class NettyServerCnxnFactoryTest {
+import java.net.InetSocketAddress;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NettyServerCnxnFactoryTest extends ClientBase {
+
+    private static final Logger LOG = LoggerFactory
+            .getLogger(NettyServerCnxnFactoryTest.class);
+
+    @Override
+    public void setUp() throws Exception {
+        System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY,
+                "org.apache.zookeeper.server.NettyServerCnxnFactory");
+        super.setUp();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
 
     @Test
     public void testRebind() throws Exception {
@@ -58,4 +89,67 @@ public class NettyServerCnxnFactoryTest {
         Assert.assertTrue(factory.getParentChannel().isActive());
     }
 
+    @Test
+    public void testOutstandingHandshakeLimit() throws Exception {
+
+        SimpleCounter tlsHandshakeExceeded = (SimpleCounter) ServerMetrics.getMetrics().TLS_HANDSHAKE_EXCEEDED;
+        tlsHandshakeExceeded.reset();
+        Assert.assertEquals(tlsHandshakeExceeded.get(), 0);
+
+        ClientX509Util x509Util = SSLAuthTest.setUpSecure();
+        NettyServerCnxnFactory factory = (NettyServerCnxnFactory) serverFactory;
+        factory.setSecure(true);
+        factory.setOutstandingHandshakeLimit(10);
+
+        int threadNum = 3;
+        int cnxnPerThread = 10;
+        Thread[] cnxnWorker = new Thread[threadNum];
+        final LinkedBlockingQueue<ZooKeeper> zks = new LinkedBlockingQueue<ZooKeeper>();
+
+        AtomicInteger cnxnCreated = new AtomicInteger(0);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        for (int i = 0; i < cnxnWorker.length; i++) {
+            cnxnWorker[i] = new Thread() {
+                @Override
+                public void run() {
+                    for (int i = 0; i < cnxnPerThread; i++) {
+                        try {
+                            zks.add(new ZooKeeper(hostPort, 3000, new Watcher() {
+                                @Override
+                                public void process(WatchedEvent event) {
+                                    int created = cnxnCreated.addAndGet(1);
+                                    if (created == threadNum * cnxnPerThread) {
+                                        latch.countDown();
+                                    }
+                                }
+                            }));
+                        } catch (Exception e) {
+                            LOG.info("Error while creating zk client", e);
+                        }
+                    }
+                }
+            };
+            cnxnWorker[i].start();
+        }
+
+        Assert.assertTrue(latch.await(3, TimeUnit.SECONDS));
+        LOG.info("created {} connections", threadNum * cnxnPerThread);
+
+        // Assert throttling not 0
+        long handshakeThrottledNum = tlsHandshakeExceeded.get();
+        LOG.info("TLS_HANDSHAKE_EXCEEDED: {}", handshakeThrottledNum);
+        Assert.assertTrue(handshakeThrottledNum > 0);
+
+        // Assert there is no outstanding handshake anymore
+        int outstandingHandshakeNum = factory.getOutstandingHandshakeNum();
+        LOG.info("outstanding handshake is {}", outstandingHandshakeNum);
+        Assert.assertTrue(outstandingHandshakeNum == 0);
+
+        // clean up
+        for (ZooKeeper zk : zks) {
+            zk.close();
+        }
+
+    }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/CommandsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/CommandsTest.java
@@ -155,7 +155,31 @@ public class CommandsTest extends ClientBase {
 
     @Test
     public void testMonitor() throws IOException, InterruptedException {
-        ArrayList<Field> fields = new ArrayList<>(Arrays.asList(new Field("version", String.class), new Field("avg_latency", Double.class), new Field("max_latency", Long.class), new Field("min_latency", Long.class), new Field("packets_received", Long.class), new Field("packets_sent", Long.class), new Field("num_alive_connections", Integer.class), new Field("outstanding_requests", Long.class), new Field("server_state", String.class), new Field("znode_count", Integer.class), new Field("watch_count", Integer.class), new Field("ephemerals_count", Integer.class), new Field("approximate_data_size", Long.class), new Field("open_file_descriptor_count", Long.class), new Field("max_file_descriptor_count", Long.class), new Field("last_client_response_size", Integer.class), new Field("max_client_response_size", Integer.class), new Field("min_client_response_size", Integer.class), new Field("uptime", Long.class), new Field("global_sessions", Long.class), new Field("local_sessions", Long.class), new Field("connection_drop_probability", Double.class)));
+        ArrayList<Field> fields = new ArrayList<>(Arrays.asList(
+                new Field("version", String.class),
+                new Field("avg_latency", Double.class),
+                new Field("max_latency", Long.class),
+                new Field("min_latency", Long.class),
+                new Field("packets_received", Long.class),
+                new Field("packets_sent", Long.class),
+                new Field("num_alive_connections", Integer.class),
+                new Field("outstanding_requests", Long.class),
+                new Field("server_state", String.class),
+                new Field("znode_count", Integer.class),
+                new Field("watch_count", Integer.class),
+                new Field("ephemerals_count", Integer.class),
+                new Field("approximate_data_size", Long.class),
+                new Field("open_file_descriptor_count", Long.class),
+                new Field("max_file_descriptor_count", Long.class),
+                new Field("last_client_response_size", Integer.class),
+                new Field("max_client_response_size", Integer.class),
+                new Field("min_client_response_size", Integer.class),
+                new Field("uptime", Long.class),
+                new Field("global_sessions", Long.class),
+                new Field("local_sessions", Long.class),
+                new Field("connection_drop_probability", Double.class),
+                new Field("outstanding_tls_handshake", Integer.class)
+        ));        
         Map<String, Object> metrics = MetricsUtils.currentServerMetrics();
 
         for (String metric : metrics.keySet()) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/CommandsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/CommandsTest.java
@@ -179,7 +179,7 @@ public class CommandsTest extends ClientBase {
                 new Field("local_sessions", Long.class),
                 new Field("connection_drop_probability", Double.class),
                 new Field("outstanding_tls_handshake", Integer.class)
-        ));        
+        ));
         Map<String, Object> metrics = MetricsUtils.currentServerMetrics();
 
         for (String metric : metrics.keySet()) {


### PR DESCRIPTION
When there are lots of clients trying to re-establish sessions, there might be lots of half finished handshake timed out, and those failed ones keep reconnecting to another server and restarting the handshake from beginning again, which caused herd effect.
 
And the number of total ZK sessions could be supported within session timeout are impacted a lot after enabling TLS.
 
To improve the throughput, we added the TLS concurrent control to reduce the herd effect, and from out benchmark this doubled the sessions we could support within session timeout.

E2E test result:

Tested performance and correctness from E2E. For correctness, tested both secure and insecure 
connections, the outstandingHandshakeNum will go to 0 eventually.

For performance, tested with 110k sessions with 10s session timeout, there is no session expire when leader election triggered, while before it can only support 50k sessions.