### PR TITLE
ZOOKEEPER-3677 owasp checker failing for - CVE-2019-17571 Apache Log4j 1.2 deserialization of untrusted data in SocketServer

### DIFF
--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -41,4 +41,9 @@
            this writing  -->
       <cve>CVE-2019-3826</cve>
    </suppress>
+   <suppress>
+      <!-- false positive for us, it is about log4j server in log4j-1.2.17.jar
+           ZOOKEEPER-3677 -->
+      <cve>CVE-2019-17571</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
Suppress error for CVE-2019-17571 as it does not affect us.
We are not running the log4j server.