### PR TITLE
ZOOKEEPER-3563: dependency check failing on 3.4 and 3.5 branches - CV…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -37,7 +37,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
 
     <property name="audience-annotations.version" value="0.5.0" />
 
-    <property name="netty.version" value="4.1.36.Final"/>
+    <property name="netty.version" value="4.1.42.Final"/>
 
     <property name="junit.version" value="4.12"/>
     <property name="mockito.version" value="2.27.0"/>

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
     <mockito.version>2.27.0</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>
     <commons-cli.version>1.2</commons-cli.version>
-    <netty.version>4.1.36.Final</netty.version>
+    <netty.version>4.1.42.Final</netty.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <jackson.version>2.9.10</jackson.version>
     <json.version>1.1.1</json.version>


### PR DESCRIPTION
…E-2019-16869 on Netty

Updated netty to 4.1.42.Final to address CVE-2019-16869

Change-Id: Ie95c38a459fb896566ddf7b5df38180bfee7c07c