### PR TITLE
ZOOKEEPER-3518: owasp check flagging jackson-databind 2.9.9.1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -55,7 +55,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="javacc.version" value="5.0"/>
 
     <property name="jetty.version" value="9.4.18.v20190429"/>
-    <property name="jackson.version" value="2.9.9.1"/>
+    <property name="jackson.version" value="2.9.9.3"/>
     <property name="dependency-check-ant.version" value="4.0.2"/>
 
     <property name="commons-io.version" value="2.6"/>

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
     <commons-cli.version>1.2</commons-cli.version>
     <netty.version>4.1.36.Final</netty.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
-    <jackson.version>2.9.9.1</jackson.version>
+    <jackson.version>2.9.9.3</jackson.version>
     <json.version>1.1.1</json.version>
     <jline.version>2.11</jline.version>
     <snappy.version>1.1.7</snappy.version>


### PR DESCRIPTION
Fix is to upgrade to latest - 2.9.9.3

Change-Id: Ibedbe434def73959c1e5209d5321e9e66c151929