### PR TITLE
ZOOKEEPER-3802 RAT check fails on fatjar module

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-fatjar/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-fatjar/pom.xml
@@ -34,6 +34,7 @@
   <properties>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <maven.source.skip>true</maven.source.skip>
+    <rat.skip>true</rat.skip>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
 - rat executes at the top level and excludes some files on fatjar module
- fatjar module does't need to run rat itself, let's disable it