### PR TITLE
ZOOKEEPER-3643: Testing and documenting secure and unsecure ZK client connections

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperProgrammers.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperProgrammers.md
@@ -1343,6 +1343,13 @@ following reference
     "zookeeper.server.principal = **zookeeper/zookeeper.apache.org@APACHE.ORG**" or
     "zookeeper.server.principal = **zookeeper/zookeeper.apache.org**"
 
+You can also use the **ZKClientConfig** object to pass properties to the ZooKeeper client when initiating 
+a new connection. The properties in the *ZKClientConfig* are overwriting the properties set based on the Java 
+System Properties. This feature is especially handy, when you don't have control over the Java System Properties 
+(e.g. because your code is running inside a map-reduce job or custom stored procedure in a database), or when you
+want to specify custom properties for different ZooKeeper connections in the same process (e.g. when you try to 
+initiate two separate connections to two ZooKeeper clusters, one using SSL and one using unsecure connection only).
+
 <a name="C+Binding"></a>
 
 ### C Binding

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
@@ -51,6 +51,7 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.common.IOUtils;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.common.X509Exception.SSLContextException;
@@ -720,8 +721,32 @@ public abstract class ClientBase extends ZKTestCase {
         return sb.toString();
     }
 
+    /**
+     * Returns ZooKeeper client after connecting to ZooKeeper Server. Session
+     * timeout is {@link #CONNECTION_TIMEOUT}. No custom client configuration is defined.
+     *
+     * @param cxnString
+     *            connection string in the form of host:port
+     * @throws IOException
+     *             in cases of network failure
+     */
     public static ZooKeeper createZKClient(String cxnString) throws Exception {
         return createZKClient(cxnString, CONNECTION_TIMEOUT);
+    }
+
+    /**
+     * Returns ZooKeeper client after connecting to ZooKeeper Server. No custom client
+     * configuration is defined.
+     *
+     * @param cxnString
+     *            connection string in the form of host:port
+     * @param sessionTimeout
+     *            session timeout in millisec
+     * @throws IOException
+     *             in cases of network failure
+     */
+    public static ZooKeeper createZKClient(String cxnString, int sessionTimeout) throws IOException {
+        return createZKClient(cxnString, sessionTimeout, null);
     }
 
     /**
@@ -731,12 +756,16 @@ public abstract class ClientBase extends ZKTestCase {
      * @param cxnString
      *            connection string in the form of host:port
      * @param sessionTimeout
+     *            session timeout in millisec
+     * @param clientConfig
+     *            custom client configuration
      * @throws IOException
      *             in cases of network failure
      */
