### PR TITLE
ZOOKEEPER-3548: Redundant zxid check in SnapStream.isValidSnapshot.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
@@ -181,13 +181,8 @@ public class SnapStream {
             return false;
         }
 
-        String fileName = file.getName();
-        if (Util.getZxidFromName(fileName, "snapshot") == -1) {
-            return false;
-        }
-
         boolean isValid = false;
-        switch (getStreamMode(fileName)) {
+        switch (getStreamMode(file.getName())) {
         case GZIP:
             isValid = isValidGZipStream(file);
             break;


### PR DESCRIPTION
`Util.getZxidFromName` is called twice in `SnapStream.isValidSnapshot`, and the second call is redundant: there is no way the check would return false when the second call of `Util.getZxidFromName` is executed as otherwise the code would already return false in the first call of `Util.getZxidFromName`.

No test as the logic is fairly obvious (and the logic is not well testable, in first place).