### PR TITLE
ZOOKEEPER-3659 Make WatchManagerFactory log more readable

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -82,6 +82,8 @@ import org.apache.zookeeper.util.ServiceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.xml.crypto.Data;
+
 /**
  * This class maintains the tree data structure. It doesn't have any networking
  * or client connection code in it so that it can be tested in a stand alone
@@ -298,8 +300,8 @@ public class DataTree {
 
         nodeDataSize.set(approximateDataSize());
         try {
-            dataWatches = WatchManagerFactory.createWatchManager();
-            childWatches = WatchManagerFactory.createWatchManager();
+            dataWatches = WatchManagerFactory.createWatchManager("datawatches");
+            childWatches = WatchManagerFactory.createWatchManager("childwatches");
         } catch (Exception e) {
             LOG.error("Unexpected exception when creating WatchManager, exiting abnormally", e);
             ServiceUtils.requestSystemExit(ExitCode.UNEXPECTED_ERROR.getValue());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/WatchManagerFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/WatchManagerFactory.java
@@ -32,14 +32,14 @@ public class WatchManagerFactory {
 
     public static final String ZOOKEEPER_WATCH_MANAGER_NAME = "zookeeper.watchManagerName";
 
-    public static IWatchManager createWatchManager() throws IOException {
+    public static IWatchManager createWatchManager(String watchers) throws IOException {
         String watchManagerName = System.getProperty(ZOOKEEPER_WATCH_MANAGER_NAME);
         if (watchManagerName == null) {
             watchManagerName = WatchManager.class.getName();
         }
         try {
             IWatchManager watchManager = (IWatchManager) Class.forName(watchManagerName).getConstructor().newInstance();
-            LOG.info("Using {} as watch manager", watchManagerName);
+            LOG.info("{} is using {} as watch manager", watchers, watchManagerName);
             return watchManager;
         } catch (Exception e) {
             IOException ioe = new IOException("Couldn't instantiate " + watchManagerName, e);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/watch/WatchManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/watch/WatchManagerTest.java
@@ -73,7 +73,7 @@ public class WatchManagerTest extends ZKTestCase {
 
     public IWatchManager getWatchManager() throws IOException {
         System.setProperty(WatchManagerFactory.ZOOKEEPER_WATCH_MANAGER_NAME, className);
-        return WatchManagerFactory.createWatchManager();
+        return WatchManagerFactory.createWatchManager(className);
     }
 
     public DumbWatcher createOrGetWatcher(int watcherId) {


### PR DESCRIPTION
According to ticket [ZOOKEEPER-3659](https://issues.apache.org/jira/browse/ZOOKEEPER-3659) we need to make WatchManagerFactory more readable. For this I have made the following changes:

- Introduce a parameter in createWatchManager
- Use the passed parameter in logger of WatchManagerFactory
- Make necessary changes in DataTree, WatchManagerFactoryTest

Please do let me know if made changes makes sense or if I missed anything else so that additional changes could be made.