### PR TITLE
ZOOKEEPER-3546 - fix missed change, default should be 0 not Long.MAX_VALUE

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ContainerManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ContainerManager.java
@@ -59,7 +59,7 @@ public class ContainerManager {
      *                     herding of container deletions
      */
     public ContainerManager(ZKDatabase zkDb, RequestProcessor requestProcessor, int checkIntervalMs, int maxPerMinute) {
-        this(zkDb, requestProcessor, checkIntervalMs, maxPerMinute, Long.MAX_VALUE);
+        this(zkDb, requestProcessor, checkIntervalMs, maxPerMinute, 0);
     }
 
     /**


### PR DESCRIPTION
fix missed change, default should be 0 not Long.MAX_VALUE