### PR TITLE
ZOOKEEPER-3519: upgrade dependency-check to 5.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>5.1.0</version>
+          <version>5.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Just upgrade to the latest 5.2.1

ran the check and it seemed to run/check correctly

Change-Id: I9770789771f4b70cdf34d220738d4832daf7b0a5