### PR TITLE
ZOOKEEPER-3579: Handle null default watcher gracefully

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -576,7 +576,7 @@ public class ClientCnxn {
                         try {
                             watcher.process(pair.event);
                         } catch (Throwable t) {
-                            LOG.error("Error while calling watcher ", t);
+                            LOG.error("Error while calling watcher.", t);
                         }
                     }
                 } else if (event instanceof LocalCallback) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
@@ -2256,19 +2256,18 @@ public class ZooKeeper implements AutoCloseable {
     /**
      * Return the stat of the node of the given path. Return null if no such a
      * node exists.
-     * <p>
-     * If the watch is true and the call is successful (no exception is thrown),
+     *
+     * <p>If the watch is true and the call is successful (no exception is thrown),
      * a watch will be left on the node with the given path. The watch will be
      * triggered by a successful operation that creates/delete the node or sets
      * the data on the node.
      *
-     * @param path
-     *                the node path
-     * @param watch
-     *                whether need to watch this node
+     * @param path the node path
+     * @param watch whether need to watch this node
      * @return the stat of the node of the given path; return null if no such a
      *         node exists.
      * @throws KeeperException If the server signals an error
+     * @throws IllegalStateException if watch this node with a null default watcher
      * @throws InterruptedException If the server transaction is interrupted.
      */
     public Stat exists(String path, boolean watch) throws KeeperException, InterruptedException {
@@ -2303,6 +2302,8 @@ public class ZooKeeper implements AutoCloseable {
 
     /**
      * The asynchronous version of exists.
+     *
+     * @throws IllegalStateException if watch this node with a null default watcher
      *
      * @see #exists(String, boolean)
      */
@@ -2373,6 +2374,7 @@ public class ZooKeeper implements AutoCloseable {
      * @param stat the stat of the node
      * @return the data of the node
      * @throws KeeperException If the server signals an error with a non-zero error code
+     * @throws IllegalStateException if watch this node with a null default watcher
      * @throws InterruptedException If the server transaction is interrupted.
      */
     public byte[] getData(String path, boolean watch, Stat stat) throws KeeperException, InterruptedException {
@@ -2407,6 +2409,8 @@ public class ZooKeeper implements AutoCloseable {
 
     /**
      * The asynchronous version of getData.
+     *
+     * @throws IllegalStateException if watch this node with a null default watcher
      *
      * @see #getData(String, boolean, Stat)
      */
@@ -2494,6 +2498,7 @@ public class ZooKeeper implements AutoCloseable {
      * @param stat the stat of the configuration node ZooDefs.CONFIG_NODE
      * @return configuration data stored in ZooDefs.CONFIG_NODE
      * @throws KeeperException If the server signals an error with a non-zero error code
+     * @throws IllegalStateException if watch this node with a null default watcher
      * @throws InterruptedException If the server transaction is interrupted.
      */
     public byte[] getConfig(boolean watch, Stat stat) throws KeeperException, InterruptedException {
@@ -2502,6 +2507,8 @@ public class ZooKeeper implements AutoCloseable {
 
     /**
      * The Asynchronous version of getConfig.
+     *
+     * @throws IllegalStateException if watch this node with a null default watcher
      *
      * @see #getData(String, boolean, Stat)
      */
@@ -2756,9 +2763,10 @@ public class ZooKeeper implements AutoCloseable {
      * A KeeperException with error code KeeperException.NoNode will be thrown
      * if no node with the given path exists.
      *
-     * @param path
-     * @param watch
+     * @param path the node path
+     * @param watch whether need to watch this node
      * @return an unordered array of children of the node with the given path
+     * @throws IllegalStateException if watch this node with a null default watcher
      * @throws InterruptedException If the server transaction is interrupted.
      * @throws KeeperException If the server signals an error with a non-zero error code.
      */
@@ -2794,6 +2802,8 @@ public class ZooKeeper implements AutoCloseable {
 
     /**
      * The asynchronous version of getChildren.
+     *
+     * @throws IllegalStateException if watch this node with a null default watcher
      *
      * @see #getChildren(String, boolean)
      */
@@ -2872,10 +2882,11 @@ public class ZooKeeper implements AutoCloseable {
      *
      * @since 3.3.0
      *
-     * @param path
-     * @param watch
+     * @param path the node path
+     * @param watch whether need to watch this node
      * @param stat stat of the znode designated by path
      * @return an unordered array of children of the node with the given path
+     * @throws IllegalStateException if watch this node with a null default watcher
      * @throws InterruptedException If the server transaction is interrupted.
      * @throws KeeperException If the server signals an error with a non-zero
      *  error code.
@@ -2919,6 +2930,8 @@ public class ZooKeeper implements AutoCloseable {
      * The asynchronous version of getChildren.
      *
      * @since 3.3.0
+     *
+     * @throws IllegalStateException if watch this node with a null default watcher
      *
      * @see #getChildren(String, boolean, Stat)
      */

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
@@ -525,12 +525,16 @@ public class ZooKeeper implements AutoCloseable {
         public Set<Watcher> materialize(
             Watcher.Event.KeeperState state,
             Watcher.Event.EventType type,
-            String clientPath) {
-            Set<Watcher> result = new HashSet<Watcher>();
+            String clientPath
+        ) {
+            final Set<Watcher> result = new HashSet<>();
 
             switch (type) {
             case None:
-                result.add(defaultWatcher);
+                if (defaultWatcher != null) {
+                    result.add(defaultWatcher);
+                }
+
                 boolean clear = disableAutoWatchReset && state != Watcher.Event.KeeperState.SyncConnected;
                 synchronized (dataWatches) {
                     for (Set<Watcher> ws : dataWatches.values()) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.jute.Record;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.AsyncCallback.ACLCallback;
@@ -2272,7 +2273,7 @@ public class ZooKeeper implements AutoCloseable {
      * @throws InterruptedException If the server transaction is interrupted.
      */
     public Stat exists(String path, boolean watch) throws KeeperException, InterruptedException {
-        return exists(path, watch ? watchManager.defaultWatcher : null);
+        return exists(path, requestDefaultWatcher(watch));
     }
 
     /**
@@ -2307,7 +2308,7 @@ public class ZooKeeper implements AutoCloseable {
      * @see #exists(String, boolean)
      */
     public void exists(String path, boolean watch, StatCallback cb, Object ctx) {
-        exists(path, watch ? watchManager.defaultWatcher : null, cb, ctx);
+        exists(path, requestDefaultWatcher(watch), cb, ctx);
     }
 
     /**
@@ -2376,7 +2377,7 @@ public class ZooKeeper implements AutoCloseable {
      * @throws InterruptedException If the server transaction is interrupted.
      */
     public byte[] getData(String path, boolean watch, Stat stat) throws KeeperException, InterruptedException {
-        return getData(path, watch ? watchManager.defaultWatcher : null, stat);
+        return getData(path, requestDefaultWatcher(watch), stat);
     }
 
     /**
@@ -2411,7 +2412,7 @@ public class ZooKeeper implements AutoCloseable {
      * @see #getData(String, boolean, Stat)
      */
     public void getData(String path, boolean watch, DataCallback cb, Object ctx) {
-        getData(path, watch ? watchManager.defaultWatcher : null, cb, ctx);
+        getData(path, requestDefaultWatcher(watch), cb, ctx);
     }
 
     /**
@@ -2497,7 +2498,7 @@ public class ZooKeeper implements AutoCloseable {
      * @throws InterruptedException If the server transaction is interrupted.
      */
     public byte[] getConfig(boolean watch, Stat stat) throws KeeperException, InterruptedException {
-        return getConfig(watch ? watchManager.defaultWatcher : null, stat);
+        return getConfig(requestDefaultWatcher(watch), stat);
     }
 
     /**
@@ -2506,7 +2507,7 @@ public class ZooKeeper implements AutoCloseable {
      * @see #getData(String, boolean, Stat)
      */
     public void getConfig(boolean watch, DataCallback cb, Object ctx) {
-        getConfig(watch ? watchManager.defaultWatcher : null, cb, ctx);
+        getConfig(requestDefaultWatcher(watch), cb, ctx);
     }
 
     /**
@@ -2763,7 +2764,7 @@ public class ZooKeeper implements AutoCloseable {
      * @throws KeeperException If the server signals an error with a non-zero error code.
      */
     public List<String> getChildren(String path, boolean watch) throws KeeperException, InterruptedException {
-        return getChildren(path, watch ? watchManager.defaultWatcher : null);
+        return getChildren(path, requestDefaultWatcher(watch));
     }
 
     /**
@@ -2798,7 +2799,7 @@ public class ZooKeeper implements AutoCloseable {
      * @see #getChildren(String, boolean)
      */
     public void getChildren(String path, boolean watch, ChildrenCallback cb, Object ctx) {
-        getChildren(path, watch ? watchManager.defaultWatcher : null, cb, ctx);
+        getChildren(path, requestDefaultWatcher(watch), cb, ctx);
     }
 
     /**
@@ -2884,7 +2885,7 @@ public class ZooKeeper implements AutoCloseable {
         String path,
         boolean watch,
         Stat stat) throws KeeperException, InterruptedException {
-        return getChildren(path, watch ? watchManager.defaultWatcher : null, stat);
+        return getChildren(path, requestDefaultWatcher(watch), stat);
     }
 
     /**
@@ -2923,7 +2924,7 @@ public class ZooKeeper implements AutoCloseable {
      * @see #getChildren(String, boolean, Stat)
      */
     public void getChildren(String path, boolean watch, Children2Callback cb, Object ctx) {
-        getChildren(path, watch ? watchManager.defaultWatcher : null, cb, ctx);
+        getChildren(path, requestDefaultWatcher(watch), cb, ctx);
     }
 
     /**
@@ -3400,6 +3401,26 @@ public class ZooKeeper implements AutoCloseable {
         } catch (Exception e) {
             throw new IOException("Couldn't instantiate " + clientCnxnSocketName, e);
         }
+    }
+
+    /**
+     * Return the default watcher of this instance if requested.
+     *
+     * @param requested if the default watcher requested
+     * @return the default watcher if request, otherwise {@code null}.
+     * @throws IllegalStateException if a null default watcher is requested
+     */
+    @Nullable
+    private Watcher requestDefaultWatcher(boolean requested) {
+        if (requested) {
+            if (watchManager.defaultWatcher != null) {
+                return watchManager.defaultWatcher;
+            } else {
+                throw new IllegalStateException("Default watcher is required, but it is null.");
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
@@ -29,7 +29,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.apache.jute.Record;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.AsyncCallback.ACLCallback;
@@ -2273,7 +2272,7 @@ public class ZooKeeper implements AutoCloseable {
      * @throws InterruptedException If the server transaction is interrupted.
      */
     public Stat exists(String path, boolean watch) throws KeeperException, InterruptedException {
-        return exists(path, requestDefaultWatcher(watch));
+        return exists(path, getDefaultWatcher(watch));
     }
 
     /**
@@ -2308,7 +2307,7 @@ public class ZooKeeper implements AutoCloseable {
      * @see #exists(String, boolean)
      */
     public void exists(String path, boolean watch, StatCallback cb, Object ctx) {
-        exists(path, requestDefaultWatcher(watch), cb, ctx);
+        exists(path, getDefaultWatcher(watch), cb, ctx);
     }
 
     /**
@@ -2377,7 +2376,7 @@ public class ZooKeeper implements AutoCloseable {
      * @throws InterruptedException If the server transaction is interrupted.
      */
     public byte[] getData(String path, boolean watch, Stat stat) throws KeeperException, InterruptedException {
-        return getData(path, requestDefaultWatcher(watch), stat);
+        return getData(path, getDefaultWatcher(watch), stat);
     }
 
     /**
@@ -2412,7 +2411,7 @@ public class ZooKeeper implements AutoCloseable {
      * @see #getData(String, boolean, Stat)
      */
     public void getData(String path, boolean watch, DataCallback cb, Object ctx) {
-        getData(path, requestDefaultWatcher(watch), cb, ctx);
+        getData(path, getDefaultWatcher(watch), cb, ctx);
     }
 
     /**
@@ -2498,7 +2497,7 @@ public class ZooKeeper implements AutoCloseable {
      * @throws InterruptedException If the server transaction is interrupted.
      */
     public byte[] getConfig(boolean watch, Stat stat) throws KeeperException, InterruptedException {
-        return getConfig(requestDefaultWatcher(watch), stat);
+        return getConfig(getDefaultWatcher(watch), stat);
     }
 
     /**
@@ -2507,7 +2506,7 @@ public class ZooKeeper implements AutoCloseable {
      * @see #getData(String, boolean, Stat)
      */
     public void getConfig(boolean watch, DataCallback cb, Object ctx) {
-        getConfig(requestDefaultWatcher(watch), cb, ctx);
+        getConfig(getDefaultWatcher(watch), cb, ctx);
     }
 
     /**
@@ -2764,7 +2763,7 @@ public class ZooKeeper implements AutoCloseable {
      * @throws KeeperException If the server signals an error with a non-zero error code.
      */
     public List<String> getChildren(String path, boolean watch) throws KeeperException, InterruptedException {
-        return getChildren(path, requestDefaultWatcher(watch));
+        return getChildren(path, getDefaultWatcher(watch));
     }
 
     /**
@@ -2799,7 +2798,7 @@ public class ZooKeeper implements AutoCloseable {
      * @see #getChildren(String, boolean)
      */
     public void getChildren(String path, boolean watch, ChildrenCallback cb, Object ctx) {
-        getChildren(path, requestDefaultWatcher(watch), cb, ctx);
+        getChildren(path, getDefaultWatcher(watch), cb, ctx);
     }
 
     /**
@@ -2885,7 +2884,7 @@ public class ZooKeeper implements AutoCloseable {
         String path,
         boolean watch,
         Stat stat) throws KeeperException, InterruptedException {
-        return getChildren(path, requestDefaultWatcher(watch), stat);
+        return getChildren(path, getDefaultWatcher(watch), stat);
     }
 
     /**
@@ -2924,7 +2923,7 @@ public class ZooKeeper implements AutoCloseable {
      * @see #getChildren(String, boolean, Stat)
      */
     public void getChildren(String path, boolean watch, Children2Callback cb, Object ctx) {
-        getChildren(path, requestDefaultWatcher(watch), cb, ctx);
+        getChildren(path, getDefaultWatcher(watch), cb, ctx);
     }
 
     /**
@@ -3404,15 +3403,14 @@ public class ZooKeeper implements AutoCloseable {
     }
 
     /**
-     * Return the default watcher of this instance if requested.
+     * Return the default watcher of this instance if required.
      *
-     * @param requested if the default watcher requested
-     * @return the default watcher if request, otherwise {@code null}.
-     * @throws IllegalStateException if a null default watcher is requested
+     * @param required if the default watcher required
+     * @return the default watcher if required, otherwise {@code null}.
+     * @throws IllegalStateException if a null default watcher is required
      */
-    @Nullable
-    private Watcher requestDefaultWatcher(boolean requested) {
-        if (requested) {
+    private Watcher getDefaultWatcher(boolean required) {
+        if (required) {
             if (watchManager.defaultWatcher != null) {
                 return watchManager.defaultWatcher;
             } else {


### PR DESCRIPTION
See also https://issues.apache.org/jira/browse/ZOOKEEPER-3579

Prevent error logs noise like

>2019-10-14 18:41:49 ERROR ClientCnxn:537 - Error while calling watcher2019-10-14 18:41:49 ERROR ClientCnxn:537 - Error while calling watcherjava.lang.NullPointerException at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:535) at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:510)2019-10-14 18:41:50 ERROR ClientCnxn:537 - Error while calling watcherjava.lang.NullPointerException at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:535) at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:510)