### PR TITLE
ZOOKEEPER-3572: correctly handle zooinspector resources

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
@@ -96,4 +96,15 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+        <includes>
+          <include>*</include>
+        </includes>
+      </resource>
+    </resources>
+  </build>
+
 </project>

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
@@ -100,9 +100,6 @@
     <resources>
       <resource>
         <directory>${project.basedir}/src/main/resources</directory>
-        <includes>
-          <include>**/*.*</include>
-        </includes>
       </resource>
     </resources>
   </build>

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
@@ -101,7 +101,7 @@
       <resource>
         <directory>${project.basedir}/src/main/resources</directory>
         <includes>
-          <include>*</include>
+          <include>**/*.*</include>
         </includes>
       </resource>
     </resources>


### PR DESCRIPTION
zooinspector will start up with blank window when directly use IDE to run ZooInspector#main.

this is caused by icos resource load failed, by default icos are loaded from /usr/local/share and /usr/local/share and fail back to classpath.

because of parent pom config, resources are excluded and directory is not default, so resource directory icos are not copyed to target/class.
[ZOOKEEPER-3572](https://issues.apache.org/jira/browse/ZOOKEEPER-3572)