### PR TITLE
ZOOKEEPER-3723 Zookeeper Client should not fail with ZSYSTEMERROR if DNS does not resolve one of the servers in the zk ensemble

### DIFF
--- a/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestClient.cc
@@ -204,6 +204,7 @@ class Zookeeper_simpleSystem : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testAsyncWatcherAutoReset);
     CPPUNIT_TEST(testDeserializeString);
     CPPUNIT_TEST(testFirstServerDown);
+    CPPUNIT_TEST(testNonexistentHost);
 #ifdef THREADED
     CPPUNIT_TEST(testNullData);
 #ifdef ZOO_IPV6_ENABLED
@@ -326,6 +327,16 @@ public:
         zhandle_t* zk = createClient("127.0.0.1:22182,127.0.0.1:22181", &ctx);
         CPPUNIT_ASSERT(zk != 0);
         CPPUNIT_ASSERT(ctx.waitForConnected(zk));
+    }
+
+    /** Checks that a non-existent host will not block the connection **/
+    void testNonexistentHost() {
+      char hosts[] = "jimmy:5555,127.0.0.1:22181,someinvalid.host.com:1234";
+      watchctx_t ctx;
+      zoo_deterministic_conn_order(true /* disable permute */);
+      zhandle_t *zh = createClient(hosts, &ctx);
+      CPPUNIT_ASSERT(ctx.waitForConnected(zh));
+      zoo_deterministic_conn_order(false /* enable permute */);
     }
     
     /** this checks for a deadlock in calling zookeeper_close and calls from a default watcher that might get triggered just when zookeeper_close() is in progress **/


### PR DESCRIPTION
The change is backported from
Jeelani Mohamed Abdul Khader <mjeelani@devvm3360.prn2.facebook.com>'s
https://github.com/apache/zookeeper/pull/579 change done in
"ZOOKEEPER-3095: Connect string fix for non-existent hosts"

Code changes to not fail the session initiation if the DNS is not able to
resolve the hostname of one of the servers in the Zookeeper ensemble.

Some Background:
The Zookeeper client resolves all the hostnames in the ensemble while establishing the session.
In Kubernetes environment with coreDNS, the hostname entry gets removed from coreDNS during the POD restarts.
Though we can manipulate the coreDNS settings to delay the removal of the hostname entry from DNS,
we don't want to leave any race where Zookeeper client is trying to establish a session and it fails
because the DNS temporarily is not able to resolve the hostname. So as long as one of the servers
in the ensemble is able to be DNS resolvable, should we not fail the session establishment with hard error
and instead try to establish the connection with one of the other servers