### PR TITLE
ZOOKEEPER-3738: Use mavanagaiata for git commit id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ zookeeper-server/version-2/*
 # SVN
 .svn
 .revision
-git.properties
 
 # Eclipse
 .metadata

--- a/pom.xml
+++ b/pom.xml
@@ -527,11 +527,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>properties-maven-plugin</artifactId>
-          <version>1.0.0</version>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.0</version>
@@ -552,6 +547,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.1.0</version>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Implementation-Build>${mvngit.commit.id}</Implementation-Build>
+              </manifestEntries>
+            </archive>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -602,10 +604,12 @@
           <version>1.6.0</version>
         </plugin>
         <plugin>
-          <groupId>pl.project13.maven</groupId>
-          <artifactId>git-commit-id-plugin</artifactId>
-          <version>2.2.5</version>
-          <inherited>false</inherited>
+          <groupId>com.github.koraktor</groupId>
+          <artifactId>mavanagaiata</artifactId>
+          <version>0.9.4</version>
+          <configuration>
+            <skipNoGit>true</skipNoGit>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -681,33 +685,17 @@
 
     <plugins>
       <plugin>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
+        <groupId>com.github.koraktor</groupId>
+        <artifactId>mavanagaiata</artifactId>
         <executions>
           <execution>
             <id>find-current-git-revision</id>
             <goals>
-              <goal>revision</goal>
+              <goal>commit</goal>
             </goals>
-            <phase>generate-resources</phase>
+            <phase>validate</phase>
           </execution>
         </executions>
-        <configuration>
-          <skipPoms>false</skipPoms>
-          <runOnlyOnce>true</runOnlyOnce>
-          <failOnNoGitDirectory>false</failOnNoGitDirectory>
-          <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-          <prefix>git</prefix>
-          <verbose>false</verbose>
-          <generateGitPropertiesFile>true</generateGitPropertiesFile>
-          <generateGitPropertiesFilename>${project.basedir}/zookeeper-server/src/main/resources/git.properties</generateGitPropertiesFilename>
-          <format>properties</format>
-          <gitDescribe>
-            <skip>false</skip>
-            <always>false</always>
-            <dirty>-dirty</dirty>
-          </gitDescribe>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.openclover</groupId>
@@ -848,7 +836,6 @@
           <excludes>
             <exclude>**/log4j.properties</exclude>
             <exclude>**/README.md</exclude>
-            <exclude>**/git.properties</exclude>
             <exclude>**/findbugsExcludeFile.xml</exclude>
             <exclude>**/checkstyle-noframes-sorted.xsl</exclude>
             <exclude>**/configure.ac</exclude>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -166,23 +166,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>initialize</phase>
-            <goals>
-              <goal>read-project-properties</goal>
-            </goals>
-            <configuration>
-              <files>
-                <file>${basedir}/src/main/resources/git.properties</file>
-              </files>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin> <!-- ${maven.build.timestamp} does not support timezone :( -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -248,7 +231,7 @@
                 <classpath />
                 <argument>org.apache.zookeeper.version.util.VerGen</argument>
                 <argument>${project.version}</argument>
-                <argument>${git.commit.id}</argument>
+                <argument>${mvngit.commit.id}</argument>
                 <argument>${build.time}</argument>
                 <argument>${project.basedir}/target/generated-sources/java</argument>
               </arguments>


### PR DESCRIPTION
Use mavanagaiata plugin to get git commit id for VerGen instead of
properties-maven-plugin (which is broken in some environments).

Also add the commit to the jar manifests for easy reference when given a
jar of unknown origin (especially useful for SNAPSHOT builds).