### PR TITLE
ZOOKEEPER-3497:Change MBeanRegistry to a standard singleton

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/jmx/MBeanRegistry.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/jmx/MBeanRegistry.java
@@ -43,7 +43,6 @@ public class MBeanRegistry {
     public static final String DOMAIN = "org.apache.ZooKeeperService";
 
     private static final Logger LOG = LoggerFactory.getLogger(MBeanRegistry.class);
-    private static volatile MBeanRegistry instance = new MBeanRegistry();
 
     private final Object LOCK = new Object();
 
@@ -51,20 +50,19 @@ public class MBeanRegistry {
 
     private MBeanServer mBeanServer;
 
+    private static class MBeanRegistryHolder {
+        private static final MBeanRegistry INSTANCE = new MBeanRegistry();
+    }
+
     /**
-     * Useful for unit tests. Change the MBeanRegistry instance
-     *
-     * @param instance new instance
+     * Return the global singleton instance for the MBeanRegistry.
+     * @return MBeanRegistry implementation.
      */
-    public static void setInstance(MBeanRegistry instance) {
-        MBeanRegistry.instance = instance;
-    }
-
     public static MBeanRegistry getInstance() {
-        return instance;
+        return MBeanRegistryHolder.INSTANCE;
     }
 
-    public MBeanRegistry() {
+    private MBeanRegistry() {
         try {
             mBeanServer = ManagementFactory.getPlatformMBeanServer();
         } catch (Error e) {


### PR DESCRIPTION
As the [ZOOKEEPER-3497](https://issues.apache.org/jira/browse/ZOOKEEPER-3497) discuss, the MBeanRegistry is a singleton, so i change the constructor of MBeanRegistry to private method.
I would like to hear any feedback, please help review and let me know if additional changes are required.