### PR TITLE
ZOOKEEPER-3797 Conflict between fatjar and full-build Maven profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,7 @@
     <profile>
       <id>full-build</id>
       <modules>
+        <module>zookeeper-it</module>
         <module>zookeeper-contrib</module>
       </modules>
     </profile>

--- a/zookeeper-contrib/pom.xml
+++ b/zookeeper-contrib/pom.xml
@@ -48,6 +48,12 @@
         <module>zookeeper-contrib-fatjar</module>
       </modules>
     </profile>
+    <profile>
+      <id>full-build</id>
+      <modules>
+        <module>zookeeper-contrib-fatjar</module>
+      </modules>
+    </profile>
   </profiles>
 
   <build>

--- a/zookeeper-it/pom.xml
+++ b/zookeeper-it/pom.xml
@@ -33,6 +33,22 @@
     ZooKeeper system tests
   </description>
 
+  <profiles>
+    <profile>
+      <id>full-build</id>
+      <build>
+         <plugins>
+            <plugin>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                 <skipTests>true</skipTests>
+              </configuration>
+	    </plugin>
+         </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>

--- a/zookeeper-it/pom.xml
+++ b/zookeeper-it/pom.xml
@@ -39,6 +39,7 @@
       <properties>
          <skipTests>true</skipTests>
          <spotbugs.skip>true</spotbugs.skip>
+	 <checkstyle.skip>true</checkstyle.skip>
       </properties>
     </profile>
   </profiles>

--- a/zookeeper-it/pom.xml
+++ b/zookeeper-it/pom.xml
@@ -38,6 +38,7 @@
       <id>full-build</id>
       <properties>
          <skipTests>true</skipTests>
+         <spotbugs.skip>true</spotbugs.skip>
       </properties>
     </profile>
   </profiles>

--- a/zookeeper-it/pom.xml
+++ b/zookeeper-it/pom.xml
@@ -36,16 +36,9 @@
   <profiles>
     <profile>
       <id>full-build</id>
-      <build>
-         <plugins>
-            <plugin>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                 <skipTests>true</skipTests>
-              </configuration>
-	    </plugin>
-         </plugins>
-      </build>
+      <properties>
+         <skipTests>true</skipTests>
+      </properties>
     </profile>
   </profiles>
 


### PR DESCRIPTION
Enable fatjar module in full-build profile.
This is a fix only for branch-3.6, on master branch maven structure is changing, there is no need for this fix 