### PR TITLE
ZOOKEEPER-3455: fix UnifiedServerSocketTest on jdk 13

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/UnifiedServerSocketTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/UnifiedServerSocketTest.java
@@ -212,6 +212,10 @@ public class UnifiedServerSocketTest extends BaseX509ParameterizedTestCase {
         synchronized byte[] getDataFromClient(int index) {
             return dataFromClients.get(index);
         }
+
+        synchronized boolean receivedAnyDataFromClient() {
+            return !dataFromClients.isEmpty();
+        }
     }
 
     private SSLSocket connectWithSSL() throws IOException, X509Exception, InterruptedException {
@@ -405,13 +409,23 @@ public class UnifiedServerSocketTest extends BaseX509ParameterizedTestCase {
         socket.getOutputStream().flush();
         byte[] buf = new byte[DATA_TO_CLIENT.length];
         try {
-            socket.getInputStream().read(buf, 0, buf.length);
+            int bytesRead = socket.getInputStream().read(buf, 0, buf.length);
+            if(bytesRead == -1) {
+                // Using the NioSocketImpl after JDK 13, the expected behaviour on the client side
+                // is to reach the end of the stream (bytesRead == -1), without a socket exception.
+                return;
+            }
         } catch (SocketException e) {
-            // We expect the other end to hang up the connection
+            // Using the old PlainSocketImpl (prior to JDK 13) we expect to get Socket Exception
             return;
         } finally {
             forceClose(socket);
             serverThread.shutdown(TIMEOUT);
+
+            // independently of the client socket implementation details, we always make sure the
+            // server didn't receive any data during the test
+            Assert.assertFalse("The strict server accepted connection without SSL.",
+                               serverThread.receivedAnyDataFromClient());
         }
         Assert.fail("Expected server to hang up the connection. Read from server succeeded unexpectedly.");
     }


### PR DESCRIPTION
The `UnifiedServerSocketTest.testConnectWithoutSSLToStrictServer` fails on OpenJDK 13 because in the new default socket implementation (https://openjdk.java.net/jeps/353) the `NioSocketImpl.getInputStream.read()` behaves differently than the old `SocketInputStream.read()`. 

A workaround could be to execute the tests using the `-Djdk.net.usePlainSocketImpl` system property (hardcoding it in the maven / ant configs), which enforces the usage of the old socket implementation in JDK 13. But I preferred instead to make the test compatible with both older and newer JDK, so it should succeed even if someone is executing it outside of our build environment.