### PR TITLE
ZOOKEEPER-1105: wait for server response in C client zookeeper_close - ADDENDUM

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -3269,13 +3269,13 @@ int wait_for_session_to_be_closed(zhandle_t *zh, int timeout_ms)
     }
 
 #ifndef WIN32
-    fd_s[0].fd = zh->fd->sock;
+    fd_s[0].fd = zh->fd;
     fd_s[0].events = POLLIN;
     ret = poll(fd_s, 1, timeout_ms);
 #else
     FD_ZERO(&rfds);
     FD_SET(zh->fd->sock , &rfds);
-    ret = select(zh->fd->sock + 1, &rfds, NULL, NULL, &waittime);
+    ret = select((int)(zh->fd)+1, &rfds, NULL, NULL, &waittime);
 #endif
 
     if (ret == 0){


### PR DESCRIPTION
On the branch-3.5 the socket is represented a bit differently (as the SSL support
in ZOOKEEPER-2122 was not backported to branch-3.5 yet) so we had to fix the
code to be compatible with the old branch.

I compiled the code and tested the C client with a real 3.5.5 server. When I used
the patched client, the warnings disappeared.