### PR TITLE
ZOOKEEPER-3231:Purge task may lost data when the recent snapshots are all invalid

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PurgeTxnLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PurgeTxnLog.java
@@ -78,7 +78,7 @@ public class PurgeTxnLog {
 
         FileTxnSnapLog txnLog = new FileTxnSnapLog(dataDir, snapDir);
 
-        List<File> snaps = txnLog.findNRecentSnapshots(num);
+        List<File> snaps = txnLog.findNValidSnapshots(num);
         int numSnaps = snaps.size();
         if (numSnaps > 0) {
             purgeOlderSnapshots(txnLog, snaps.get(numSnaps - 1));

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileSnap.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileSnap.java
@@ -150,7 +150,7 @@ public class FileSnap implements SnapShot {
      * less than n in case enough snapshots are not available).
      * @throws IOException
      */
-    private List<File> findNValidSnapshots(int n) throws IOException {
+    protected List<File> findNValidSnapshots(int n) throws IOException {
         List<File> files = Util.sortDataDir(snapDir.listFiles(), SNAPSHOT_FILE_PREFIX, false);
         int count = 0;
         List<File> list = new ArrayList<File>();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -523,6 +523,18 @@ public class FileTxnSnapLog {
     }
 
     /**
+     * the n recent valid snapshots
+     * @param n the number of recent valid snapshots
+     * @return the list of n recent valid snapshots, with
+     * the most recent in front
+     * @throws IOException
+     */
+    public List<File> findNValidSnapshots(int n) throws IOException {
+        FileSnap snaplog = new FileSnap(snapDir);
+        return snaplog.findNValidSnapshots(n);
+    }
+
+    /**
      * get the snapshot logs which may contain transactions newer than the given zxid.
      * This includes logs with starting zxid greater than given zxid, as well as the
      * newest transaction log with starting zxid less than given zxid.  The latter log

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/PurgeTxnTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/PurgeTxnTest.java
@@ -49,6 +49,7 @@ import org.apache.zookeeper.server.persistence.SnapStream;
 import org.apache.zookeeper.server.persistence.Util;
 import org.apache.zookeeper.test.ClientBase;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +61,11 @@ public class PurgeTxnTest extends ZKTestCase {
     private static final int CONNECTION_TIMEOUT = 3000;
     private static final long OP_TIMEOUT_IN_MILLIS = 90000;
     private File tmpDir;
+
+    @Before
+    public void setUp() throws Exception {
+        tmpDir = ClientBase.createTmpDir();
+    }
 
     @After
     public void teardown() {
@@ -74,7 +80,6 @@ public class PurgeTxnTest extends ZKTestCase {
      */
     @Test
     public void testPurge() throws Exception {
-        tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
         ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
         SyncRequestProcessor.setSnapCount(100);
@@ -118,7 +123,6 @@ public class PurgeTxnTest extends ZKTestCase {
      */
     @Test
     public void testPurgeWhenLogRollingInProgress() throws Exception {
-        tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
         ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
         SyncRequestProcessor.setSnapCount(30);
@@ -173,7 +177,6 @@ public class PurgeTxnTest extends ZKTestCase {
         int nRecentCount = 30;
         int offset = 0;
 
-        tmpDir = ClientBase.createTmpDir();
         File version2 = new File(tmpDir.toString(), "version-2");
         assertTrue("Failed to create version_2 dir:" + version2.toString(), version2.mkdir());
 
@@ -228,7 +231,6 @@ public class PurgeTxnTest extends ZKTestCase {
         int fileAboveRecentCount = 4;
         int fileToPurgeCount = 2;
         AtomicInteger offset = new AtomicInteger(0);
-        tmpDir = ClientBase.createTmpDir();
         File version2 = new File(tmpDir.toString(), "version-2");
         assertTrue("Failed to create version_2 dir:" + version2.toString(), version2.mkdir());
         List<File> snapsToPurge = new ArrayList<File>();
@@ -280,7 +282,6 @@ public class PurgeTxnTest extends ZKTestCase {
     public void internalTestSnapFilesEqualsToRetain(boolean testWithPrecedingLogFile) throws Exception {
         int nRecentCount = 3;
         AtomicInteger offset = new AtomicInteger(0);
-        tmpDir = ClientBase.createTmpDir();
         File version2 = new File(tmpDir.toString(), "version-2");
         assertTrue("Failed to create version_2 dir:" + version2.toString(), version2.mkdir());
         List<File> snaps = new ArrayList<File>();
@@ -303,7 +304,6 @@ public class PurgeTxnTest extends ZKTestCase {
         int nRecentCount = 4;
         int fileToPurgeCount = 2;
         AtomicInteger offset = new AtomicInteger(0);
-        tmpDir = ClientBase.createTmpDir();
         File version2 = new File(tmpDir.toString(), "version-2");
         assertTrue("Failed to create version_2 dir:" + version2.toString(), version2.mkdir());
         List<File> snapsToPurge = new ArrayList<File>();
@@ -335,7 +335,6 @@ public class PurgeTxnTest extends ZKTestCase {
      */
     @Test
     public void testPurgeTxnLogWithDataDir() throws Exception {
-        tmpDir = ClientBase.createTmpDir();
         File dataDir = new File(tmpDir, "dataDir");
         File dataLogDir = new File(tmpDir, "dataLogDir");
 
@@ -367,8 +366,6 @@ public class PurgeTxnTest extends ZKTestCase {
         assertEquals(numberOfSnapFilesToKeep, dataDirVersion2.listFiles().length);
         // Since for each snapshot we have a log file with same zxid, expect same # logs as snaps to be kept
         assertEquals(numberOfSnapFilesToKeep, dataLogDirVersion2.listFiles().length);
-        ClientBase.recursiveDelete(tmpDir);
-
     }
 
     /**
@@ -377,7 +374,6 @@ public class PurgeTxnTest extends ZKTestCase {
      */
     @Test
     public void testPurgeTxnLogWithoutDataDir() throws Exception {
-        tmpDir = ClientBase.createTmpDir();
         File dataDir = new File(tmpDir, "dataDir");
         File dataLogDir = new File(tmpDir, "dataLogDir");
 
@@ -408,8 +404,6 @@ public class PurgeTxnTest extends ZKTestCase {
                 numberOfSnapFilesToKeep
                         * 2, // Since for each snapshot we have a log file with same zxid, expect same # logs as snaps to be kept
                 dataLogDirVersion2.listFiles().length);
-        ClientBase.recursiveDelete(tmpDir);
-
     }
 
     /**
@@ -433,7 +427,6 @@ public class PurgeTxnTest extends ZKTestCase {
         SyncRequestProcessor.setSnapCount(SNAP_RETAIN_COUNT * NUM_ZNODES_PER_SNAPSHOT * 10);
 
         // Create Zookeeper and connect to it.
-        tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
         ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
@@ -496,7 +489,6 @@ public class PurgeTxnTest extends ZKTestCase {
 
     @Test
     public void testPurgeTxnLogWhenRecentSnapshotsAreAllInvalid() throws Exception {
-        tmpDir = ClientBase.createTmpDir();
         File dataDir = new File(tmpDir, "dataDir");
         File dataLogDir = new File(tmpDir, "dataLogDir");
 
@@ -532,8 +524,6 @@ public class PurgeTxnTest extends ZKTestCase {
         assertEquals(numberOfSnapFilesToKeep + numberOfSnapFilesToKeep, dataDirVersion2.listFiles().length);
         // Since for each snapshot we have a log file with same zxid, expect same # logs as snaps to be kept
         assertEquals(numberOfSnapFilesToKeep + numberOfSnapFilesToKeep, dataLogDirVersion2.listFiles().length);
-        ClientBase.recursiveDelete(tmpDir);
-
     }
 
     private File createDataDirLogFile(File version_2, int Zxid) throws IOException {


### PR DESCRIPTION
- Purge task uses `FileTxnSnapLog#findNRecentSnapshot`, which's likely to lost data when the recent 3 snapshots are all invalid(a new valid snapshot has not generated yet) and at the same time, Purge task(`e.g ./zkCleanup.sh -n 3`) has started a new round work to clean up the preceding snapshots. we will lose all the data.that's a small probability events, but it's reproducible.
- Overall, using `snaplog.findNValidSnapshots` to make sure the purge task tries to retain N valid snapshots(rather than N snapshots) to avoid a risk of data loss.
- For the unit test, it's not easy to use the `mock` way for the following reasons:
   - when we want to test the `dataDir` which some Snapshots are valid, others not.Just writing a little data contents to the snapshot to make it valid/invalid has a better flexibility.
   - too much code changes in the `PurgeTxnTest.java`(pass the original UT) and `FileTxnSnapLog.java`(have some handles)
- more details in the [ZOOKEEPER-3231](https://issues.apache.org/jira/browse/ZOOKEEPER-3231)