### PR TITLE
Zookeeper-3735: fix the bad format of RATE_LOGGER

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -1818,8 +1818,8 @@ public class DataTree {
         }
         // do not compare digest if there is digest version change
         if (digestCalculator.getDigestVersion() != digest.getVersion()) {
-            RATE_LOGGER.rateLimitLog("Digest version not the same on zxid.",
-                    String.valueOf(zxid));
+            RATE_LOGGER.rateLimitLog("Digest version not the same on Zxid",
+                    "0x" + Long.toHexString(zxid));
             return true;
         }
 
@@ -1849,7 +1849,8 @@ public class DataTree {
      */
     public void reportDigestMismatch(long zxid) {
         ServerMetrics.getMetrics().DIGEST_MISMATCHES_COUNT.add(1);
-        RATE_LOGGER.rateLimitLog("Digests are not matching. Value is Zxid.", String.valueOf(zxid));
+        RATE_LOGGER.rateLimitLog("Digests are not matching. Zxid",
+                "0x" + Long.toHexString(zxid));
 
         for (DigestWatcher watcher : digestWatchers) {
             watcher.process(zxid);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -1790,8 +1790,8 @@ public class DataTree {
             }
             digestFromLoadedSnapshot = null;
         } else if (digestFromLoadedSnapshot.zxid != 0 && zxid > digestFromLoadedSnapshot.zxid) {
-            RATE_LOGGER.rateLimitLog("A txn of snapshot digest does not exist.",
-                    "Txn 0x" + Long.toHexString(digestFromLoadedSnapshot.zxid));
+            RATE_LOGGER.rateLimitLog("Txn of snapshot digest does not exist for value.",
+                    "0x" + Long.toHexString(digestFromLoadedSnapshot.zxid));
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -1790,8 +1790,8 @@ public class DataTree {
             }
             digestFromLoadedSnapshot = null;
         } else if (digestFromLoadedSnapshot.zxid != 0 && zxid > digestFromLoadedSnapshot.zxid) {
-            RATE_LOGGER.rateLimitLog("The txn 0x{} of snapshot digest does not "
-                    + "exist.", Long.toHexString(digestFromLoadedSnapshot.zxid));
+            RATE_LOGGER.rateLimitLog("A txn of snapshot digest does not exist.",
+                    "Txn 0x" + Long.toHexString(digestFromLoadedSnapshot.zxid));
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/RateLogger.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/RateLogger.java
@@ -51,7 +51,7 @@ public class RateLogger {
             }
             log += "Message: " + msg;
             if (value != null) {
-                log += " Last value:" + value;
+                log += ", Last value: " + value;
             }
             LOG.warn(log);
         }
@@ -65,14 +65,29 @@ public class RateLogger {
     }
 
     /**
-     * In addition to the message, it also takes a value.
+     * Any new message is logged once to the underlying logger.
+     *
+     *
+     * If subsequent messages remain the same as the previous
+     * they are not logged unless a specified time interval has elapsed.
+     * A subsequent message that is different to the previous also logs the
+     * previous message.
+     * At any time the current message can be logged using {@link #flush()}.
+     * <p>
+     * Messages are written to log with format '
+     *
+     *
+     * @param newMsg the message to log;
+     * @param value the value provided while logging the message
+     *                     message value; Optional
      */
     public void rateLimitLog(String newMsg, String value) {
         long now = Time.currentElapsedTime();
         if (newMsg.equals(msg)) {
             ++count;
-            this.value = value;
+            this.value = value;  // should this go in an else block?
             if (now - timestamp >= LOG_INTERVAL) {
+                // log previous message and value
                 flush();
                 msg = newMsg;
                 timestamp = now;
@@ -83,7 +98,12 @@ public class RateLogger {
             msg = newMsg;
             this.value = value;
             timestamp = now;
-            LOG.warn("Message:{} Value:{}", msg, value);
+            // initially log message once, optionally with value.
+            if (null == value) {
+                LOG.warn("Message: {}", msg);
+            } else {
+                LOG.warn("Message: {}, Value: {}", msg, value);
+            }
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/RateLogger.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/RateLogger.java
@@ -100,7 +100,7 @@ public class RateLogger {
      * @param value the value to log with the message; Optional
      */
     public void rateLimitLog(String newMsg, String value) {
-        long now = Time.currentElapsedTime();
+        long now = getCurrentElapsedTime();
         if (newMsg.equals(msg)) {
             if (now - timestamp >= LOG_INTERVAL) {
                 // log previous message and value
@@ -125,5 +125,13 @@ public class RateLogger {
                 LOG.warn("Message: {} Value: {}", msg, value);
             }
         }
+    }
+
+    /**
+     * Gets the current system time.
+     */
+    // package access for unit testing
+    long getCurrentElapsedTime() {
+        return Time.currentElapsedTime();
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/RateLogger.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/RateLogger.java
@@ -80,7 +80,7 @@ public class RateLogger {
             }
             log += "Message: " + msg;
             if (value != null) {
-                log += ", Last value: " + value;
+                log += " Last value: " + value;
             }
             LOG.warn(log);
         }
@@ -122,7 +122,7 @@ public class RateLogger {
             if (null == value) {
                 LOG.warn("Message: {}", msg);
             } else {
-                LOG.warn("Message: {}, Value: {}", msg, value);
+                LOG.warn("Message: {} Value: {}", msg, value);
             }
         }
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/RateLogger.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/RateLogger.java
@@ -29,13 +29,12 @@ import org.slf4j.Logger;
  * <p> All messages are logged at the WARN level.</p>
  *
  * <p> Single Logged messages have format:
- * {@literal 'Message: <provided-message>,
- * Value: <provided-value>'}</p>
+ * {@literal 'Message: <provided-message> Value: <provided-value>'}</p>
  *
  * <p> Multiple instances of the same message are logged with format:
- * {@literal '[<n> times] Message: <provided-message>,
- * Last value: <last-provided-value>'}</p>
- *
+ * {@literal
+ * '[<n> times] Message: <provided-message> Last value: <last-provided-value>'}
+ * </p>
  * <p>Value is optional and is omitted from the logged message when
  * not provided.</p>
  */
@@ -44,7 +43,7 @@ public class RateLogger {
     private final long LOG_INTERVAL; // Duration is in ms
 
     /**
-     * Log received messages at a default interval of 100 milliseconds.
+     * Log any received messages at a default interval of 100 milliseconds.
      *
      * @param log the {@link Logger} to write messages to
      */
@@ -53,7 +52,7 @@ public class RateLogger {
     }
 
     /**
-     * Log received messages according to a specified interval.
+     * Log any received messages according to a specified interval.
      *
      * @param log the {@link Logger} to write messages to
      * @param interval the minimal interval at which messages are written
@@ -70,7 +69,7 @@ public class RateLogger {
     private String value = null;
 
     /**
-     * Explictly write any message(s) received to the underlying log.
+     * Write any held message to the underlying log.
      */
     public void flush() {
         if (msg != null && count > 0) {
@@ -94,7 +93,8 @@ public class RateLogger {
     }
 
     /**
-     * Write the message to the log with a value.
+     * Writes a message to the underlying log with an
+     * optional value.
      * @see RateLogger
      * @param newMsg the message to log;
      * @param value the value to log with the message; Optional

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/RateLoggerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/RateLoggerTest.java
@@ -72,25 +72,25 @@ public class RateLoggerTest {
     @Test
     public void singleMessageWithValueExplicitFlush() {
         RateLogger rateLogger = new RateLogger(LOGGER, 5 * 1000L);
-        rateLogger.rateLimitLog("test message", "testValue");
+        rateLogger.rateLimitLog("test message.", "testValue");
         rateLogger.flush();
         assertThat(testAppender.messages,
-                contains("Message: test message, Value: testValue"));
+                contains("Message: test message. Value: testValue"));
     }
 
     /** Verify that a repeated message and value is not logged until flushed. */
     @Test
     public void recurringMessageWithValueExplicitFlush() {
         RateLogger rateLogger = new RateLogger(LOGGER, 5 * 1000L);
-        rateLogger.rateLimitLog("test message", "value-one");
-        rateLogger.rateLimitLog("test message", "value-two");
+        rateLogger.rateLimitLog("test message.", "value-one");
+        rateLogger.rateLimitLog("test message.", "value-two");
         assertThat(testAppender.messages,
-                contains("Message: test message, Value: value-one"));
+                contains("Message: test message. Value: value-one"));
         // flush logs second message
         rateLogger.flush();
         assertThat(testAppender.messages,
-                contains("Message: test message, Value: value-one",
-                        "Message: test message, Last value: value-two"));
+                contains("Message: test message. Value: value-one",
+                        "Message: test message. Last value: value-two"));
     }
 
     /** Verify that a message change writes the previous message. */
@@ -110,13 +110,13 @@ public class RateLoggerTest {
     @Test
     public void recurringMessageWithValueImplicitFlush() {
         RateLogger rateLogger = new RateLogger(LOGGER, 5 * 1000L);
-        rateLogger.rateLimitLog("test message one", "value-one");
-        rateLogger.rateLimitLog("test message one", "value-two");
-        rateLogger.rateLimitLog("test message one", "value-three");
+        rateLogger.rateLimitLog("test message one.", "value-one");
+        rateLogger.rateLimitLog("test message one.", "value-two");
+        rateLogger.rateLimitLog("test message one.", "value-three");
         rateLogger.flush();
         assertThat(testAppender.messages,
-                contains("Message: test message one, Value: value-one",
-                        "[2 times] Message: test message one, Last value: value-three"));
+                contains("Message: test message one. Value: value-one",
+                        "[2 times] Message: test message one. Last value: value-three"));
     }
 
     /** Verify the a message written after the rate interval logs the previous message. */
@@ -124,23 +124,23 @@ public class RateLoggerTest {
     public void recurringMessageTimedImplicitFlush() throws InterruptedException {
         long rateLogInterval = 500L;
         RateLogger rateLogger = new RateLogger(LOGGER, rateLogInterval);
-        rateLogger.rateLimitLog("test message one", "value-one");
-        rateLogger.rateLimitLog("test message one", "value-two");
-        rateLogger.rateLimitLog("test message one", "value-three");
+        rateLogger.rateLimitLog("test message one.", "value-one");
+        rateLogger.rateLimitLog("test message one.", "value-two");
+        rateLogger.rateLimitLog("test message one.", "value-three");
         Thread.sleep(2 * rateLogInterval);
         // implicit flush
-        rateLogger.rateLimitLog("test message one", "value-four");
+        rateLogger.rateLimitLog("test message one.", "value-four");
 
         assertThat(testAppender.messages,
-                contains("Message: test message one, Value: value-one",
-                        "[2 times] Message: test message one, Last value: value-three"));
+                contains("Message: test message one. Value: value-one",
+                        "[2 times] Message: test message one. Last value: value-three"));
 
         // explicit flush writes last message
         rateLogger.flush();
         assertThat(testAppender.messages,
-                contains("Message: test message one, Value: value-one",
-                        "[2 times] Message: test message one, Last value: value-three",
-                        "Message: test message one, Last value: value-four"));
+                contains("Message: test message one. Value: value-one",
+                        "[2 times] Message: test message one. Last value: value-three",
+                        "Message: test message one. Last value: value-four"));
     }
 }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/RateLoggerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/RateLoggerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server;
+
+import org.apache.log4j.*;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+
+/**
+ * Unit tests for {@link RateLogger}.
+ */
+public class RateLoggerTest {
+
+    /**
+     * The underlying logger that is passed into {@code RateLogger} instance under test.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(RateLoggerTest.class);
+
+    /**
+     * The log4j appender for capturing messages logged using the {@code RateLogger}.
+     */
+    private static TestAppender testAppender = null;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        testAppender = new TestAppender();
+        org.apache.log4j.Logger logger =
+                org.apache.log4j.Logger.getLogger(RateLoggerTest.class);
+        logger.setAdditivity(false);
+        logger.addAppender(testAppender);
+    }
+
+    @Before
+    public void setUpBefore() {
+        testAppender.messages.clear();
+    }
+
+    /** Verify that a single message is logged. */
+    @Test
+    public void singleMessageExplicitFlush() {
+        RateLogger rateLogger = new RateLogger(LOGGER, 5 * 1000L);
+        rateLogger.rateLimitLog("test message");
+        assertThat(testAppender.messages,
+                contains("Message: test message"));
+    }
+
+    /** Verify that a single message with value is logged. */
+    @Test
+    public void singleMessageWithValueExplicitFlush() {
+        RateLogger rateLogger = new RateLogger(LOGGER, 5 * 1000L);
+        rateLogger.rateLimitLog("test message", "testValue");
+        rateLogger.flush();
+        assertThat(testAppender.messages,
+                contains("Message: test message, Value: testValue"));
+    }
+
+    /** Verify that a repeated message and value is not logged until flushed. */
+    @Test
+    public void recurringMessageWithValueExplicitFlush() {
+        RateLogger rateLogger = new RateLogger(LOGGER, 5 * 1000L);
+        rateLogger.rateLimitLog("test message", "value-one");
+        rateLogger.rateLimitLog("test message", "value-two");
+        assertThat(testAppender.messages,
+                contains("Message: test message, Value: value-one"));
+        // flush logs second message
+        rateLogger.flush();
+        assertThat(testAppender.messages,
+                contains("Message: test message, Value: value-one",
+                        "Message: test message, Last value: value-two"));
+    }
+
+    /** Verify that a message change writes the previous message. */
+    @Test
+    public void messageChangeImplicitFlush() {
+        RateLogger rateLogger = new RateLogger(LOGGER, 5 * 1000L);
+        rateLogger.rateLimitLog("test message one");
+        rateLogger.rateLimitLog("test message one");
+        rateLogger.rateLimitLog("test message two");
+        assertThat(testAppender.messages,
+                contains("Message: test message one",
+                         "Message: test message one",
+                         "Message: test message two"));
+    }
+
+    /** Verify that a count is included for more than one message and value. */
+    @Test
+    public void recurringMessageWithValueImplicitFlush() {
+        RateLogger rateLogger = new RateLogger(LOGGER, 5 * 1000L);
+        rateLogger.rateLimitLog("test message one", "value-one");
+        rateLogger.rateLimitLog("test message one", "value-two");
+        rateLogger.rateLimitLog("test message one", "value-three");
+        rateLogger.flush();
+        assertThat(testAppender.messages,
+                contains("Message: test message one, Value: value-one",
+                        "[2 times] Message: test message one, Last value: value-three"));
+    }
+
+    /** Verify the a message written after the rate interval logs the previous message. */
+    @Test
+    public void recurringMessageTimedImplicitFlush() throws InterruptedException {
+        long rateLogInterval = 500L;
+        RateLogger rateLogger = new RateLogger(LOGGER, rateLogInterval);
+        rateLogger.rateLimitLog("test message one", "value-one");
+        rateLogger.rateLimitLog("test message one", "value-two");
+        rateLogger.rateLimitLog("test message one", "value-three");
+        Thread.sleep(2 * rateLogInterval);
+        // same message after rate interval triggers implicit flush
+        rateLogger.rateLimitLog("test message one", "value-four");
+
+        testAppender.messages.forEach(a-> System.out.println(a));
+        //        assertThat(testAppender.messages,
+//                contains("Message: test message one, Value: value-one",
+//                        "[3 times] Message: test message one, Last value: value-four"));
+
+        // TODO
+        rateLogger.flush();
+        testAppender.messages.forEach(a-> System.out.println(a));
+    }
+}
+
+/**
+ * A Log4j appender that saves logged messages to a {@code List}.
+ */
+class TestAppender extends AppenderSkeleton {
+    public List<String> messages = new ArrayList<>();
+    @Override
+    public void append(LoggingEvent event) {
+        messages.add( event.getMessage().toString() );
+    }
+    @Override
+    public void close() {
+        // intentionally does nothing
+    }
+    @Override
+    public boolean requiresLayout() {
+        return false;
+    }
+}


### PR DESCRIPTION
The message written to the Rate-logger was modified to conform with the way the Rate-logger composes messages it writes to the underlying logger.  

RateLogger updates:
1. Added Javadoc and Unit-tests.
2. Updated code to omit logging the value when none is provided, and to prevent a previously logged value from being re-written after a flush. 



![image](https://user-images.githubusercontent.com/653157/75764424-b1f61100-5da2-11ea-9b58-42387f727cf5.png)


