### PR TITLE
ZOOKEEPER-3056: Fails to load database with missing snapshot file but with valid transaction log file.

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -918,10 +918,15 @@ property, when available, is noted below.
 * *snapshot.trust.empty* :
     (Java system property only: **zookeeper.snapshot.trust.empty**)
     **New in 3.5.6:**
-    Set to true to allow ZooKeeper servers recovery without snapshot
-    files. This should only be set when upgrading from old versions of
+    This property controls whether or not ZooKeeper should treat missing
+    snapshot files as a fatal state that can't be recovered from.
+    Set to true to allow ZooKeeper servers recover without snapshot
+    files. This should only be set during upgrading from old versions of
     ZooKeeper (3.4.x, pre 3.5.3) where ZooKeeper might only have transaction
-    log files without any presence of snapshot files.
+    log files but without presence of snapshot files. If the value is set
+    during upgrade, we recommend to set the value back to false after upgrading
+    and restart ZooKeeper process so ZooKeeper can continue normal data
+    consistency check during recovery process.
     Default value is false.
 
 <a name="sc_clusterOptions"></a>

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -915,6 +915,15 @@ property, when available, is noted below.
     ZooKeeper when loading database from disk, and syncing with leader.
     By default, this feautre is disabled, set "true" to enable it.
 
+* *snapshot.trust.empty* :
+    (Java system property only: **zookeeper.snapshot.trust.empty**)
+    **New in 3.5.6:**
+    Set to true to allow ZooKeeper servers recovery without snapshot
+    files. This should only be set when upgrading from old versions of
+    ZooKeeper (3.4.x, pre 3.5.3) where ZooKeeper might only have transaction
+    log files without any presence of snapshot files.
+    Default value is false.
+
 <a name="sc_clusterOptions"></a>
 
 #### Cluster Options

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -59,7 +59,7 @@ public class FileTxnSnapLog {
     TxnLog txnLog;
     SnapShot snapLog;
     private final boolean autoCreateDB;
-    private boolean trustEmptySnapshot;
+    private final boolean trustEmptySnapshot;
     public static final int VERSION = 2;
     public static final String version = "version-";
 
@@ -251,7 +251,6 @@ public class FileTxnSnapLog {
                     throw new IOException(EMPTY_SNAPSHOT_WARNING + "Something is broken!");
                 } else {
                     LOG.warn(EMPTY_SNAPSHOT_WARNING + "This should only be allowed during upgrading.");
-                    trustEmptySnapshot = false;
                 }
             }
 
