### PR TITLE
ZOOKEEPER-2293 Log warning msg once by adding flag

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -1348,15 +1348,19 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         ServerMetrics.getMetrics().CONNECTION_REQUEST_COUNT.add(1);
 
         boolean readOnly = false;
+        boolean logWarning = false;
         try {
             readOnly = bia.readBool("readOnly");
             cnxn.isOldClient = false;
         } catch (IOException e) {
             // this is ok -- just a packet from an old client which
             // doesn't contain readOnly field
-            LOG.warn(
-                "Connection request from old client {}; will be dropped if server is in r-o mode",
-                cnxn.getRemoteSocketAddress());
+            if (!logWarning) {
+                LOG.warn(
+                        "Connection request from old client {}; will be dropped if server is in r-o mode",
+                        cnxn.getRemoteSocketAddress());
+                logWarning = true;
+            }
         }
         if (!readOnly && this instanceof ReadOnlyZooKeeperServer) {
             String msg = "Refusing session request for not-read-only client " + cnxn.getRemoteSocketAddress();


### PR DESCRIPTION
As per ticket [ZOOKEEPER-2293](https://issues.apache.org/jira/browse/ZOOKEEPER-2293) we need to log warning message just once. For this, I have introduced a boolean flag as false then after logging the message it will be set to true.

Please do let me know if made changes make sense and solves the ticket description as mentioned above.