### PR TITLE
ZOOKEEPER-3760: remove a useless throwing CliException

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -289,7 +289,7 @@ public class ZooKeeperMain {
         zk = new ZooKeeperAdmin(host, Integer.parseInt(cl.getOption("timeout")), new MyWatcher(), readOnly);
     }
 
-    public static void main(String[] args) throws CliException, IOException, InterruptedException {
+    public static void main(String[] args) throws IOException, InterruptedException {
         ZooKeeperMain main = new ZooKeeperMain(args);
         main.run();
     }
@@ -304,7 +304,7 @@ public class ZooKeeperMain {
         this.zk = zk;
     }
 
-    void run() throws CliException, IOException, InterruptedException {
+    void run() throws IOException, InterruptedException {
         if (cl.getCommand() == null) {
             System.out.println("Welcome to ZooKeeper!");
 
@@ -353,7 +353,7 @@ public class ZooKeeperMain {
         ServiceUtils.requestSystemExit(exitCode);
     }
 
-    public void executeLine(String line) throws CliException, InterruptedException, IOException {
+    public void executeLine(String line) throws InterruptedException, IOException {
         if (!line.equals("")) {
             cl.parseCommand(line);
             addToHistory(commandCount, line);
@@ -362,7 +362,7 @@ public class ZooKeeperMain {
         }
     }
 
-    protected boolean processCmd(MyCommandOptions co) throws CliException, IOException, InterruptedException {
+    protected boolean processCmd(MyCommandOptions co) throws IOException, InterruptedException {
         boolean watch = false;
         try {
             watch = processZKCmd(co);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZOOKEEPER-3760

When I upgrade zookeeper from 3.4.13 to 3.5.7 in my application, I find the function processCmd in ZooKeeperMain.java throws a CliException which has been caught in the function. So I think it can be removed