### PR TITLE
ZOOKEEPER-3641: New ZOO_VERSION define breaks Perl & Python contribs

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-zkperl/build/check_zk_version.c
+++ b/zookeeper-contrib/zookeeper-contrib-zkperl/build/check_zk_version.c
@@ -23,7 +23,7 @@
 #include "check_zk_version.h"
 
 int main() {
-  printf("%d.%d.%d\n", ZOO_MAJOR_VERSION, ZOO_MINOR_VERSION, ZOO_PATCH_VERSION);
+  puts(ZOO_VERSION);
   return 0;
 }
 

--- a/zookeeper-contrib/zookeeper-contrib-zkperl/build/check_zk_version.h
+++ b/zookeeper-contrib/zookeeper-contrib-zkperl/build/check_zk_version.h
@@ -18,10 +18,13 @@
  */
 
 /* keep in sync with Makefile.PL */
+#if defined(ZOO_VERSION)
+/* ZOO_VERSION was introduced by ZOOKEEPER-3635 (3.6.0-pre). */
+#else /* !defined(ZOO_VERSION) */
 #if !defined(ZOO_MAJOR_VERSION) || ZOO_MAJOR_VERSION != 3 || \
     !defined(ZOO_MINOR_VERSION) || ZOO_MINOR_VERSION < 1 || \
     !defined(ZOO_PATCH_VERSION) || \
     (ZOO_MINOR_VERSION == 1 && ZOO_PATCH_VERSION < 1)
 #error "Net::ZooKeeper requires at least ZooKeeper version 3.1.1"
 #endif
-
+#endif /* !defined(ZOO_VERSION) */

--- a/zookeeper-contrib/zookeeper-contrib-zkpython/src/c/zookeeper.c
+++ b/zookeeper-contrib/zookeeper-contrib-zkpython/src/c/zookeeper.c
@@ -1578,11 +1578,7 @@ PyMODINIT_FUNC initzookeeper(void) {
   PyModule_AddObject(module, "ZooKeeperException", ZooKeeperException);
   Py_INCREF(ZooKeeperException);
 
-  int size = 10;
-  char version_str[size];
-  snprintf(version_str, size, "%i.%i.%i", ZOO_MAJOR_VERSION, ZOO_MINOR_VERSION, ZOO_PATCH_VERSION);
-
-  PyModule_AddStringConstant(module, "__version__", version_str);
+  PyModule_AddStringConstant(module, "__version__", ZOO_VERSION);
 
   ADD_INTCONSTANT(PERM_READ);
   ADD_INTCONSTANT(PERM_WRITE);


### PR DESCRIPTION
[ZOOKEEPER-3635](https://issues.apache.org/jira/browse/ZOOKEEPER-3635) changed the versioning scheme for the C client from integer-valued `ZOO_{MAJOR,MINOR,PATCH}_VERSION` definitions to a single string-valued `#define ZOO_VERSION "3.6.0"`.

This caused the Perl and Python contribs to fail to build.  The attached patches should repair the issue.

@eolivelli, @nkalmar: What do you think?