### PR TITLE
ZOOKEEPER-3765: Use https everywhere possible

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,7 +1,7 @@
 # Apache ZooKeeper
-Copyright 2009-2018 The Apache Software Foundation
+Copyright 2009-2020 The Apache Software Foundation
 
-This product includes software developed at The Apache Software Foundation [http://www.apache.org/](http://www.apache.org/).
+This product includes software developed at The Apache Software Foundation [https://www.apache.org/](https://www.apache.org/).
 
 ---
 # Bootstrap

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 In the `src/main/resources/markdown` directory you will find text files formatted using Markdown, with an `.md` suffix.
 
-Building the site requires [Maven](http://maven.apache.org/) 3.5.0 or newer. 
-The easiest way to [install Maven](http://maven.apache.org/install.html) depends on your OS.
+Building the site requires [Maven](https://maven.apache.org/) 3.5.0 or newer.
+The easiest way to [install Maven](https://maven.apache.org/install.html) depends on your OS.
 The build process will create a directory called `target/html` containing `index.html` as well as the rest of the
 compiled directories and files. `target` should not be committed to git as it is generated content.
 
@@ -17,7 +17,7 @@ production website.
 
 ## Docs sub-dir
 
-The product documentation creation is not part of the website generation process. They are built separately for each release 
+The product documentation creation is not part of the website generation process. They are built separately for each release
 of ZooKeeper from the ZooKeeper source repository.
 
 Typically during a release the versioned documentation will be recreated and should be copied, and committed,

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <!--
     /**
      * Licensed to the Apache Software Foundation (ASF) under one

--- a/src/main/resources/.htaccess
+++ b/src/main/resources/.htaccess
@@ -1,8 +1,12 @@
 # .htaccess for ZooKeeper
 #
+# Redirect HTTP to HTTPS
+RewriteEngine On
+RewriteCond %{HTTPS} !=on
+RewriteRule .* https://%{SERVER_NAME}%{REQUEST_URI} [R,L]
 # Old site had /docs while new site has /doc
 RedirectMatch Permanent ^/docs/(.+)$ /doc/$1
 # Old site had /mailing_lists.html while new site has /lists.html
 RedirectMatch Permanent ^/mailing_lists.html$ /lists.html
 # redirect bookkeeper site
-RedirectMatch Permanent ^/bookkeeper/(.+)$ http://bookkeeper.apache.org/$1
+RedirectMatch Permanent ^/bookkeeper/(.+)$ https://bookkeeper.apache.org/$1

--- a/src/main/resources/markdown/html/header.html
+++ b/src/main/resources/markdown/html/header.html
@@ -66,16 +66,12 @@
 					ASF
 				</a>
 				<div class="dropdown-menu" aria-labelledby="navbarDropdown">
-					<a class="dropdown-item" href="http://www.apache.org/foundation/" target="_blank" title="Apache Software Foundation">Apache Software Foundation</a>
-					<a class="dropdown-item" href="http://www.apache.org/foundation/how-it-works.html" target="_blank" title="How Apache Works">How Apache Works</a>
-					<a class="dropdown-item" href="http://www.apache.org/foundation/sponsorship.html" target="_blank" title="Sponsoring Apache">Sponsoring Apache</a>
+					<a class="dropdown-item" href="https://www.apache.org/foundation/" target="_blank" title="Apache Software Foundation">Apache Software Foundation</a>
+					<a class="dropdown-item" href="https://www.apache.org/foundation/how-it-works.html" target="_blank" title="How Apache Works">How Apache Works</a>
+					<a class="dropdown-item" href="https://www.apache.org/foundation/sponsorship.html" target="_blank" title="Sponsoring Apache">Sponsoring Apache</a>
 				</div>
 			</li>
 		</ul>
-		<form class="form-inline my-2 my-lg-0" action="http://search-hadoop.com/zookeeper" method="get">
-			<input name="q" id="query" size="25" class="form-control mr-sm-2" type="search" placeholder="Search with Apache Solr" aria-label="Search with Apache Solr">
-			<button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
-		</form>
 	</div>
 </nav>
 

--- a/src/main/resources/markdown/security.md
+++ b/src/main/resources/markdown/security.md
@@ -99,7 +99,7 @@ This issue was identified by Földi Tamás and Eugene Koontz
 References:
 https://issues.apache.org/jira/browse/ZOOKEEPER-1045
 https://cwiki.apache.org/confluence/display/ZOOKEEPER/Server-Server+mutual+authentication
-http://zookeeper.apache.org/doc/current/zookeeperAdmin.html
+https://zookeeper.apache.org/doc/current/zookeeperAdmin.html
 
 
 <a name="CVE-2017-5637"></a>


### PR DESCRIPTION
* Redirect http://zookeeper.apache.org to https://zookeeper.apache.org
* Update any links to use https where possible
* Remove search-hadoop.com search box because
  1. It won't work on secure browsers (because it uses http for form
     submission) or, at the very least, it will show a mixed-content
     security warning when accessing https://zookeeper.apache.org
  2. More importantly, the site doesn't work to show legitimate search
     results... the domain appears to have been taken over by an
     advertising service.
* Also update copyright date in NOTICE, while I was in there