### PR TITLE
ZOOKEEPER-3692: Change Java Package For TestStringUtils

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/StringUtilsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/StringUtilsTest.java
@@ -16,14 +16,13 @@
  * limitations under the License.
  */
 
-package org.apache.zookeeper.test;
+package org.apache.zookeeper.common;
 
 import static org.junit.Assert.assertEquals;
 import org.apache.zookeeper.ZKTestCase;
-import org.apache.zookeeper.common.StringUtils;
 import org.junit.Test;
 
-public class StringUtilTest extends ZKTestCase {
+public class StringUtilsTest extends ZKTestCase {
 
     @Test
     public void testStrings() {


### PR DESCRIPTION
As per [ZOOKEEPER-3692](https://issues.apache.org/jira/browse/ZOOKEEPER-3692), I moved the class StringUtilTest.java from test to common package and renamed StringUtilTest.java to StringUtilsTest.java.

Please let me know if additional changes are required.