### PR TITLE
Backport of  ZOOKEEPER-3539 Fix branch-3.5 after upgrade on ASF CI (3.4)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1873,7 +1873,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
 		to Ant on the command-line." />
     </target>
 
-    <target name="test-patch" depends="patch.check,findbugs.check">
+    <target name="test-patch" depends="patch.check">
   	<exec executable="bash" failonerror="true">
     		<arg value="${test_patch_sh}"/>
     		<arg value="DEVELOPER"/>
@@ -1882,13 +1882,13 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     		<arg value="${svn.cmd}"/>
     		<arg value="${grep.cmd}"/>
     		<arg value="${patch.cmd}"/>
-    		<arg value="${findbugs.home}"/>
+                <arg value="${findbugs.home}"/> <!-- no more used -->
     		<arg value="${basedir}"/>
     		<arg value="${java5.home}"/>
   	</exec>
     </target>
 
-    <target name="hudson-test-patch" depends="findbugs.check">
+    <target name="hudson-test-patch" >
   	<exec executable="bash" failonerror="true">
     		<arg value="${test_patch_sh}"/>
     		<arg value="HUDSON"/>
@@ -1908,7 +1908,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
     	</exec>
      </target>
 
-     <target name="qa-test-pullrequest" depends="findbugs.check">
+     <target name="qa-test-pullrequest" >
         <exec executable="bash" failonerror="true">
                 <arg value="${test_pullrequest_sh}"/>
                 <arg value="QABUILD"/>
@@ -1919,7 +1919,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
                 <arg value="${git.cmd}"/>
                 <arg value="${grep.cmd}"/>
                 <arg value="${patch.cmd}"/>
-                <arg value="${findbugs.home}"/>
+                <arg value="${findbugs.home}"/> <!-- no more used -->
                 <arg value="${basedir}"/>
                 <arg value="${jira.passwd}"/>
                 <arg value="${java5.home}"/>
@@ -1929,7 +1929,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
 
 
      <!-- this target runs the hudson trunk build -->
-     <target name="hudson-test-trunk" depends="tar,findbugs"/>
+     <target name="hudson-test-trunk" depends="tar"/>
 
      <target name="api-xml" depends="ivy-retrieve-jdiff, javadoc, write-null">
        <javadoc>

--- a/zookeeper-client/zookeeper-client-c/Makefile.am
+++ b/zookeeper-client/zookeeper-client-c/Makefile.am
@@ -99,14 +99,14 @@ check_PROGRAMS = zktest-st
 TESTS_ENVIRONMENT = ZKROOT=${srcdir}/../.. \
                     CLASSPATH=$$CLASSPATH:$$CLOVER_HOME/lib/clover*.jar
 nodist_zktest_st_SOURCES = $(TEST_SOURCES)
-zktest_st_LDADD = libzkst.la libhashtable.la $(CPPUNIT_LIBS)
+zktest_st_LDADD = libzkst.la libhashtable.la $(CPPUNIT_LIBS) -ldl
 zktest_st_CXXFLAGS = -DUSE_STATIC_LIB $(CPPUNIT_CFLAGS) $(USEIPV6) $(SOLARIS_CPPFLAGS)
 zktest_st_LDFLAGS = -static-libtool-libs $(SYMBOL_WRAPPERS) $(SOLARIS_LIB_LDFLAGS)
 
 if WANT_SYNCAPI
   check_PROGRAMS += zktest-mt
   nodist_zktest_mt_SOURCES = $(TEST_SOURCES) tests/PthreadMocks.cc
-  zktest_mt_LDADD = libzkmt.la libhashtable.la -lpthread $(CPPUNIT_LIBS)
+  zktest_mt_LDADD = libzkmt.la libhashtable.la -lpthread $(CPPUNIT_LIBS) -ldl
   zktest_mt_CXXFLAGS = -DUSE_STATIC_LIB -DTHREADED $(CPPUNIT_CFLAGS) $(USEIPV6)
 if SOLARIS
   SHELL_SYMBOL_WRAPPERS_MT = cat ${srcdir}/tests/wrappers-mt.opt

