### PR TITLE
ZOOKEEPER-3703 - publish a test JAR

### DIFF
--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -294,7 +294,20 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
-    </plugins>
+	  
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>publish-test-jar</id>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+     </plugins>
   </build>
 
 </project>


### PR DESCRIPTION
It would be very helpful to Apache Curator and others if ZooKeeper published its testing code as a Maven Test JAR. Curator, for example, could use it to improve its testing server to make it easier to inject error conditions without having to have forced time delays and other hacks.

NOTE: if we move forward with gRPC (ZOOKEEPER-102) that would be in a new module and this would be required. So, might as well do it now.