### PR TITLE
ZOOKEEPER-1112: Add support for C client for SASL authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -792,6 +792,7 @@
             <exclude>src/main/resources/markdown/skin/*</exclude>
             <exclude>src/main/resources/markdown/html/*</exclude>
             <exclude>src/main/resources/markdown/images/*</exclude>
+            <exclude>tests/jaas.digest.server.conf</exclude>
             <!-- contrib -->
             <exclude>zookeeper-contrib-monitoring/JMX-RESOURCES</exclude>
             <exclude>zookeeper-contrib-fatjar/src/main/resources/mainClasses</exclude>

--- a/zookeeper-client/zookeeper-client-c/Makefile.am
+++ b/zookeeper-client/zookeeper-client-c/Makefile.am
@@ -74,6 +74,14 @@ cli_st_SOURCES = src/cli.c
 cli_st_LDADD = libzookeeper_st.la
 cli_st_CFLAGS = $(SASL_CFLAGS)
 
+if WANT_SASL
+bin_PROGRAMS += cli_sasl_st
+
+cli_sasl_st_SOURCES = src/cli_sasl.c
+cli_sasl_st_LDADD = libzookeeper_st.la
+cli_sasl_st_CFLAGS = $(SASL_CFLAGS)
+endif
+
 if WANT_SYNCAPI
 bin_PROGRAMS += cli_mt load_gen
 
@@ -84,6 +92,14 @@ cli_mt_CFLAGS = -DTHREADED $(SASL_CFLAGS)
 load_gen_SOURCES = src/load_gen.c
 load_gen_LDADD = libzookeeper_mt.la
 load_gen_CFLAGS = -DTHREADED $(SASL_CFLAGS)
+
+if WANT_SASL
+bin_PROGRAMS += cli_sasl_mt
+
+cli_sasl_mt_SOURCES = src/cli_sasl.c
+cli_sasl_mt_LDADD = libzookeeper_mt.la
+cli_sasl_mt_CFLAGS = -DTHREADED $(SASL_CFLAGS)
+endif
 
 endif
 

--- a/zookeeper-client/zookeeper-client-c/Makefile.am
+++ b/zookeeper-client/zookeeper-client-c/Makefile.am
@@ -18,7 +18,17 @@ endif
 
 LIB_LDFLAGS = -no-undefined -version-info 2 $(SOLARIS_LIB_LDFLAGS)
 
-pkginclude_HEADERS = include/zookeeper.h include/zookeeper_version.h include/zookeeper_log.h include/proto.h include/recordio.h generated/zookeeper.jute.h
+if WANT_SASL
+SASL_CFLAGS = -DSASL
+SASL_LIBS = -lsasl2
+SASL_HDR = include/zookeeper_sasl.h
+SASL_SRC = src/zk_sasl.c $(SASL_HDR)
+else
+STATIC_CXX=-DUSE_STATIC_LIB
+STATIC_LD=-static-libtool-libs
+endif
+
+pkginclude_HEADERS = include/zookeeper.h include/zookeeper_version.h include/zookeeper_log.h include/proto.h include/recordio.h generated/zookeeper.jute.h $(SASL_HDR)
 EXTRA_DIST=LICENSE
 
 HASHTABLE_SRC = src/hashtable/hashtable_itr.h src/hashtable/hashtable_itr.c \
@@ -31,13 +41,13 @@ COMMON_SRC = src/zookeeper.c include/zookeeper.h include/zookeeper_version.h inc
     src/recordio.c include/recordio.h include/proto.h \
     src/zk_adaptor.h generated/zookeeper.jute.c \
     src/zk_log.c src/zk_hashtable.h src/zk_hashtable.c \
-	src/addrvec.h src/addrvec.c
+    src/addrvec.h src/addrvec.c $(SASL_SRC)
 
 # These are the symbols (classes, mostly) we want to export from our library.
 EXPORT_SYMBOLS = '(zoo_|zookeeper_|zhandle|Z|format_log_message|log_message|logLevel|deallocate_|allocate_|zerror|is_unrecoverable)'
 noinst_LTLIBRARIES += libzkst.la
 libzkst_la_SOURCES =$(COMMON_SRC) src/st_adaptor.c
-libzkst_la_LIBADD = -lm $(CLOCK_GETTIME_LIBS)
+libzkst_la_LIBADD = -lm $(CLOCK_GETTIME_LIBS) $(SASL_LIBS)
 
 lib_LTLIBRARIES = libzookeeper_st.la
 libzookeeper_st_la_SOURCES =
@@ -49,7 +59,7 @@ if WANT_SYNCAPI
 noinst_LTLIBRARIES += libzkmt.la
 libzkmt_la_SOURCES =$(COMMON_SRC) src/mt_adaptor.c
 libzkmt_la_CFLAGS = -DTHREADED
-libzkmt_la_LIBADD = -lm $(CLOCK_GETTIME_LIBS)
+libzkmt_la_LIBADD = -lm $(CLOCK_GETTIME_LIBS) $(SASL_LIBS)
 
 lib_LTLIBRARIES += libzookeeper_mt.la
 libzookeeper_mt_la_SOURCES =
@@ -62,17 +72,18 @@ bin_PROGRAMS = cli_st
 
 cli_st_SOURCES = src/cli.c
 cli_st_LDADD = libzookeeper_st.la
+cli_st_CFLAGS = $(SASL_CFLAGS)
 
 if WANT_SYNCAPI
 bin_PROGRAMS += cli_mt load_gen
 
 cli_mt_SOURCES = src/cli.c
 cli_mt_LDADD = libzookeeper_mt.la
-cli_mt_CFLAGS = -DTHREADED
+cli_mt_CFLAGS = -DTHREADED $(SASL_CFLAGS)
 
 load_gen_SOURCES = src/load_gen.c
 load_gen_LDADD = libzookeeper_mt.la
-load_gen_CFLAGS = -DTHREADED
+load_gen_CFLAGS = -DTHREADED $(SASL_CFLAGS)
 
 endif
 
@@ -122,14 +133,14 @@ TESTS_ENVIRONMENT = ZKROOT=${srcdir}/../.. \
                     CLASSPATH=$$CLASSPATH:$$CLOVER_HOME/lib/clover*.jar
 nodist_zktest_st_SOURCES = $(TEST_SOURCES)
 zktest_st_LDADD = libzkst.la libhashtable.la $(CPPUNIT_LIBS) -ldl
-zktest_st_CXXFLAGS = -DUSE_STATIC_LIB $(CPPUNIT_CFLAGS) $(USEIPV6) $(SOLARIS_CPPFLAGS)
+zktest_st_CXXFLAGS = -DUSE_STATIC_LIB $(CPPUNIT_CFLAGS) $(USEIPV6) $(SASL_CFLAGS) $(SOLARIS_CPPFLAGS)
 zktest_st_LDFLAGS = -shared $(SYMBOL_WRAPPERS) $(SOLARIS_LIB_LDFLAGS)
 
 if WANT_SYNCAPI
   check_PROGRAMS += zktest-mt
   nodist_zktest_mt_SOURCES = $(TEST_SOURCES) tests/PthreadMocks.cc
   zktest_mt_LDADD = libzkmt.la libhashtable.la -lpthread $(CPPUNIT_LIBS) -ldl
-  zktest_mt_CXXFLAGS = -DUSE_STATIC_LIB -DTHREADED $(CPPUNIT_CFLAGS) $(USEIPV6)
+  zktest_mt_CXXFLAGS = -DUSE_STATIC_LIB -DTHREADED $(CPPUNIT_CFLAGS) $(USEIPV6) $(SASL_CFLAGS)
 if SOLARIS
   SHELL_SYMBOL_WRAPPERS_MT = cat ${srcdir}/tests/wrappers-mt.opt
   SYMBOL_WRAPPERS_MT=$(SYMBOL_WRAPPERS) $(SHELL_SYMBOL_WRAPPERS_MT:sh)

--- a/zookeeper-client/zookeeper-client-c/configure.ac
+++ b/zookeeper-client/zookeeper-client-c/configure.ac
@@ -111,6 +111,23 @@ fi
 
 AM_CONDITIONAL([WANT_SYNCAPI],[test "x$with_syncapi" != xno])
 
+AC_ARG_WITH([sasl],
+ [AS_HELP_STRING([--with-sasl],[build with support for SASL [default=yes]])],
+ [],[with_sasl=yes])
+
+AC_CHECK_LIB([sasl2], [sasl_client_init],[have_sasl=yes],[have_sasl=no])
+
+if test "x$with_sasl" != xno && test "x$have_sasl" = xno; then
+    AC_MSG_WARN([cannot build SASL support -- sasl2 not found])
+    with_sasl=no
+fi
+if test "x$with_sasl" != xno; then
+    AC_MSG_NOTICE([building with SASL support])
+else
+    AC_MSG_NOTICE([building without SASL support])
+fi
+AM_CONDITIONAL([WANT_SASL],[test "x$with_sasl" != xno])
+
 # Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdlib.h string.h sys/socket.h sys/time.h unistd.h sys/utsname.h])

--- a/zookeeper-client/zookeeper-client-c/include/proto.h
+++ b/zookeeper-client/zookeeper-client-c/include/proto.h
@@ -46,6 +46,7 @@ extern "C" {
 #define ZOO_CLOSE_OP -11
 #define ZOO_SETAUTH_OP 100
 #define ZOO_SETWATCHES_OP 101
+#define ZOO_SASL_OP 102
 
 #ifdef __cplusplus
 }

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper.h
@@ -1676,6 +1676,29 @@ ZOOAPI int zoo_aremove_all_watches(zhandle_t *zh, const char *path,
         ZooWatcherType wtype, int local, void_completion_t *completion,
         const void *data);
 
+typedef struct zoo_sasl_conn zoo_sasl_conn_t;
+
+typedef int (*sasl_completion_t)(int rc, zhandle_t *zh, zoo_sasl_conn_t *conn,
+        const char *serverin, int serverinlen);
+
+/**
+ * \brief send a sasl request asynchronously.
+ *
+ * \param zh the zookeeper handle obtained by a call to \ref zookeeper_init
+ * \param zh the connection handle obtained by a call to \ref zoo_sasl_connect
+ * \param clientout the token
+ * \param clientoutlen the token length
+ * \param cptr function to call with the server response
+ * \return ZMARSHALLINGERROR if sending failed, ZOK otherwise
+ */
+ZOOAPI int zoo_asasl(zhandle_t *zh, zoo_sasl_conn_t *conn, const char *clientout,
+        unsigned clientoutlen, sasl_completion_t cptr);
+
+struct sasl_completion_ctx {
+    zhandle_t *zh;
+    zoo_sasl_conn_t *conn;
+};
+
 #ifdef THREADED
 /**
  * \brief create a node synchronously.
@@ -2288,7 +2311,22 @@ ZOOAPI int zoo_multi(zhandle_t *zh, int count, const zoo_op_t *ops, zoo_op_resul
  */
 ZOOAPI int zoo_remove_watches(zhandle_t *zh, const char *path,
         ZooWatcherType wtype, watcher_fn watcher, void *watcherCtx, int local);
