### PR TITLE
ZOOKEEPER-3792: Generate aggregated documents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -590,7 +590,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.2.0</version>
           <configuration>
             <doclint>none</doclint>
           </configuration>
@@ -598,7 +598,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -803,14 +803,8 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <executions>
           <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-          <execution>
             <id>aggregate</id>
-            <phase>site</phase>
+            <phase>prepare-package</phase>
             <goals>
               <goal>aggregate</goal>
             </goals>

--- a/zookeeper-assembly/src/main/assembly/bin-package.xml
+++ b/zookeeper-assembly/src/main/assembly/bin-package.xml
@@ -57,16 +57,9 @@
       <directoryMode>${rwx.file.permission}</directoryMode>
     </fileSet>
     <fileSet>
-      <!-- ZooKeeper jute generated api document -->
-      <directory>${project.basedir}/../zookeeper-jute/target/apidocs</directory>
-      <outputDirectory>docs/apidocs/zookeeper-jute</outputDirectory>
-      <fileMode>${rw.file.permission}</fileMode>
-      <directoryMode>${rwx.file.permission}</directoryMode>
-    </fileSet>
-    <fileSet>
-      <!-- ZooKeeper server generated api document -->
-      <directory>${project.basedir}/../zookeeper-server/target/apidocs</directory>
-      <outputDirectory>docs/apidocs/zookeeper-server</outputDirectory>
+      <!-- ZooKeeper generated api document -->
+      <directory>${project.basedir}/../target/site/apidocs</directory>
+      <outputDirectory>docs/api</outputDirectory>
       <fileMode>${rw.file.permission}</fileMode>
       <directoryMode>${rwx.file.permission}</directoryMode>
     </fileSet>


### PR DESCRIPTION
After ZOOKEEPER-3369 we generate document in apidocs/ instead of api/ before. Moreover, the document site cannot proper linked to apidocs in 3.6.0(but in 3.5.7, thought it is wrong in website branch, it is manually corrected in asf-site branch}}.

I propose we generate single aggregated document and place it under api/ folder, as well as bumping website for the update.

cc @eolivelli @anmolnar I'm not sure the procedure we bump website, possibly we have a clear README or page on wiki.