### PR TITLE
ZOOKEEPER-3649 Add a line break in ls -s CLI

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/LsCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/LsCommand.java
@@ -133,7 +133,7 @@ public class LsCommand extends CliCommand {
             }
             out.append(child);
         }
-        out.append("]");
+        out.append("]\n");
         if (stat != null) {
             new StatPrinter(out).print(stat);
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/LsCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/LsCommand.java
@@ -137,7 +137,6 @@ public class LsCommand extends CliCommand {
         if (stat != null) {
             new StatPrinter(out).print(stat);
         }
-        out.append("\n");
     }
 
 }


### PR DESCRIPTION
As per the ticket [ZOOKEEEPER-3649](https://issues.apache.org/jira/browse/ZOOKEEPER-3649) we need to add line break ls -s command.

To achieve the desired behavior I have added new line character in option.add of  LsCommand.printChildren(). Please do let me know if made changes gives us the desired behavior or if anything else needs to be changed.