+
+/**
+ * \brief send a sasl request synchronously.
+ *
+ * \param zh the zookeeper handle obtained by a call to \ref zookeeper_init
+ * \param zh the connection handle obtained by a call to \ref zoo_sasl_connect
+ * \param clientout the token to send
+ * \param clientoutlen the token  length
+ * \param serverin the received token
+ * \param serverinlen the token length
+ * \return
+ */
+ZOOAPI int zoo_sasl(zhandle_t *zh, zoo_sasl_conn_t *conn, const char *clientout,
+        unsigned clientoutlen, const char **serverin, unsigned *serverinlen);
 #endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper.h
@@ -1694,11 +1694,6 @@ typedef int (*sasl_completion_t)(int rc, zhandle_t *zh, zoo_sasl_conn_t *conn,
 ZOOAPI int zoo_asasl(zhandle_t *zh, zoo_sasl_conn_t *conn, const char *clientout,
         unsigned clientoutlen, sasl_completion_t cptr);
 
-struct sasl_completion_ctx {
-    zhandle_t *zh;
-    zoo_sasl_conn_t *conn;
-};
-
 #ifdef THREADED
 /**
  * \brief create a node synchronously.

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper.h
@@ -2311,15 +2311,16 @@ ZOOAPI int zoo_remove_watches(zhandle_t *zh, const char *path,
  * \brief send a sasl request synchronously.
  *
  * \param zh the zookeeper handle obtained by a call to \ref zookeeper_init
- * \param zh the connection handle obtained by a call to \ref zoo_sasl_connect
  * \param clientout the token to send
  * \param clientoutlen the token  length
- * \param serverin the received token
- * \param serverinlen the token length
+ * \param serverin a buffer in which to receive the server token
+ * \param serverinsize the size of the receive buffer
+ * \param serverinlen set to the length of the received token
  * \return
  */
-ZOOAPI int zoo_sasl(zhandle_t *zh, zoo_sasl_conn_t *conn, const char *clientout,
-        unsigned clientoutlen, const char **serverin, unsigned *serverinlen);
+ZOOAPI int zoo_sasl(zhandle_t *zh,
+        const char *clientout, unsigned clientoutlen,
+        char *serverin, unsigned serverinsize, unsigned *serverinlen);
 #endif
 
 #ifdef __cplusplus

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper_sasl.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper_sasl.h
@@ -26,6 +26,14 @@ extern "C" {
 #endif
 
 /**
+ * \brief Zookeeper SASL handle.
+ *
+ * This is an opaque handle to the SASL client state.  A handle is
+ * obtained using \zoo_sasl_connect.
+ */
+typedef struct zoo_sasl_conn zoo_sasl_conn_t;
+
+/**
  * \brief initialize sasl library
  *
  * \param zh the zookeeper handle obtained by a call to \ref zookeeper_init

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper_sasl.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper_sasl.h
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ZOOKEEPER_SASL_H_
+#define ZOOKEEPER_SASL_H_
+
+#include <sasl/sasl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief initialize sasl library
+ *
+ * \param zh the zookeeper handle obtained by a call to \ref zookeeper_init
+ * \param callbacks sasl callbacks
+ * \return ZSYSTEMERROR if initialization failed
+ */
+ZOOAPI int zoo_sasl_init(zhandle_t *zh, sasl_callback_t *callbacks);
+
+/**
+ * \brief creates a sasl connection for the zookeeper socket
+ *
+ * \param zh the zookeeper handle obtained by a call to \ref zookeeper_init
+ * \param servicename name of the zookeeper service
+ * \param host host of the zookeeper service
+ * \param sasl_conn out parameter for the created sasl connection
+ * \param mech out parameter for the sasl mechanisms supported by the client
+ * \param mechlen out parameter for the count of supported mechs
+ * \return ZSYSTEMERRROR if connection failed
+ */
+ZOOAPI int zoo_sasl_connect(zhandle_t *zh, char *servicename,
+        char *host, zoo_sasl_conn_t **sasl_conn, const char **mechs, int *mechlen);
+
+/**
+ * \brief authenticates asynchronously
+ *
+ * \param zh the zookeeper handle obtained by a call to \ref zookeeper_init
+ * \param zh the connection handle obtained by a call to \ref zoo_sasl_connect
+ * \param mech the selected mechanism
+ * \param supportedmechs mechanisms supported by client (obtained by a call
+ * to \ref zoo_sasl_connect)
+ * \return
+ */
+ZOOAPI int zoo_asasl_authenticate(zhandle_t *th, zoo_sasl_conn_t *conn, const char *mech,
+        const char *supportedmechs);
+
+#ifdef THREADED
+/**
+ * \brief authenticates synchronously
+ *
+ * \param zh the zookeeper handle obtained by a call to \ref zookeeper_init
+ * \param zh the connection handle obtained by a call to \ref zoo_sasl_connect
+ * \param mech the selected mechanism
+ * \param supportedmechs mechanisms supported by client (obtained by a call
+ * to \ref zoo_sasl_connect)
+ * \return
+ */
+ZOOAPI int zoo_sasl_authenticate(zhandle_t *th, zoo_sasl_conn_t *conn, const char *mech,
+        const char *supportedmechs);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZOOKEEPER_SASL_H_ */

--- a/zookeeper-client/zookeeper-client-c/src/cli_sasl.c
+++ b/zookeeper-client/zookeeper-client-c/src/cli_sasl.c
@@ -138,12 +138,14 @@ static int getsecret(sasl_conn_t *conn, void *context __attribute__((unused)),
     return SASL_OK;
 }
 
+typedef int (* sasl_callback_fn_t)(void);
+
 /* callbacks we support */
 sasl_callback_t callbacks[] = {
-        { SASL_CB_GETREALM, &getrealm, NULL },
-        { SASL_CB_USER, &simple, NULL },
-        { SASL_CB_AUTHNAME, &simple, NULL },
-        { SASL_CB_PASS, &getsecret, NULL },
+        { SASL_CB_GETREALM, (sasl_callback_fn_t)&getrealm, NULL },
+        { SASL_CB_USER, (sasl_callback_fn_t)&simple, NULL },
+        { SASL_CB_AUTHNAME, (sasl_callback_fn_t)&simple, NULL },
+        { SASL_CB_PASS, (sasl_callback_fn_t)&getsecret, NULL },
         { SASL_CB_LIST_END, NULL, NULL } };
 #endif
 

--- a/zookeeper-client/zookeeper-client-c/src/cli_sasl.c
+++ b/zookeeper-client/zookeeper-client-c/src/cli_sasl.c
@@ -1,0 +1,813 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <zookeeper.h>
+#include <proto.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifndef WIN32
+#include <sys/time.h>
+#include <unistd.h>
+#include <sys/select.h>
+#else
+#include "winport.h"
+//#include <io.h> <-- can't include, conflicting definitions of close()
+int read(int _FileHandle, void * _DstBuf, unsigned int _MaxCharCount);
+int write(int _Filehandle, const void * _Buf, unsigned int _MaxCharCount);
+#define ctime_r(tctime, buffer) ctime_s (buffer, 40, tctime)
+#endif
+
+#include <time.h>
+#include <errno.h>
+#include <assert.h>
+
+#ifdef YCA
+#include <yca/yca.h>
+#endif
+
+#ifdef SASL
+#include <zookeeper_sasl.h>
+#endif
+
+#define _LL_CAST_ (long long)
+
+static zhandle_t *zh;
+static clientid_t myid;
+static const char *clientIdFile = 0;
+struct timeval startTime;
+static char cmd[1024];
+static int batchMode=0;
+
+static int to_send=0;
+static int sent=0;
+static int recvd=0;
+
+static int shutdownThisThing=0;
+
+#ifdef SASL
+zoo_sasl_conn_t *my_sasl_conn = NULL;
+char *service = "zookeeper";
+char *host;
+char *mech;
+char *user;
+char *realm;
+#endif
+
+void processline(char *line);
+
+#ifdef SASL
+static int getrealm(void *context __attribute__((unused)), int id,
+        const char **availrealms, const char **result) {
+    *result = realm;
+    return SASL_OK;
+}
+
+static int simple(void *context __attribute__((unused)), int id,
+        const char **result, unsigned *len) {
+    /* paranoia check */
+    if (!result)
+        return SASL_BADPARAM;
+
+    switch (id) {
+    case SASL_CB_USER:
+        *result = user;
+        break;
+    case SASL_CB_AUTHNAME:
+        *result = user;
+        break;
+    default:
+        return SASL_BADPARAM;
+    }
+
+    return SASL_OK;
+}
+
+#ifndef HAVE_GETPASSPHRASE
+static char *
+getpassphrase(const char *prompt) {
+    return getpass(prompt);
+}
+#endif /* ! HAVE_GETPASSPHRASE */
+
+static int getsecret(sasl_conn_t *conn, void *context __attribute__((unused)),
+        int id, sasl_secret_t **psecret) {
+    char *password;
+    size_t len;
+    static sasl_secret_t *x;
+
+    /* paranoia check */
+    if (!conn || !psecret || id != SASL_CB_PASS
+    )
+        return SASL_BADPARAM;
+
+    password = getpassphrase("Password: ");
+    if (!password)
+        return SASL_FAIL;
+
+    len = strlen(password);
+
+    x = (sasl_secret_t *) realloc(x, sizeof(sasl_secret_t) + len);
+
+    if (!x) {
+        memset(password, 0, len);
+        return SASL_NOMEM;
+    }
+
+    x->len = len;
+    strcpy((char *) x->data, password);
+    memset(password, 0, len);
+
+    *psecret = x;
+    return SASL_OK;
+}
+
+/* callbacks we support */
+sasl_callback_t callbacks[] = {
+        { SASL_CB_GETREALM, &getrealm, NULL },
+        { SASL_CB_USER, &simple, NULL },
+        { SASL_CB_AUTHNAME, &simple, NULL },
+        { SASL_CB_PASS, &getsecret, NULL },
+        { SASL_CB_LIST_END, NULL, NULL } };
+#endif
+
+static __attribute__ ((unused)) void 
+printProfileInfo(struct timeval start, struct timeval end, int thres,
+                 const char* msg)
+{
+  int delay=(end.tv_sec*1000+end.tv_usec/1000)-
+    (start.tv_sec*1000+start.tv_usec/1000);
+  if(delay>thres)
+    fprintf(stderr,"%s: execution time=%dms\n",msg,delay);
+}
+
+static const char* state2String(int state){
+  if (state == 0)
+    return "CLOSED_STATE";
+  if (state == ZOO_CONNECTING_STATE)
+    return "CONNECTING_STATE";
+  if (state == ZOO_ASSOCIATING_STATE)
+    return "ASSOCIATING_STATE";
+  if (state == ZOO_CONNECTED_STATE)
+    return "CONNECTED_STATE";
+  if (state == ZOO_EXPIRED_SESSION_STATE)
+    return "EXPIRED_SESSION_STATE";
+  if (state == ZOO_AUTH_FAILED_STATE)
+    return "AUTH_FAILED_STATE";
+
+  return "INVALID_STATE";
+}
+
+void watcher(zhandle_t *zzh, int type, int state, const char *path,
+             void* context)
+{
+    /* Be careful using zh here rather than zzh - as this may be mt code
+     * the client lib may call the watcher before zookeeper_init returns */
+
+    fprintf(stderr, "Watcher %d state = %s", type, state2String(state));
+    if (path && strlen(path) > 0) {
+      fprintf(stderr, " for path %s", path);
+    }
+    fprintf(stderr, "\n");
+
+    if (type == ZOO_SESSION_EVENT) {
+        if (state == ZOO_CONNECTED_STATE) {
+            const clientid_t *id = zoo_client_id(zzh);
+            if (myid.client_id == 0 || myid.client_id != id->client_id) {
+                myid = *id;
+                fprintf(stderr, "Got a new session id: 0x%llx\n",
+                        _LL_CAST_ myid.client_id);
+                if (clientIdFile) {
+                    FILE *fh = fopen(clientIdFile, "w");
+                    if (!fh) {
+                        perror(clientIdFile);
+                    } else {
+                        int rc = fwrite(&myid, sizeof(myid), 1, fh);
+                        if (rc != sizeof(myid)) {
+                            perror("writing client id");
+                        }
+                        fclose(fh);
+                    }
+                }
+#ifdef SASL
+                const char *mechs;
+                int mechlen;
+
+                if(mech) {
+                    if(strcmp("GSSAPI", mech)==0 || (user && host)) {
+                        zoo_sasl_connect(zzh, "zookeeper", host, &my_sasl_conn, &mechs, &mechlen);
+                        fprintf(stderr, "Mechs [%d]: %s\n", mechlen, mechs);
+#ifdef THREADED
+                        zoo_sasl_authenticate(zh, my_sasl_conn, mech, mechs);
+#else
+                        zoo_asasl_authenticate(zh, my_sasl_conn, mech, mechs);
+#endif
+                    } else {
+                        fprintf(stderr, "Mechanism %s requires username (-u) and host (-h zk-sasl-md5) to be specified\n", mech);
+                    }
+                }
+#endif
+                if(batchMode) {
+                    processline(cmd);
+                    shutdownThisThing = 1;
+                }
+            }
+        } else if (state == ZOO_AUTH_FAILED_STATE) {
+            fprintf(stderr, "Authentication failure. Shutting down...\n");
+            zookeeper_close(zzh);
+            shutdownThisThing=1;
+            zh=0;
+        } else if (state == ZOO_EXPIRED_SESSION_STATE) {
+            fprintf(stderr, "Session expired. Shutting down...\n");
+            zookeeper_close(zzh);
+            shutdownThisThing=1;
+            zh=0;
+        }
+    }
+}
+
+void dumpStat(const struct Stat *stat) {
+    char tctimes[40];
+    char tmtimes[40];
+    time_t tctime;
+    time_t tmtime;
+
+    if (!stat) {
+        fprintf(stderr,"null\n");
+        return;
+    }
+    tctime = stat->ctime/1000;
+    tmtime = stat->mtime/1000;
+       
+    ctime_r(&tmtime, tmtimes);
+    ctime_r(&tctime, tctimes);
+       
+    fprintf(stderr, "\tctime = %s\tczxid=%llx\n"
+    "\tmtime=%s\tmzxid=%llx\n"
+    "\tversion=%x\taversion=%x\n"
+    "\tephemeralOwner = %llx\n",
+     tctimes, _LL_CAST_ stat->czxid, tmtimes,
+    _LL_CAST_ stat->mzxid,
+    (unsigned int)stat->version, (unsigned int)stat->aversion,
+    _LL_CAST_ stat->ephemeralOwner);
+}
+
+void my_string_completion(int rc, const char *name, const void *data) {
+    fprintf(stderr, "[%s]: rc = %d\n", (char*)(data==0?"null":data), rc);
+    if (!rc) {
+        fprintf(stderr, "\tname = %s\n", name);
+    }
+    if(batchMode)
+      shutdownThisThing=1;
+}
+
+void my_data_completion(int rc, const char *value, int value_len,
+        const struct Stat *stat, const void *data) {
+    struct timeval tv;
+    int sec;
+    int usec;
+    gettimeofday(&tv, 0);
+    sec = tv.tv_sec - startTime.tv_sec;
+    usec = tv.tv_usec - startTime.tv_usec;
+    fprintf(stderr, "time = %d msec\n", sec*1000 + usec/1000);
+    fprintf(stderr, "%s: rc = %d\n", (char*)data, rc);
+    if (value) {
+        fprintf(stderr, " value_len = %d\n", value_len);
+        assert(write(2, value, value_len) == value_len);
+    }
+    fprintf(stderr, "\nStat:\n");
+    dumpStat(stat);
+    free((void*)data);
+    if(batchMode)
+      shutdownThisThing=1;
+}
+
+void my_silent_data_completion(int rc, const char *value, int value_len,
+        const struct Stat *stat, const void *data) {
+    recvd++;
+    fprintf(stderr, "Data completion %s rc = %d\n",(char*)data,rc);
+    free((void*)data);
+    if (recvd==to_send) {
+        fprintf(stderr,"Recvd %d responses for %d requests sent\n",recvd,to_send);
+        if(batchMode)
+          shutdownThisThing=1;
+    }
+}
+
+void my_strings_completion(int rc, const struct String_vector *strings,
+        const void *data) {
+    struct timeval tv;
+    int sec;
+    int usec;
+    int i;
+
+    gettimeofday(&tv, 0);
+    sec = tv.tv_sec - startTime.tv_sec;
+    usec = tv.tv_usec - startTime.tv_usec;
+    fprintf(stderr, "time = %d msec\n", sec*1000 + usec/1000);
+    fprintf(stderr, "%s: rc = %d\n", (char*)data, rc);
+    if (strings)
+        for (i=0; i < strings->count; i++) {
+            fprintf(stderr, "\t%s\n", strings->data[i]);
+        }
+    free((void*)data);
+    gettimeofday(&tv, 0);
+    sec = tv.tv_sec - startTime.tv_sec;
+    usec = tv.tv_usec - startTime.tv_usec;
+    fprintf(stderr, "time = %d msec\n", sec*1000 + usec/1000);
+    if(batchMode)
+      shutdownThisThing=1;
+}
+
+void my_strings_stat_completion(int rc, const struct String_vector *strings,
+        const struct Stat *stat, const void *data) {
+    my_strings_completion(rc, strings, data);
+    dumpStat(stat);
+    if(batchMode)
+      shutdownThisThing=1;
+}
+
+void my_void_completion(int rc, const void *data) {
+    fprintf(stderr, "%s: rc = %d\n", (char*)data, rc);
+    free((void*)data);
+    if(batchMode)
+      shutdownThisThing=1;
+}
+
+void my_stat_completion(int rc, const struct Stat *stat, const void *data) {
+    fprintf(stderr, "%s: rc = %d Stat:\n", (char*)data, rc);
+    dumpStat(stat);
+    free((void*)data);
+    if(batchMode)
+      shutdownThisThing=1;
+}
+
+void my_silent_stat_completion(int rc, const struct Stat *stat,
+        const void *data) {
+    //    fprintf(stderr, "State completion: [%s] rc = %d\n", (char*)data, rc);
+    sent++;
+    free((void*)data);
+}
+
+static void sendRequest(const char* data) {
+    zoo_aset(zh, "/od", data, strlen(data), -1, my_silent_stat_completion,
+            strdup("/od"));
+    zoo_aget(zh, "/od", 1, my_silent_data_completion, strdup("/od"));
+}
+
+void od_completion(int rc, const struct Stat *stat, const void *data) {
+    int i;
+    fprintf(stderr, "od command response: rc = %d Stat:\n", rc);
+    dumpStat(stat);
+    // send a whole bunch of requests
+    recvd=0;
+    sent=0;
+    to_send=200;
+    for (i=0; i<to_send; i++) {
+        char buf[4096*16];
+        memset(buf, -1, sizeof(buf)-1);
+        buf[sizeof(buf)-1]=0;
+        sendRequest(buf);
+    }
+}
+
+int startsWith(const char *line, const char *prefix) {
+    int len = strlen(prefix);
+    return strncmp(line, prefix, len) == 0;
+}
+
+static const char *hostPort;
+static int verbose = 0;
+
+void processline(char *line) {
+    int rc;
+    int async = ((line[0] == 'a') && !(startsWith(line, "addauth ")));
+    if (async) {
+        line++;
+    }
+    if (startsWith(line, "help")) {
+      fprintf(stderr, "    create [+[e|s]] <path>\n");
+      fprintf(stderr, "    delete <path>\n");
+      fprintf(stderr, "    set <path> <data>\n");
+      fprintf(stderr, "    get <path>\n");
+      fprintf(stderr, "    ls <path>\n");
+      fprintf(stderr, "    ls2 <path>\n");
+      fprintf(stderr, "    sync <path>\n");
+      fprintf(stderr, "    exists <path>\n");
+      fprintf(stderr, "    myid\n");
+      fprintf(stderr, "    verbose\n");
+      fprintf(stderr, "    addauth <id> <scheme>\n");
+      fprintf(stderr, "    quit\n");
+      fprintf(stderr, "\n");
+      fprintf(stderr, "    prefix the command with the character 'a' to run the command asynchronously.\n");
+      fprintf(stderr, "    run the 'verbose' command to toggle verbose logging.\n");
+      fprintf(stderr, "    i.e. 'aget /foo' to get /foo asynchronously\n");
+    } else if (startsWith(line, "verbose")) {
+      if (verbose) {
+        verbose = 0;
+        zoo_set_debug_level(ZOO_LOG_LEVEL_WARN);
+        fprintf(stderr, "logging level set to WARN\n");
+      } else {
+        verbose = 1;
+        zoo_set_debug_level(ZOO_LOG_LEVEL_DEBUG);
+        fprintf(stderr, "logging level set to DEBUG\n");
+      }
+    } else if (startsWith(line, "get ")) {
+        line += 4;
+        if (line[0] != '/') {
+            fprintf(stderr, "Path must start with /, found: %s\n", line);
+            return;
+        }
+               
+        rc = zoo_aget(zh, line, 1, my_data_completion, strdup(line));
+        if (rc) {
+            fprintf(stderr, "Error %d for %s\n", rc, line);
+        }
+    } else if (startsWith(line, "set ")) {
+        char *ptr;
+        line += 4;
+        if (line[0] != '/') {
+            fprintf(stderr, "Path must start with /, found: %s\n", line);
+            return;
+        }
+        ptr = strchr(line, ' ');
+        if (!ptr) {
+            fprintf(stderr, "No data found after path\n");
+            return;
+        }
+        *ptr = '\0';
+        ptr++;
+        if (async) {
+            rc = zoo_aset(zh, line, ptr, strlen(ptr), -1, my_stat_completion,
+                    strdup(line));
+        } else {
+#ifdef THREADED
+            struct Stat stat;
+            rc = zoo_set2(zh, line, ptr, strlen(ptr), -1, &stat);
+#else
+            rc = ZSYSTEMERROR;
+#endif
+        }
+        if (rc) {
+            fprintf(stderr, "Error %d for %s\n", rc, line);
+        }
+    } else if (startsWith(line, "ls ")) {
+        line += 3;
+        if (line[0] != '/') {
+            fprintf(stderr, "Path must start with /, found: %s\n", line);
+            return;
+        }
+        gettimeofday(&startTime, 0);
+        rc= zoo_aget_children(zh, line, 1, my_strings_completion, strdup(line));
+        if (rc) {
+            fprintf(stderr, "Error %d for %s\n", rc, line);
+        }
+    } else if (startsWith(line, "ls2 ")) {
+        line += 4;
+        if (line[0] != '/') {
+            fprintf(stderr, "Path must start with /, found: %s\n", line);
+            return;
+        }
+        gettimeofday(&startTime, 0);
+        rc= zoo_aget_children2(zh, line, 1, my_strings_stat_completion, strdup(line));
+        if (rc) {
+            fprintf(stderr, "Error %d for %s\n", rc, line);
+        }
+    } else if (startsWith(line, "create ")) {
+        int flags = 0;
+        line += 7;
+        if (line[0] == '+') {
+            line++;
+            if (line[0] == 'e') {
+                flags |= ZOO_EPHEMERAL;
+                line++;
+            }
+            if (line[0] == 's') {
+                flags |= ZOO_SEQUENCE;
+                line++;
+            }
+            line++;
+        }
+        if (line[0] != '/') {
+            fprintf(stderr, "Path must start with /, found: %s\n", line);
+            return;
+        }
+        fprintf(stderr, "Creating [%s] node\n", line);
+//        {
+//            struct ACL _CREATE_ONLY_ACL_ACL[] = {{ZOO_PERM_CREATE, ZOO_ANYONE_ID_UNSAFE}};
+//            struct ACL_vector CREATE_ONLY_ACL = {1,_CREATE_ONLY_ACL_ACL};
+//            rc = zoo_acreate(zh, line, "new", 3, &CREATE_ONLY_ACL, flags,
+//                    my_string_completion, strdup(line));
+//        }
+        rc = zoo_acreate(zh, line, "new", 3, &ZOO_OPEN_ACL_UNSAFE, flags,
+                my_string_completion, strdup(line));
+        if (rc) {
+            fprintf(stderr, "Error %d for %s\n", rc, line);
+        }
+    } else if (startsWith(line, "delete ")) {
+        line += 7;
+        if (line[0] != '/') {
+            fprintf(stderr, "Path must start with /, found: %s\n", line);
+            return;
+        }
+        if (async) {
+            rc = zoo_adelete(zh, line, -1, my_void_completion, strdup(line));
+        } else {
+#ifdef THREADED
+            rc = zoo_delete(zh, line, -1);
+#else
+            rc = ZSYSTEMERROR;
+#endif
+        }
+        if (rc) {
+            fprintf(stderr, "Error %d for %s\n", rc, line);
+        }
+    } else if (startsWith(line, "sync ")) {
+        line += 5;
+        if (line[0] != '/') {
+            fprintf(stderr, "Path must start with /, found: %s\n", line);
+            return;
+        }
+        rc = zoo_async(zh, line, my_string_completion, strdup(line));
+        if (rc) {
+            fprintf(stderr, "Error %d for %s\n", rc, line);
+        }
+    } else if (startsWith(line, "exists ")) {
+#ifdef THREADED
+        struct Stat stat;
+#endif
+        line += 7;
+        if (line[0] != '/') {
+            fprintf(stderr, "Path must start with /, found: %s\n", line);
+            return;
+        }
+#ifndef THREADED
+        rc = zoo_aexists(zh, line, 1, my_stat_completion, strdup(line));
+#else
+        rc = zoo_exists(zh, line, 1, &stat);
+#endif
+        if (rc) {
+            fprintf(stderr, "Error %d for %s\n", rc, line);
+        }
+    } else if (strcmp(line, "myid") == 0) {
+        printf("session Id = %llx\n", _LL_CAST_ zoo_client_id(zh)->client_id);
+    } else if (strcmp(line, "reinit") == 0) {
+        zookeeper_close(zh);
+        // we can't send myid to the server here -- zookeeper_close() removes 
+        // the session on the server. We must start anew.
+        zh = zookeeper_init(hostPort, watcher, 30000, 0, 0, 0);
+    } else if (startsWith(line, "quit")) {
+        fprintf(stderr, "Quitting...\n");
+        shutdownThisThing=1;
+    } else if (startsWith(line, "od")) {
+        const char val[]="fire off";
+        fprintf(stderr, "Overdosing...\n");
+        rc = zoo_aset(zh, "/od", val, sizeof(val)-1, -1, od_completion, 0);
+        if (rc)
+            fprintf(stderr, "od command failed: %d\n", rc);
+    } else if (startsWith(line, "addauth ")) {
+      char *ptr;
+      line += 8;
+      ptr = strchr(line, ' ');
+      if (ptr) {
+        *ptr = '\0';
+        ptr++;
+      }
+      zoo_add_auth(zh, line, ptr, ptr ? strlen(ptr)-1 : 0, NULL, NULL);
+    }
+}
+
+static int usage(char **argv) {
+#ifdef SASL
+    const char *SASL_FEATURE = " (with sasl support)";
+#else
+    const char *SASL_FEATURE = "";
+#endif
+    fprintf(stderr,
+            "USAGE %s [-u sasluser -m saslmech] [-r saslrealm] [-i clientIdFile] [-c cmd] zookeeper_host_list\n",
+            argv[0]);
+    fprintf(stderr,
+            "Version: ZooKeeper cli (c client) version %d.%d.%d%s\n",
+            ZOO_MAJOR_VERSION,
+            ZOO_MINOR_VERSION,
+            ZOO_PATCH_VERSION,
+            SASL_FEATURE);
+    return 2;
+}
+
+int main(int argc, char **argv) {
+#ifndef THREADED
+    fd_set rfds, wfds, efds;
+    int processed=0;
+#endif
+    char buffer[4096];
+    char p[2048];
+#ifdef YCA  
+    char *cert=0;
+    char appId[64];
+#endif
+    int bufoff = 0;
+    FILE *fh;
+    int c;
+#ifdef SASL
+    while ((c = getopt(argc, argv, "u:h:i:s:m:c:r:")) != EOF) {
+    switch(c) {
+    case 'u':
+        user = optarg;
+        break;
+
+    case 's':
+        service = optarg;
+        break;
+
+    case 'h':
+        host = optarg;
+        break;
+
+    case 'm':
+        mech = optarg;
+        break;
+
+    case 'r':
+        realm = optarg;
+        break;
+#else
+    while ((c = getopt(argc, argv, "i:c:")) != EOF) {
+    switch(c) {
+#endif
+    case 'i':
+        clientIdFile = optarg;
+        fh = fopen(clientIdFile, "r");
+        if (fh) {
+            if (fread(&myid, sizeof(myid), 1, fh) != sizeof(myid)) {
+                memset(&myid, 0, sizeof(myid));
+            }
+            fclose(fh);
+        }
+        break;
+
+    case 'c':
+        strcpy(cmd,optarg);
+        batchMode = 1;
+        break;
+
+    default:
+        return usage(argv);
+        break;
+    }
+    }
+
+    if (optind > argc - 1) {
+    return usage(argv);
+    }
+    if (optind == argc - 1) {
+    hostPort = argv[optind];
+    }
+#ifdef YCA
+    strcpy(appId,"yahoo.example.yca_test");
+    cert = yca_get_cert_once(appId);
+    if(cert!=0) {
+        fprintf(stderr,"Certificate for appid [%s] is [%s]\n",appId,cert);
+        strncpy(p,cert,sizeof(p)-1);
+        free(cert);
+    } else {
+      fprintf(stderr,"Certificate for appid [%s] not found\n",appId);
+      strcpy(p,"dummy");
+    }
+#else
+    strcpy(p, "dummy");
+#endif
+    verbose = 1;
+
+    zoo_set_debug_level(ZOO_LOG_LEVEL_DEBUG);
+    zoo_deterministic_conn_order(1); // enable deterministic order
+    zh = zookeeper_init(hostPort, watcher, 30000, &myid, 0, 0);
+    if (!zh) {
+        return errno;
+    }
+
+#ifdef SASL
+    if(zoo_sasl_init(zh, callbacks)!=ZOK) {
+        return 1;
+    }
+#endif
+
+#ifdef YCA
+    if(zoo_add_auth(zh,"yca",p,strlen(p),0,0)!=ZOK)
+    return 2;
+#endif
+
+#ifdef THREADED
+    while(!shutdownThisThing) {
+        int rc;
+        int len = sizeof(buffer) - bufoff -1;
+        if (len <= 0) {
+            fprintf(stderr, "Can't handle lines that long!\n");
+            exit(2);
+        }
+        rc = read(0, buffer+bufoff, len);
+        if (rc <= 0) {
+            fprintf(stderr, "bye\n");
+            shutdownThisThing=1;
+            break;
+        }
+        bufoff += rc;
+        buffer[bufoff] = '\0';
+        while (strchr(buffer, '\n')) {
+            char *ptr = strchr(buffer, '\n');
+            *ptr = '\0';
+            processline(buffer);
+            ptr++;
+            memmove(buffer, ptr, strlen(ptr)+1);
+            bufoff = 0;
+        }
+	}
+#else
+    FD_ZERO(&rfds);
+    FD_ZERO(&wfds);
+    FD_ZERO(&efds);
+    while (!shutdownThisThing) {
+        int fd;
+        int interest;
+        int events;
+        struct timeval tv;
+        int rc;
+        zookeeper_interest(zh, &fd, &interest, &tv);
+        if (fd != -1) {
+            if (interest&ZOOKEEPER_READ) {
+                FD_SET(fd, &rfds);
+            } else {
+                FD_CLR(fd, &rfds);
+            }
+            if (interest&ZOOKEEPER_WRITE) {
+                FD_SET(fd, &wfds);
+            } else {
+                FD_CLR(fd, &wfds);
+            }
+        } else {
+            fd = 0;
+        }
+        FD_SET(0, &rfds);
+        rc = select(fd+1, &rfds, &wfds, &efds, &tv);
+        events = 0;
+        if (rc > 0) {
+            if (FD_ISSET(fd, &rfds)) {
+                events |= ZOOKEEPER_READ;
+            }
+            if (FD_ISSET(fd, &wfds)) {
+                events |= ZOOKEEPER_WRITE;
+            }
+        }
+        if(batchMode && processed==0){
+          //batch mode
+          processline(cmd);
+          processed=1;
+        }
+        if (FD_ISSET(0, &rfds)) {
+            int rc;
+            int len = sizeof(buffer) - bufoff -1;
+            if (len <= 0) {
+                fprintf(stderr, "Can't handle lines that long!\n");
+                exit(2);
+            }
+            rc = read(0, buffer+bufoff, len);
+            if (rc <= 0) {
+                fprintf(stderr, "bye\n");
+                break;
+            }
+            bufoff += rc;
+            buffer[bufoff] = '\0';
+            while (strchr(buffer, '\n')) {
+                char *ptr = strchr(buffer, '\n');
+                *ptr = '\0';
+                processline(buffer);
+                ptr++;
+                memmove(buffer, ptr, strlen(ptr)+1);
+                bufoff = 0;
+            }
+        }
+        zookeeper_process(zh, events);
+    }
+#endif
+    if (to_send!=0)
+        fprintf(stderr,"Recvd %d responses for %d requests sent\n",recvd,sent);
+    zookeeper_close(zh);
+    return 0;
+}
+

--- a/zookeeper-client/zookeeper-client-c/src/zk_adaptor.h
+++ b/zookeeper-client/zookeeper-client-c/src/zk_adaptor.h
@@ -104,6 +104,10 @@ struct sync_completion {
             struct String_vector strs2;
             struct Stat stat2;
         } strs_stat;
+        struct {
+            char *token;
+            int token_len;
+        } sasl;
     } u;
     int complete;
 #ifdef THREADED

--- a/zookeeper-client/zookeeper-client-c/src/zk_adaptor.h
+++ b/zookeeper-client/zookeeper-client-c/src/zk_adaptor.h
@@ -105,8 +105,8 @@ struct sync_completion {
             struct Stat stat2;
         } strs_stat;
         struct {
-            char *token;
-            int token_len;
+            char *buffer;
+            int buff_len;
         } sasl;
     } u;
     int complete;

--- a/zookeeper-client/zookeeper-client-c/src/zk_sasl.c
+++ b/zookeeper-client/zookeeper-client-c/src/zk_sasl.c
@@ -120,10 +120,10 @@ static int sasl_proceed(int sr, zhandle_t *zh, zoo_sasl_conn_t *conn,
     if (sr == SASL_CONTINUE || clientoutlen > 0) {
         if(sync) {
 #ifdef THREADED
-            const char *serverin;
+            char serverin[8192];
             unsigned serverinlen;
 
-            r = zoo_sasl(zh, conn, clientout, clientoutlen, &serverin, &serverinlen);
+            r = zoo_sasl(zh, clientout, clientoutlen, serverin, sizeof(serverin), &serverinlen);
             if (sr == SASL_CONTINUE) {
                 r = sasl_step(r, zh, conn, sync, serverin, serverinlen);
             } else {

--- a/zookeeper-client/zookeeper-client-c/src/zk_sasl.c
+++ b/zookeeper-client/zookeeper-client-c/src/zk_sasl.c
@@ -1,0 +1,246 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <string.h>
+
+#include "zk_adaptor.h"
+#include "zookeeper_log.h"
+#include "zookeeper_sasl.h"
+
+#define SAMPLE_SEC_BUF_SIZE (2048)
+
+
+static int sasl_proceed(int sr, zhandle_t *zh, zoo_sasl_conn_t *conn,
+        const char *clientout, int clientoutlen, int sync);
+
+static int sasl_auth(zhandle_t *zh, zoo_sasl_conn_t *conn, const char *mech,
+        const char *supportedmechs, int sync) {
+    const char *clientout;
+    const char *chosenmech;
+    unsigned clientoutlen;
+    int sr = 0;
+
+    /*
+     if (supportedmechs) {
+     serverin = (char *) malloc(strlen(supportedmechs));
+     strncpy(serverin, supportedmechs, strlen(supportedmechs));
+     }
+     */
+
+    if (mech) {
+        if (!strstr(supportedmechs, mech)) {
+            LOG_DEBUG(LOGCALLBACK(zh), "client doesn't support mandatory mech '%s'\n", mech);
+            return ZSYSTEMERROR;
+        }
+    }
+
+    sr = sasl_client_start((sasl_conn_t *) conn, mech, NULL, &clientout, &clientoutlen,
+            &chosenmech);
+
+    LOG_DEBUG(LOGCALLBACK(zh), "SASL Authentication mechanism: %s", chosenmech);
+
+    return sasl_proceed(sr, zh, conn, clientout, clientoutlen, sync);
+}
+
+#ifdef THREADED
+int zoo_sasl_authenticate(zhandle_t *zh, zoo_sasl_conn_t *conn, const char *mech,
+        const char *supportedmechs) {
+    return sasl_auth(zh, conn, mech, supportedmechs, 1);
+}
+#endif
+
+int zoo_asasl_authenticate(zhandle_t *zh, zoo_sasl_conn_t *conn, const char *mech,
+        const char *supportedmechs) {
+    return sasl_auth(zh, conn, mech, supportedmechs, 0);
+}
+
+static int sasl_step(int rc, zhandle_t *zh, zoo_sasl_conn_t *conn, int sync,
+        const char *serverin, int serverinlen) {
+    const char *clientout;
+    unsigned clientoutlen;
+    int sr;
+    int r = rc;
+
+    if (r != ZOK) {
+        LOG_ERROR(LOGCALLBACK(zh), "Reading sasl response failed: %d", r);
+        return r;
+    }
+
+    sr = sasl_client_step((sasl_conn_t *) conn, serverin, serverinlen, NULL, &clientout,
+            &clientoutlen);
+
+    return sasl_proceed(sr, zh, conn, clientout, clientoutlen, sync);
+}
+
+static int sasl_step_async(int rc, zhandle_t *zh, zoo_sasl_conn_t *conn,
+        const char *serverin, int serverinlen) {
+    return sasl_step(rc, zh, conn, 0, serverin, serverinlen);
+}
+
+static int sasl_complete(int rc, zhandle_t *zh, zoo_sasl_conn_t *conn,
+        const char *serverin, int serverinlen) {
+    if (rc != ZOK) {
+        LOG_ERROR(LOGCALLBACK(zh), "Reading sasl response failed: %d", rc);
+        return rc;
+    }
+
+    LOG_DEBUG(LOGCALLBACK(zh), "SASL Authentication complete [%d]", rc);
+    return rc;
+}
+
+static int sasl_proceed(int sr, zhandle_t *zh, zoo_sasl_conn_t *conn,
+        const char *clientout, int clientoutlen, int sync) {
+    int r = ZOK;
+    if (sr != SASL_OK && sr != SASL_CONTINUE) {
+        LOG_ERROR(LOGCALLBACK(zh), "starting SASL negotiation: %s %s",
+                sasl_errstring(sr, NULL, NULL),
+                sasl_errdetail((sasl_conn_t *) conn));
+        return ZSYSTEMERROR;
+    }
+
+    if (sr == SASL_CONTINUE || clientoutlen > 0) {
+        if(sync) {
+#ifdef THREADED
+            const char *serverin;
+            unsigned serverinlen;
+
+            r = zoo_sasl(zh, conn, clientout, clientoutlen, &serverin, &serverinlen);
+            if (sr == SASL_CONTINUE) {
+                r = sasl_step(r, zh, conn, sync, serverin, serverinlen);
+            } else {
+                r = sasl_complete(r, zh, conn, serverin, serverinlen);
+            }
+#else
+            LOG_ERROR(LOGCALLBACK(zh), "Sync sasl_proceed used without threads");
+            abort();
+#endif
+        } else {
+            r = zoo_asasl(zh, conn, clientout, clientoutlen,
+                           (sr == SASL_CONTINUE) ? sasl_step_async : sasl_complete);
+        }
+    }
+    if (r != ZOK) {
+        LOG_ERROR(LOGCALLBACK(zh), "Sending sasl request failed: %d", r);
+        return r;
+    }
+    return r;
+}
+
+int zoo_sasl_init(zhandle_t *zh, sasl_callback_t *callbacks) {
+    int rc = sasl_client_init(callbacks);
+    if (rc != SASL_OK) {
+        LOG_ERROR(LOGCALLBACK(zh), "initializing libsasl: %s",
+                 sasl_errstring(rc, NULL, NULL));
+        rc = ZSYSTEMERROR;
+    } else {
+        rc = ZOK;
+    }
+    return rc;
+}
+
+int zoo_sasl_connect(zhandle_t *zh, char *servicename, char *host, zoo_sasl_conn_t **sasl_conn,
+        const char **mechs, int *mechlen) {
+    char localaddr[NI_MAXHOST + NI_MAXSERV], remoteaddr[NI_MAXHOST + NI_MAXSERV];
+    char hbuf[NI_MAXHOST], pbuf[NI_MAXSERV];
+    int r;
+    int salen;
+    int niflags, error;
+    struct sockaddr_storage local_ip, remote_ip;
+    sasl_conn_t *conn;
+    //sasl_security_properties_t secprops;
+    //sasl_ssf_t extssf = 128;
+
+    /* set ip addresses */
+    salen = sizeof(local_ip);
+    if (getsockname(zh->fd, (struct sockaddr *) &local_ip,
+                    (unsigned *) &salen) < 0) {
+        LOG_ERROR(LOGCALLBACK(zh), "getsockname");
+        return ZSYSTEMERROR;
+    }
+
+    niflags = (NI_NUMERICHOST | NI_NUMERICSERV);
+#ifdef NI_WITHSCOPEID
+    if (((struct sockaddr *)&local_ip)->sa_family ==AF_INET6)
+    niflags |= NI_WITHSCOPEID;
+#endif
+    error = getnameinfo((struct sockaddr *) &local_ip, salen, hbuf,
+            sizeof(hbuf), pbuf, sizeof(pbuf), niflags);
+    if (error != 0) {
+        LOG_ERROR(LOGCALLBACK(zh), "getnameinfo: %s\n", gai_strerror(error));
+        strcpy(hbuf, "unknown");
+        strcpy(pbuf, "unknown");
+        return ZSYSTEMERROR;
+    }
+    snprintf(localaddr, sizeof(localaddr), "%s;%s", hbuf, pbuf);
+
+    salen = sizeof(remote_ip);
+    if (getpeername(zh->fd, (struct sockaddr *) &remote_ip,
+                    (unsigned *) &salen) < 0) {
+        LOG_ERROR(LOGCALLBACK(zh), "getpeername");
+        return ZSYSTEMERROR;
+    }
+
+    niflags = (NI_NUMERICHOST | NI_NUMERICSERV);
+#ifdef NI_WITHSCOPEID
+    if (((struct sockaddr *)&remote_ip)->sa_family == AF_INET6)
+    niflags |= NI_WITHSCOPEID;
+#endif
+    error = getnameinfo((struct sockaddr *) &remote_ip, salen, hbuf,
+            sizeof(hbuf), pbuf, sizeof(pbuf), niflags);
+    if (error != 0) {
+        LOG_ERROR(LOGCALLBACK(zh), "getnameinfo: %s\n", gai_strerror(error));
+        strcpy(hbuf, "unknown");
+        strcpy(pbuf, "unknown");
+        return ZSYSTEMERROR;
+    }
+    snprintf(remoteaddr, sizeof(remoteaddr), "%s;%s", hbuf, pbuf);
+
+    LOG_DEBUG(LOGCALLBACK(zh), "Zookeeper Host: %s %s %s", "ubook", localaddr, remoteaddr);
+
+    /*
+     memset(&secprops, 0L, sizeof(secprops));
+     secprops.maxbufsize = SAMPLE_SEC_BUF_SIZE;
+     secprops.max_ssf = 2048;
+     secprops.min_ssf = 128;
+     */
+
+    /* client new connection */
+    r = sasl_client_new(servicename, host ? host : hbuf, localaddr, remoteaddr,
+            NULL, 0, &conn);
+    if (r != SASL_OK) {
+        LOG_ERROR(LOGCALLBACK(zh), "allocating connection state: %s %s",
+                sasl_errstring(r, NULL, NULL), sasl_errdetail(conn));
+        return ZSYSTEMERROR;
+    } else {
+        r = ZOK;
+    }
+
+    //sasl_setprop(conn, SASL_SSF_EXTERNAL, &extssf);
+
+    //sasl_setprop(conn, SASL_SEC_PROPS, &secprops);
+
+    sasl_listmech(conn, NULL, NULL, " ", NULL, mechs, NULL, mechlen);
+
+    *sasl_conn = (zoo_sasl_conn_t *) conn;
+
+    return r;
+}

--- a/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
@@ -41,6 +41,10 @@ using namespace std;
 #include "Util.h"
 #include "ZKMocks.h"
 
+#ifdef SASL
+#include <zookeeper_sasl.h>
+#endif
+
 struct buff_struct_2 {
     int32_t len;
     int32_t off;
@@ -225,7 +229,9 @@ class Zookeeper_simpleSystem : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testGetChildren2);
     CPPUNIT_TEST(testLastZxid);
     CPPUNIT_TEST(testRemoveWatchers);
+#ifdef SASL
     CPPUNIT_TEST(testSasl);
+#endif
 #endif
     CPPUNIT_TEST_SUITE_END();
 
@@ -510,6 +516,53 @@ public:
         CPPUNIT_ASSERT(strstr(serverin, nonce)!=NULL);
         return rc;
     }
+
+#ifdef SASL
+    static int saslSimpleCallback(void *context __attribute__((unused)), int id,
+            const char **result, unsigned *len) {
+        const char *user = "super";
+
+        /* paranoia check */
+        if (!result) {
+            return -1;
+        }
+
+        switch (id) {
+        case SASL_CB_USER:
+            *result = user;
+            break;
+        case SASL_CB_AUTHNAME:
+            *result = user;
+            break;
+        default:
+            return -1;
+        }
+        return 0;
+    }
+
+    static int saslPassCallback(sasl_conn_t *conn, void *context __attribute__((unused)),
+            int id, sasl_secret_t **psecret) {
+        const char *pass = "test";
+        unsigned long int len;
+
+        /* paranoia check */
+        if (!psecret) {
+            return -1;
+        }
+
+        switch (id) {
+        case SASL_CB_PASS:
+            len = strlen(pass);
+            *psecret = (sasl_secret_t *) malloc(sizeof(sasl_secret_t) + len);
+            (*psecret)->len = len;
+            strcpy((char *)(*psecret)->data, (char *) pass);
+            break;
+        default:
+            return -1;
+        }
+        return 0;
+    }
+#endif
 
     static void verifyCreateFails(const char *path, zhandle_t *zk) {
       CPPUNIT_ASSERT_EQUAL((int)ZBADARGUMENTS, zoo_create(zk,
@@ -1485,11 +1538,19 @@ public:
       CPPUNIT_ASSERT_EQUAL((int)ZOK,rc);
     }
 
+#ifdef SASL
     void testSasl() {
         int rc;
         const char *saslopt = "-sasl";
         count = 0;
-        watchctx_t ctx1, ctx2;
+        watchctx_t ctx1, ctx2, ctx3, ctx4;
+
+        zoo_sasl_conn_t *sasl_conn;
+        const char *supportedmechs;
+        const char *mech = "DIGEST-MD5";
+        const char *service = "zookeeper";
+        const char *host = "zk-sasl-md5";
+        int supportedmechcount;
 
         const char *serverin;
         unsigned serverinlen;
@@ -1513,10 +1574,31 @@ public:
 
         zhandle_t *zk2 = createClient(&ctx2);
         rc = zoo_asasl(zk2, NULL, (const char *) "", 0, saslDigestInitCompletion);
+#ifdef THREADED
+
+        sasl_callback_t callbacks[] = {
+                { SASL_CB_USER, (int (*)())&saslSimpleCallback, NULL },
+                { SASL_CB_AUTHNAME, (int (*)())&saslSimpleCallback, NULL },
+                { SASL_CB_PASS, (int (*)())&saslPassCallback, NULL },
+                { SASL_CB_LIST_END, NULL, NULL } };
+
+        rc = zoo_sasl_init(callbacks);
+        CPPUNIT_ASSERT_EQUAL((int) ZOK, rc);
+
+        zhandle_t *zk3 = createClient(&ctx3);
+
+        rc = zoo_sasl_connect(zk3, (char *) service, (char *) host, &sasl_conn,
+                &supportedmechs, &supportedmechcount);
+        CPPUNIT_ASSERT_EQUAL((int) ZOK, rc);
+
+        rc = zoo_sasl_authenticate(zk3, sasl_conn, mech, supportedmechs);
+        CPPUNIT_ASSERT_EQUAL((int) ZOK, rc);
+#endif
         stopServer();
         startServer();
 
     }
+#endif
 };
 
 volatile int Zookeeper_simpleSystem::count;

--- a/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
@@ -1552,7 +1552,7 @@ public:
         const char *host = "zk-sasl-md5";
         int supportedmechcount;
 
-        const char *serverin;
+        char serverin[8192];
         unsigned serverinlen;
         const char *realm = "realm";
         const char *nonce = "nonce";
@@ -1564,7 +1564,7 @@ public:
         // zoo_set_debug_level(ZOO_LOG_LEVEL_DEBUG);
 
         zhandle_t *zk1 = createClient(&ctx1);
-        rc = zoo_sasl(zk1, NULL, (const char *) "", 0, &serverin, &serverinlen);
+        rc = zoo_sasl(zk1, (const char *) "", 0, serverin, sizeof(serverin), &serverinlen);
         CPPUNIT_ASSERT_EQUAL((int) ZOK, rc);
         // response should look like
         // realm="zk-sasl-md5",nonce="4n7iytvP7E9GyRVvGQ8pATPPnXJ0GjOB5rmTzk3a",...

--- a/zookeeper-client/zookeeper-client-c/tests/jaas.digest.server.conf
+++ b/zookeeper-client/zookeeper-client-c/tests/jaas.digest.server.conf
@@ -1,0 +1,4 @@
+Server {
+       org.apache.zookeeper.server.auth.DigestLoginModule required
+       user_super="test";
+};

--- a/zookeeper-client/zookeeper-client-c/tests/zkServer.sh
+++ b/zookeeper-client/zookeeper-client-c/tests/zkServer.sh
@@ -21,7 +21,7 @@ ZOOPORT=22181
 
 if [ "x$1" == "x" ]
 then
-    echo "USAGE: $0 startClean|start|startReadOnly|startRequireSASLAuth|stop hostPorts"
+    echo "USAGE: $0 startClean|start|startReadOnly|startRequireSASLAuth|stop hostPorts [-sasl] [-verbose]"
     exit 2
 fi
 
@@ -109,6 +109,27 @@ then
 fi
 
 PROPERTIES="-Dzookeeper.extendedTypesEnabled=true -Dznode.container.checkIntervalMs=100"
+
+for var in "$@"
+do
+    if [[ "x$var" != "x0" && "x$var" != "x1" && "x$var" != "x2" ]]
+    then
+        if [ "$var" == "-sasl" ]
+        then
+            SASLCONFFILE=tests/jaas.digest.server.conf
+            if [ "x${base_dir}" != "x" ]
+            then
+                SASLCONFFILE="${base_dir}/zookeeper-client/zookeeper-client-c/$SASLCONFFILE"
+            fi
+            PROPERTIES="$PROPERTIES -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
+            PROPERTIES="$PROPERTIES -Djava.security.auth.login.config=$SASLCONFFILE"
+        fi
+        if [ "$var" == "-verbose" ]
+        then
+            PROPERTIES="$PROPERTIES -Dzookeeper.root.logger=DEBUG,CONSOLE -Dzookeeper.console.threshold=DEBUG"
+        fi
+    fi
+done
 
 case $1 in
 start|startClean)

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/util/SecurityUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/util/SecurityUtils.java
@@ -18,8 +18,6 @@
 
 package org.apache.zookeeper.util;
 
-import java.util.HashMap;
-
 import java.security.Principal;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -155,11 +153,6 @@ public final class SecurityUtils {
     public static SaslServer createSaslServer(final Subject subject,
             final String protocol, final String serverName,
             final CallbackHandler callbackHandler, final Logger LOG) {
-        // required by c client api - Sasl.QOP="auth" is not set
-        // by default although stated in javadoc (Sun JRE 1.6.0_26-b03)
-        HashMap<String, Object> props = new HashMap<String, Object>();
-        props.put(Sasl.QOP, "auth-conf,auth-int,auth");
-
         if (subject != null) {
             // server is using a JAAS-authenticated subject: determine service
             // principal name and hostname from zk server's subject.
@@ -238,7 +231,7 @@ public final class SecurityUtils {
                                             SaslServer saslServer;
                                             saslServer = Sasl.createSaslServer(
                                                     mech, servicePrincipalName,
-                                                    serviceHostname, props,
+                                                    serviceHostname, null,
                                                     callbackHandler);
                                             return saslServer;
                                         } catch (SaslException e) {
@@ -260,7 +253,7 @@ public final class SecurityUtils {
                 // TODO: use 'authMech=' value in zoo.cfg.
                 try {
                     SaslServer saslServer = Sasl.createSaslServer("DIGEST-MD5",
-                            protocol, serverName, props, callbackHandler);
+                            protocol, serverName, null, callbackHandler);
                     return saslServer;
                 } catch (SaslException e) {
                     LOG.error("Zookeeper Quorum member failed to create a SaslServer to interact with a client during session initiation", e);


### PR DESCRIPTION
This is a forward-port of Tom Klonikowski's (@kloni) [ZOOKEEPER-1112](https://issues.apache.org/jira/browse/ZOOKEEPER-1112) patches on top of the current `master` branch.

It stays close to the original patches, and only adds a number of commits on top:

 1. A simple way to pass passwords to the console client via files;
 2. Fixes and cleanups in the C library;
 3. An Apache Rat exclusion rule for the test configuration file.

Open questions:

 1. The patches add an optional dependency on the Cyrus SASL library.
    [Eric Yang wrote](https://issues.apache.org/jira/browse/ZOOKEEPER-1112?focusedCommentId=13080468&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13080468):

    > Apache Web Server has a module for authenticate sasl using Cyrus SASL library. I think the license should be compatible with written agreement from CMU.

    Who should take care of this?  Is there an established procedure?

 2. [Tom Klonikowski wrote](https://issues.apache.org/jira/browse/ZOOKEEPER-1112?focusedCommentId=13126379&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13126379):

    > Maybe part #2 (sasl auth implementation via cyrus sasl) and #3 (cli using #2) should be moved to the recipes section (recipes/sasl). What do you think?

    What do you think?

 3. Should `cli_sasl_{st,mt}` be folded back into `cli_{st,mt}`?

The existing tests as well as the added SASL tests pass in `st` and `mt` modes.  Both `cli_sasl_*` utilities have been tested against a `DIGEST-MD5` server; I intend to test them against a GSSAPI one in the near future.
