### PR TITLE
ZOOKEEPER-3780 - restore Version.getRevision() to be bacward compatible

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Version.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Version.java
@@ -27,8 +27,8 @@ public class Version implements org.apache.zookeeper.version.Info {
     /*
      * Since the SVN to Git port this field doesn't return the revision anymore
      * In version 3.5.6, 3.5.7 and 3.6.0 this function is removed by accident.
-     * All other versions until 3.7.0 will contain this for backward compatibility
-     * @deprecated deprecated in 3.5.5, use @see {@link #getHashRevision()} instead
+     * From version 3.5.8+ and 3.6.1+ it is restored for backward compatibility, but will be removed later
+     * @deprecated deprecated in 3.5.5, use @see {@link #getRevisionHash()} instead
      * @return the default value -1
      */
     @Deprecated

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Version.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Version.java
@@ -24,6 +24,18 @@ import org.apache.zookeeper.util.ServiceUtils;
 
 public class Version implements org.apache.zookeeper.version.Info {
 
+    /*
+     * Since the SVN to Git port this field doesn't return the revision anymore
+     * In version 3.5.6, 3.5.7 and 3.6.0 this function is removed by accident.
+     * All other versions until 3.7.0 will contain this for backward compatibility
+     * @deprecated deprecated in 3.5.5, use @see {@link #getHashRevision()} instead
+     * @return the default value -1
+     */
+    @Deprecated
+    public static int getRevision() {
+        return REVISION;
+    }
+
     public static String getRevisionHash() {
         return REVISION_HASH;
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
@@ -84,7 +84,7 @@ public class VerGen {
             if (rev.equals("-1")) {
                 System.out.println("Unknown REVISION number, using " + rev);
             }
-            w.write("    int REVISION=-1; //@deprecated, will be removed in 3.7.0\n");
+            w.write("    int REVISION=-1; //@deprecated, please use REVISION_HASH\n");
             w.write("    String REVISION_HASH=\"" + rev + "\";\n");
             w.write("    String BUILD_DATE=\"" + buildDate + "\";\n");
             w.write("}\n");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
@@ -84,6 +84,7 @@ public class VerGen {
             if (rev.equals("-1")) {
                 System.out.println("Unknown REVISION number, using " + rev);
             }
+            w.write("    int REVISION=-1; //@deprecated, will be removed in 3.7.0\n");
             w.write("    String REVISION_HASH=\"" + rev + "\";\n");
             w.write("    String BUILD_DATE=\"" + buildDate + "\";\n");
             w.write("}\n");


### PR DESCRIPTION
Added a warning in https://cwiki.apache.org/confluence/display/ZOOKEEPER/Upgrade+FAQ