### PR TITLE
ZOOKEEPER-3530: add new artifact for compiled c-client code

### DIFF
--- a/README_packaging.md
+++ b/README_packaging.md
@@ -64,6 +64,7 @@ The compiled C client can be found here:
 - `zookeeper-client/zookeeper-client-c/target/c/lib`                 - Native libraries
 - `zookeeper-client/zookeeper-client-c/target/c/include/zookeeper`   - Native library headers
 
+The same folders gets archived to the `zookeeper-assembly/target/apache-zookeeper-<version>-lib.tar.gz` file, assuming you activated the `full-build` maven profile.
 
 ## Package build command (using ant)
 

--- a/zookeeper-assembly/pom.xml
+++ b/zookeeper-assembly/pom.xml
@@ -33,9 +33,20 @@
   <name>Apache ZooKeeper - Assembly</name>
   <description>ZooKeeper Assembly</description>
 
+  <profiles>
+    <profile>
+      <id>full-build</id>
+      <properties>
+        <skip.lib.artifact>false</skip.lib.artifact>
+      </properties>
+    </profile>
+  </profiles>
+
+
   <properties>
     <rw.file.permission>0644</rw.file.permission>
     <rwx.file.permission>0755</rwx.file.permission>
+    <skip.lib.artifact>true</skip.lib.artifact>
   </properties>
 
   <dependencies>
@@ -141,6 +152,22 @@
               <finalName>apache-zookeeper-${project.version}-bin</finalName>
               <appendAssemblyId>false</appendAssemblyId>
               <tarLongFileMode>posix</tarLongFileMode>
+            </configuration>
+          </execution>
+        <execution>
+            <id>lib-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>${project.basedir}/src/main/assembly/lib-package.xml</descriptor>
+              </descriptors>
+              <finalName>apache-zookeeper-${project.version}-lib</finalName>
+              <appendAssemblyId>false</appendAssemblyId>
+              <tarLongFileMode>posix</tarLongFileMode>
+              <skipAssembly>${skip.lib.artifact}</skipAssembly>
             </configuration>
           </execution>
         </executions>

--- a/zookeeper-assembly/src/main/assembly/lib-package.xml
+++ b/zookeeper-assembly/src/main/assembly/lib-package.xml
@@ -1,0 +1,63 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+  <id>lib-package</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <includeBaseDirectory>true</includeBaseDirectory>
+
+  <fileSets>
+    <fileSet>
+      <!-- ZooKeeper C client lib and include files -->
+      <directory>${project.basedir}/../zookeeper-client/zookeeper-client-c/target/c</directory>
+      <outputDirectory>usr</outputDirectory>
+      <includes>
+        <include>include/**/*</include>
+        <include>lib/*</include>
+      </includes>
+      <fileMode>${rw.file.permission}</fileMode>
+      <directoryMode>${rwx.file.permission}</directoryMode>
+    </fileSet>
+    <fileSet>
+      <!-- ZooKeeper C client binaries-->
+      <directory>${project.basedir}/../zookeeper-client/zookeeper-client-c/target/c</directory>
+      <outputDirectory>usr</outputDirectory>
+      <includes>
+        <include>bin/*</include>
+      </includes>
+      <fileMode>${rwx.file.permission}</fileMode>
+      <directoryMode>${rwx.file.permission}</directoryMode>
+    </fileSet>
+    <fileSet>
+      <!-- ZooKeeper license -->
+      <directory>${project.basedir}/..</directory>
+      <includes>
+        <include>LICENSE.txt</include>
+      </includes>
+      <fileMode>${rw.file.permission}</fileMode>
+      <directoryMode>${rwx.file.permission}</directoryMode>
+    </fileSet>
+
+  </fileSets>
+
+</assembly>


### PR DESCRIPTION

During the old ZooKeeper 3.4 ant builds (ant package-native), there was an artifact (zookeeper-<version>-lib.tar.gz) created just for the C-client, with the following content:

```
usr
  |--- bin
         |--- cli_mt
         |--- cli_st
         |--- load_gen
  |--- include
         |--- zookeeper
                |--- proto.h
                |--- recordio.h
                |--- zookeeper.h
                |--- zookeeper.jute.h
                |--- zookeeper_log.h
                |--- zookeeper_version.h
  |--- lib
         |--- libzookeeper_mt.a
         |--- libzookeeper_mt.la
         |--- libzookeeper_mt.so
         |--- libzookeeper_mt.so.2
         |--- libzookeeper_mt.so.2.0.0
         |--- libzookeeper_st.a
         |--- libzookeeper_st.la
         |--- libzookeeper_st.so
         |--- libzookeeper_st.so.2
         |--- libzookeeper_st.so.2.0.0
```

Currently with maven, when we are generating a tarball during full-build then the C-client is not getting archived. In [PR-1078](https://github.com/apache/zookeeper/pull/1078) we discussed that we should re-introduce the apache-zookeeper-<version>-lib.tar.gz artifact.

The goals of this PR are:
- re-introduce the 'lib' artifact, with the same structure we had for the older zookeeper 3.4.x ant generated tar file
- we should also add the LICENSE.txt file to the archive (it was missing from the 3.4.x version tar.gz file)
- the new artifact should be generated only when the full-build profile is set for maven
- we should also update the README_packaging.md file