-    public static ZooKeeper createZKClient(String cxnString, int sessionTimeout) throws IOException {
+    public static ZooKeeper createZKClient(String cxnString, int sessionTimeout,
+                                           ZKClientConfig clientConfig) throws IOException {
         CountdownWatcher watcher = new CountdownWatcher();
-        ZooKeeper zk = new ZooKeeper(cxnString, sessionTimeout, watcher);
+        ZooKeeper zk = new ZooKeeper(cxnString, sessionTimeout, watcher, clientConfig);
         try {
             watcher.waitForConnected(CONNECTION_TIMEOUT);
         } catch (InterruptedException | TimeoutException e) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientSSLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientSSLTest.java
@@ -96,35 +96,15 @@ public class ClientSSLTest extends QuorumPeerTestBase {
     public void testClientServerSSL(boolean useSecurePort) throws Exception {
         final int SERVER_COUNT = 3;
         final int[] clientPorts = new int[SERVER_COUNT];
-        final Integer[] secureClientPorts = new Integer[SERVER_COUNT];
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < SERVER_COUNT; i++) {
-            clientPorts[i] = PortAssignment.unique();
-            secureClientPorts[i] = PortAssignment.unique();
-            String server = String.format("server.%d=127.0.0.1:%d:%d:participant;127.0.0.1:%d%n", i, PortAssignment.unique(), PortAssignment.unique(), clientPorts[i]);
-            sb.append(server);
-        }
-        String quorumCfg = sb.toString();
-
-        MainThread[] mt = new MainThread[SERVER_COUNT];
-        for (int i = 0; i < SERVER_COUNT; i++) {
-            if (useSecurePort) {
-                mt[i] = new MainThread(i, quorumCfg, secureClientPorts[i], true);
-            } else {
-                mt[i] = new MainThread(i, quorumCfg, true);
-            }
-            mt[i].start();
+        int[] secureClientPorts = null;
+        if (useSecurePort) {
+          secureClientPorts = new int[SERVER_COUNT];
         }
 
-        // Add some timing margin for the quorum to elect a leader
-        // (without this margin, timeouts have been observed in parallel test runs)
-        ClientBase.waitForServerUp("127.0.0.1:" + clientPorts[0], 2 * TIMEOUT);
+        MainThread[] mt = startThreeNodeSSLCluster(clientPorts, secureClientPorts);
 
         // Servers have been set up. Now go test if secure connection is successful.
         for (int i = 0; i < SERVER_COUNT; i++) {
-            assertTrue(
-                    "waiting for server " + i + " being up",
-                    ClientBase.waitForServerUp("127.0.0.1:" + clientPorts[i], TIMEOUT));
             final int port = useSecurePort ? secureClientPorts[i] : clientPorts[i];
             ZooKeeper zk = ClientBase.createZKClient("127.0.0.1:" + port, TIMEOUT);
             // Do a simple operation to make sure the connection is fine.
@@ -139,6 +119,55 @@ public class ClientSSLTest extends QuorumPeerTestBase {
     }
 
     /**
+     * This test covers the case when from the same JVM we connect to both secure and unsecure
+     * clusters. In this case we can't use the Java System Properties, but we need to specify client
+     * configuration.
+     *
+     * In this test the servers has two client ports open, one used only for secure connection and one
+     * used only for unsecure connections. (the client port unification is disabled)
+     */
+    @Test
+    public void testClientCanConnectBothSecureAndUnsecure() throws Exception {
+
+      // to make sure the test is testing the case we want, we disable client port unification in the
+      // server, and also disable the property which would instruct the client to connect using SSL
+      System.clearProperty(NettyServerCnxnFactory.PORT_UNIFICATION_KEY);
+      System.clearProperty(ZKClientConfig.SECURE_CLIENT);
+
+      final int SERVER_COUNT = 3;
+      final int[] clientPorts = new int[SERVER_COUNT];
+      int[] secureClientPorts = new int[SERVER_COUNT];
+
+      MainThread[] mt = startThreeNodeSSLCluster(clientPorts, secureClientPorts);
+
+      // Servers have been set up. Now go test if both secure and unsecure connection is successful.
+      for (int i = 0; i < SERVER_COUNT; i++) {
+
+        // testing the secure connection, also do some simple operation to verify that it works
+        ZKClientConfig secureClientConfig = new ZKClientConfig();
+        secureClientConfig.setProperty(ZKClientConfig.SECURE_CLIENT, "true");
+        ZooKeeper zkSecure = ClientBase.createZKClient("127.0.0.1:" + secureClientPorts[i], TIMEOUT, secureClientConfig);
+        zkSecure.create("/test", "".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+
+        // testing the unsecure connection, also do some simple operation to verify that it works
+        ZKClientConfig unsecureClientConfig = new ZKClientConfig();
+        unsecureClientConfig.setProperty(ZKClientConfig.SECURE_CLIENT, "false");
+        ZooKeeper zkUnsecure = ClientBase.createZKClient("127.0.0.1:" + clientPorts[i], TIMEOUT, unsecureClientConfig);
+        zkUnsecure.delete("/test", -1);
+
+        zkSecure.close();
+        zkUnsecure.close();
+      }
+
+      for (int i = 0; i < mt.length; i++) {
+        mt[i].shutdown();
+      }
+
+    }
+
+
+
+    /**
      * Developers might use standalone mode (which is the default for one server).
      * This test checks SSL works in standalone mode of ZK server.
      * <p>
@@ -146,7 +175,7 @@ public class ClientSSLTest extends QuorumPeerTestBase {
      */
     @Test
     public void testSecureStandaloneServer() throws Exception {
-        Integer secureClientPort = PortAssignment.unique();
+        int secureClientPort = PortAssignment.unique();
         MainThread mt = new MainThread(MainThread.UNSET_MYID, "", secureClientPort, false);
         mt.start();
 
@@ -157,4 +186,51 @@ public class ClientSSLTest extends QuorumPeerTestBase {
         mt.shutdown();
     }
 
+
+   /**
+    * This method starts a ZK quorum with random client ports. It always define clientPort, but defines
+    * secureClientPort optionally as well. We will also wait for the quorum to be started.
+    *
+    * @param clientPorts mandatory option, it will be populated with the client ports
+    * @param secureClientPorts optional option, if it is specified (not null) then it will be populated
+    *                          with the secureClientPorts for each ZooKeeper server. If it is set to
+    *                          null, then no SecureClientPort will be defined for the ZooKeeper servers
+    * @return array of ZooKeeper server main threads
+    * @throws Exception
+    */
+    private MainThread[] startThreeNodeSSLCluster(final int[] clientPorts, final int[] secureClientPorts) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        int serverCount = clientPorts.length;
+        boolean useSecurePort = secureClientPorts != null && secureClientPorts.length == clientPorts.length;
+        for (int i = 0; i < serverCount; i++) {
+            clientPorts[i] = PortAssignment.unique();
+            if (useSecurePort) {
+              secureClientPorts[i] = PortAssignment.unique();
+            }
+            String server = String.format("server.%d=localhost:%d:%d:participant;localhost:%d",
+                                          i, PortAssignment.unique(), PortAssignment.unique(), clientPorts[i]);
+            sb.append(server + "\n");
+        }
+        String quorumCfg = sb.toString();
+
+        MainThread[] mt = new MainThread[serverCount];
+        for (int i = 0; i < serverCount; i++) {
+          if (useSecurePort) {
+            mt[i] = new MainThread(i, quorumCfg, secureClientPorts[i], true);
+          } else {
+            mt[i] = new MainThread(i, quorumCfg, true);
+          }
+          mt[i].start();
+        }
+
+        // Add some timing margin for the quorum to elect a leader
+        // (without this margin, timeouts have been observed in parallel test runs)
+        for (int i = 0; i < serverCount; i++) {
+          assertTrue(
+            "waiting for server " + i + " being up",
+            ClientBase.waitForServerUp("127.0.0.1:" + clientPorts[i], 2 * TIMEOUT));
+        }
+
+        return mt;
+    }
 }


### PR DESCRIPTION
We are working in the ZooKeeper SSL integration in HBase. By default, one can enable ZooKeeper SSL client connections using Java System Properties. However, there are certain use-cases, when we need to connect to two ZooKeeper quorum from the same JVM (e.g. when connecting to two HBase clusters for data synchronization). It is possible, that one of the ZooKeeper quorum use SSL while the other doesn't.

In this case it is not possible to use Java System Properties, as those will be affecting both ZooKeeper client connections. These use-cases require code modifications e.g. in HBase to use custom ZooKeeper client configurations. We need to add unit test in ZooKeeper to verify that it works and also make sense to document this use-case to help other open source projects to start using ZooKeeper SSL.