### PR TITLE
Update zoo_lock.c (vector not release)

### DIFF
--- a/zookeeper-recipes/zookeeper-recipes-lock/src/main/c/src/zoo_lock.c
+++ b/zookeeper-recipes/zookeeper-recipes-lock/src/main/c/src/zoo_lock.c
@@ -340,6 +340,7 @@ static int zkr_lock_operation(zkr_lock_mutex_t *mutex, struct timespec *ts) {
                     if (mutex->completion != NULL) {
                         mutex->completion(0, mutex->cbdata);
                     }
+		    free_String_vector(vector);
                     return ZOK;
                 }
             }


### PR DESCRIPTION
This branch exits without releasing the vector, causing a memory leak.