### PR TITLE
ZOOKEEPER-3756: Members slow to rejoin quorum using Kubernetes

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -127,8 +127,7 @@ public class QuorumCnxManager {
     final Map<Long, QuorumPeer.QuorumServer> view;
     final boolean listenOnAllIPs;
     private ThreadPoolExecutor connectionExecutor;
-    private final Set<Long> inprogressConnections = Collections
-            .synchronizedSet(new HashSet<Long>());
+    private final Set<Long> inprogressConnections = Collections.synchronizedSet(new HashSet<>());
     private QuorumAuthServer authServer;
     private QuorumAuthLearner authLearner;
     private boolean quorumSaslAuthEnabled;
@@ -313,46 +312,29 @@ public class QuorumCnxManager {
         this.socketTimeout = socketTimeout;
         this.view = view;
         this.listenOnAllIPs = listenOnAllIPs;
+        this.authServer = authServer;
+        this.authLearner = authLearner;
+        this.quorumSaslAuthEnabled = quorumSaslAuthEnabled;
 
-        initializeAuth(mySid, authServer, authLearner, quorumCnxnThreadsSize,
-                quorumSaslAuthEnabled);
+        initializeConnectionExecutor(mySid, quorumCnxnThreadsSize);
 
         // Starts listener thread that waits for connection requests
         listener = new Listener();
         listener.setName("QuorumPeerListener");
     }
 
-    private void initializeAuth(final long mySid,
-                                final QuorumAuthServer authServer,
-                                final QuorumAuthLearner authLearner,
-                                final int quorumCnxnThreadsSize,
-                                final boolean quorumSaslAuthEnabled) {
-        this.authServer = authServer;
-        this.authLearner = authLearner;
-        this.quorumSaslAuthEnabled = quorumSaslAuthEnabled;
-        if (!this.quorumSaslAuthEnabled) {
-            LOG.debug("Not initializing connection executor as quorum sasl auth is disabled");
-            return;
-        }
-
-        // init connection executors
+    // we always use the Connection Executor during connection initiation (to handle connection
+    // timeouts), and optionally use it during receiving connections (as the Quorum SASL authentication
+    // can take extra time)
+    private void initializeConnectionExecutor(final long mySid, final int quorumCnxnThreadsSize) {
         final AtomicInteger threadIndex = new AtomicInteger(1);
         SecurityManager s = System.getSecurityManager();
         final ThreadGroup group = (s != null) ? s.getThreadGroup()
                 : Thread.currentThread().getThreadGroup();
-        ThreadFactory daemonThFactory = new ThreadFactory() {
-
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(group, r, "QuorumConnectionThread-"
-                        + "[myid=" + mySid + "]-"
-                        + threadIndex.getAndIncrement());
-                return t;
-            }
-        };
-        this.connectionExecutor = new ThreadPoolExecutor(3,
-                quorumCnxnThreadsSize, 60, TimeUnit.SECONDS,
-                new SynchronousQueue<Runnable>(), daemonThFactory);
+        final ThreadFactory daemonThFactory = runnable -> new Thread(group, runnable, "QuorumConnectionThread-"
+                    + "[myid=" + mySid + "]-" + threadIndex.getAndIncrement());
+        this.connectionExecutor = new ThreadPoolExecutor(3, quorumCnxnThreadsSize, 60, TimeUnit.SECONDS,
+                                                         new SynchronousQueue<>(), daemonThFactory);
         this.connectionExecutor.allowCoreThreadTimeOut(true);
     }
 
@@ -362,26 +344,52 @@ public class QuorumCnxManager {
      *
      * @param sid
      */
-    public void testInitiateConnection(long sid) throws Exception {
+    public void testInitiateConnection(long sid) {
         LOG.debug("Opening channel to server " + sid);
-        Socket sock = SOCKET_FACTORY.get();
-        setSockOpts(sock);
-        sock.connect(self.getVotingView().get(sid).electionAddr, cnxTO);
-        initiateConnection(sock, sid);
+        initiateConnection(self.getVotingView().get(sid).electionAddr, sid);
     }
 
     /**
-     * If this server has initiated the connection, then it gives up on the
+     * First we create the socket, perform SSL handshake and authentication if needed.
+     * Then we perform the initiaion protocol.
+     *  If this server has initiated the connection, then it gives up on the
      * connection if it loses challenge. Otherwise, it keeps the connection.
      */
-    public void initiateConnection(final Socket sock, final Long sid) {
+    public void initiateConnection(final InetSocketAddress electionAddr, final Long sid) {
+
+        Socket sock = null;
+        try {
+            LOG.debug("Opening channel to server " + sid);
+            if (self.isSslQuorum()) {
+                SSLSocket sslSock = self.getX509Util().createSSLSocket();
+                setSockOpts(sslSock);
+                sslSock.connect(electionAddr, cnxTO);
+                sslSock.startHandshake();
+                sock = sslSock;
+                LOG.info("SSL handshake complete with {} - {} - {}", sslSock.getRemoteSocketAddress(),
+                         sslSock.getSession().getProtocol(), sslSock.getSession().getCipherSuite());
+            } else {
+                sock = SOCKET_FACTORY.get();
+                setSockOpts(sock);
+                sock.connect(electionAddr, cnxTO);
+            }
+            LOG.debug("Connected to server " + sid);
+        } catch (X509Exception e) {
+            LOG.warn("Cannot open secure channel to {} at election address {}", sid, electionAddr, e);
+            closeSocket(sock);
+            return;
+        } catch (UnresolvedAddressException | IOException e) {
+            LOG.warn("Cannot open channel to {} at election address {}", sid, electionAddr, e);
+            closeSocket(sock);
+            return;
+        }
+
         try {
             startConnection(sock, sid);
         } catch (IOException e) {
             LOG.error("Exception while connecting, id: {}, addr: {}, closing learner connection",
                     new Object[] { sid, sock.getRemoteSocketAddress() }, e);
             closeSocket(sock);
-            return;
         }
     }
 
@@ -389,18 +397,16 @@ public class QuorumCnxManager {
      * Server will initiate the connection request to its peer server
      * asynchronously via separate connection thread.
      */
-    public void initiateConnectionAsync(final Socket sock, final Long sid) {
+    public boolean initiateConnectionAsync(final InetSocketAddress electionAddr, final Long sid) {
         if(!inprogressConnections.add(sid)){
             // simply return as there is a connection request to
             // server 'sid' already in progress.
             LOG.debug("Connection request to server id: {} is already in progress, so skipping this request",
                     sid);
-            closeSocket(sock);
-            return;
+            return true;
         }
         try {
-            connectionExecutor.execute(
-                    new QuorumConnectionReqThread(sock, sid));
+            connectionExecutor.execute(new QuorumConnectionReqThread(electionAddr, sid));
             connectionThreadCnt.incrementAndGet();
         } catch (Throwable e) {
             // Imp: Safer side catching all type of exceptions and remove 'sid'
@@ -408,26 +414,27 @@ public class QuorumCnxManager {
             // connection requests from this 'sid' in case of errors.
             inprogressConnections.remove(sid);
             LOG.error("Exception while submitting quorum connection request", e);
-            closeSocket(sock);
+            return false;
         }
+        return true;
     }
 
     /**
      * Thread to send connection request to peer server.
      */
     private class QuorumConnectionReqThread extends ZooKeeperThread {
-        final Socket sock;
+        final InetSocketAddress electionAddr;
         final Long sid;
-        QuorumConnectionReqThread(final Socket sock, final Long sid) {
+        QuorumConnectionReqThread(final InetSocketAddress electionAddr, final Long sid) {
             super("QuorumConnectionReqThread-" + sid);
-            this.sock = sock;
+            this.electionAddr = electionAddr;
             this.sid = sid;
         }
 
         @Override
         public void run() {
             try{
-                initiateConnection(sock, sid);
+                initiateConnection(electionAddr, sid);
             } finally {
                 inprogressConnections.remove(sid);
             }
@@ -674,6 +681,7 @@ public class QuorumCnxManager {
 
     /**
      * Try to establish a connection to server with id sid using its electionAddr.
+     * The function will return quickly and the connection will be established asynchronously.
      *
      *  @param sid  server id
      *  @return boolean success indication
@@ -684,58 +692,15 @@ public class QuorumCnxManager {
             return true;
         }
 
-        Socket sock = null;
-        try {
-            LOG.debug("Opening channel to server " + sid);
-            if (self.isSslQuorum()) {
-                 SSLSocket sslSock = self.getX509Util().createSSLSocket();
-                 setSockOpts(sslSock);
-                 sslSock.connect(electionAddr, cnxTO);
-                 sslSock.startHandshake();
-                 sock = sslSock;
-                 LOG.info("SSL handshake complete with {} - {} - {}", sslSock.getRemoteSocketAddress(), sslSock.getSession().getProtocol(), sslSock.getSession().getCipherSuite());
-             } else {
-                 sock = SOCKET_FACTORY.get();
-                 setSockOpts(sock);
-                 sock.connect(electionAddr, cnxTO);
-
-             }
-             LOG.debug("Connected to server " + sid);
-            // Sends connection request asynchronously if the quorum
-            // sasl authentication is enabled. This is required because
-            // sasl server authentication process may take few seconds to
-            // finish, this may delay next peer connection requests.
-            if (quorumSaslAuthEnabled) {
-                initiateConnectionAsync(sock, sid);
-            } else {
-                initiateConnection(sock, sid);
-            }
-            return true;
-        } catch (UnresolvedAddressException e) {
-            // Sun doesn't include the address that causes this
-            // exception to be thrown, also UAE cannot be wrapped cleanly
-            // so we log the exception in order to capture this critical
-            // detail.
-            LOG.warn("Cannot open channel to " + sid
-                    + " at election address " + electionAddr, e);
-            closeSocket(sock);
-            throw e;
-        } catch (X509Exception e) {
-            LOG.warn("Cannot open secure channel to " + sid
-                    + " at election address " + electionAddr, e);
-            closeSocket(sock);
-            return false;
-        } catch (IOException e) {
-            LOG.warn("Cannot open channel to " + sid
-                            + " at election address " + electionAddr,
-                    e);
-            closeSocket(sock);
-            return false;
-        }
+        // we are doing connection initiation always asynchronously, since it is possible that
+        // the socket connection timeouts or the SSL handshake takes too long and don't want
+        // to keep the rest of the connections to wait
+        return initiateConnectionAsync(electionAddr, sid);
     }
 
     /**
      * Try to establish a connection to server with id sid.
+     * The function will return quickly and the connection will be established asynchronously.
      *
      *  @param sid  server id
      */

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -183,7 +183,6 @@ public class QuorumCnxManager {
     }
 
 
-
     static public class Message {
         Message(ByteBuffer buffer, long sid) {
             this.buffer = buffer;
@@ -331,8 +330,8 @@ public class QuorumCnxManager {
         SecurityManager s = System.getSecurityManager();
         final ThreadGroup group = (s != null) ? s.getThreadGroup()
                 : Thread.currentThread().getThreadGroup();
-        final ThreadFactory daemonThFactory = runnable -> new Thread(group, runnable, "QuorumConnectionThread-"
-                    + "[myid=" + mySid + "]-" + threadIndex.getAndIncrement());
+        final ThreadFactory daemonThFactory = runnable -> new Thread(group, runnable,
+            String.format("QuorumConnectionThread-[myid=%d]-%d", mySid, threadIndex.getAndIncrement()));
         this.connectionExecutor = new ThreadPoolExecutor(3, quorumCnxnThreadsSize, 60, TimeUnit.SECONDS,
                                                          new SynchronousQueue<>(), daemonThFactory);
         this.connectionExecutor.allowCoreThreadTimeOut(true);
@@ -351,7 +350,7 @@ public class QuorumCnxManager {
 
     /**
      * First we create the socket, perform SSL handshake and authentication if needed.
-     * Then we perform the initiaion protocol.
+     * Then we perform the initiation protocol.
      *  If this server has initiated the connection, then it gives up on the
      * connection if it loses challenge. Otherwise, it keeps the connection.
      */

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumCnxManagerSocketConnectionTimeoutTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumCnxManagerSocketConnectionTimeoutTest.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.test.ClientBase;
+import org.apache.zookeeper.test.QuorumRestartTest;
+import org.apache.zookeeper.test.QuorumUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketTimeoutException;
+
+import static org.junit.Assert.assertTrue;
+
+public class QuorumCnxManagerSocketConnectionTimeoutTest extends ZKTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QuorumRestartTest.class);
+    private QuorumUtil qu;
+
+    @Before
+    public void setUp() throws Exception {
+        // starting a 3 node ensemble without observers
+        qu = new QuorumUtil(1, 2);
+        qu.startAll();
+    }
+
+    /**
+     * Testing an error case reported in ZOOKEEPER-3756:
+     *
+     * When a new leader election happens after a ZooKeeper server restarted, in Kubernetes
+     * the rest of the servers can not initiate connection to the restarted one. But they
+     * get Timeout instead of immediate HostUnreachableException. The Leader Election was
+     * time-outing quicker than the socket.connect call, so we ended up with cycles of broken
+     * leader elections.
+     *
+     * The fix was to make the connection initiation asynchronous, so one 'broken' connection
+     * doesn't make the whole leader election to be blocked.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSocketConnectionTimeoutDuringConnectingToElectionAddress() throws Exception {
+
+        int leaderId = qu.getLeaderServer();
+
+        // use a custom socket factory that will cause timeout instead of connecting to the
+        // leader election port of the current leader
+        final InetSocketAddress leaderElectionAddress =
+            qu.getLeaderQuorumPeer().getElectionAddress();
+        QuorumCnxManager.setSocketFactory(() -> new SocketStub(leaderElectionAddress));
+
+        qu.shutdown(leaderId);
+
+        assertTrue("Timeout during waiting for current leader to go down",
+                   ClientBase.waitForServerDown("127.0.0.1:" + qu.getPeer(leaderId).clientPort,
+                                                ClientBase.CONNECTION_TIMEOUT));
+
+        String errorMessage = "No new leader was elected";
+        waitFor(errorMessage, () -> qu.leaderExists() && qu.getLeaderServer() != leaderId, 15);
+    }
+
+    final class SocketStub extends Socket {
+
+        private final InetSocketAddress addressToTimeout;
+
+        SocketStub(InetSocketAddress addressToTimeout) {
+            this.addressToTimeout = addressToTimeout;
+        }
+
+        @Override
+        public void connect(SocketAddress endpoint, int timeout) throws IOException {
+            if (addressToTimeout.equals(endpoint)) {
+                try {
+                    Thread.sleep(timeout);
+                } catch (InterruptedException e) {
+                    LOG.warn("interrupted SocketStub.connect", e);
+                }
+                throw new SocketTimeoutException("timeout reached in SocketStub.connect()");
+            }
+
+            super.connect(endpoint, timeout);
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        qu.shutdownAll();
+        QuorumCnxManager.setSocketFactory(QuorumCnxManager.DEFAULT_SOCKET_FACTORY);
+    }
+
+
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumCnxManagerSocketConnectionTimeoutTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumCnxManagerSocketConnectionTimeoutTest.java
@@ -18,6 +18,12 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import static org.junit.Assert.assertTrue;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketTimeoutException;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.test.ClientBase;
 import org.apache.zookeeper.test.QuorumRestartTest;
@@ -27,14 +33,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.net.SocketAddress;
-import java.net.SocketTimeoutException;
-
-import static org.junit.Assert.assertTrue;
 
 public class QuorumCnxManagerSocketConnectionTimeoutTest extends ZKTestCase {
 
@@ -53,12 +51,12 @@ public class QuorumCnxManagerSocketConnectionTimeoutTest extends ZKTestCase {
      *
      * When a new leader election happens after a ZooKeeper server restarted, in Kubernetes
      * the rest of the servers can not initiate connection to the restarted one. But they
-     * get Timeout instead of immediate HostUnreachableException. The Leader Election was
+     * get SocketTimeoutException instead of immediate IOException. The Leader Election was
      * time-outing quicker than the socket.connect call, so we ended up with cycles of broken
      * leader elections.
      *
      * The fix was to make the connection initiation asynchronous, so one 'broken' connection
-     * doesn't make the whole leader election to be blocked.
+     * doesn't make the whole leader election to be blocked, even in case of SocketTimeoutException.
      *
      * @throws Exception
      */
@@ -111,6 +109,5 @@ public class QuorumCnxManagerSocketConnectionTimeoutTest extends ZKTestCase {
         qu.shutdownAll();
         QuorumCnxManager.setSocketFactory(QuorumCnxManager.DEFAULT_SOCKET_FACTORY);
     }
-
 
 }


### PR DESCRIPTION
Whenever we close the current master ZooKeeper server, a new leader election
is triggered. During the new election, a connection will be established between
all the servers, by calling the synchronized 'connectOne' method in
QuorumCnxManager. The method will open the socket and send a single small
initial message to the other server, usually very quickly. If the destination
host is unreachable, it should fail immediately.

However, when we use Kubernetes, then the destination host is always reachable
as it points to Kubernetes services. If the actual container / pod is not
available then the 'socket.connect' method will timeout (by default after 5 sec)
instead of failing immediately with NoRouteToHostException. As the 'connectOne'
method is synchronized, this timeout will block the creation of other
connections, so a single unreachable host can cause timeout in the leader
election protocol.

One workaround is to decrease the socket connection timeout with the
'-Dzookeeper.cnxTimeout' stystem property, but the proper fix would be to
make the connection initiation fully asynchronous, as using very low timeout can
have its own side effect. Fortunately most of the initial message sending
is already made async: the SASL authentication can take more time, so the
second (authentication + initial message sending) part of the initiation protocol
is already called in a separate thread, when Quorum SASL authentication is enabled.

In the following patch I made the whole connection initiation async, by
always using the async executor (not only when Quorum SASL is enabled) and
also moving the socket.connect call into the async thread.

I also created a unit test to verify my fix. I added a static socket factory that can be
changed by the tests using a packet private setter method. My test failed (and
produced the same error logs as we see in the original Jira ticket) before I applied
my changes and a time-outed as no leader election succeeded after 15 seconds.
After the changes the test runs very quickly, in 1-2 seconds.

Note: due to the multiAddress changes, we will need different PRs to the branch 3.5
and to the 3.6+ branches. I will submit the other PR once this got reviewed.