### PR TITLE
ZOOKEEPER-3635 Use Docker and Maven Release Plugin to prepare ZooKeeper releases

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM maven:3.6.1-jdk-11
+FROM maven:3.6.3-jdk-8
 
 RUN apt-get update
 RUN apt-get install -y g++ cmake autoconf libcppunit-dev libtool

--- a/pom.xml
+++ b/pom.xml
@@ -845,7 +845,7 @@
                </goals>
                <configuration>
                  <pushChanges>false</pushChanges>
-                 <includes>zookeeper-client/zookeeper-client-c/CMakeLists.txt,zookeeper-client/zookeeper-client-c/configure.ac</includes>
+                 <includes>zookeeper-client/zookeeper-client-c/CMakeLists.txt,zookeeper-client/zookeeper-client-c/configure.ac,zookeeper-client/zookeeper-client-c/include/zookeeper_version.h</includes>
                </configuration>
             </execution>
             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>21</version>
     <relativePath />
     <!-- no parent resolution -->
   </parent>
@@ -244,6 +244,12 @@
       <name>Allan Lyu</name>
       <email>fangmin@apache.org</email>
       <timezone>-8</timezone>
+    </developer>
+    <developer>
+        <id>eolivelli</id>
+        <name>Enrico Olivelli</name>
+        <email>eolivelli@apache.org</email>
+        <timezone>+1</timezone>
     </developer>
   </developers>
 
@@ -517,10 +523,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
           <version>2.5.3</version>
-          <configuration>
-            <releaseProfiles>apache-release</releaseProfiles>
-            <arguments>-Dmaven.test.skip.exec ${arguments}</arguments>
-          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-scm-plugin</artifactId>
+          <version>1.11.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -815,8 +822,47 @@
           <consoleOutput>true</consoleOutput>
         </configuration>
       </plugin>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <inherited>false</inherited>
+          <configuration>
+            <!-- update the version inside the C sources -->
+            <preparationGoals>clean install -DskipTests antrun:run@replace-cclient-files-during-release scm:add@add-cclient-files-during-release scm:checkin@commit-cclient-files-during-release</preparationGoals>
+            <completionGoals>clean install -DskipTests antrun:run@replace-cclient-files-during-release scm:add@add-cclient-files-during-release scm:checkin@commit-cclient-files-during-release</completionGoals>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-scm-plugin</artifactId>
+          <inherited>false</inherited>
+          <executions>
+             <execution>
+               <id>add-cclient-files-during-release</id>
+               <phase>none</phase>
+               <goals>
+                 <goal>add</goal>
+               </goals>
+               <configuration>
+                 <pushChanges>false</pushChanges>
+                 <includes>zookeeper-client/zookeeper-client-c/CMakeLists.txt,zookeeper-client/zookeeper-client-c/configure.ac</includes>
+               </configuration>
+            </execution>
+            <execution>
+               <id>commit-cclient-files-during-release</id>
+               <phase>none</phase>
+               <goals>
+                   <!-- git commit -->
+                <goal>checkin</goal>
+              </goals>
+              <configuration>
+                 <pushChanges>false</pushChanges>
+                 <message>Prepared ${project.version}</message>
+              </configuration>
+            </execution>
+        </executions>
+      </plugin>
     </plugins>
-
     <resources>
       <resource>
         <directory>${project.basedir}src/main/java/resources</directory>

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper_version.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper_version.h
@@ -22,9 +22,7 @@
 extern "C" {
 #endif
 
-#define ZOO_MAJOR_VERSION 3
-#define ZOO_MINOR_VERSION 6
-#define ZOO_PATCH_VERSION 0
+#define ZOO_VERSION "3.6.0"
 
 #ifdef __cplusplus
 }

--- a/zookeeper-client/zookeeper-client-c/pom.xml
+++ b/zookeeper-client/zookeeper-client-c/pom.xml
@@ -159,6 +159,10 @@
             </goals>
             <configuration>
                <target>
+                  <replaceregexp file="include/zookeeper_version.h" match="project.*" replace="project(zookeeper VERSION ${project.version})" byline="true" />
+                  <replace file="include/zookeeper_version.h" value="">
+                      <replaceToken>-SNAPSHOT</replaceToken>
+                  </replace>
                   <replaceregexp file="CMakeLists.txt" match="project.*" replace="project(zookeeper VERSION ${project.version})" byline="true" />
                   <replace file="CMakeLists.txt" value="">
                       <replaceToken>-SNAPSHOT</replaceToken>

--- a/zookeeper-client/zookeeper-client-c/pom.xml
+++ b/zookeeper-client/zookeeper-client-c/pom.xml
@@ -151,6 +151,25 @@
               <goal>run</goal>
             </goals>
           </execution>
+          <execution>
+            <id>replace-cclient-files-during-release</id>
+            <phase>none</phase>
+            <goals>
+               <goal>run</goal>
+            </goals>
+            <configuration>
+               <target>
+                  <replaceregexp file="CMakeLists.txt" match="project.*" replace="project(zookeeper VERSION ${project.version})" byline="true" />
+                  <replace file="CMakeLists.txt" value="">
+                      <replaceToken>-SNAPSHOT</replaceToken>
+                  </replace>
+                  <replaceregexp file="configure.ac" match="AC_INIT.*" replace="AC_INIT([zookeeper C client],${project.version},[user@zookeeper.apache.org],[zookeeper])" byline="true" />
+                  <replace file="configure.ac" value="">
+                      <replaceToken>-SNAPSHOT</replaceToken>
+                  </replace>
+               </target>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/zookeeper-client/zookeeper-client-c/src/cli.c
+++ b/zookeeper-client/zookeeper-client-c/src/cli.c
@@ -836,10 +836,6 @@ int main(int argc, char **argv) {
         fprintf(stderr,
                 "Version: ZooKeeper cli (c client) version %s\n",
                 ZOO_VERSION);
-                "Version: ZooKeeper cli (c client) version %d.%d.%d\n",
-                ZOO_MAJOR_VERSION,
-                ZOO_MINOR_VERSION,
-                ZOO_PATCH_VERSION);
         return 2;
     }
 

--- a/zookeeper-client/zookeeper-client-c/src/cli.c
+++ b/zookeeper-client/zookeeper-client-c/src/cli.c
@@ -760,10 +760,8 @@ int main(int argc, char **argv) {
                 "USAGE %s zookeeper_host_list [clientid_file|cmd:(ls|ls2|create|create2|od|...)]\n", 
                 argv[0]);
         fprintf(stderr,
-                "Version: ZooKeeper cli (c client) version %d.%d.%d\n", 
-                ZOO_MAJOR_VERSION,
-                ZOO_MINOR_VERSION,
-                ZOO_PATCH_VERSION);
+                "Version: ZooKeeper cli (c client) version %s\n",
+                ZOO_VERSION);
         return 2;
     }
     if (argc > 2) {


### PR DESCRIPTION
- configure maven-release-plugin
- configure maven-scm-plugin
- use maven-antrun-plugin in order to alter C client files during release procedure
- update Apache Parent pom to 21
- use openjdk8 for building releases