### PR TITLE
ZOOKEEPER-3594: Ability to skip proposing requests with error transactions

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ExitCode.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ExitCode.java
@@ -48,7 +48,10 @@ public enum ExitCode {
     QUORUM_PACKET_ERROR(13),
 
     /** Unable to bind to the quorum (election) port after multiple retry */
-    UNABLE_TO_BIND_QUORUM_PORT(14);
+    UNABLE_TO_BIND_QUORUM_PORT(14),
+
+    /** Used to detect if skip txn ran onto the ordering issue */
+    QUORUM_PEER_SKIP_OUT_OF_ORDER(15);
 
     private final int value;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
@@ -151,6 +151,9 @@ public final class ServerMetrics {
         WRITES_QUEUED_IN_COMMIT_PROCESSOR = metricsContext.getSummary("write_commit_proc_req_queued", DetailLevel.BASIC);
         COMMITS_QUEUED_IN_COMMIT_PROCESSOR = metricsContext.getSummary("commit_commit_proc_req_queued", DetailLevel.BASIC);
         COMMITS_QUEUED = metricsContext.getCounter("request_commit_queued");
+        QUORUM_PEER_SKIP_SENT = metricsContext.getCounter("quorum_peer_skip_sent");
+        QUORUM_PEER_SKIP_OUT_OF_ORDER = metricsContext.getCounter("quorum_peer_skip_out_of_order");
+        QUORUM_PEER_SKIP_QUEUE_SIZE = metricsContext.getCounter("quorum_peer_skip_queue_size");
         READS_ISSUED_IN_COMMIT_PROC = metricsContext.getSummary("read_commit_proc_issued", DetailLevel.BASIC);
         WRITES_ISSUED_IN_COMMIT_PROC = metricsContext.getSummary("write_commit_proc_issued", DetailLevel.BASIC);
 
@@ -183,6 +186,7 @@ public final class ServerMetrics {
          */
         OM_PROPOSAL_PROCESS_TIME = metricsContext.getSummary("om_proposal_process_time_ms", DetailLevel.ADVANCED);
         OM_COMMIT_PROCESS_TIME = metricsContext.getSummary("om_commit_process_time_ms", DetailLevel.ADVANCED);
+        OM_SKIP_PROCESS_TIME = metricsContext.getSummary("om_skip_process_time_ms", DetailLevel.ADVANCED);
 
         /**
          * Time spent by the final processor. This is tracked in the commit processor.
@@ -193,8 +197,10 @@ public final class ServerMetrics {
         PROPOSAL_LATENCY = metricsContext.getSummary("proposal_latency", DetailLevel.ADVANCED);
         PROPOSAL_ACK_CREATION_LATENCY = metricsContext.getSummary("proposal_ack_creation_latency", DetailLevel.ADVANCED);
         COMMIT_PROPAGATION_LATENCY = metricsContext.getSummary("commit_propagation_latency", DetailLevel.ADVANCED);
+        SKIP_PROPAGATION_LATENCY = metricsContext.getSummary("skip_propagation_latency", DetailLevel.ADVANCED);
         LEARNER_PROPOSAL_RECEIVED_COUNT = metricsContext.getCounter("learner_proposal_received_count");
         LEARNER_COMMIT_RECEIVED_COUNT = metricsContext.getCounter("learner_commit_received_count");
+        LEARNER_SKIP_RECEIVED_COUNT = metricsContext.getCounter("learner_skip_received_count");
 
         /**
          * Learner handler quorum packet metrics.
@@ -218,6 +224,7 @@ public final class ServerMetrics {
         QUORUM_ACK_LATENCY = metricsContext.getSummary("quorum_ack_latency", DetailLevel.ADVANCED);
         ACK_LATENCY = metricsContext.getSummarySet("ack_latency", DetailLevel.ADVANCED);
         PROPOSAL_COUNT = metricsContext.getCounter("proposal_count");
+        SKIP_COUNT = metricsContext.getCounter("skip_count");
         QUIT_LEADING_DUE_TO_DISLOYAL_VOTER = metricsContext.getCounter("quit_leading_due_to_disloyal_voter");
 
         STALE_REQUESTS = metricsContext.getCounter("stale_requests");
@@ -304,8 +311,10 @@ public final class ServerMetrics {
     public final Summary PROPOSAL_LATENCY;
     public final Summary PROPOSAL_ACK_CREATION_LATENCY;
     public final Summary COMMIT_PROPAGATION_LATENCY;
+    public final Summary SKIP_PROPAGATION_LATENCY;
     public final Counter LEARNER_PROPOSAL_RECEIVED_COUNT;
     public final Counter LEARNER_COMMIT_RECEIVED_COUNT;
+    public final Counter LEARNER_SKIP_RECEIVED_COUNT;
 
     public final Summary STARTUP_TXNS_LOADED;
     public final Summary STARTUP_TXNS_LOAD_TIME;
@@ -323,6 +332,7 @@ public final class ServerMetrics {
     public final Summary QUORUM_ACK_LATENCY;
     public final SummarySet ACK_LATENCY;
     public final Counter PROPOSAL_COUNT;
+    public final Counter SKIP_COUNT;
     public final Counter QUIT_LEADING_DUE_TO_DISLOYAL_VOTER;
 
     /**
@@ -376,6 +386,9 @@ public final class ServerMetrics {
     public final Summary WRITES_QUEUED_IN_COMMIT_PROCESSOR;
     public final Summary COMMITS_QUEUED_IN_COMMIT_PROCESSOR;
     public final Counter COMMITS_QUEUED;
+    public final Counter QUORUM_PEER_SKIP_SENT;
+    public final Counter QUORUM_PEER_SKIP_OUT_OF_ORDER;
+    public final Counter QUORUM_PEER_SKIP_QUEUE_SIZE;
     public final Summary READS_ISSUED_IN_COMMIT_PROC;
     public final Summary WRITES_ISSUED_IN_COMMIT_PROC;
 
@@ -408,6 +421,7 @@ public final class ServerMetrics {
      */
     public final Summary OM_PROPOSAL_PROCESS_TIME;
     public final Summary OM_COMMIT_PROCESS_TIME;
+    public final Summary OM_SKIP_PROCESS_TIME;
 
     /**
      * Time spent by the final processor. This is tracked in the commit processor.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -561,7 +561,11 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
     }
 
     long getNextZxid() {
-        return hzxid.incrementAndGet();
+        return hzxid.get() + 1;
+    }
+
+    void incrementZxid() {
+        hzxid.incrementAndGet();
     }
 
     public void setZxid(long zxid) {
@@ -1716,7 +1720,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
             }
 
             // do not add non quorum packets to the queue.
-            if (quorumRequest) {
+            if (quorumRequest && !request.isSkipped()) {
                 getZKDatabase().addCommittedProposal(request);
             }
             return rc;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Follower.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Follower.java
@@ -195,6 +195,18 @@ public class Follower extends Learner {
                 ServerMetrics.getMetrics().OM_PROPOSAL_PROCESS_TIME.add(Time.currentElapsedTime() - startTime);
             }
             break;
+        case Leader.SKIP:
+            ServerMetrics.getMetrics().LEARNER_SKIP_RECEIVED_COUNT.add(1);
+            fzk.skip(qp.getData());
+            if (om != null) {
+                final long startTime = Time.currentElapsedTime();
+                // We need to create a new QuorumPacket object that will be queued for sending
+                QuorumPacket observerPacket = new QuorumPacket(
+                        qp.getType(), qp.getZxid(), qp.getData(), qp.getAuthinfo());
+                om.proposalSkipped(observerPacket);
+                ServerMetrics.getMetrics().OM_SKIP_PROCESS_TIME.add(Time.currentElapsedTime() - startTime);
+            }
+            break;
         case Leader.COMMIT:
             ServerMetrics.getMetrics().LEARNER_COMMIT_RECEIVED_COUNT.add(1);
             fzk.commit(qp.getZxid());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderHandler.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderHandler.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.server.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * This class is used to process commits on the Leader side.
+ *
+ * When -Dzookeeper.quorum.skipTxnEnabled=true:
+ *   After commit is processed, LeaderHandler will commit
+ *   the request and try to flush a queue of skipped transactions
+ *   that occurred right before that commit.
+ */
+public class LeaderHandler implements SkipRequestHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(LeaderHandler.class);
+
+    private final CommitProcessor commitProcessor;
+    private final SkippedRequestQueue skippedRequestQueue;
+
+    public LeaderHandler(CommitProcessor commitProcessor) {
+        this.commitProcessor = commitProcessor;
+        this.skippedRequestQueue = new SkippedRequestQueue();
+    }
+
+    /**
+     * This method must be called from the RP chain thread
+     * right after PrepRequestProcessor. Once it's known that
+     * the request is invalid we can skip sending PROPOSE and go directly to
+     * COMMIT but we need to wait to do that in order with the other requests.
+     *
+     * The request will be immediately sent back to the learner if there is no pending commits
+     * otherwise the request will be put inside the handler's queue to wait for pending commit
+     * to complete before is sent so we make sure we send all requests in order.
+     */
+    @Override
+    public void skipProposing(Request request) {
+        List<Request> requests = skippedRequestQueue.addAndGet(request);
+        processSkippedRequests(requests);
+    }
+
+    /**
+     * Leader specific commitProcessing logic
+     */
+    public void processCommit(Request request) {
+        commitProcessor.commit(request);
+        List<Request> requests = skippedRequestQueue.setLastCommittedAndGet(request.zxid);
+        processSkippedRequests(requests);
+    }
+
+    /**
+     * This method gets called from the getSkippedRequests() method
+     * For each request inside the queue we will run this method.
+     *
+     * Note this method is differently implemented
+     * in LeaderHandler and LearnerHandler.
+     *
+     * LeaderHandler commits directly in it's own commit processor.
+     * LearnerHandler must send SKIP message to the Learners so they can
+     * commit the request in their own commit processor.
+     */
+    @Override
+    public void processSkip(Request request) {
+        commitProcessor.commit(request);
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderRequestProcessor.java
@@ -70,7 +70,7 @@ public class LeaderRequestProcessor implements RequestProcessor {
         if (upgradeRequest != null) {
             nextProcessor.processRequest(upgradeRequest);
         }
-
+        request.setSkipRequestHandler(lzks.getLeaderHandler());
         nextProcessor.processRequest(request);
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
@@ -412,6 +412,12 @@ public class ObserverMaster extends LearnerMaster implements Runnable {
         sendPacket(pkt);
     }
 
+    synchronized void proposalSkipped(QuorumPacket qp) {
+        for (LearnerHandler lh : activeObservers) {
+            lh.queuePacket(qp);
+        }
+    }
+
     synchronized void informAndActivate(long zxid, long suggestedLeaderId) {
         QuorumPacket pkt = removeProposedPacket(zxid);
         if (pkt == null) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverZooKeeperServer.java
@@ -81,6 +81,16 @@ public class ObserverZooKeeperServer extends LearnerZooKeeperServer {
     }
 
     /**
+     * When we have a write request in the commit processor that ends up being skipped
+     * we want to process it in the order so it doesn't block all other requests
+     *
+     * @param request
+     */
+    public void skipRequest(Request request) {
+        commitProcessor.commit(request);
+    }
+
+    /**
      * Set up the request processors for an Observer:
      * firstProcesor-&gt;commitProcessor-&gt;finalProcessor
      */

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
@@ -215,4 +215,8 @@ public abstract class QuorumZooKeeperServer extends ZooKeeperServer {
         response.accept("peer_state", self.getDetailedPeerState());
     }
 
+    public static boolean isSkipTxnAvailable(int learnerProtocolVersion) {
+        return true;
+    }
+
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/SkipRequestHandler.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/SkipRequestHandler.java
@@ -1,0 +1,38 @@
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.server.Request;
+
+import java.util.List;
+
+public interface SkipRequestHandler {
+    /**
+     * This method must be called from the RP chain thread
+     * right after PrepRequestProcessor. Once it's known that
+     * the request is invalid we can skip sending PROPOSE and go directly to
+     * COMMIT but we need to wait to do that in order with the other requests.
+     *
+     * The request will be immediately sent back to the learner if there is no pending commits
+     * otherwise the request will be put inside the handler's queue to wait for pending commit
+     * to complete before is sent so we make sure we send all requests in order.
+     */
+    void skipProposing(Request request);
+
+    /**
+     * This may be called from the RP chain and Leader threads.
+     * Note that LeaderHandler and LearnerHandler process skipped requests differently.
+     *
+     * LeaderHandler modifies the CommitProcessor directly while
+     * LearnerHandler needs to send the SKIP packet over the network.
+     */
+    void processSkip(Request request);
+
+
+    /**
+     * Default method to abstract skip request processing
+     */
+    default void processSkippedRequests(List<Request> requests) {
+        for (Request request : requests) {
+            processSkip(request);
+        }
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/SkipRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/SkipRequestProcessor.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.server.Request;
+import org.apache.zookeeper.server.RequestProcessor;
+import org.apache.zookeeper.server.ServerMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SkipRequestProcessor implements RequestProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SkipRequestProcessor.class);
+    private final RequestProcessor nextProcessor;
+    private final RequestProcessor commitProcessor;
+
+    public SkipRequestProcessor(RequestProcessor nextProcessor, RequestProcessor commitProcessor) {
+        this.nextProcessor = nextProcessor;
+        this.commitProcessor = commitProcessor;
+    }
+
+    @Override
+    public void processRequest(Request request) throws RequestProcessorException {
+        if (request.isSkipped()) {
+            /**
+             * In case when the request is coming from a client that is connected to the Leader,
+             * we need to submit the request to the Leader's CommitProcessor so we can SKIP it in order
+             * and return the status back to the client.
+             *
+             * We don't need to do this when the request comes from a Follower because the request will
+             * already be submitted to their own CommitProcessor and waiting to hear COMMIT or SKIP from
+             * the Leader so it could reply the request status back to the client.
+             */
+            if (request.isFromLeader()) {
+                commitProcessor.processRequest(request);
+            }
+
+            SkipRequestHandler handler = request.getSkipRequestHandler();
+            handler.skipProposing(request);
+            ServerMetrics.getMetrics().SKIP_COUNT.add(1);
+        } else {
+            nextProcessor.processRequest(request);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        LOG.info("Shutting down");
+        nextProcessor.shutdown();
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/SkippedRequestQueue.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/SkippedRequestQueue.java
@@ -1,0 +1,78 @@
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.server.ExitCode;
+import org.apache.zookeeper.server.Request;
+import org.apache.zookeeper.server.ServerMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class SkippedRequestQueue {
+    private static final Logger LOG = LoggerFactory.getLogger(SkippedRequestQueue.class);
+
+    private final AtomicLong lastCommitted = new AtomicLong(-1);
+    private final LinkedBlockingQueue<Request> waitingRequests = new LinkedBlockingQueue<>();
+
+    /**
+     * Setter method for lastCommitted zxid
+     */
+    public void setLastCommitted(long zxid) {
+        lastCommitted.set(zxid);
+    }
+
+    public List<Request> setLastCommittedAndGet(long zxid) {
+        synchronized (this) {
+            setLastCommitted(zxid);
+            return getSkippedRequests();
+        }
+    }
+
+    /**
+     * Adds skipped request to the end of the queue that way we ensure the order.
+     * Returns all the skipped requests that are ready to be sent back to the origin,
+     * meaning if there was a COMMIT that they were waiting for
+     */
+    public List<Request> addAndGet(Request request) {
+        ServerMetrics.getMetrics().QUORUM_PEER_SKIP_QUEUE_SIZE.add(1);
+        synchronized (this) {
+            waitingRequests.add(request);
+            return getSkippedRequests();
+        }
+    }
+
+    /**
+     * This method flushed the error request queue. This method gets called from two different
+     * threads thorough skipProposing() and updateLastZxidAndGetSkippedRequests().
+     *
+     * Leader thread calls this method every time the leader processes a COMMIT in order
+     * to try to flush all the pending error requests that we short circuited.
+     *
+     * The RP chain thread will try to call this when short-circuiting requests
+     *
+     */
+    public List<Request> getSkippedRequests() {
+        List<Request> requestsToSkip = new ArrayList<>();
+        long lastZxid = lastCommitted.get();
+
+        while (!waitingRequests.isEmpty()) {
+            Request request = waitingRequests.peek();
+            if (lastZxid > request.zxid) {
+                ServerMetrics.getMetrics().QUORUM_PEER_SKIP_OUT_OF_ORDER.add(1);
+                LOG.error("Skip request is out of order!!!");
+                System.exit(ExitCode.QUORUM_PEER_SKIP_OUT_OF_ORDER.getValue());
+            }
+            if (lastZxid < request.zxid) {
+                break;
+            }
+            waitingRequests.poll();
+            requestsToSkip.add(request);
+            ServerMetrics.getMetrics().QUORUM_PEER_SKIP_SENT.add(1);
+        }
+
+        return requestsToSkip;
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerSkipErrorsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerSkipErrorsTest.java
@@ -1,0 +1,169 @@
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class QuorumPeerSkipErrorsTest extends QuorumPeerTestBase {
+    @Test
+    public void testRequestSkipConsistencyAfterLeaderElection() throws Exception {
+        LeaderZooKeeperServer.setSkipTxnEnabled(true);
+
+        numServers = 3;
+        servers = LaunchServers(numServers);
+        int leader = servers.findLeader();
+
+        // make sure there is a leader
+        assertTrue("There should be a leader", leader >= 0);
+
+        int nonleader = (leader + 1) % numServers;
+        byte[] input = new byte[1];
+        input[0] = 1;
+
+        // this will be an existing node to be used to create error txns
+        servers.zk[leader].create("/client", "client-data".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        Thread.sleep(500);
+
+        // Shutdown every one else but the leader
+        for (int i = 0; i < numServers; i++) {
+            if (i != leader) {
+                servers.mt[i].shutdown();
+            }
+        }
+        Thread.sleep(500);
+
+        // shut the leader down
+        servers.mt[leader].shutdown();
+        System.gc();
+
+        waitForAll(servers.zk, ZooKeeper.States.CONNECTING);
+
+        // Start everyone but the leader
+        for (int i = 0; i < numServers; i++) {
+            if (i != leader) {
+                servers.mt[i].start();
+            }
+        }
+
+        // wait to connect to one of these
+        waitForOne(servers.zk[nonleader], ZooKeeper.States.CONNECTED);
+
+        // start the old leader
+        servers.mt[leader].start();
+        waitForOne(servers.zk[leader], ZooKeeper.States.CONNECTED);
+
+        String mainNodePath = "/client";
+        String mainNodeData = "test-data";
+
+        // start with an error
+        try {
+            servers.zk[leader].create(mainNodePath, mainNodeData.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        } catch (KeeperException e) {
+            assertEquals("KeeperErrorCode = NodeExists for /client", e.getMessage());
+        }
+
+        // one client per server to simulate some normal load
+        // - create a new node that doest exist
+        // - try to create a node that already exists -> error transaction
+        Thread[] clients = new Thread[numServers];
+        for (int cid = 0; cid < numServers; cid++) {
+            final int id = cid;
+            clients[cid] = new Thread(() -> {
+                for (int i = 0; i < 10000; i++) {
+                    String threadNodePath = "/client-" + id + "-" + i;
+                    String threadNodeData = "test-data";
+
+                    try {
+                        // valid transaction
+                        servers.zk[id].create(threadNodePath, threadNodeData.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                        // valid read
+                        servers.zk[id].getData(threadNodePath, null, null);
+                        // invalid transaction
+                        servers.zk[id].create(mainNodePath, mainNodeData.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                    } catch (InterruptedException | KeeperException e) {
+                    }
+                }
+            });
+        }
+
+        // start the client threads
+        for (Thread client : clients) {
+            client.start();
+        }
+
+        // let the client threads finish work
+        for (Thread client : clients) {
+            client.join();
+        }
+
+        leader = servers.findLeader();
+        Leader leaderPeer = servers.mt[leader].main.quorumPeer.leader;
+        assertEquals(leaderPeer.lastCommitted, leaderPeer.lastProposed);
+        assertEquals(0, leaderPeer.zk.commitProcessor.pendingRequests.size());
+        assertEquals(0, leaderPeer.zk.commitProcessor.committedRequests.size());
+        assertEquals(0, leaderPeer.zk.commitProcessor.queuedRequests.size());
+        assertEquals(0, leaderPeer.zk.commitProcessor.queuedWriteRequests.size());
+        assertEquals(0, leaderPeer.zk.commitProcessor.numRequestsProcessing.get());
+    }
+
+    @Test
+    public void testRequestSkipConsistency() throws Exception {
+        LeaderZooKeeperServer.setSkipTxnEnabled(true);
+
+        numServers = 3;
+        servers = LaunchServers(numServers);
+        int leader = servers.findLeader();
+
+        // shared node for both client 1 and client 2
+        servers.zk[leader].create("/shared", "shared-data".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        assertEquals(new String(servers.zk[leader].getData("/shared", null, null)), "shared-data");
+
+        // znode owned by client 1
+        servers.zk[leader].create("/client-1", "client-1-data".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        assertEquals(new String(servers.zk[leader].getData("/client-1", null, null)), "client-1-data");
+
+        // znode owned by client 2
+        servers.zk[leader].create("/client-2", "client-2-data".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        assertEquals(new String(servers.zk[leader].getData("/client-2", null, null)), "client-2-data");
+
+        Thread[] clients = new Thread[numServers];
+        for (int cid = 0; cid < numServers; cid++) {
+            final int id = cid;
+            clients[cid] = new Thread(() -> {
+                for (int i = 0; i < 10000; i++) {
+                    try {
+                        String threadNodePath = "/client-" + id + "-" + i;
+                        String threadNodeData = "data-" + id + "-" + i;
+
+                        servers.zk[id].setData("/shared", threadNodeData.getBytes(), -1);
+                        servers.zk[id].create(threadNodePath, threadNodeData.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                        servers.zk[id].create(threadNodePath, threadNodeData.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                    } catch (InterruptedException | KeeperException e) {
+                    }
+                }
+            });
+        }
+
+        for (Thread client : clients) {
+            client.start();
+        }
+
+        for (Thread client : clients) {
+            client.join();
+        }
+
+        leader = servers.findLeader();
+        Leader leaderPeer = servers.mt[leader].main.quorumPeer.leader;
+        assertEquals(leaderPeer.lastCommitted, leaderPeer.lastProposed);
+        assertEquals(0, leaderPeer.zk.commitProcessor.pendingRequests.size());
+        assertEquals(0, leaderPeer.zk.commitProcessor.committedRequests.size());
+        assertEquals(0, leaderPeer.zk.commitProcessor.queuedRequests.size());
+        assertEquals(0, leaderPeer.zk.commitProcessor.queuedWriteRequests.size());
+        assertEquals(0, leaderPeer.zk.commitProcessor.numRequestsProcessing.get());
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/SkipRequestHandlerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/SkipRequestHandlerTest.java
@@ -1,0 +1,110 @@
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.server.Request;
+import org.apache.zookeeper.txn.TxnHeader;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class SkipRequestHandlerTest {
+    private static class TestSkipRequestHandler implements SkipRequestHandler {
+        boolean isSkipProcessed = false;
+        SkippedRequestQueue skippedRequestQueue = spy(new SkippedRequestQueue());
+
+        @Override
+        public void skipProposing(Request request) {
+            List<Request> requestsToSkip = skippedRequestQueue.addAndGet(request);
+            for (Request requestToSkip : requestsToSkip) {
+                processSkip(requestToSkip);
+            }
+        }
+
+        void processCommit(Request request) {
+            List<Request> requestsToSkip = skippedRequestQueue.setLastCommittedAndGet(request.zxid);
+            for (Request requestToSkip : requestsToSkip) {
+                processSkip(requestToSkip);
+            }
+        }
+
+        @Override
+        public void processSkip(Request request) {
+            isSkipProcessed = true;
+        }
+    }
+
+    @Test
+    public void testSkipProposingAndSendingRequestWithoutWaiting() throws Exception {
+        TestSkipRequestHandler handler = spy(new TestSkipRequestHandler());
+        handler.skippedRequestQueue.setLastCommitted(1);
+
+        Request request = getSampleErrorRequest();
+        request.zxid = 1;
+        handler.skipProposing(request);
+
+        verify(handler.skippedRequestQueue, times(1)).getSkippedRequests();
+        assertTrue(handler.isSkipProcessed);
+    }
+
+    @Test
+    public void testSkipProposingAndWaitingToSendRequest() throws Exception {
+        TestSkipRequestHandler handler = spy(new TestSkipRequestHandler());
+        handler.skippedRequestQueue.setLastCommitted(1);
+
+        Request request = getSampleErrorRequest();
+        request.zxid = 2;
+        handler.skipProposing(request);
+
+        verify(handler.skippedRequestQueue, times(1)).getSkippedRequests();
+        assertFalse(handler.isSkipProcessed);
+    }
+
+    @Test
+    public void testProcessCommit() throws Exception {
+        TestSkipRequestHandler handler = spy(new TestSkipRequestHandler());
+        handler.skippedRequestQueue.setLastCommitted(1);
+
+        Request errRequest = getSampleErrorRequest();
+        errRequest.zxid = 2;
+        handler.skipProposing(errRequest);
+
+        verify(handler.skippedRequestQueue, times(1)).getSkippedRequests();
+        assertFalse(handler.isSkipProcessed);
+
+        Request okRequest = getSampleRequest();
+        okRequest.zxid = 2;
+        handler.processCommit(okRequest);
+
+        assertTrue(handler.isSkipProcessed);
+    }
+
+    private Request getSampleErrorRequest() {
+        Request request = spy(new Request(null, 0, 0, ZooDefs.OpCode.delete, null, null));
+
+        request.setException(new KeeperException.NoNodeException());
+        request.setHdr(new TxnHeader());
+        request.getHdr().setType(ZooDefs.OpCode.error);
+        request.setSkipRequestHandler(mock(LearnerHandler.class));
+
+        return request;
+    }
+
+    private Request getSampleRequest() {
+        Request request = spy(new Request(null, 0, 0, ZooDefs.OpCode.delete, null, null));
+
+        request.setException(new KeeperException.NoNodeException());
+        request.setHdr(new TxnHeader());
+        request.getHdr().setType(ZooDefs.OpCode.create);
+        request.setSkipRequestHandler(mock(LearnerHandler.class));
+
+        return request;
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/SkipRequestProcessorTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/SkipRequestProcessorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server.quorum;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs.OpCode;
+import org.apache.zookeeper.server.Request;
+import org.apache.zookeeper.server.ServerCnxn;
+import org.apache.zookeeper.txn.TxnHeader;
+import org.junit.Test;
+
+public class SkipRequestProcessorTest {
+
+    private SkipRequestProcessor processor;
+
+    @Test
+    public void testProcessingValidRequests() throws Exception {
+        ProposalRequestProcessor proposalProcessor = mock(ProposalRequestProcessor.class);
+        CommitProcessor commitProcessor = mock(CommitProcessor.class);
+
+        Request request = spy(new Request(null, 0, 0, OpCode.create, null, null));
+        request.setHdr(new TxnHeader());
+
+        processor = spy(new SkipRequestProcessor(proposalProcessor, commitProcessor));
+        processor.processRequest(request);
+
+        verify(request, times(1)).isSkipped();
+        verify(proposalProcessor, times(1)).processRequest(request);
+        verify(commitProcessor, times(0)).processRequest(request);
+    }
+
+    @Test
+    public void testSkippingInvalidRequestsFromFollower() throws Exception {
+        ProposalRequestProcessor proposalProcessor = mock(ProposalRequestProcessor.class);
+        CommitProcessor commitProcessor = mock(CommitProcessor.class);
+
+        Request request = spy(new Request(null, 0, 0, OpCode.delete, null, null));
+        LearnerHandler handler = mock(LearnerHandler.class);
+
+        request.setException(new KeeperException.NoNodeException());
+        request.setHdr(new TxnHeader());
+        request.getHdr().setType(OpCode.error);
+        request.setSkipRequestHandler(handler);
+        request.setSkipped();
+
+        processor = spy(new SkipRequestProcessor(proposalProcessor, commitProcessor));
+        processor.processRequest(request);
+
+        verify(request, times(1)).isSkipped();
+        verify(handler, times(1)).skipProposing(request);
+        verify(proposalProcessor, times(0)).processRequest(request);
+    }
+
+    @Test
+    public void testSkippingInvalidRequestsFromLeader() throws Exception {
+        LeaderZooKeeperServer server = mock(LeaderZooKeeperServer.class);
+        Leader leader = mock(Leader.class);
+        leader.lastCommitted = 100;
+        when(server.getLeader()).thenReturn(leader);
+
+        ProposalRequestProcessor proposalProcessor = mock(ProposalRequestProcessor.class);
+        CommitProcessor commitProcessor = mock(CommitProcessor.class);
+
+        Request request = spy(new Request(null, 0, 0, OpCode.error, null, null));
+        LeaderHandler handler = mock(LeaderHandler.class);
+
+        request.setException(new KeeperException.NoNodeException());
+        request.setHdr(new TxnHeader());
+        request.getHdr().setType(OpCode.error);
+        request.setSkipRequestHandler(handler);
+        request.setOwner(ServerCnxn.me);
+        request.setSkipped();
+
+        processor = spy(new SkipRequestProcessor(proposalProcessor, commitProcessor));
+        processor.processRequest(request);
+
+        verify(request, times(1)).isSkipped();
+        verify(handler, times(1)).skipProposing(request);
+        verify(proposalProcessor, times(0)).processRequest(request);
+        verify(commitProcessor, times(1)).processRequest(request);
+    }
+}


### PR DESCRIPTION
Ensembles that have a high write request rate could be skipping proposing requests that contain errors instead of having the quorum vote on those transactions.

For example, having a sizable write traffic that results in error transactions would be creating additional network and log disk space overhead for each of the requests that would only return errors to the client in the end (e.g. delete non-existing path, version mismatch, trying to create a node that already exists etc). 

Currently, there is no such logic in the ProposalRequestProcessor, every request that comes out of PrepRequestProcessor will be proposed to the quorum.  

Proposed solution workflow:

A client sends a new write request trying to setData on an non-existing node
The server accepts the request and sends it through the PrepRequestProcessor
PrepRequestProcessor detects the error and assigns the error transaction to the request
Between PrepRequestProcessor and ProposalRequestProcessor there is another processor named SkipRequestProcessor which sole responsibility is to decide will the request be forwarded or returned to the originating quorum peer (Leader or Learner).
The quorum peer waits for all previous requests to complete before the error request proceeds with echoing the error back to the client.
Requirements: 

We should be conservative about the use of ZXID. If the request generates an error transaction we don't want to increment the last proposed ZXID and cause any gaps in the log.
Request that are found to be invalid should be sent directly to the origin (either to the corresponding Learner or to the Leader directly) so there is exactly one roundtrip for each request with error transaction.
All the requests must preserve its order, the changes must be backwards compatible with the Zookeeper ordering guarantees. 
 Challenges:

Skipping request without having them go through the proposal pipeline poses a challenge in preserving Zookeeper transaction order.
Avoiding any additional changes inside CommitProcessor if possible.
Have unified logic for all three different paths in which write requests can come through:
Via Leader placed directly into the PrepRequestProcessor
Via Follower where the request is forwarded to the leader and also passed to CommitProcessor to wait for COMMIT packet
Via Observer, where the request is forwarded to the Leader and the Observer waits for the INFORM packet

https://issues.apache.org/jira/browse/ZOOKEEPER-3594 