### PR TITLE
ZOOKEEPER-3722: make logs of ResponseCache more readable

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ResponseCache.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ResponseCache.java
@@ -39,10 +39,10 @@ public class ResponseCache {
 
     private final Map<String, Entry> cache;
 
-    public ResponseCache(int cacheSize) {
+    public ResponseCache(int cacheSize, String requestType) {
         this.cacheSize = cacheSize;
         cache = Collections.synchronizedMap(new LRUCache<>(cacheSize));
-        LOG.info("Response cache size is initialized with value {}.", cacheSize);
+        LOG.info("{} response cache size is initialized with value {}.", requestType, cacheSize);
     }
 
     public int getCacheSize() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -314,11 +314,11 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
         readResponseCache = new ResponseCache(Integer.getInteger(
             GET_DATA_RESPONSE_CACHE_SIZE,
-            ResponseCache.DEFAULT_RESPONSE_CACHE_SIZE));
+            ResponseCache.DEFAULT_RESPONSE_CACHE_SIZE), "getData");
 
         getChildrenResponseCache = new ResponseCache(Integer.getInteger(
             GET_CHILDREN_RESPONSE_CACHE_SIZE,
-            ResponseCache.DEFAULT_RESPONSE_CACHE_SIZE));
+            ResponseCache.DEFAULT_RESPONSE_CACHE_SIZE), "getChild");
 
         this.initialConfig = initialConfig;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -318,7 +318,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
         getChildrenResponseCache = new ResponseCache(Integer.getInteger(
             GET_CHILDREN_RESPONSE_CACHE_SIZE,
-            ResponseCache.DEFAULT_RESPONSE_CACHE_SIZE), "getChild");
+            ResponseCache.DEFAULT_RESPONSE_CACHE_SIZE), "getChildren");
 
         this.initialConfig = initialConfig;
 


### PR DESCRIPTION
As per [ZOOKEEPER-3722](https://issues.apache.org/jira/browse/ZOOKEEPER-3722), we need to make ResponseCache logs more readable by adding the request type to the logs. For this I made the following changes:
- Added a parameter named requestType to ResponseCache constructor.
- Passed requestType as getData and getChild when the constructor is called to initialize readResponseCache and getChildrenResponseCache respectively.

Please let me know if additional changes are required.