### PR TITLE
ZOOKEEPER-3056: fix documentation.

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -969,7 +969,7 @@ property, when available, is noted below.
     By default, this feautre is disabled, set "true" to enable it.
 
 * *snapshot.trust.empty* :
-    (Java system property only: **zookeeper.snapshot.trust.empty**)
+    (Java system property: **zookeeper.snapshot.trust.empty**)
     **New in 3.5.6:**
     This property controls whether or not ZooKeeper should treat missing
     snapshot files as a fatal state that can't be recovered from.


### PR DESCRIPTION
snapshot.trust.empty can be used in both zoo.cfg file (with name snapshot.trust.empty), and as a system property (with name zookeeper.snapshot.trust.empty).