### PR TITLE
ZOOKEEPER-3748. Resolve release requirements in download page

### DIFF
--- a/src/main/resources/markdown/releases.md
+++ b/src/main/resources/markdown/releases.md
@@ -49,7 +49,7 @@ Older releases are available.
 <a name="verifying"></a>
 ## Verifying Hashes and Signatures
 
-You can verify the integrity of a downloaded release using any of these release-signing [KEYS](https://www.apache.org/dist/zookeeper/KEYS). For additional information, refer to the Apache documentation for [verifying the integrity of Apache project releases](http://www.apache.org/info/verification.html).
+You can verify the integrity of a downloaded release using any of these release-signing [KEYS](https://www.apache.org/dist/zookeeper/KEYS). For additional information, refer to the Apache documentation for [verifying the integrity of Apache project releases](https://www.apache.org/info/verification.html).
 
 <a name="releasenotes"></a>
 ## Release Notes

--- a/src/main/resources/markdown/releases.md
+++ b/src/main/resources/markdown/releases.md
@@ -49,7 +49,7 @@ Older releases are available.
 <a name="verifying"></a>
 ## Verifying Hashes and Signatures
 
-You can verify the integrity of a downloaded release using any of these release-signing [KEYS](https://www.apache.org/dist/zookeeper/KEYS). For additional information, refer to the Apache documentation for [verifying the integrity of Apache project releases](https://www.apache.org/info/verification.html).
+You can verify the integrity of a downloaded release using release-signing [KEYS](https://www.apache.org/dist/zookeeper/KEYS). For additional information, refer to the Apache documentation for [verifying the integrity of Apache project releases](https://www.apache.org/info/verification.html).
 
 <a name="releasenotes"></a>
 ## Release Notes

--- a/src/main/resources/markdown/releases.md
+++ b/src/main/resources/markdown/releases.md
@@ -17,6 +17,7 @@ limitations under the License.
 The Apache ZooKeeper system for distributed coordination is a high-performance service for building distributed applications.
 
 * [Download](#download)
+* [Verifying Hashes and Signatures](#verifying)
 * [Release Notes](#releasenotes)
 * [News](#news)
 
@@ -27,11 +28,9 @@ Apache ZooKeeper 3.6.0 is our latest stable release.
 
 ### Apache ZooKeeper 3.6.0
 
-[Apache ZooKeeper 3.6.0](https://downloads.apache.org/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0-bin.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0-bin.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0-bin.tar.gz.sha512))
+[Apache ZooKeeper 3.6.0](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0-bin.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0-bin.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0-bin.tar.gz.sha512))
 
-[Apache ZooKeeper 3.6.0 Source Release](https://downloads.apache.org/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0.tar.gz.sha512))
-
-You can verify the integrity of a downloaded release using the PGP signatures and hashes (MD5 or SHA1) hosted at the main [Apache distro site](https://apache.org/dist/zookeeper/).  For additional information, refer to the Apache documentation for [verifying the integrity of Apache project releases](https://www.apache.org/dyn/closer.cgi#verify).
+[Apache ZooKeeper 3.6.0 Source Release](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0.tar.gz.sha512))
 
 ---
 
@@ -39,15 +38,18 @@ Older releases are available.
 
 ### Apache ZooKeeper 3.5.7
 
-[Apache ZooKeeper 3.5.7](https://downloads.apache.org/zookeeper/zookeeper-3.5.7/apache-zookeeper-3.5.7-bin.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.5.7/apache-zookeeper-3.5.7-bin.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.5.7/apache-zookeeper-3.5.7-bin.tar.gz.sha512))
+[Apache ZooKeeper 3.5.7](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.5.7/apache-zookeeper-3.5.7-bin.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.5.7/apache-zookeeper-3.5.7-bin.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.5.7/apache-zookeeper-3.5.7-bin.tar.gz.sha512))
 
-[Apache ZooKeeper 3.5.7 Source Release](https://downloads.apache.org/zookeeper/zookeeper-3.5.7/apache-zookeeper-3.5.7.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.5.7/apache-zookeeper-3.5.7.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.5.7/apache-zookeeper-3.5.7.tar.gz.sha512))
+[Apache ZooKeeper 3.5.7 Source Release](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.5.7/apache-zookeeper-3.5.7.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.5.7/apache-zookeeper-3.5.7.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.5.7/apache-zookeeper-3.5.7.tar.gz.sha512))
 
 ### Apache ZooKeeper 3.4.14
 
-[Apache ZooKeeper 3.4.14](https://downloads.apache.org/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz.asc), [sha256](https://downloads.apache.org/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz.sha256), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz.sha512))
+[Apache ZooKeeper 3.4.14](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz.asc), [sha256](https://downloads.apache.org/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz.sha256), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz.sha512))
 
-You can verify the integrity of a downloaded release using the PGP signatures and hashes (MD5 or SHA1) hosted at the main [Apache distro site](https://apache.org/dist/zookeeper/).  For additional information, refer to the Apache documentation for [verifying the integrity of Apache project releases](https://www.apache.org/dyn/closer.cgi#verify).
+<a name="verifying"></a>
+## Verifying Hashes and Signatures
+
+You can verify the integrity of a downloaded release using any of these release-signing [KEYS](https://www.apache.org/dist/zookeeper/KEYS). For additional information, refer to the Apache documentation for [verifying the integrity of Apache project releases](http://www.apache.org/info/verification.html).
 
 <a name="releasenotes"></a>
 ## Release Notes

--- a/src/main/resources/markdown/releases.md
+++ b/src/main/resources/markdown/releases.md
@@ -49,7 +49,7 @@ Older releases are available.
 <a name="verifying"></a>
 ## Verifying Hashes and Signatures
 
-You can verify the integrity of a downloaded release using release-signing [KEYS](https://www.apache.org/dist/zookeeper/KEYS). For additional information, refer to the Apache documentation for [verifying the integrity of Apache project releases](https://www.apache.org/info/verification.html).
+You can verify the integrity of a downloaded release using release-signing [KEYS](https://downloads.apache.org/zookeeper/KEYS). For additional information, refer to the Apache documentation for [verifying the integrity of Apache project releases](https://www.apache.org/info/verification.html).
 
 <a name="releasenotes"></a>
 ## Release Notes
@@ -291,5 +291,4 @@ See the ZooKeeper 3.0.1 Release Notes for details. Alternatively, you can look a
 This release contains many improvements, new features, bug fixes and optimizations.
 
 See the ZooKeeper 3.0.0 Release Notes for details. Alternatively, you can look at the [Jira](https://issues.apache.org/jira/browse/ZOOKEEPER?report=com.atlassian.jira.plugin.system.project:changelog-panel) issue log for all releases.
-
 


### PR DESCRIPTION
1. Add direct link to KEYS
2. Use mirror system to link to release artifact

It would be helpful if we could invite a release manager to verify the change that avoids further reworking.