### PR TITLE
[ZOOKEEPER-3598] Fix potential data inconsistency issue due to CommitProcessor not gracefully shutdown

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ExitCode.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ExitCode.java
@@ -48,7 +48,10 @@ public enum ExitCode {
     QUORUM_PACKET_ERROR(13),
 
     /** Unable to bind to the quorum (election) port after multiple retry */
-    UNABLE_TO_BIND_QUORUM_PORT(14);
+    UNABLE_TO_BIND_QUORUM_PORT(14),
+
+    /** Failed to shutdown the request processor pipeline gracefully **/
+    SHUTDOWN_UNGRACEFULLY(16);
 
     private final int value;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/CommitProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/CommitProcessor.java
@@ -29,6 +29,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.zookeeper.ZooDefs.OpCode;
 import org.apache.zookeeper.common.Time;
+import org.apache.zookeeper.server.ExitCode;
 import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.RequestProcessor;
 import org.apache.zookeeper.server.ServerMetrics;
@@ -619,6 +620,20 @@ public class CommitProcessor extends ZooKeeperCriticalThread implements RequestP
 
         if (workerPool != null) {
             workerPool.join(workerShutdownTimeoutMS);
+        }
+
+        try {
+            this.join(workerShutdownTimeoutMS);
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while waiting for CommitProcessor to finish");
+            Thread.currentThread().interrupt();
+        }
+
+        if (this.isAlive()) {
+            LOG.warn("CommitProcessor does not shutdown gracefully after "
+                    + "waiting for {} ms, exit to avoid potential "
+                    + "inconsistency issue", workerShutdownTimeoutMS);
+            System.exit(ExitCode.SHUTDOWN_UNGRACEFULLY.getValue());
         }
 
         if (nextProcessor != null) {


### PR DESCRIPTION
Note: use exit code 16 for SHUTDOWN_UNGRACEFULLY, since internally we've already using 15 for other exit code, which will be upstreamed later.