### PR TITLE
ZOOKEEPER-3498: Move jute generated sources to generated-source/java

### DIFF
--- a/zookeeper-jute/pom.xml
+++ b/zookeeper-jute/pom.xml
@@ -65,7 +65,7 @@
               </includes>
               <lookAhead>2</lookAhead>
               <isStatic>false</isStatic>
-              <outputDirectory>${project.build.directory}/classes/</outputDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
             </configuration>
           </execution>
         </executions>
@@ -94,7 +94,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <workingDirectory>${project.build.directory}/classes/</workingDirectory>
+              <workingDirectory>${project.build.directory}/generated-sources/java</workingDirectory>
               <executable>java</executable>
               <arguments>
                 <argument>-classpath</argument>
@@ -139,7 +139,7 @@
             </goals>
             <configuration>
               <sources>
-                <source>${basedir}/target/classes</source>
+                <source>${basedir}/target/generated-sources/java</source>
               </sources>
             </configuration>
           </execution>


### PR DESCRIPTION
Avoid mixup with class files.

cc @phunt @anmolnar @eolivelli @nkalmar 