### PR TITLE
ZOOKEEPER-3532 Provide a docker-based environment to work on a known OS

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM maven:3.6.1-jdk-11
+
+RUN apt-get update
+RUN apt-get install -y g++ cmake autoconf libcppunit-dev libtool

--- a/dev/docker/run.sh
+++ b/dev/docker/run.sh
@@ -46,7 +46,7 @@ RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME} && \
 ENV  HOME /home/${USER_NAME}
 UserSpecificDocker
 
-BOOKKEEPER_ROOT=${SCRIPT_DIR}/../..
+ZOOKEEPER_ROOT=${SCRIPT_DIR}/../..
 
 CMD="
 echo
@@ -57,13 +57,13 @@ echo
 bash
 "
 
-pushd ${BOOKKEEPER_ROOT}
+pushd ${ZOOKEEPER_ROOT}
 
 docker run -i -t \
   --rm=true \
-  -w ${BOOKKEEPER_ROOT} \
+  -w ${ZOOKEEPER_ROOT} \
   -u "${USER}" \
-  -v "$(realpath $BOOKKEEPER_ROOT):${BOOKKEEPER_ROOT}" \
+  -v "$(realpath $ZOOKEEPER_ROOT):${ZOOKEEPER_ROOT}" \
   -v "${LOCAL_HOME}:/home/${USER_NAME}" \
   ${IMAGE_NAME}-${USER_NAME} \
   bash -c "${CMD}"

--- a/dev/docker/run.sh
+++ b/dev/docker/run.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -x -u
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+export IMAGE_NAME="zookeeper/dev"
+
+pushd ${SCRIPT_DIR}
+
+docker build --rm=true -t ${IMAGE_NAME} .
+
+popd
+
+if [ "$(uname -s)" == "Linux" ]; then
+  USER_NAME=${SUDO_USER:=$USER}
+  USER_ID=$(id -u "${USER_NAME}")
+  GROUP_ID=$(id -g "${USER_NAME}")
+  LOCAL_HOME=$(realpath ~)
+else # boot2docker uid and gid
+  USER_NAME=$USER
+  USER_ID=1000
+  GROUP_ID=50
+  LOCAL_HOME="/Users/${USER_NAME}"
+fi
+
+docker build -t "${IMAGE_NAME}-${USER_NAME}" - <<UserSpecificDocker
+FROM ${IMAGE_NAME}
+RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME} && \
+  useradd -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME}
+ENV  HOME /home/${USER_NAME}
+UserSpecificDocker
+
+BOOKKEEPER_ROOT=${SCRIPT_DIR}/../..
+
+CMD="
+echo
+echo 'Welcome to Apache ZooKeeper Development Env'
+echo 'To build, execute'
+echo '  mvn clean install'
+echo
+bash
+"
+
+pushd ${BOOKKEEPER_ROOT}
+
+docker run -i -t \
+  --rm=true \
+  -w ${BOOKKEEPER_ROOT} \
+  -u "${USER}" \
+  -v "$(realpath $BOOKKEEPER_ROOT):${BOOKKEEPER_ROOT}" \
+  -v "${LOCAL_HOME}:/home/${USER_NAME}" \
+  ${IMAGE_NAME}-${USER_NAME} \
+  bash -c "${CMD}"
+
+popd
+


### PR DESCRIPTION
Just run dev/docker/run.sh and you will have a Linux environment with all that is needed to build ZooKeeper, even on MacOs.

The original idea patch was from Sijie Guo (@sijie), Apache BookKeeper project.

The script creates a local image that accesses the local filesystem with the current user (UID), this way the container can work on local files without problems of ownership of files.