### PR TITLE
ZOOKEEPER-3710: [trivial bug] fix compile error in PurgeTxnTest introduced by ZOOKEEPER-3231

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/PurgeTxnTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/PurgeTxnTest.java
@@ -597,7 +597,7 @@ public class PurgeTxnTest extends ZKTestCase {
 
     private void makeValidSnapshot(File snapFile) throws IOException {
         SnapStream.setStreamMode(SnapStream.StreamMode.CHECKED);
-        CheckedOutputStream os = SnapStream.getOutputStream(snapFile);
+        CheckedOutputStream os = SnapStream.getOutputStream(snapFile, true);
         OutputArchive oa = BinaryOutputArchive.getArchive(os);
         FileHeader header = new FileHeader(FileSnap.SNAP_MAGIC, 2, 1);
         header.serialize(oa, "fileheader");
@@ -610,7 +610,7 @@ public class PurgeTxnTest extends ZKTestCase {
 
     private void makeInvalidSnapshot(File snapFile) throws IOException {
         SnapStream.setStreamMode(SnapStream.StreamMode.CHECKED);
-        OutputStream os = SnapStream.getOutputStream(snapFile);
+        OutputStream os = SnapStream.getOutputStream(snapFile, true);
         os.write(1);
         os.flush();
         os.close();


### PR DESCRIPTION
- Link to [PR-1079](https://github.com/apache/zookeeper/pull/1079#issuecomment-580275886)
- more details in the [ZOOKEEPER-3710](https://issues.apache.org/jira/browse/ZOOKEEPER-3710)