### PR TITLE
ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
     <commons-cli.version>1.2</commons-cli.version>
     <netty.version>4.1.42.Final</netty.version>
     <jetty.version>9.4.24.v20191120</jetty.version>
-    <jackson.version>2.9.10.1</jackson.version>
+    <jackson.version>2.9.10.2</jackson.version>
     <json.version>1.1.1</json.version>
     <jline.version>2.11</jline.version>
     <snappy.version>1.1.7</snappy.version>


### PR DESCRIPTION
Latest version of jackson-databind is 2.9.10.2.

Change-Id: Id2b0f17c2dfa9a9765fd4893643007b49f06816d