### PR TITLE
ZOOKEEPER-3525: Add project status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache ZooKeeper
+# Apache ZooKeeper [![Build Status](https://travis-ci.org/apache/zookeeper.svg?branch=master)](https://travis-ci.org/apache/zookeeper) [![Maven Central](https://img.shields.io/maven-central/v/org.apache.zookeeper/zookeeper)](https://zookeeper.apache.org/releases.html) [![License](https://img.shields.io/github/license/apache/zookeeper)](https://github.com/apache/zookeeper/blob/master/LICENSE.txt)
 ![alt text](https://zookeeper.apache.org/images/zookeeper_small.gif "ZooKeeper")
 
 For the latest information about Apache ZooKeeper, please visit our website at:


### PR DESCRIPTION
Other projects like [Spark](https://github.com/apache/spark) and [Hive](https://github.com/apache/hive) have status badges on their READMEs. I'd like to start contributing to ZooKeeper so I think this is a simple first task.




![image](https://user-images.githubusercontent.com/15751908/63908880-9b2ac800-c9d5-11e9-9122-49ad94f433d1.png)
