### PR TITLE
ZOOKEEPER-3598. Fix trunk build

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/CommitProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/CommitProcessor.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
@@ -26,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.zookeeper.ZooDefs.OpCode;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.server.ExitCode;
@@ -38,8 +38,6 @@ import org.apache.zookeeper.server.ZooKeeperCriticalThread;
 import org.apache.zookeeper.server.ZooKeeperServerListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * This RequestProcessor matches the incoming committed requests with the

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/CommitProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/CommitProcessor.java
@@ -18,7 +18,6 @@
 
 package org.apache.zookeeper.server.quorum;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
@@ -27,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.zookeeper.ZooDefs.OpCode;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.server.ExitCode;
@@ -38,6 +38,8 @@ import org.apache.zookeeper.server.ZooKeeperCriticalThread;
 import org.apache.zookeeper.server.ZooKeeperServerListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * This RequestProcessor matches the incoming committed requests with the
@@ -624,21 +626,19 @@ public class CommitProcessor extends ZooKeeperCriticalThread implements RequestP
 
         try {
             this.join(workerShutdownTimeoutMS);
+            if (this.isAlive()) {
+                LOG.warn("CommitProcessor does not shutdown gracefully after "
+                        + "waiting for {} ms, exit to avoid potential "
+                        + "inconsistency issue", workerShutdownTimeoutMS);
+                System.exit(ExitCode.SHUTDOWN_UNGRACEFULLY.getValue());
+            }
+
+            if (nextProcessor != null) {
+                nextProcessor.shutdown();
+            }
         } catch (InterruptedException e) {
             LOG.warn("Interrupted while waiting for CommitProcessor to finish");
             Thread.currentThread().interrupt();
         }
-
-        if (this.isAlive()) {
-            LOG.warn("CommitProcessor does not shutdown gracefully after "
-                    + "waiting for {} ms, exit to avoid potential "
-                    + "inconsistency issue", workerShutdownTimeoutMS);
-            System.exit(ExitCode.SHUTDOWN_UNGRACEFULLY.getValue());
-        }
-
-        if (nextProcessor != null) {
-            nextProcessor.shutdown();
-        }
     }
-
 }


### PR DESCRIPTION
@lvfangmin @hanm @eolivelli 

You were working on #1130 . Please check this fix, I'm not sure if it's appropriate.
When running the unit test tearDown() thread gets an interrupt which will cause the entire test runner to shut down. This affects both Maven and Ant builds. I have no idea why we can't see it in Maven jobs.