### PR TITLE
ZOOKEEPER-3681: Add s390x support for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,21 @@
 language: java
 sudo: false
-jdk:
-  - openjdk8
-  - openjdk11
+
+matrix:
+  include:
+    - os: linux
+      jdk: openjdk8
+    - os: linux
+      jdk: openjdk11
+    - os: linux
+      arch: s390x
+      jdk: openjdk11
+      addons:
+        apt:
+          update: true
+          packages:
+            - maven
+            - libcppunit-dev
 
 cache:
   directories:


### PR DESCRIPTION
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.