### PR TITLE
ZOOKEEPER-3414 sync api throws NoNodeException when path is non-existent

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SyncCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SyncCommand.java
@@ -27,6 +27,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.Parser;
 import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.KeeperException;
 
 /**
  * sync command for cli
@@ -74,7 +75,7 @@ public class SyncCommand extends CliCommand {
             if (resultCode == 0) {
                 out.println("Sync is OK");
             } else {
-                out.println("Sync has failed. rc=" + resultCode);
+                throw new CliWrapperException(new KeeperException.NoNodeException(path));
             }
         } catch (IllegalArgumentException ex) {
             throw new MalformedPathException(ex.getMessage());


### PR DESCRIPTION
As per ticket [ZOOKEEPER-3414](https://issues.apache.org/jira/browse/ZOOKEEPER-3414) while executing sync cmd NoNodeException should be thrown when path doesn't exist. To implement this I have used CliWrapperException and KeeperException.NoNodeException in the else condition of exec() present in SyncCommand.java

Please do let me know if the changes made make sense or if I have missed something.