### PR TITLE
ZOOKEEPER-3599: cli.c: Resuscitate "old-style" argument parsing

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/cli.c
+++ b/zookeeper-client/zookeeper-client-c/src/cli.c
@@ -58,8 +58,8 @@ static zhandle_t *zh;
 static clientid_t myid;
 static const char *clientIdFile = 0;
 struct timeval startTime;
-static char *cmd;
-static char *cert;
+static const char *cmd;
+static const char *cert;
 static int batchMode=0;
 
 static int to_send=0;
@@ -778,10 +778,10 @@ int main(int argc, char **argv) {
     while ((opt = getopt_long(argc, argv, "h:s:m:c:rd", long_options, &option_index)) != -1) {
         switch (opt) {
             case 'h':
-                hostPort = strdup(optarg);
+                hostPort = optarg;
                 break;
             case 'm':
-                clientIdFile = strdup(optarg);
+                clientIdFile = optarg;
                 fh = fopen(clientIdFile, "r");
                 if (fh) {
                     if (fread(&myid, sizeof(myid), 1, fh) != sizeof(myid)) {
@@ -794,12 +794,12 @@ int main(int argc, char **argv) {
                 flags = ZOO_READONLY;
                 break;
             case 'c':
-                cmd = strdup(optarg);
+                cmd = optarg;
                 batchMode = 1;
                 fprintf(stderr,"Batch mode: %s\n",cmd);
                 break;
             case 's':
-                cert = strdup(optarg);
+                cert = optarg;
                 break;
             case 'd':
                 verbose = 1;

--- a/zookeeper-client/zookeeper-client-c/src/cli.c
+++ b/zookeeper-client/zookeeper-client-c/src/cli.c
@@ -330,7 +330,7 @@ int startsWith(const char *line, const char *prefix) {
 static const char *hostPort;
 static int verbose = 0;
 
-void processline(char *line) {
+void processline(const char *line) {
     int rc;
     int async = ((line[0] == 'a') && !(startsWith(line, "addauth ")));
     if (async) {
@@ -545,6 +545,7 @@ void processline(char *line) {
             int sequential = 0;
             int container = 0;
             int ttl = 0;
+            char *p = NULL;
 
             line++;
 
@@ -571,7 +572,7 @@ void processline(char *line) {
 
                     line++;
 
-                    ttl_value = strtol(line, &line, 10);
+                    ttl_value = strtol(line, &p, 10);
 
                     if (ttl_value <= 0) {
                         fprintf(stderr, "ttl value must be a positive integer\n");
@@ -579,7 +580,7 @@ void processline(char *line) {
                     }
 
                     // move back line pointer to the last digit
-                    line--;
+                    line = p - 1;
 
                     break;
                 default:


### PR DESCRIPTION
ZOOKEEPER-2122 added SSL support to the C client and to the `cli_st`/`mt` tools.  It introduced (much-welcome!) GNU-style `getopt_long` argument parsing, but did not try to preserve backwards compatibility.
    
An earlier version of this https://github.com/apache/zookeeper/pull/1131 introduced (optional) POSIX-style `getopt` argument parsing, and was consequently largely obsoleted by the SSL update.  It did, however, support "old-style" arguments to avoid [breaking workflows](https://xkcd.com/1172/).
    
This patch salvages that feature while preserving the `getopt_long` goodness.  It is "legacy-only"; adding new positional arguments is not supported—as discussed in this thread: https://github.com/apache/zookeeper/pull/1131#pullrequestreview-320870245.