### PR TITLE
ZOOKEEPER-3510: Make 'zkServer.sh stop' more reliable

### DIFF
--- a/bin/zkServer.sh
+++ b/bin/zkServer.sh
@@ -212,6 +212,7 @@ stop)
     else
       $KILL $(cat "$ZOOPIDFILE")
       rm "$ZOOPIDFILE"
+      sleep 1
       echo STOPPED
     fi
     exit 0


### PR DESCRIPTION
As mentioned in https://github.com/apache/zookeeper/pull/1054#discussion_r314208678 :

There is a `sleep 3` statement in `zkServer.sh restart`. I am unable to unearth the history of that particular line, but I believe part—if not all—of that sleep should be part of `zkServer.sh stop`.

I frequently observe `FAILED TO START` errors in the C test suite; the logs consistently show that those are caused by `java.net.BindException: Address already in use`. Adding a simple `sleep 1` before `echo STOPPED` "fixes" it for me.

As noted in the commit message, the `sleep` is far from optimal, an adaptive mechanism would be better—but I do not want to make the first iteration too complicated.