### PR TITLE
ZOOKEEPER-3638: Update Jetty to 9.4.24.v20191120

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
     <mockito.version>2.27.0</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>
     <commons-cli.version>1.2</commons-cli.version>
-    <jetty.version>9.4.17.v20190418</jetty.version>
+    <jetty.version>9.4.24.v20191120</jetty.version>
     <netty.version>4.1.42.Final</netty.version>
     <jackson.version>2.9.10.1</jackson.version>
     <json.version>1.1.1</json.version>


### PR DESCRIPTION
Author: Colm O hEigeartaigh <coheigea@apache.org>

Reviewers: eolivelli@apache.org, andor@apache.org

Closes #1165 from coheigea/ZOOKEEPER-3638

(cherry picked from commit 178e8de664bed018c339108f168ae4ae4989b3b6)
Signed-off-by: Andor Molnar <andor@apache.org>