### PR TITLE
ZOOKEEPER-3494 - remove unnecessary broad netty-all dependency

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -60,8 +60,11 @@
     <dependency org="org.apache.yetus" name="audience-annotations"
                 rev="${audience-annotations.version}"/>
 
-    <dependency org="io.netty" name="netty-all" conf="default" rev="${netty.version}">
-      <artifact name="netty-all" type="jar" conf="default"/>
+    <dependency org="io.netty" name="netty-handler" conf="default" rev="${netty.version}">
+      <artifact name="netty-handler" type="jar" conf="default"/>
+    </dependency>
+    <dependency org="io.netty" name="netty-transport-native-epoll" conf="default" rev="${netty.version}">
+      <artifact name="netty-transport-native-epoll" type="jar" conf="default"/>
     </dependency>
 
     <dependency org="com.googlecode.json-simple" name="json-simple" rev="${json.version}" >

--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,12 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-all</artifactId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
         <version>${netty.version}</version>
       </dependency>
       <dependency>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -70,7 +70,11 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
+      <artifactId>netty-handler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Currently netty-all is a 4MB dependency.
Using netty-handler (429KB) and netty-transport-native-epoll (115KB) brings it down to about 1/8 in size.