@@ -615,15 +614,5 @@ public class FileTxnSnapLog {
 
     public long getTotalLogSize() {
         return txnLog.getTotalLogSize();
-    }
-
-    // For testing only
-    public void setTrustEmptySnapshotFlag(boolean value) {
-        trustEmptySnapshot = value;
-    }
-
-    // For testing only
-    public boolean getTrustEmptySnapshotFlag() {
-        return trustEmptySnapshot;
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -42,6 +42,8 @@ import org.apache.zookeeper.txn.TxnHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * This is a helper class
  * above the implementations
@@ -59,6 +61,7 @@ public class FileTxnSnapLog {
     TxnLog txnLog;
     SnapShot snapLog;
     private final boolean autoCreateDB;
+    private boolean trustEmptySnapshot;
     public static final int VERSION = 2;
     public static final String version = "version-";
 
@@ -72,15 +75,9 @@ public class FileTxnSnapLog {
 
     private static final String ZOOKEEPER_DB_AUTOCREATE_DEFAULT = "true";
 
-    private static boolean trustEmptySnapshot;
-
     public static final String ZOOKEEPER_SNAPSHOT_TRUST_EMPTY = "zookeeper.snapshot.trust.empty";
 
     private static final String EMPTY_SNAPSHOT_WARNING = "No snapshot found, but there are log entries. ";
-    static {
-        trustEmptySnapshot = Boolean.getBoolean(ZOOKEEPER_SNAPSHOT_TRUST_EMPTY);
-        LOG.info(ZOOKEEPER_SNAPSHOT_TRUST_EMPTY + " : " + trustEmptySnapshot);
-    }
 
     /**
      * This listener helps
@@ -111,6 +108,9 @@ public class FileTxnSnapLog {
         // See ZOOKEEPER-1161 for more details
         boolean enableAutocreate = Boolean.parseBoolean(
             System.getProperty(ZOOKEEPER_DATADIR_AUTOCREATE, ZOOKEEPER_DATADIR_AUTOCREATE_DEFAULT));
+
+        trustEmptySnapshot = Boolean.getBoolean(ZOOKEEPER_SNAPSHOT_TRUST_EMPTY);
+        LOG.info(ZOOKEEPER_SNAPSHOT_TRUST_EMPTY + " : " + trustEmptySnapshot);
 
         if (!this.dataDir.exists()) {
             if (!enableAutocreate) {
@@ -620,12 +620,12 @@ public class FileTxnSnapLog {
     }
 
     // For testing only
-    public static void setTrustEmptySnapshotFlag(boolean value) {
+    public void setTrustEmptySnapshotFlag(boolean value) {
         trustEmptySnapshot = value;
     }
 
     // For testing only
-    public static boolean getTrustEmptySnapshotFlag() {
+    public boolean getTrustEmptySnapshotFlag() {
         return trustEmptySnapshot;
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -42,8 +42,6 @@ import org.apache.zookeeper.txn.TxnHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 /**
  * This is a helper class
  * above the implementations

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/EmptiedSnapshotRecoveryTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/EmptiedSnapshotRecoveryTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.zookeeper.test;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.io.File;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/EmptiedSnapshotRecoveryTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/EmptiedSnapshotRecoveryTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.zookeeper.test;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.IOException;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/EmptiedSnapshotRecoveryTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/EmptiedSnapshotRecoveryTest.java
@@ -95,6 +95,9 @@ public class EmptiedSnapshotRecoveryTest extends ZKTestCase implements Watcher {
 
         // start server again with corrupted database
         zks = new ZooKeeperServer(tmpSnapDir, tmpLogDir, 3000);
+        if (trustEmptySnap) {
+            zks.getTxnLogFactory().setTrustEmptySnapshotFlag(true);
+        }
         try {
             zks.startdata();
             zxid = zks.getZKDatabase().loadDataBase();
@@ -106,6 +109,11 @@ public class EmptiedSnapshotRecoveryTest extends ZKTestCase implements Watcher {
             if (trustEmptySnap) {
                 fail("Should not get exception for empty database");
             }
+        }
+
+        if (trustEmptySnap) {
+            assertFalse("Trust empty snapshot flag should be reset after first use.",
+                zks.getTxnLogFactory().getTrustEmptySnapshotFlag());
         }
         zks.shutdown();
     }
@@ -130,10 +138,7 @@ public class EmptiedSnapshotRecoveryTest extends ZKTestCase implements Watcher {
 
     @Test
     public void testRestoreWithTrustedEmptySnapFiles() throws Exception {
-        FileTxnSnapLog.setTrustEmptySnapshotFlag(true);
         runTest(false, true);
-        assertFalse("Trust empty snapshot flag should be reset after first use.",
-            FileTxnSnapLog.getTrustEmptySnapshotFlag());
     }
 
     public void process(WatchedEvent event) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/EmptiedSnapshotRecoveryTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/EmptiedSnapshotRecoveryTest.java
@@ -93,11 +93,11 @@ public class EmptiedSnapshotRecoveryTest extends ZKTestCase implements Watcher {
             }
         }
 
+        if (trustEmptySnap) {
+            System.setProperty(FileTxnSnapLog.ZOOKEEPER_SNAPSHOT_TRUST_EMPTY, "true");
+        }
         // start server again with corrupted database
         zks = new ZooKeeperServer(tmpSnapDir, tmpLogDir, 3000);
-        if (trustEmptySnap) {
-            zks.getTxnLogFactory().setTrustEmptySnapshotFlag(true);
-        }
         try {
             zks.startdata();
             zxid = zks.getZKDatabase().loadDataBase();
@@ -109,12 +109,12 @@ public class EmptiedSnapshotRecoveryTest extends ZKTestCase implements Watcher {
             if (trustEmptySnap) {
                 fail("Should not get exception for empty database");
             }
+        } finally {
+            if (trustEmptySnap) {
+                System.clearProperty(FileTxnSnapLog.ZOOKEEPER_SNAPSHOT_TRUST_EMPTY);
+            }
         }
 
-        if (trustEmptySnap) {
-            assertFalse("Trust empty snapshot flag should be reset after first use.",
-                zks.getTxnLogFactory().getTrustEmptySnapshotFlag());
-        }
         zks.shutdown();
     }
 


### PR DESCRIPTION
ZOOKEEPER-2325 introduced a check on snapshot and transaction log files during recovery, which will treat empty or missing snapshot files with the presence of transaction log files illegal state, and abort start up process. 

For old versions of ZooKeeper, it's possible to have valid transaction log files but no snapshot. For example, if snap count set too low, or server crashes before the first snapshot was taken. For new versions of ZooKeeper with ZOOKEEPER-2325, this is not a problem as ZooKeeper will make sure the presence of at least one snapshot file (e.g. on a fresh start with empty local data, ZooKeeper will create one snapshot file as part of the start up.).

So we need provide a smooth upgrade path for users with old version of ZooKeeper. This patch introduces a system property flag, once set, will skip the empty snapshot validation during start up. The default value of this flag is false, as we don't want to disable the features introduced in ZOOKEEPER-2325. We also want the flag to be explicitly set by admin, as ZooKeeper itself is not able to tell when to trust missing snapshot or not.
