### PR TITLE
ZOOKEEPER-3506:correct the javaDoc of the SessionTrackerImpl#initializeNextSessionId

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/SessionTrackerImpl.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/SessionTrackerImpl.java
@@ -83,10 +83,13 @@ public class SessionTrackerImpl extends ZooKeeperCriticalThread implements Sessi
     }
 
     /**
-     * Generates an initial sessionId. High order byte is serverId, next 5
+     * Generates an initial sessionId. High order 1 byte is serverId, next
      * 5 bytes are from timestamp, and low order 2 bytes are 0s.
+     * Use ">>> 8", not ">> 8" to make sure that the high order 1 byte is entirely up to the server Id(@see ZOOKEEPER-1622).
+     * @param id server Id
+     * @return the Session Id
      */
-    public static long initializeNextSession(long id) {
+    public static long initializeNextSessionId(long id) {
         long nextSid;
         nextSid = (Time.currentElapsedTime() << 24) >>> 8;
         nextSid = nextSid | (id << 56);
@@ -103,7 +106,7 @@ public class SessionTrackerImpl extends ZooKeeperCriticalThread implements Sessi
         this.expirer = expirer;
         this.sessionExpiryQueue = new ExpiryQueue<SessionImpl>(tickTime);
         this.sessionsWithTimeout = sessionsWithTimeout;
-        this.nextSessionId.set(initializeNextSession(serverId));
+        this.nextSessionId.set(initializeNextSessionId(serverId));
         for (Entry<Long, Integer> e : sessionsWithTimeout.entrySet()) {
             trackSession(e.getKey(), e.getValue());
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerSessionTracker.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerSessionTracker.java
@@ -65,7 +65,7 @@ public class LearnerSessionTracker extends UpgradeableSessionTracker {
         this.touchTable.set(new ConcurrentHashMap<Long, Integer>());
         this.globalSessionsWithTimeouts = sessionsWithTimeouts;
         this.serverId = id;
-        nextSessionId.set(SessionTrackerImpl.initializeNextSession(serverId));
+        nextSessionId.set(SessionTrackerImpl.initializeNextSessionId(serverId));
 
         this.localSessionsEnabled = localSessionsEnabled;
         if (this.localSessionsEnabled) {


### PR DESCRIPTION
- A analyst of this method
suppose that current timestamp:1566197268432(10110110010101000101000011011111111010000), myid=1

```
 00000000 00000000 00000001 01101100 10101000 10100001 10111111 11010000
<<24
 01101100 10101000 10100001 10111111 11010000 00000000 00000000 00000000
 >>>8
 00000000 01101100 10101000 10100001 10111111 11010000 00000000 00000000
|
 00000001 00000000 00000000 00000000 00000000 00000000 00000000 00000000(id << 56)
=
 00000001 01101100 10101000 10100001 10111111 11010000 00000000 00000000
```

- more details in the [ZOOKEEPER-3506](https://issues.apache.org/jira/browse/ZOOKEEPER-3506)