### PR TITLE
ZOOKEEPER-3719: C Client compilation issues in 3.5.7-rc

### DIFF
--- a/zookeeper-client/zookeeper-client-c/pom.xml
+++ b/zookeeper-client/zookeeper-client-c/pom.xml
@@ -80,7 +80,7 @@
         <executions>
           <execution>
             <id>autoreconf</id>
-            <phase>test-compile</phase>
+            <phase>process-sources</phase>
             <goals>
               <goal>exec</goal>
             </goals>
@@ -97,7 +97,7 @@
           </execution>
           <execution>
             <id>configure</id>
-            <phase>test-compile</phase>
+            <phase>process-sources</phase>
             <goals>
               <goal>exec</goal>
             </goals>
@@ -111,6 +111,21 @@
               <arguments>
                 <argument>--prefix=${project.build.directory}/c</argument>
                 <argument>--enable-gcov</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>build-c-client</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <workingDirectory>${project.build.directory}/c</workingDirectory>
+              <executable>make</executable>
+              <arguments>
+                <argument>clean</argument>
+                <argument>install</argument>
               </arguments>
             </configuration>
           </execution>

--- a/zookeeper-client/zookeeper-client-c/src/cli.c
+++ b/zookeeper-client/zookeeper-client-c/src/cli.c
@@ -747,7 +747,8 @@ int main(int argc, char **argv) {
                   sizeof(cmd));
           return 2;
         }
-        strncpy(cmd, argv[2]+4, sizeof(cmd));
+        strncpy(cmd, argv[2]+4, sizeof(cmd)-1);
+        cmd[sizeof(cmd)-1] = '\0';
         batchMode=1;
         fprintf(stderr,"Batch mode: %s\n",cmd);
       }else{

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -4557,7 +4557,7 @@ int zoo_add_auth(zhandle_t *zh,const char* scheme,const char* cert,
 
 static const char* format_endpoint_info(const struct sockaddr_storage* ep)
 {
-    static char buf[128] = { 0 };
+    static char buf[128+6] = { 0 };
     char addrstr[128] = { 0 };
     void *inaddr;
 #ifdef _WIN32

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -3274,7 +3274,7 @@ int wait_for_session_to_be_closed(zhandle_t *zh, int timeout_ms)
     ret = poll(fd_s, 1, timeout_ms);
 #else
     FD_ZERO(&rfds);
-    FD_SET(zh->fd->sock , &rfds);
+    FD_SET(zh->fd , &rfds);
     ret = select((int)(zh->fd)+1, &rfds, NULL, NULL, &waittime);
 #endif
 


### PR DESCRIPTION
This series fixes the following:

  * Actually build the C code in `full-build` profile:
    
    Without this, the C client is configured by Maven, but not built.
    This helps avoiding compilation errors, but has other downsides.

  * Fix Windows compilation issue:
    
    The backport of ZOOKEEPER-1105 introduced a compilation error in
    one of the `WIN32` branches of the C client code.
    
    This happened because the "socket object" does not use the same
    representation on `branch-3.5` (as it does not include the SSL
    support introduced by ZOOKEEPER-2122).

  * Fix GCC 8.3 compilation issues:
    
    `Makefile.am` uses `-Werror`, and this causes the build to fail
    with GCC 8.3, which warns about a couple possible buffer overruns.
