### PR TITLE
ZOOKEEPER-3530 Include compiled C-client in the binary tarball

### DIFF
--- a/zookeeper-assembly/src/main/assembly/bin-package.xml
+++ b/zookeeper-assembly/src/main/assembly/bin-package.xml
@@ -71,6 +71,18 @@
       <directoryMode>${rwx.file.permission}</directoryMode>
     </fileSet>
     <fileSet>
+      <!-- ZooKeeper C client -->
+      <directory>${project.basedir}/../zookeeper-client/zookeeper-client-c/target/c</directory>
+      <outputDirectory>usr</outputDirectory>
+      <includes>
+        <include>bin/*</include>
+        <include>include/**/*</include>
+        <include>lib/*</include>
+      </includes>
+      <fileMode>${rw.file.permission}</fileMode>
+      <directoryMode>${rwx.file.permission}</directoryMode>
+    </fileSet>
+    <fileSet>
       <!-- License files for 3rd party libs -->
       <directory>${project.basedir}/../zookeeper-server/src/main/resources/lib</directory>
       <includes>


### PR DESCRIPTION
After PR https://github.com/apache/zookeeper/pull/993 for ZOOKEEPER-3436 is merged, maven will build the C-client and put them under the folder `zookeeper-client/zookeeper-client-c/target/c`.

When we are generating a tarball during full-build using e.g. the `mvn clean install -DskipTests -Pfull-build` command, then we would expect the compiled C-client to end up in the binary tarball, just like it happened during the older (3.4.x) ant builds.