### PR TITLE
ZOOKEEPER-3571: Ensure test base directory before tests

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ZKTestCase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ZKTestCase.java
@@ -18,8 +18,11 @@
 
 package org.apache.zookeeper;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import java.io.File;
 import java.time.LocalDateTime;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
@@ -33,16 +36,32 @@ import org.slf4j.LoggerFactory;
  * Basic utilities shared by all tests. Also logging of various events during
  * the test execution (start/stop/success/failure/etc...)
  */
-@SuppressWarnings("deprecation")
 @RunWith(JUnit4ZKTestRunner.class)
 public class ZKTestCase {
 
+    protected static final File testBaseDir = new File(System.getProperty("build.test.dir", "build"));
     private static final Logger LOG = LoggerFactory.getLogger(ZKTestCase.class);
 
     private String testName;
 
     protected String getTestName() {
         return testName;
+    }
+
+    @BeforeClass
+    public static void before() {
+        if (!testBaseDir.exists()) {
+            assertTrue(
+                "Cannot properly create test base directory " + testBaseDir.getAbsolutePath(),
+                testBaseDir.mkdirs());
+        } else if (!testBaseDir.isDirectory()) {
+            assertTrue(
+                "Cannot properly delete file with duplicate name of test base directory " + testBaseDir.getAbsolutePath(),
+                testBaseDir.delete());
+            assertTrue(
+                "Cannot properly create test base directory " + testBaseDir.getAbsolutePath(),
+                testBaseDir.mkdirs());
+        }
     }
 
     @Rule

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
@@ -70,7 +70,6 @@ public abstract class ClientBase extends ZKTestCase {
     protected static final Logger LOG = LoggerFactory.getLogger(ClientBase.class);
 
     public static int CONNECTION_TIMEOUT = 30000;
-    static final File BASETEST = new File(System.getProperty("build.test.dir", "build"));
 
     protected String hostPort = "127.0.0.1:" + PortAssignment.unique();
     protected int maxCnxns = 0;
@@ -344,11 +343,11 @@ public abstract class ClientBase extends ZKTestCase {
     }
 
     public static File createEmptyTestDir() throws IOException {
-        return createTmpDir(BASETEST, false);
+        return createTmpDir(testBaseDir, false);
     }
 
     public static File createTmpDir() throws IOException {
-        return createTmpDir(BASETEST, true);
+        return createTmpDir(testBaseDir, true);
     }
 
     static File createTmpDir(File parentDir, boolean createInitFile) throws IOException {
@@ -495,7 +494,7 @@ public abstract class ClientBase extends ZKTestCase {
 
         setUpAll();
 
-        tmpDir = createTmpDir(BASETEST, true);
+        tmpDir = createTmpDir(testBaseDir, true);
 
         startServer(serverId);
 


### PR DESCRIPTION
Ensure `build.test.dir` is present as a directory. Otherwise many times it suffers from

```
java.io.IOException: No such file or directory

	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createTempFile(File.java:2024)
	at org.apache.zookeeper.test.ClientBase.createTmpDir(ClientBase.java:371)
	at org.apache.zookeeper.test.ClientBase.setUpWithServerId(ClientBase.java:514)
	at org.apache.zookeeper.test.ClientBase.setUp(ClientBase.java:491)
```