### PR TITLE
ZOOKEEPER-2907: Logged request buffer isn't useful

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
@@ -575,9 +575,9 @@ public class FinalRequestProcessor implements RequestProcessor {
             ByteBuffer bb = request.request;
             bb.rewind();
             while (bb.hasRemaining()) {
-                sb.append(Integer.toHexString(bb.get() & 0xff));
+                sb.append(String.format("%02x", (0xff & bb.get())));
             }
-            LOG.error("Dumping request buffer: 0x{}", sb.toString());
+            LOG.error("Dumping request buffer for request type {}: 0x{}", Request.op2String(request.type), sb);
             err = Code.MARSHALLINGERROR;
         }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -927,13 +927,13 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             if (bb != null) {
                 bb.rewind();
                 while (bb.hasRemaining()) {
-                    sb.append(Integer.toHexString(bb.get() & 0xff));
+                    sb.append(String.format("%02x", (0xff & bb.get())));
                 }
             } else {
                 sb.append("request buffer is null");
             }
 
-            LOG.error("Dumping request buffer: 0x{}", sb.toString());
+            LOG.error("Dumping request buffer for request type {}: 0x{}", Request.op2String(request.type), sb);
             if (request.getHdr() != null) {
                 request.getHdr().setType(OpCode.error);
                 request.setTxn(new ErrorTxn(Code.MARSHALLINGERROR.intValue()));


### PR DESCRIPTION
As per [ZOOKEEPER-2907](https://issues.apache.org/jira/browse/ZOOKEEPER-2907), we have no padding while converting byte to hex and the request type is not part of the output. So I made the following changes:
- Used String formatter to convert byte to hex with padding.
- Added request type as part of the log message.

Please let me know if additional changes are required.