### PR TITLE
ZOOKEEPER-3741: fix buffer length in C client causing warning with new gcc

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -4956,7 +4956,7 @@ int zoo_add_auth(zhandle_t *zh,const char* scheme,const char* cert,
 
 static const char* format_endpoint_info(const struct sockaddr_storage* ep)
 {
-    static char buf[128] = { 0 };
+    static char buf[134] = { 0 };
     char addrstr[INET6_ADDRSTRLEN] = { 0 };
     const char *fmtstring;
     void *inaddr;


### PR DESCRIPTION
We get a warning that we are trying to call like `sprintf(buf,"%s:%d",addrstr,port);`, and both `buf` and `addrstr` are 128 long char arrays. So in theory, we can overflow. The fix is to increase the length of the destination string array (`buf`).

Actually this problem only causing compile time warning / failure only on the 3.5.5 and 3.5.6. On 3.5.7 this was fixed and on 3.6+ branches the compiler can not detect the problem due to some code refactoring made by ZOOKEEPER-3068, but the issue is still present on the master branch.