### PR TITLE
ZOOKEEPER-3523: Replace dummy watcher with a unified singleton

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Watcher.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Watcher.java
@@ -31,6 +31,8 @@ import org.apache.yetus.audience.InterfaceAudience;
 @InterfaceAudience.Public
 public interface Watcher {
 
+    Watcher DUMMY_WATCHER = event -> { };
+
     /**
      * This interface defines the possible states an Event may represent
      */

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Watcher.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Watcher.java
@@ -31,8 +31,6 @@ import org.apache.yetus.audience.InterfaceAudience;
 @InterfaceAudience.Public
 public interface Watcher {
 
-    Watcher DUMMY_WATCHER = event -> { };
-
     /**
      * This interface defines the possible states an Event may represent
      */

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/CustomHostProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/CustomHostProviderTest.java
@@ -64,13 +64,13 @@ public class CustomHostProviderTest extends ZKTestCase {
         ZooKeeper zkDefaults = new ZooKeeper(
             "127.0.0.1:" + CLIENT_PORT,
             ClientBase.CONNECTION_TIMEOUT,
-            Watcher.DUMMY_WATCHER,
+            DummyWatcher.INSTANCE,
             false);
 
         ZooKeeper zkSpecial = new ZooKeeper(
                 "127.0.0.1:" + CLIENT_PORT,
                 ClientBase.CONNECTION_TIMEOUT,
-                Watcher.DUMMY_WATCHER,
+                DummyWatcher.INSTANCE,
                 false,
                 specialHostProvider);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/CustomHostProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/CustomHostProviderTest.java
@@ -27,7 +27,7 @@ import org.apache.zookeeper.client.HostProvider;
 import org.apache.zookeeper.test.ClientBase;
 import org.junit.Test;
 
-public class CustomHostProviderTest extends ZKTestCase implements Watcher {
+public class CustomHostProviderTest extends ZKTestCase {
 
     private AtomicInteger counter = new AtomicInteger(3);
 
@@ -53,9 +53,6 @@ public class CustomHostProviderTest extends ZKTestCase implements Watcher {
         }
 
     }
-    @Override
-    public void process(WatchedEvent event) {
-    }
 
     @Test
     public void testZooKeeperWithCustomHostProvider() throws IOException, InterruptedException {
@@ -64,12 +61,16 @@ public class CustomHostProviderTest extends ZKTestCase implements Watcher {
         int expectedCounter = 3;
         counter.set(expectedCounter);
 
-        ZooKeeper zkDefaults = new ZooKeeper("127.0.0.1:" + CLIENT_PORT, ClientBase.CONNECTION_TIMEOUT, this, false);
+        ZooKeeper zkDefaults = new ZooKeeper(
+            "127.0.0.1:" + CLIENT_PORT,
+            ClientBase.CONNECTION_TIMEOUT,
+            Watcher.DUMMY_WATCHER,
+            false);
 
         ZooKeeper zkSpecial = new ZooKeeper(
                 "127.0.0.1:" + CLIENT_PORT,
                 ClientBase.CONNECTION_TIMEOUT,
-                this,
+                Watcher.DUMMY_WATCHER,
                 false,
                 specialHostProvider);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/DummyWatcher.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/DummyWatcher.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper;
+
+/**
+ * A dummy implementation of {@link Watcher}. Used in tests.
+ */
+public class DummyWatcher implements Watcher {
+
+    public static final DummyWatcher INSTANCE = new DummyWatcher();
+
+    @Override
+    public void process(WatchedEvent event) {
+        // no op
+    }
+
+    private DummyWatcher() {
+        // singleton
+    }
+
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/RemoveWatchesCmdTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/RemoveWatchesCmdTest.java
@@ -64,7 +64,7 @@ public class RemoveWatchesCmdTest extends ClientBase {
      */
     @Test(timeout = 30000)
     public void testRemoveWatchesWithNoPassedOptions() throws Exception {
-        List<EventType> expectedEvents = new ArrayList<Watcher.Event.EventType>();
+        List<EventType> expectedEvents = new ArrayList<>();
         expectedEvents.add(EventType.ChildWatchRemoved);
         expectedEvents.add(EventType.DataWatchRemoved);
         MyWatcher myWatcher = new MyWatcher("/testnode1", expectedEvents, 2);
@@ -98,7 +98,7 @@ public class RemoveWatchesCmdTest extends ClientBase {
     @Test(timeout = 30000)
     public void testRemoveNodeDataChangedWatches() throws Exception {
         LOG.info("Adding data watcher using getData()");
-        List<EventType> expectedEvents = new ArrayList<Watcher.Event.EventType>();
+        List<EventType> expectedEvents = new ArrayList<>();
         expectedEvents.add(EventType.DataWatchRemoved);
         MyWatcher myWatcher = new MyWatcher("/testnode1", expectedEvents, 1);
 
@@ -122,7 +122,7 @@ public class RemoveWatchesCmdTest extends ClientBase {
      */
     @Test(timeout = 30000)
     public void testRemoveNodeCreatedWatches() throws Exception {
-        List<EventType> expectedEvents = new ArrayList<Watcher.Event.EventType>();
+        List<EventType> expectedEvents = new ArrayList<>();
         expectedEvents.add(EventType.DataWatchRemoved);
         MyWatcher myWatcher1 = new MyWatcher("/testnode1", expectedEvents, 1);
         MyWatcher myWatcher2 = new MyWatcher("/testnode1/testnode2", expectedEvents, 1);
@@ -156,7 +156,7 @@ public class RemoveWatchesCmdTest extends ClientBase {
      */
     @Test(timeout = 30000)
     public void testRemoveNodeChildrenChangedWatches() throws Exception {
-        List<EventType> expectedEvents = new ArrayList<Watcher.Event.EventType>();
+        List<EventType> expectedEvents = new ArrayList<>();
         expectedEvents.add(EventType.ChildWatchRemoved);
         MyWatcher myWatcher = new MyWatcher("/testnode1", expectedEvents, 1);
 
@@ -178,7 +178,7 @@ public class RemoveWatchesCmdTest extends ClientBase {
     @Test(timeout = 30000)
     public void testRemoveNodeDeletedWatches() throws Exception {
         LOG.info("Adding NodeDeleted watcher");
-        List<EventType> expectedEvents = new ArrayList<Watcher.Event.EventType>();
+        List<EventType> expectedEvents = new ArrayList<>();
         expectedEvents.add(EventType.ChildWatchRemoved);
         expectedEvents.add(EventType.NodeDeleted);
         MyWatcher myWatcher = new MyWatcher("/testnode1", expectedEvents, 1);
@@ -222,7 +222,7 @@ public class RemoveWatchesCmdTest extends ClientBase {
     }
 
     private void verifyRemoveAnyWatches(boolean local) throws Exception {
-        final Map<String, List<EventType>> pathVsEvent = new HashMap<String, List<EventType>>();
+        final Map<String, List<EventType>> pathVsEvent = new HashMap<>();
         LOG.info("Adding NodeChildrenChanged, NodeDataChanged watchers");
         final CountDownLatch watcherLatch = new CountDownLatch(2);
         Watcher watcher = new Watcher() {
@@ -231,27 +231,20 @@ public class RemoveWatchesCmdTest extends ClientBase {
             public void process(WatchedEvent event) {
                 switch (event.getType()) {
                 case ChildWatchRemoved:
-                case DataWatchRemoved: {
+                case DataWatchRemoved:
                     addWatchNotifications(pathVsEvent, event);
                     watcherLatch.countDown();
                     break;
-                }
                 case NodeChildrenChanged:
-                case NodeDataChanged: {
+                case NodeDataChanged:
                     addWatchNotifications(pathVsEvent, event);
                     break;
                 }
-                }
             }
 
-            private void addWatchNotifications(
-                    final Map<String, List<EventType>> pathVsEvent, WatchedEvent event) {
-                List<EventType> events = pathVsEvent.get(event.getPath());
-                if (null == events) {
-                    events = new ArrayList<Watcher.Event.EventType>();
-                    pathVsEvent.put(event.getPath(), events);
-                }
-                events.add(event.getType());
+            private void addWatchNotifications(Map<String, List<EventType>> pathVsEvent, WatchedEvent event) {
+                pathVsEvent.computeIfAbsent(event.getPath(), k -> new ArrayList<>())
+                           .add(event.getType());
             }
         };
         zk.create("/testnode1", "data".getBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
@@ -274,21 +267,21 @@ public class RemoveWatchesCmdTest extends ClientBase {
         assertTrue("Didn't receives ChildWatchRemoved!", pathVsEvent.get("/testnode1").contains(EventType.ChildWatchRemoved));
     }
 
-    private class MyWatcher implements Watcher {
+    private static class MyWatcher implements Watcher {
 
         private final String path;
         private String eventPath;
         private final CountDownLatch latch;
-        private final List<EventType> expectedEvents = new ArrayList<EventType>();
+        private final List<EventType> expectedEvents = new ArrayList<>();
 
-        public MyWatcher(String path, List<EventType> expectedEvents, int count) {
+        MyWatcher(String path, List<EventType> expectedEvents, int count) {
             this.path = path;
             this.latch = new CountDownLatch(count);
             this.expectedEvents.addAll(expectedEvents);
         }
 
         public void process(WatchedEvent event) {
-            LOG.debug("Event path : {}, eventPath : {}" + new Object[]{path, event.getPath()});
+            LOG.debug("Event path : {}, eventPath : {}", path, event.getPath());
             this.eventPath = event.getPath();
             if (expectedEvents.contains(event.getType())) {
                 latch.countDown();
@@ -300,7 +293,7 @@ public class RemoveWatchesCmdTest extends ClientBase {
                 LOG.error("Failed to get watch notifications!");
                 return false;
             }
-            LOG.debug("Client path : {} eventPath : {}", new Object[]{path, eventPath});
+            LOG.debug("Client path : {} eventPath : {}", path, eventPath);
             return path.equals(eventPath);
         }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/RemoveWatchesTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/RemoveWatchesTest.java
@@ -715,20 +715,14 @@ public class RemoveWatchesTest extends ClientBase {
         zk1.create("/node1", null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         final CountDownLatch dataWatchCount = new CountDownLatch(1);
         final CountDownLatch rmWatchCount = new CountDownLatch(1);
-        Watcher w1 = new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                if (event.getType() == EventType.DataWatchRemoved) {
-                    rmWatchCount.countDown();
-                }
+        Watcher w1 = event -> {
+            if (event.getType() == EventType.DataWatchRemoved) {
+                rmWatchCount.countDown();
             }
         };
-        Watcher w2 = new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                if (event.getType() == EventType.NodeDataChanged) {
-                    dataWatchCount.countDown();
-                }
+        Watcher w2 = event -> {
+            if (event.getType() == EventType.NodeDataChanged) {
+                dataWatchCount.countDown();
             }
         };
         // Add multiple data watches
@@ -754,20 +748,14 @@ public class RemoveWatchesTest extends ClientBase {
         zk1.create("/node1", null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         final CountDownLatch childWatchCount = new CountDownLatch(1);
         final CountDownLatch rmWatchCount = new CountDownLatch(1);
-        Watcher w1 = new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                if (event.getType() == EventType.ChildWatchRemoved) {
-                    rmWatchCount.countDown();
-                }
+        Watcher w1 = event -> {
+            if (event.getType() == EventType.ChildWatchRemoved) {
+                rmWatchCount.countDown();
             }
         };
-        Watcher w2 = new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                if (event.getType() == EventType.NodeChildrenChanged) {
-                    childWatchCount.countDown();
-                }
+        Watcher w2 = event -> {
+            if (event.getType() == EventType.NodeChildrenChanged) {
+                childWatchCount.countDown();
             }
         };
         // Add multiple child watches
@@ -793,34 +781,28 @@ public class RemoveWatchesTest extends ClientBase {
         zk1.create("/node1", null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         final CountDownLatch dWatchCount = new CountDownLatch(2);
         final CountDownLatch rmWatchCount = new CountDownLatch(2);
-        Watcher w1 = new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                switch (event.getType()) {
-                case DataWatchRemoved:
-                    rmWatchCount.countDown();
-                    break;
-                case NodeDataChanged:
-                    dWatchCount.countDown();
-                    break;
-                default:
-                    break;
-                }
+        Watcher w1 = event -> {
+            switch (event.getType()) {
+            case DataWatchRemoved:
+                rmWatchCount.countDown();
+                break;
+            case NodeDataChanged:
+                dWatchCount.countDown();
+                break;
+            default:
+                break;
             }
         };
-        Watcher w2 = new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                switch (event.getType()) {
-                case DataWatchRemoved:
-                    rmWatchCount.countDown();
-                    break;
-                case NodeDataChanged:
-                    dWatchCount.countDown();
-                    break;
-                default:
-                    break;
-                }
+        Watcher w2 = event -> {
+            switch (event.getType()) {
+            case DataWatchRemoved:
+                rmWatchCount.countDown();
+                break;
+            case NodeDataChanged:
+                dWatchCount.countDown();
+                break;
+            default:
+                break;
             }
         };
         // Add multiple data watches
@@ -845,34 +827,28 @@ public class RemoveWatchesTest extends ClientBase {
         zk1.create("/node1", null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         final CountDownLatch cWatchCount = new CountDownLatch(2);
         final CountDownLatch rmWatchCount = new CountDownLatch(2);
-        Watcher w1 = new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                switch (event.getType()) {
-                case ChildWatchRemoved:
-                    rmWatchCount.countDown();
-                    break;
-                case NodeChildrenChanged:
-                    cWatchCount.countDown();
-                    break;
-                default:
-                    break;
-                }
+        Watcher w1 = event -> {
+            switch (event.getType()) {
+            case ChildWatchRemoved:
+                rmWatchCount.countDown();
+                break;
+            case NodeChildrenChanged:
+                cWatchCount.countDown();
+                break;
+            default:
+                break;
             }
         };
-        Watcher w2 = new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                switch (event.getType()) {
-                case ChildWatchRemoved:
-                    rmWatchCount.countDown();
-                    break;
-                case NodeChildrenChanged:
-                    cWatchCount.countDown();
-                    break;
-                default:
-                    break;
-                }
+        Watcher w2 = event -> {
+            switch (event.getType()) {
+            case ChildWatchRemoved:
+                rmWatchCount.countDown();
+                break;
+            case NodeChildrenChanged:
+                cWatchCount.countDown();
+                break;
+            default:
+                break;
             }
         };
         // Add multiple child watches
@@ -897,38 +873,32 @@ public class RemoveWatchesTest extends ClientBase {
         zk1.create("/node1", null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         final CountDownLatch watchCount = new CountDownLatch(2);
         final CountDownLatch rmWatchCount = new CountDownLatch(4);
-        Watcher w1 = new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                switch (event.getType()) {
-                case ChildWatchRemoved:
-                case DataWatchRemoved:
-                    rmWatchCount.countDown();
-                    break;
-                case NodeChildrenChanged:
-                case NodeDataChanged:
-                    watchCount.countDown();
-                    break;
-                default:
-                    break;
-                }
+        Watcher w1 = event -> {
+            switch (event.getType()) {
+            case ChildWatchRemoved:
+            case DataWatchRemoved:
+                rmWatchCount.countDown();
+                break;
+            case NodeChildrenChanged:
+            case NodeDataChanged:
+                watchCount.countDown();
+                break;
+            default:
+                break;
             }
         };
-        Watcher w2 = new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                switch (event.getType()) {
-                case ChildWatchRemoved:
-                case DataWatchRemoved:
-                    rmWatchCount.countDown();
-                    break;
-                case NodeChildrenChanged:
-                case NodeDataChanged:
-                    watchCount.countDown();
-                    break;
-                default:
-                    break;
-                }
+        Watcher w2 = event -> {
+            switch (event.getType()) {
+            case ChildWatchRemoved:
+            case DataWatchRemoved:
+                rmWatchCount.countDown();
+                break;
+            case NodeChildrenChanged:
+            case NodeDataChanged:
+                watchCount.countDown();
+                break;
+            default:
+                break;
             }
         };
         // Add multiple child watches

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/TimeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/TimeTest.java
@@ -23,7 +23,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
@@ -69,12 +68,9 @@ public class TimeTest extends ClientBase {
 
     private static Watcher createWatcher() {
         watchCount.incrementAndGet();
-        return new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                watchCount.decrementAndGet();
-                System.out.printf("%d event = %s\n", discrepancy(), event);
-            }
+        return event -> {
+            watchCount.decrementAndGet();
+            System.out.printf("%d event = %s\n", discrepancy(), event);
         };
 
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/FileTxnLogTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/FileTxnLogTest.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.Random;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
@@ -217,11 +218,10 @@ public class FileTxnLogTest extends ZKTestCase {
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
         f.startup(zks);
         assertTrue("waiting for server being up ", ClientBase.waitForServerUp(HOSTPORT, CONNECTION_TIMEOUT));
-        ZooKeeper zk = new ZooKeeper(HOSTPORT, CONNECTION_TIMEOUT, event -> {
-        });
+        ZooKeeper zk = new ZooKeeper(HOSTPORT, CONNECTION_TIMEOUT, Watcher.DUMMY_WATCHER);
 
         // Generate transactions
-        HashSet<Long> zxids = new HashSet<Long>();
+        HashSet<Long> zxids = new HashSet<>();
         byte[] bytes = new byte[NODE_SIZE];
         Random random = new Random();
         random.nextBytes(bytes);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/FileTxnLogTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/FileTxnLogTest.java
@@ -31,8 +31,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Random;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.DummyWatcher;
 import org.apache.zookeeper.PortAssignment;
-import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
@@ -218,7 +218,7 @@ public class FileTxnLogTest extends ZKTestCase {
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
         f.startup(zks);
         assertTrue("waiting for server being up ", ClientBase.waitForServerUp(HOSTPORT, CONNECTION_TIMEOUT));
-        ZooKeeper zk = new ZooKeeper(HOSTPORT, CONNECTION_TIMEOUT, Watcher.DUMMY_WATCHER);
+        ZooKeeper zk = new ZooKeeper(HOSTPORT, CONNECTION_TIMEOUT, DummyWatcher.INSTANCE);
 
         // Generate transactions
         HashSet<Long> zxids = new HashSet<>();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
@@ -84,18 +84,6 @@ public abstract class ClientBase extends ZKTestCase {
         super();
     }
 
-    /**
-     * In general don't use this. Only use in the special case that you
-     * want to ignore results (for whatever reason) in your test. Don't
-     * use empty watchers in real code!
-     *
-     */
-    protected static class NullWatcher implements Watcher {
-
-        public void process(WatchedEvent event) { /* nada */ }
-
-    }
-
     public static class CountdownWatcher implements Watcher {
 
         // TODO this doesn't need to be volatile! (Should probably be final)

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/MultiOperationTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/MultiOperationTest.java
@@ -272,12 +272,9 @@ public class MultiOperationTest extends ClientBase {
 
         final CountDownLatch latch = new CountDownLatch(1);
 
-        zk.exists("/foo/bar", new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                if (event.getType() == Event.EventType.NodeDeleted) {
-                    latch.countDown();
-                }
+        zk.exists("/foo/bar", event -> {
+            if (event.getType() == Watcher.Event.EventType.NodeDeleted) {
+                latch.countDown();
             }
         });
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ObserverMasterTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ObserverMasterTest.java
@@ -590,11 +590,7 @@ public class ObserverMasterTest extends QuorumPeerTestBase implements Watcher {
         ZooKeeperAdmin admin = new ZooKeeperAdmin(
             "127.0.0.1:" + clientPort,
             ClientBase.CONNECTION_TIMEOUT,
-            new Watcher() {
-                public void process(WatchedEvent event) {
-
-                }
-            });
+            Watcher.DUMMY_WATCHER);
         admin.addAuthInfo("digest", "super:test".getBytes());
         return admin;
     }
@@ -648,14 +644,11 @@ public class ObserverMasterTest extends QuorumPeerTestBase implements Watcher {
         ZooKeeper observerClient = new ZooKeeper(
             "127.0.0.1:" + observerClientPort,
             ClientBase.CONNECTION_TIMEOUT,
-            new Watcher() {
-                @Override
-                public void process(WatchedEvent event) {
-                    try {
-                        states.put(event.getState());
-                    } catch (InterruptedException e) {
+            event -> {
+                try {
+                    states.put(event.getState());
+                } catch (InterruptedException ignore) {
 
-                    }
                 }
             });
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ObserverMasterTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ObserverMasterTest.java
@@ -47,6 +47,7 @@ import javax.management.ReflectionException;
 import javax.management.RuntimeMBeanException;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.DummyWatcher;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.ConnectionLossException;
 import org.apache.zookeeper.PortAssignment;
@@ -590,7 +591,7 @@ public class ObserverMasterTest extends QuorumPeerTestBase implements Watcher {
         ZooKeeperAdmin admin = new ZooKeeperAdmin(
             "127.0.0.1:" + clientPort,
             ClientBase.CONNECTION_TIMEOUT,
-            Watcher.DUMMY_WATCHER);
+            DummyWatcher.INSTANCE);
         admin.addAuthInfo("digest", "super:test".getBytes());
         return admin;
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumTest.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.DummyWatcher;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Op;
 import org.apache.zookeeper.WatchedEvent;
@@ -132,7 +133,7 @@ public class QuorumTest extends ZKTestCase {
         ZooKeeper zk = new DisconnectableZooKeeper(
             qb.hostPort,
             ClientBase.CONNECTION_TIMEOUT,
-            Watcher.DUMMY_WATCHER);
+            DummyWatcher.INSTANCE);
         zk.create("/blah", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.create("/blah/blah", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         Leader leader = qb.s1.leader;
@@ -200,7 +201,7 @@ public class QuorumTest extends ZKTestCase {
         DisconnectableZooKeeper zk = new DisconnectableZooKeeper(
             hostPorts[0],
             ClientBase.CONNECTION_TIMEOUT,
-            Watcher.DUMMY_WATCHER);
+            DummyWatcher.INSTANCE);
         zk.create("/sessionMoveTest", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
         // we want to loop through the list twice
         for (int i = 0; i < hostPorts.length * 2; i++) {
@@ -209,7 +210,7 @@ public class QuorumTest extends ZKTestCase {
             DisconnectableZooKeeper zknew = new DisconnectableZooKeeper(
                 hostPorts[(i + 1) % hostPorts.length],
                 ClientBase.CONNECTION_TIMEOUT,
-                Watcher.DUMMY_WATCHER,
+                DummyWatcher.INSTANCE,
                 zk.getSessionId(),
                 zk.getSessionPasswd());
             zknew.setData("/", new byte[1], -1);
@@ -265,14 +266,14 @@ public class QuorumTest extends ZKTestCase {
         DisconnectableZooKeeper zk = new DisconnectableZooKeeper(
             hostPorts[0],
             ClientBase.CONNECTION_TIMEOUT,
-            Watcher.DUMMY_WATCHER);
+            DummyWatcher.INSTANCE);
         zk.multi(Arrays.asList(Op.create("/testSessionMovedWithMultiOp", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL)));
 
         // session moved to the next server
         ZooKeeper zknew = new ZooKeeper(
             hostPorts[1],
             ClientBase.CONNECTION_TIMEOUT,
-            Watcher.DUMMY_WATCHER,
+            DummyWatcher.INSTANCE,
             zk.getSessionId(),
             zk.getSessionPasswd());
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumZxidSyncTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumZxidSyncTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.DummyWatcher;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
@@ -48,7 +48,7 @@ public class QuorumZxidSyncTest extends ZKTestCase {
         // crank up the epoch numbers
         ClientBase.waitForServerUp(qb.hostPort, 10000);
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        ZooKeeper zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
+        ZooKeeper zk = new ZooKeeper(qb.hostPort, 10000, DummyWatcher.INSTANCE);
         zk.create("/0", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.close();
         qb.shutdownServers();
@@ -57,7 +57,7 @@ public class QuorumZxidSyncTest extends ZKTestCase {
         qb.shutdownServers();
         qb.startServers();
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
+        zk = new ZooKeeper(qb.hostPort, 10000, DummyWatcher.INSTANCE);
         zk.create("/1", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.close();
         qb.shutdownServers();
@@ -66,7 +66,7 @@ public class QuorumZxidSyncTest extends ZKTestCase {
         qb.shutdownServers();
         qb.startServers();
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
+        zk = new ZooKeeper(qb.hostPort, 10000, DummyWatcher.INSTANCE);
         zk.create("/2", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.close();
         qb.shutdownServers();
@@ -102,7 +102,7 @@ public class QuorumZxidSyncTest extends ZKTestCase {
         // crank up the epoch numbers
         ClientBase.waitForServerUp(qb.hostPort, 10000);
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        ZooKeeper zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
+        ZooKeeper zk = new ZooKeeper(qb.hostPort, 10000, DummyWatcher.INSTANCE);
         zk.create("/0", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.close();
         qb.shutdownServers();
@@ -111,7 +111,7 @@ public class QuorumZxidSyncTest extends ZKTestCase {
         qb.shutdownServers();
         qb.startServers();
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
+        zk = new ZooKeeper(qb.hostPort, 10000, DummyWatcher.INSTANCE);
         zk.create("/1", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.close();
         qb.shutdownServers();
@@ -125,13 +125,13 @@ public class QuorumZxidSyncTest extends ZKTestCase {
         deleteLogs(qb.s5dir);
         qb.startServers();
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
+        zk = new ZooKeeper(qb.hostPort, 10000, DummyWatcher.INSTANCE);
         zk.create("/2", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.close();
         qb.shutdownServers();
         qb.startServers();
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
+        zk = new ZooKeeper(qb.hostPort, 10000, DummyWatcher.INSTANCE);
         boolean saw2 = false;
         for (String child : zk.getChildren("/", false)) {
             if (child.equals("2")) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumZxidSyncTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumZxidSyncTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
@@ -49,10 +48,7 @@ public class QuorumZxidSyncTest extends ZKTestCase {
         // crank up the epoch numbers
         ClientBase.waitForServerUp(qb.hostPort, 10000);
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        ZooKeeper zk = new ZooKeeper(qb.hostPort, 10000, new Watcher() {
-            public void process(WatchedEvent event) {
-            }
-        });
+        ZooKeeper zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
         zk.create("/0", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.close();
         qb.shutdownServers();
@@ -61,10 +57,7 @@ public class QuorumZxidSyncTest extends ZKTestCase {
         qb.shutdownServers();
         qb.startServers();
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        zk = new ZooKeeper(qb.hostPort, 10000, new Watcher() {
-            public void process(WatchedEvent event) {
-            }
-        });
+        zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
         zk.create("/1", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.close();
         qb.shutdownServers();
@@ -73,10 +66,7 @@ public class QuorumZxidSyncTest extends ZKTestCase {
         qb.shutdownServers();
         qb.startServers();
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        zk = new ZooKeeper(qb.hostPort, 10000, new Watcher() {
-            public void process(WatchedEvent event) {
-            }
-        });
+        zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
         zk.create("/2", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.close();
         qb.shutdownServers();
@@ -112,10 +102,7 @@ public class QuorumZxidSyncTest extends ZKTestCase {
         // crank up the epoch numbers
         ClientBase.waitForServerUp(qb.hostPort, 10000);
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        ZooKeeper zk = new ZooKeeper(qb.hostPort, 10000, new Watcher() {
-            public void process(WatchedEvent event) {
-            }
-        });
+        ZooKeeper zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
         zk.create("/0", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.close();
         qb.shutdownServers();
@@ -124,10 +111,7 @@ public class QuorumZxidSyncTest extends ZKTestCase {
         qb.shutdownServers();
         qb.startServers();
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        zk = new ZooKeeper(qb.hostPort, 10000, new Watcher() {
-            public void process(WatchedEvent event) {
-            }
-        });
+        zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
         zk.create("/1", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.close();
         qb.shutdownServers();
@@ -141,19 +125,13 @@ public class QuorumZxidSyncTest extends ZKTestCase {
         deleteLogs(qb.s5dir);
         qb.startServers();
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        zk = new ZooKeeper(qb.hostPort, 10000, new Watcher() {
-            public void process(WatchedEvent event) {
-            }
-        });
+        zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
         zk.create("/2", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         zk.close();
         qb.shutdownServers();
         qb.startServers();
         ClientBase.waitForServerUp(qb.hostPort, 10000);
-        zk = new ZooKeeper(qb.hostPort, 10000, new Watcher() {
-            public void process(WatchedEvent event) {
-            }
-        });
+        zk = new ZooKeeper(qb.hostPort, 10000, Watcher.DUMMY_WATCHER);
         boolean saw2 = false;
         for (String child : zk.getChildren("/", false)) {
             if (child.equals("2")) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
@@ -33,9 +33,9 @@ import java.util.LinkedList;
 import java.util.List;
 import org.apache.zookeeper.AsyncCallback.DataCallback;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.DummyWatcher;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.PortAssignment;
-import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
@@ -223,9 +223,9 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
         for (int i = 1; i <= qu.ALL; i++) {
             // server ids are 1, 2 and 3
             zkArr[i] = new ZooKeeper(
-                    "127.0.0.1:" + qu.getPeer(i).peer.getClientPort(),
-                    ClientBase.CONNECTION_TIMEOUT,
-                    Watcher.DUMMY_WATCHER);
+                "127.0.0.1:" + qu.getPeer(i).peer.getClientPort(),
+                ClientBase.CONNECTION_TIMEOUT,
+                DummyWatcher.INSTANCE);
         }
         return zkArr;
     }
@@ -240,7 +240,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
             zkAdminArr[i] = new ZooKeeperAdmin(
                     "127.0.0.1:" + qu.getPeer(i).peer.getClientPort(),
                     ClientBase.CONNECTION_TIMEOUT,
-                    Watcher.DUMMY_WATCHER);
+                    DummyWatcher.INSTANCE);
             zkAdminArr[i].addAuthInfo("digest", "super:test".getBytes());
         }
 
@@ -645,13 +645,13 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
         zkArr[followerIndex] = new ZooKeeper(
                 "127.0.0.1:" + oldClientPort,
                 ClientBase.CONNECTION_TIMEOUT,
-                Watcher.DUMMY_WATCHER);
+                DummyWatcher.INSTANCE);
 
         zkAdminArr[followerIndex].close();
         zkAdminArr[followerIndex] = new ZooKeeperAdmin(
                 "127.0.0.1:" + oldClientPort,
                 ClientBase.CONNECTION_TIMEOUT,
-                Watcher.DUMMY_WATCHER);
+                DummyWatcher.INSTANCE);
         zkAdminArr[followerIndex].addAuthInfo("digest", "super:test".getBytes());
 
         for (int i = 0; i < 10; i++) {
@@ -667,13 +667,13 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
         zkArr[followerIndex] = new ZooKeeper(
             "127.0.0.1:" + newClientPort,
             ClientBase.CONNECTION_TIMEOUT,
-            Watcher.DUMMY_WATCHER);
+            DummyWatcher.INSTANCE);
 
         zkAdminArr[followerIndex].close();
         zkAdminArr[followerIndex] = new ZooKeeperAdmin(
                 "127.0.0.1:" + newClientPort,
                 ClientBase.CONNECTION_TIMEOUT,
-                Watcher.DUMMY_WATCHER);
+                DummyWatcher.INSTANCE);
         zkAdminArr[followerIndex].addAuthInfo("digest", "super:test".getBytes());
 
         testNormalOperation(zkArr[followerIndex], zkArr[leaderIndex]);
@@ -776,13 +776,13 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
             zkArr[serverIndex] = new ZooKeeper(
                     "127.0.0.1:" + newClientPort,
                     ClientBase.CONNECTION_TIMEOUT,
-                    Watcher.DUMMY_WATCHER);
+                    DummyWatcher.INSTANCE);
 
             zkAdminArr[serverIndex].close();
             zkAdminArr[serverIndex] = new ZooKeeperAdmin(
                     "127.0.0.1:" + newClientPort,
                     ClientBase.CONNECTION_TIMEOUT,
-                    Watcher.DUMMY_WATCHER);
+                    DummyWatcher.INSTANCE);
 
             try {
                 Thread.sleep(1000);
@@ -809,7 +809,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
             zkArr[serverIndex] = new ZooKeeper(
                 "127.0.0.1:" + oldClientPort,
                 ClientBase.CONNECTION_TIMEOUT,
-                Watcher.DUMMY_WATCHER);
+                DummyWatcher.INSTANCE);
 
             testNormalOperation(zkArr[followerIndex], zkArr[leaderIndex]);
             testServerHasConfig(zkArr[serverIndex], joiningServers, null);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
@@ -35,7 +35,6 @@ import org.apache.zookeeper.AsyncCallback.DataCallback;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.PortAssignment;
-import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
@@ -226,10 +225,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
             zkArr[i] = new ZooKeeper(
                     "127.0.0.1:" + qu.getPeer(i).peer.getClientPort(),
                     ClientBase.CONNECTION_TIMEOUT,
-                    new Watcher() {
-                        public void process(WatchedEvent event) {
-                        }
-                    });
+                    Watcher.DUMMY_WATCHER);
         }
         return zkArr;
     }
@@ -244,10 +240,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
             zkAdminArr[i] = new ZooKeeperAdmin(
                     "127.0.0.1:" + qu.getPeer(i).peer.getClientPort(),
                     ClientBase.CONNECTION_TIMEOUT,
-                    new Watcher() {
-                        public void process(WatchedEvent event) {
-                        }
-                    });
+                    Watcher.DUMMY_WATCHER);
             zkAdminArr[i].addAuthInfo("digest", "super:test".getBytes());
         }
 
@@ -652,19 +645,13 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
         zkArr[followerIndex] = new ZooKeeper(
                 "127.0.0.1:" + oldClientPort,
                 ClientBase.CONNECTION_TIMEOUT,
-                new Watcher() {
-                    public void process(WatchedEvent event) {
-                    }
-                });
+                Watcher.DUMMY_WATCHER);
 
         zkAdminArr[followerIndex].close();
         zkAdminArr[followerIndex] = new ZooKeeperAdmin(
                 "127.0.0.1:" + oldClientPort,
                 ClientBase.CONNECTION_TIMEOUT,
-                new Watcher() {
-                    public void process(WatchedEvent event) {
-                    }
-                });
+                Watcher.DUMMY_WATCHER);
         zkAdminArr[followerIndex].addAuthInfo("digest", "super:test".getBytes());
 
         for (int i = 0; i < 10; i++) {
@@ -680,20 +667,13 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
         zkArr[followerIndex] = new ZooKeeper(
             "127.0.0.1:" + newClientPort,
             ClientBase.CONNECTION_TIMEOUT,
-            new Watcher() {
-                public void process(WatchedEvent event) {
-
-                }
-            });
+            Watcher.DUMMY_WATCHER);
 
         zkAdminArr[followerIndex].close();
         zkAdminArr[followerIndex] = new ZooKeeperAdmin(
                 "127.0.0.1:" + newClientPort,
                 ClientBase.CONNECTION_TIMEOUT,
-                new Watcher() {
-                    public void process(WatchedEvent event) {
-                    }
-                });
+                Watcher.DUMMY_WATCHER);
         zkAdminArr[followerIndex].addAuthInfo("digest", "super:test".getBytes());
 
         testNormalOperation(zkArr[followerIndex], zkArr[leaderIndex]);
@@ -796,19 +776,13 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
             zkArr[serverIndex] = new ZooKeeper(
                     "127.0.0.1:" + newClientPort,
                     ClientBase.CONNECTION_TIMEOUT,
-                    new Watcher() {
-                        public void process(WatchedEvent event) {
-                        }
-                    });
+                    Watcher.DUMMY_WATCHER);
 
             zkAdminArr[serverIndex].close();
             zkAdminArr[serverIndex] = new ZooKeeperAdmin(
                     "127.0.0.1:" + newClientPort,
                     ClientBase.CONNECTION_TIMEOUT,
-                    new Watcher() {
-                        public void process(WatchedEvent event) {
-                        }
-                    });
+                    Watcher.DUMMY_WATCHER);
 
             try {
                 Thread.sleep(1000);
@@ -835,10 +809,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
             zkArr[serverIndex] = new ZooKeeper(
                 "127.0.0.1:" + oldClientPort,
                 ClientBase.CONNECTION_TIMEOUT,
-                new Watcher() {
-                    public void process(WatchedEvent event) {
-                    }
-                });
+                Watcher.DUMMY_WATCHER);
 
             testNormalOperation(zkArr[followerIndex], zkArr[leaderIndex]);
             testServerHasConfig(zkArr[serverIndex], joiningServers, null);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SessionTimeoutTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SessionTimeoutTest.java
@@ -51,12 +51,9 @@ public class SessionTimeoutTest extends ClientBase {
     @Test
     public void testSessionExpiration() throws InterruptedException, KeeperException {
         final CountDownLatch expirationLatch = new CountDownLatch(1);
-        Watcher watcher = new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                if (event.getState() == Event.KeeperState.Expired) {
-                    expirationLatch.countDown();
-                }
+        Watcher watcher = event -> {
+            if (event.getState() == Watcher.Event.KeeperState.Expired) {
+                expirationLatch.countDown();
             }
         };
         zk.exists("/foo", watcher);
@@ -78,13 +75,10 @@ public class SessionTimeoutTest extends ClientBase {
     @Test
     public void testQueueEvent() throws InterruptedException, KeeperException {
         final CountDownLatch eventLatch = new CountDownLatch(1);
-        Watcher watcher = new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                if (event.getType() == Event.EventType.NodeDataChanged) {
-                    if (event.getPath().equals("/foo/bar")) {
-                        eventLatch.countDown();
-                    }
+        Watcher watcher = event -> {
+            if (event.getType() == Watcher.Event.EventType.NodeDataChanged) {
+                if (event.getPath().equals("/foo/bar")) {
+                    eventLatch.countDown();
                 }
             }
         };

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SyncCallTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SyncCallTest.java
@@ -32,7 +32,7 @@ import org.apache.zookeeper.AsyncCallback.Create2Callback;
 import org.apache.zookeeper.AsyncCallback.StringCallback;
 import org.apache.zookeeper.AsyncCallback.VoidCallback;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.DummyWatcher;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
@@ -42,7 +42,7 @@ public class SyncCallTest extends ClientBase implements ChildrenCallback, Childr
 
     private CountDownLatch opsCount;
 
-    List<Integer> results = new LinkedList<Integer>();
+    List<Integer> results = new LinkedList<>();
     Integer limit = 100 + 1 + 100 + 100;
 
     @Test
@@ -54,23 +54,21 @@ public class SyncCallTest extends ClientBase implements ChildrenCallback, Childr
 
             LOG.info("Beginning test:" + (new Date()).toString());
             for (int i = 0; i < 50; i++) {
-                zk.create("/test"
-                                  + i, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT, (StringCallback) this, results);
+                zk.create("/test" + i, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT, (StringCallback) this, results);
             }
 
             for (int i = 50; i < 100; i++) {
-                zk.create("/test"
-                                  + i, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT, (Create2Callback) this, results);
+                zk.create("/test" + i, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT, (Create2Callback) this, results);
             }
             zk.sync("/test", this, results);
             for (int i = 0; i < 100; i++) {
                 zk.delete("/test" + i, 0, this, results);
             }
             for (int i = 0; i < 100; i++) {
-                zk.getChildren("/", Watcher.DUMMY_WATCHER, (ChildrenCallback) this, results);
+                zk.getChildren("/", DummyWatcher.INSTANCE, (ChildrenCallback) this, results);
             }
             for (int i = 0; i < 100; i++) {
-                zk.getChildren("/", Watcher.DUMMY_WATCHER, (Children2Callback) this, results);
+                zk.getChildren("/", DummyWatcher.INSTANCE, (Children2Callback) this, results);
             }
             LOG.info("Submitted all operations:" + (new Date()).toString());
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SyncCallTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SyncCallTest.java
@@ -32,6 +32,7 @@ import org.apache.zookeeper.AsyncCallback.Create2Callback;
 import org.apache.zookeeper.AsyncCallback.StringCallback;
 import org.apache.zookeeper.AsyncCallback.VoidCallback;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
@@ -66,10 +67,10 @@ public class SyncCallTest extends ClientBase implements ChildrenCallback, Childr
                 zk.delete("/test" + i, 0, this, results);
             }
             for (int i = 0; i < 100; i++) {
-                zk.getChildren("/", new NullWatcher(), (ChildrenCallback) this, results);
+                zk.getChildren("/", Watcher.DUMMY_WATCHER, (ChildrenCallback) this, results);
             }
             for (int i = 0; i < 100; i++) {
-                zk.getChildren("/", new NullWatcher(), (Children2Callback) this, results);
+                zk.getChildren("/", Watcher.DUMMY_WATCHER, (Children2Callback) this, results);
             }
             LOG.info("Submitted all operations:" + (new Date()).toString());
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/WatcherTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/WatcherTest.java
@@ -153,16 +153,12 @@ public class WatcherTest extends ClientBase {
 
             MyWatcher connWatcher = new MyWatcher();
 
-            Watcher watcher = new Watcher() {
-                @Override
-                public void process(WatchedEvent event) {
-                    try {
-                        queue.put(event);
-                    } catch (InterruptedException e) {
-                        // Oh well, never mind
-                    }
+            Watcher watcher = event -> {
+                try {
+                    queue.put(event);
+                } catch (InterruptedException e) {
+                    // Oh well, never mind
                 }
-
             };
 
             zk = createClient(connWatcher, hostPort);


### PR DESCRIPTION
Revisit subclasses of `Watcher` and replace dummy implement with a global singleton `Watcher.DUMMY_WATCHER`.

A followup could be use separated `Watcher` in tests instead of implement `Watcher` for `XXXTests`. It would be better to keep test case "class" alone IMO.