### PR TITLE
ZOOKEEPER-3738: Fix VerGen when mvngit.commit.id is null

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
@@ -35,7 +35,7 @@ public class VerGen {
 
     static void printUsage() {
         System.out.print("Usage:\tjava  -cp <classpath> org.apache.zookeeper."
-                         + "version.util.VerGen maj.min.micro[-qualifier] rev buildDate outputDirectory");
+                         + "version.util.VerGen maj.min.micro[-qualifier] [rev] buildDate outputDirectory");
         System.exit(ExitCode.UNEXPECTED_ERROR.getValue());
     }
 
@@ -177,8 +177,11 @@ public class VerGen {
      *            </ul>
      */
     public static void main(String[] args) {
-        if (args.length != 4) {
+        if (args.length != 3 && args.length != 4) {
             printUsage();
+        }
+        if (args.length == 3) {
+            args = new String[]{args[0], null, args[1], args[2]};
         }
         try {
             Version version = parseVersionString(args[0]);


### PR DESCRIPTION
Workaround for exec-maven-plugin treating an empty
`<argument>${mvngit.commit.id}</argument>` as null and passing an
incorrect number of arguments to VerGen.

This change allows the revision to be omitted in the command-line args
to VerGen.

This allows the mavanagaiata-maven-plugin to provide the git commit id,
when available, to the VerGen command. This change is superseded in
ZooKeeper 3.7.0 and later by ZOOKEEPER-3786
(https://github.com/apache/zookeeper/pull/1310), which simplifies
generating the version information and removes VerGen.