--- a/zookeeper-client/zookeeper-client-c/acinclude.m4
+++ b/zookeeper-client/zookeeper-client-c/acinclude.m4
@@ -310,3 +310,18 @@ esac
 #echo DX_FLAG_ps=$DX_FLAG_ps
 #echo DX_ENV=$DX_ENV
 ])
+
+# CHECK_CPPUNIT
+# ------------------
+# Check for cppunit presence.
+AC_DEFUN([CHECK_CPPUNIT], [
+  ifdef(
+    [AM_PATH_CPPUNIT],
+    [AM_PATH_CPPUNIT($1)],
+    [ifdef(
+      [PKG_CHECK_MODULES],
+      [PKG_CHECK_MODULES([CPPUNIT], [cppunit >= $1])],
+      [m4_fatal([Missing AM_PATH_CPPUNIT or PKG_CHECK_MODULES m4 macro.])]
+    )]
+  )
+])

--- a/zookeeper-client/zookeeper-client-c/configure.ac
+++ b/zookeeper-client/zookeeper-client-c/configure.ac
@@ -34,7 +34,7 @@ if test "$with_cppunit" = "no" ; then
    CPPUNIT_INCLUDE=
    CPPUNIT_LIBS=
 else
-   AM_PATH_CPPUNIT(1.10.2)
+   CHECK_CPPUNIT(1.10.2)
 fi
 
 if test "$CALLER" = "ANT" ; then

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -227,8 +227,6 @@ static void cleanup_bufs(zhandle_t *zh,int callCompletion,int rc);
 
 static int disable_conn_permute=0; // permute enabled by default
 
-static __attribute__((unused)) void print_completion_queue(zhandle_t *zh);
-
 static void *SYNCHRONOUS_MARKER = (void*)&SYNCHRONOUS_MARKER;
 static int isValidPath(const char* path, const int flags);
 
@@ -1842,26 +1840,6 @@ int api_epilog(zhandle_t *zh,int rc)
     if(inc_ref_counter(zh,-1)==0 && zh->close_requested!=0)
         zookeeper_close(zh);
     return rc;
-}
-
-static __attribute__((unused)) void print_completion_queue(zhandle_t *zh)
-{
-    completion_list_t* cptr;
-
-    if(logLevel<ZOO_LOG_LEVEL_DEBUG) return;
-
-    LOG_DEBUG(LOGSTREAM,"Completion queue: ");
-    if (zh->sent_requests.head==0) {
-        LOG_DEBUG(LOGSTREAM,"empty\n");
-        return;
-    }
-
-    cptr=zh->sent_requests.head;
-    while(cptr){
-        LOG_DEBUG(LOGSTREAM,"%d,",cptr->xid);
-        cptr=cptr->next;
-    }
-    LOG_DEBUG(LOGSTREAM,"end\n");
 }
 
 //#ifdef THREADED

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -1850,18 +1850,18 @@ static __attribute__((unused)) void print_completion_queue(zhandle_t *zh)
 
     if(logLevel<ZOO_LOG_LEVEL_DEBUG) return;
 
-    fprintf(LOGSTREAM,"Completion queue: ");
+    LOG_DEBUG(LOGSTREAM,"Completion queue: ");
     if (zh->sent_requests.head==0) {
-        fprintf(LOGSTREAM,"empty\n");
+        LOG_DEBUG(LOGSTREAM,"empty\n");
         return;
     }
 
     cptr=zh->sent_requests.head;
     while(cptr){
-        fprintf(LOGSTREAM,"%d,",cptr->xid);
+        LOG_DEBUG(LOGSTREAM,"%d,",cptr->xid);
         cptr=cptr->next;
     }
-    fprintf(LOGSTREAM,"end\n");
+    LOG_DEBUG(LOGSTREAM,"end\n");
 }
 
 //#ifdef THREADED


### PR DESCRIPTION
- do not execute findbugs on CI for ant-based tasks
- fix usage of fprintf on C client

Maven + Spotbugs superseded Ant + Findbugs

Author: Enrico Olivelli <eolivelli@apache.org>

Reviewers: Norbert Kalmar <nkalmar@apache.org>

Closes #1082 from eolivelli/fix/fix-ci-35