### PR TITLE
ZOOKEEPER-3541: Wrong placeholder '{}' in logs.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java
@@ -274,7 +274,7 @@ public class ZooKeeperSaslClient {
             } catch (SaslException e) {
                 LOG.error("SASL authentication failed using login context '"
                           + this.getLoginContext()
-                          + "' with exception: {}", e);
+                          + "' with exception: ", e);
                 saslState = SaslState.FAILED;
                 gotLastPacket = true;
             }


### PR DESCRIPTION
The placeholder '{}' in the method 'org.apache.zookeeper.client.ZooKeeperSaslClient#respondToServer' is wrong. It doesn't  work. It's redundant.