### PR TITLE
ZOOKEEPER-3300 CLI "history" to show 10 commands

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -410,7 +410,7 @@ public class ZooKeeperMain {
             history.put(commandCount, history.get(i));
             processCmd(cl);
         } else if (cmd.equals("history")) {
-            for (int i = commandCount - 10; i <= commandCount; ++i) {
+            for (int i = commandCount - 9; i <= commandCount; ++i) {
                 if (i < 0) {
                     continue;
                 }


### PR DESCRIPTION
Currently CLI: "history" shows 11 previous commands used. As per the ticket [ZOOKEEPER-3300](https://issues.apache.org/jira/browse/ZOOKEEPER-3300) intended behavior is to show 10.

I saw two ways to do so which are mentioned as follows:

- Include "history" in the list of 10 previous commands used. The changes made in this PR follows this. (I have changed the initialization of "i" in loop to commandCount -9) 
- Don't include command "history" in the list of 10 previous commands. To do this change comparison part of loop to i < commandCount

Please do let me know if the change I made is preferred, there might be some other way to address this or if I have missed something else.