### PR TITLE
ZOOKEEPER-3782: Replace filter() with list comprehension for returning list

### DIFF
--- a/zk-merge-pr.py
+++ b/zk-merge-pr.py
@@ -307,12 +307,12 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     fix_versions = fix_versions.replace(" ", "").split(",")
 
     def get_version_json(version_str):
-        return filter(lambda v: v.name == version_str, versions)[0].raw
+        return [v for v in versions if v.name == version_str][0].raw
 
     jira_fix_versions = [get_version_json(v) for v in fix_versions]
 
-    resolve = filter(lambda a: a['name'] == "Resolve Issue", asf_jira.transitions(jira_id))[0]
-    resolution = filter(lambda r: r.raw['name'] == "Fixed", asf_jira.resolutions())[0]
+    resolve = [a for a in asf_jira.transitions(jira_id) if a['name'] == "Resolve Issue"][0]
+    resolution = [r for r in asf_jira.resolutions() if r.raw['name'] == "Fixed"][0]
     asf_jira.transition_issue(
         jira_id, resolve["id"], fixVersions = jira_fix_versions,
         comment = comment, resolution = {'id': resolution.raw['id']})


### PR DESCRIPTION
After Py3, `filter` return a `filter object` instead of `list object`, which causes

```
Traceback (most recent call last):
  File "zk-merge-pr.py", line 533, in <module>
    main()
  File "zk-merge-pr.py", line 519, in main
    resolve_jira_issues(commit_title, merged_refs, jira_comment)
  File "zk-merge-pr.py", line 329, in resolve_jira_issues
    resolve_jira_issue(merge_branches, comment, jira_id)
  File "zk-merge-pr.py", line 312, in resolve_jira_issue
    jira_fix_versions = [get_version_json(v) for v in fix_versions]
  File "zk-merge-pr.py", line 312, in <listcomp>
    jira_fix_versions = [get_version_json(v) for v in fix_versions]
  File "zk-merge-pr.py", line 310, in get_version_json
    return filter(lambda v: v.name == version_str, versions)[0].raw
TypeError: 'filter' object is not subscriptable
```

We can replace filter with list comprehension to fix it.