### PR TITLE
ZOOKEEPER-3715: fix Kerberos test failures for new JDK versions

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -59,7 +59,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="dependency-check-ant.version" value="5.2.4"/>
 
     <property name="commons-io.version" value="2.6"/>
-    <property name="kerby.version" value="1.1.0"/>
+    <property name="kerby.version" value="2.0.0"/>
 
     <property name="clover.version" value="4.2.1" />
 

--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
     <json.version>1.1.1</json.version>
     <jline.version>2.11</jline.version>
     <snappy.version>1.1.7</snappy.version>
-    <kerby.version>1.1.0</kerby.version>
+    <kerby.version>2.0.0</kerby.version>
     <bouncycastle.version>1.60</bouncycastle.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <spotbugsannotations.version>3.1.9</spotbugsannotations.version>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java
@@ -340,7 +340,7 @@ public class ZooKeeperSaslClient {
                     error += " Zookeeper Client will go to AUTH_FAILED state.";
                     LOG.error(error);
                     saslState = SaslState.FAILED;
-                    throw new SaslException(error);
+                    throw new SaslException(error, e);
                 }
             }
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/auth/SaslQuorumAuthLearner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/auth/SaslQuorumAuthLearner.java
@@ -211,7 +211,7 @@ public class SaslQuorumAuthLearner implements QuorumAuthLearner {
                                 + " '-Dsun.net.spi.nameservice.provider.1=dns,sun' to your server's JVMFLAGS environment.";
                     }
                     LOG.error(error);
-                    throw new SaslException(error);
+                    throw new SaslException(error, e);
                 }
             }
         } else {


### PR DESCRIPTION
Using OpenJDK 8u.242 or OpenJDK 11.0.6, we have some kerberos exceptions
when running the following, Kerberos Authentication related tests:
- QuorumKerberosAuthTest
- QuorumKerberosHostBasedAuthTest
- SaslKerberosAuthOverSSLTest

After trying this with different JDK versions, we see that the problem
seems to appear:
- between OpenJDK 8u.232 and 8u.242 for java 8
- and between 11.0.3 and 11.0.6 for java 11

There are a lot of kerberos related changes after 8u.232:
see https://hg.openjdk.java.net/jdk8u/jdk8u/jdk

I didn't really found the root cause of the issue, but the problem disappeared
after upgrading the Apache Kerby. Kerby is used only by the tests to start a local
embedded KDC server. I also checked the dependencies of the new Kerby version
and there is nothing to exclude there as far as I saw.

I also improved the logging of errors during Kerberos authentication problems by
printing out some more exceptions.