### PR TITLE
[ZOOKEEPER-3480] Fix the flaky test in CommitProcessorMetricsTest

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/CommitProcessorMetricsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/CommitProcessorMetricsTest.java
@@ -377,9 +377,11 @@ public class CommitProcessorMetricsTest extends ZKTestCase {
 
         //three read requests will be processed in parallel
         commitSeen = new CountDownLatch(1);
+        requestScheduled = new CountDownLatch(3);
         commitProcessor.processRequest(createReadRequest(1l, 2));
         commitProcessor.processRequest(createReadRequest(1l, 3));
         commitProcessor.processRequest(createReadRequest(1l, 4));
+        requestScheduled.await(5, TimeUnit.SECONDS);
 
         //add a commit request to trigger waitForEmptyPool, which will record number of requests being proccessed
         poolEmpytied = new CountDownLatch(1);


### PR DESCRIPTION
This test is pretty flaky on Jenkins, the previous code doesn't wait all requests being processed, which may cause flaky.