### PR TITLE
ZOOKEEPER-2164: Quorum members can not rejoin after restart

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/CnxManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/CnxManagerTest.java
@@ -667,6 +667,17 @@ public class CnxManagerTest extends ZKTestCase {
         }
     }
 
+    @Test
+    public void testWildcardAddressRecognition() {
+        assertTrue(QuorumCnxManager.InitialMessage.isWildcardAddress("0.0.0.0"));
+        assertTrue(QuorumCnxManager.InitialMessage.isWildcardAddress("::"));
+        assertFalse(QuorumCnxManager.InitialMessage.isWildcardAddress("some.unresolvable.host.com"));
+        assertFalse(QuorumCnxManager.InitialMessage.isWildcardAddress("127.0.0.1"));
+        assertFalse(QuorumCnxManager.InitialMessage.isWildcardAddress("255.255.255.255"));
+        assertFalse(QuorumCnxManager.InitialMessage.isWildcardAddress("1.2.3.4"));
+        assertFalse(QuorumCnxManager.InitialMessage.isWildcardAddress("www.google.com"));
+    }
+
     private String createLongString(int size) {
         StringBuilder sb = new StringBuilder(size);
         for (int i = 0; i < size; i++) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumRestartTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumRestartTest.java
@@ -123,6 +123,8 @@ public class QuorumRestartTest extends ZKTestCase {
     @After
     public void tearDown() throws Exception {
         qu.shutdownAll();
+        System.clearProperty(ZOOKEEPER_CLIENT_CNXN_SOCKET);
+        System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
     }
 
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumRestartTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumRestartTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import static org.apache.zookeeper.client.ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET;
+import static org.junit.Assert.assertTrue;
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class QuorumRestartTest extends ZKTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QuorumRestartTest.class);
+    private QuorumUtil qu;
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty(ZOOKEEPER_CLIENT_CNXN_SOCKET, "org.apache.zookeeper.ClientCnxnSocketNetty");
+        System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY, "org.apache.zookeeper.server.NettyServerCnxnFactory");
+
+        // starting a 3 node ensemble without observers
+        qu = new QuorumUtil(1, 2);
+        qu.startAll();
+    }
+
+
+    /**
+     * A basic test for rolling restart. We are restarting the ZooKeeper servers one by one,
+     * starting from the first server. We always make sure that all the nodes joined to the
+     * Quorum before moving forward.
+     * @throws Exception
+     */
+    @Test
+    public void testRollingRestart() throws Exception {
+        for (int serverToRestart = 1; serverToRestart <= 3; serverToRestart++) {
+            LOG.info("***** restarting: " + serverToRestart);
+            qu.shutdown(serverToRestart);
+
+            assertTrue(String.format("Timeout during waiting for server %d to go down", serverToRestart),
+                    ClientBase.waitForServerDown("127.0.0.1:" + qu.getPeer(serverToRestart).clientPort, ClientBase.CONNECTION_TIMEOUT));
+
+            qu.restart(serverToRestart);
+
+            final String errorMessage = "Not all the quorum members are connected after restarting server " + serverToRestart;
+            waitFor(errorMessage, () -> qu.allPeersAreConnected(), 30);
+
+            LOG.info("***** Restart {} succeeded", serverToRestart);
+        }
+    }
+
+    /**
+     * Testing one of the errors reported in ZOOKEEPER-2164, when some servers can not
+     * rejoin to the Quorum after restarting the servers backwards
+     * @throws Exception
+     */
+    @Test
+    public void testRollingRestartBackwards() throws Exception {
+        for (int serverToRestart = 3; serverToRestart >= 1; serverToRestart--) {
+            LOG.info("***** restarting: " + serverToRestart);
+            qu.shutdown(serverToRestart);
+
+            assertTrue(String.format("Timeout during waiting for server %d to go down", serverToRestart),
+                    ClientBase.waitForServerDown("127.0.0.1:" + qu.getPeer(serverToRestart).clientPort, ClientBase.CONNECTION_TIMEOUT));
+
+            qu.restart(serverToRestart);
+
+            final String errorMessage = "Not all the quorum members are connected after restarting server " + serverToRestart;
+            waitFor(errorMessage, () -> qu.allPeersAreConnected(), 30);
+
+            LOG.info("***** Restart {} succeeded", serverToRestart);
+        }
+    }
+
+
+    /**
+     * Testing one of the errors reported in ZOOKEEPER-2164, when some servers can not
+     * rejoin to the Quorum after restarting the current leader multiple times
+     * @throws Exception
+     */
+    @Test
+    public void testRestartingLeaderMultipleTimes() throws Exception {
+        for (int restartCount = 1; restartCount <= 3; restartCount++) {
+            int leaderId = qu.getLeaderServer();
+            LOG.info("***** new leader: " + leaderId);
+            qu.shutdown(leaderId);
+
+            assertTrue("Timeout during waiting for current leader to go down",
+                    ClientBase.waitForServerDown("127.0.0.1:" + qu.getPeer(leaderId).clientPort, ClientBase.CONNECTION_TIMEOUT));
+
+            String errorMessage = "No new leader was elected";
+            waitFor(errorMessage, () -> qu.leaderExists() && qu.getLeaderServer() != leaderId, 30);
+
+            qu.restart(leaderId);
+
+            errorMessage = "Not all the quorum members are connected after restarting the old leader";
+            waitFor(errorMessage, () -> qu.allPeersAreConnected(), 30);
+
+            LOG.info("***** Leader Restart {} succeeded", restartCount);
+        }
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+        qu.shutdownAll();
+    }
+
+
+
+
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumUtil.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumUtil.java
@@ -25,12 +25,14 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.server.quorum.Election;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
@@ -51,6 +53,8 @@ public class QuorumUtil {
     // TODO refactor QuorumBase to be special case of this
 
     private static final Logger LOG = LoggerFactory.getLogger(QuorumUtil.class);
+    private static final Set<QuorumPeer.ServerState> CONNECTED_STATES = new TreeSet<>(
+        Arrays.asList(QuorumPeer.ServerState.LEADING, QuorumPeer.ServerState.FOLLOWING, QuorumPeer.ServerState.OBSERVING));
 
     public static class PeerStruct {
 
@@ -97,7 +101,7 @@ public class QuorumUtil {
             N = n;
             ALL = 2 * N + 1;
             tickTime = 2000;
-            initLimit = 3;
+            initLimit = 5;
             this.syncLimit = syncLimit;
             connectToLearnerMasterLimit = 3;
             electionAlg = 3;
@@ -274,6 +278,12 @@ public class QuorumUtil {
         return "127.0.0.1:" + peer.getClientPort();
     }
 
+    public boolean allPeersAreConnected() {
+        return peers.values().stream()
+          .map(ps -> ps.peer)
+          .allMatch(peer -> CONNECTED_STATES.contains(peer.getPeerState()));
+    }
+
     public QuorumPeer getLeaderQuorumPeer() {
         for (PeerStruct ps : peers.values()) {
             if (ps.peer.leader != null) {
@@ -318,6 +328,15 @@ public class QuorumUtil {
 
         assertTrue("Leader server not found.", index > 0);
         return index;
+    }
+
+    public boolean leaderExists() {
+        for (int i = 1; i <= ALL; i++) {
+            if (getPeer(i).peer.leader != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public String getConnectionStringForServer(final int index) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumUtil.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumUtil.java
@@ -101,7 +101,7 @@ public class QuorumUtil {
             N = n;
             ALL = 2 * N + 1;
             tickTime = 2000;
-            initLimit = 5;
+            initLimit = 3;
             this.syncLimit = syncLimit;
             connectToLearnerMasterLimit = 3;
             electionAlg = 3;


### PR DESCRIPTION
Ever since ZOOKEEPER-107 (released in 3.5.0) the servers are sending
their addresses during initial connection requests. The receiving
server can potentially use these addresses to send back a new
connection request if the challenge is won by the receiver.

If the server config contains wildcard address (e.g. 0.0.0.0 in case
of IPv4) then the first connection request sent by A to B will contain
this address. If the ID of A is smaller than the ID of B, then A will
lose the challenge and the second connection request sent back by B
will never reach A, as B will send the initial message to 0.0.0.0.

So in any 3.5+ ZooKeeper, if wildcard addresses are used in the configs,
then there might be some servers never able to rejoin to the quorum
after they got restarted.

In 3.5+ for backward compatibility reasons (needed during rolling
upgrade) there is a version of the QuorumCnxManager.connectOne()
method that needs no election address but use the last known address
to initiate the connection. In this commit, we simply call this method
if the address is a wildcard address.

I also added a few restart realted tests, to make sure that restart
still works when we don't use wildcard addresses. We can not test
the original error with unit tests, as it would require to start
the quorum on multiple hosts.

I also tested the patch for rolling restart manually both with and 
without wildcard addresses in the config.