### PR TITLE
ZOOKEEPER-3453: missing 'SET' in zkCli on windows

### DIFF
--- a/bin/zkCli.cmd
+++ b/bin/zkCli.cmd
@@ -17,7 +17,7 @@ REM limitations under the License.
 setlocal
 call "%~dp0zkEnv.cmd"
 
-ZOO_LOG_FILE=zookeeper-%USERNAME%-cli-%COMPUTERNAME%.log
+set ZOO_LOG_FILE=zookeeper-%USERNAME%-cli-%COMPUTERNAME%.log
 
 set ZOOMAIN=org.apache.zookeeper.ZooKeeperMain
 call %JAVA% "-Dzookeeper.log.dir=%ZOO_LOG_DIR%" "-Dzookeeper.root.logger=%ZOO_LOG4J_PROP%" "-Dzookeeper.log.file=%ZOO_LOG_FILE%" -cp "%CLASSPATH%" %ZOOMAIN% %*


### PR DESCRIPTION
line 20 lost set, it caused this error in this picture when i run zkServer.cmd.
![image](https://user-images.githubusercontent.com/25249417/71575227-2b654f00-2b27-11ea-9219-4dde54537015.png)
