### PR TITLE
ZOOKEEPER-2313 Refactor ZooKeeperServerBean and its subclasses

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerBean.java
@@ -40,6 +40,12 @@ public class ZooKeeperServerBean implements ZooKeeperServerMXBean, ZKMBeanInfo {
         name = "StandaloneServer_port" + zks.getClientPort();
     }
 
+    public ZooKeeperServerBean(ZooKeeperServer zks, String name) {
+        startTime = new Date();
+        this.zks = zks;
+        this.name = name;
+    }
+
     public String getClientPort() {
         return Integer.toString(zks.getClientPort());
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerBean.java
@@ -29,12 +29,8 @@ public class FollowerBean extends ZooKeeperServerBean implements FollowerMXBean 
     private final Follower follower;
 
     public FollowerBean(Follower follower, ZooKeeperServer zks) {
-        super(zks);
+        super(zks, "FollowerServer_port" + zks.getClientPort());
         this.follower = follower;
-    }
-
-    public String getName() {
-        return "Follower";
     }
 
     public String getQuorumAddress() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderBean.java
@@ -30,12 +30,8 @@ public class LeaderBean extends ZooKeeperServerBean implements LeaderMXBean {
     private final Leader leader;
 
     public LeaderBean(Leader leader, ZooKeeperServer zks) {
-        super(zks);
+        super(zks, "LeaderServer_port" + zks.getClientPort());
         this.leader = leader;
-    }
-
-    public String getName() {
-        return "Leader";
     }
 
     public String getCurrentZxid() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Observer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Observer.java
@@ -21,7 +21,6 @@ package org.apache.zookeeper.server.quorum;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.jute.Record;
-import org.apache.zookeeper.server.ObserverBean;
 import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.ServerMetrics;
 import org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverBean.java
@@ -16,9 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.zookeeper.server;
+package org.apache.zookeeper.server.quorum;
 
 import java.net.InetSocketAddress;
+
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.apache.zookeeper.server.ZooKeeperServerBean;
 import org.apache.zookeeper.server.quorum.Observer;
 import org.apache.zookeeper.server.quorum.ObserverMXBean;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
@@ -32,12 +35,8 @@ public class ObserverBean extends ZooKeeperServerBean implements ObserverMXBean 
     private Observer observer;
 
     public ObserverBean(Observer observer, ZooKeeperServer zks) {
-        super(zks);
+        super(zks, "ObserverServer_port" + zks.getClientPort());
         this.observer = observer;
-    }
-
-    public String getName() {
-        return "Observer";
     }
 
     public int getPendingRevalidationCount() {


### PR DESCRIPTION
As per ticket [ZOOKEEPER-2313](https://issues.apache.org/jira/browse/ZOOKEEPER-2313) following changes have been made:

- Added a constructor in ZookeeperServerBean and passed required parameter from its sub-classes (FollowerBean, LeaderBean, ObserverBean). 
- getName() methods from FollowerBean, LeaderBean, ObserverBean have been removed as well.
- ObserverBean class is moved to under quorum package.

Please do let me know if any additional changes are required.