### PR TITLE
ZOOKEEPER-3802: Fix rat checks in full-build and fatjar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
       <id>fatjar</id>
       <modules>
         <module>zookeeper-it</module>
-        <module>zookeeper-contrib/zookeeper-contrib-fatjar</module>
+        <module>zookeeper-contrib</module>
       </modules>
     </profile>
     <profile>
@@ -365,7 +365,7 @@
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-lang.version>2.6</commons-lang.version>
     <dropwizard.version>3.2.5</dropwizard.version>
-    <spotbugsannotations.version>3.1.9</spotbugsannotations.version>
+    <spotbugsannotations.version>4.0.2</spotbugsannotations.version>
     <checkstyle.version>8.17</checkstyle.version>
 
     <!-- parameter to pass to C client build -->
@@ -656,7 +656,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>3.1.9</version>
+          <version>4.0.0</version>
           <configuration>
             <excludeFilterFile>excludeFindBugsFilter.xml</excludeFilterFile>
           </configuration>
@@ -876,23 +876,22 @@
             <exclude>src/main/resources/markdown/html/*</exclude>
             <exclude>src/main/resources/markdown/images/*</exclude>
             <!-- contrib -->
-            <exclude>zookeeper-contrib-monitoring/JMX-RESOURCES</exclude>
-            <exclude>zookeeper-contrib-fatjar/src/main/resources/mainClasses</exclude>
-            <exclude>zookeeper-contrib-zkperl/Changes</exclude>
-            <exclude>zookeeper-contrib-zkperl/MANIFEST</exclude>
-            <exclude>zookeeper-contrib-zkpython/src/test/zoo.cfg</exclude>
-            <exclude>zookeeper-contrib-loggraph/src/main/resources/webapp/org/apache/zookeeper/graph/resources/*</exclude>
-            <exclude>src/main/resources/webapp/org/apache/zookeeper/graph/resources/*</exclude>
-            <exclude>src/main/java/com/nitido/utils/toaster/Toaster.java</exclude>
-            <exclude>TODO</exclude>
+            <exclude>**/JMX-RESOURCES</exclude>
+            <exclude>**/src/main/resources/mainClasses</exclude>
+            <exclude>**/Changes</exclude>
+            <exclude>**/MANIFEST</exclude>
+            <exclude>**/src/test/zoo.cfg</exclude>
+            <exclude>**/src/main/resources/webapp/org/apache/zookeeper/graph/resources/*</exclude>
+            <exclude>**/src/main/java/com/nitido/utils/toaster/Toaster.java</exclude>
+            <exclude>**/TODO</exclude>
             <!-- c client -->
             <exclude>**/acinclude.m4</exclude>
             <exclude>**/aminclude.am</exclude>
-            <exclude>src/hashtable/*</exclude>
-            <exclude>include/winconfig.h</exclude>
-            <exclude>tests/wrappers.opt</exclude>
-            <exclude>tests/zoo.cfg</exclude>
-            <exclude>tests/wrappers-mt.opt</exclude>
+            <exclude>**/src/hashtable/*</exclude>
+            <exclude>**/include/winconfig.h</exclude>
+            <exclude>**/tests/wrappers.opt</exclude>
+            <exclude>**/tests/zoo.cfg</exclude>
+            <exclude>**/tests/wrappers-mt.opt</exclude>
             <exclude>**/c-doc.Doxyfile</exclude>
           </excludes>
           <consoleOutput>true</consoleOutput>

--- a/zookeeper-contrib/pom.xml
+++ b/zookeeper-contrib/pom.xml
@@ -35,11 +35,9 @@
     Contrib projects to Apache ZooKeeper
   </description>
 
-  <modules>
-    <module>zookeeper-contrib-loggraph</module>
-    <module>zookeeper-contrib-rest</module>
-    <module>zookeeper-contrib-zooinspector</module>
-  </modules>
+  <properties>
+    <spotbugs.skip>true</spotbugs.skip>
+  </properties>
 
   <profiles>
     <profile>
@@ -52,6 +50,9 @@
       <id>full-build</id>
       <modules>
         <module>zookeeper-contrib-fatjar</module>
+        <module>zookeeper-contrib-loggraph</module>
+        <module>zookeeper-contrib-rest</module>
+        <module>zookeeper-contrib-zooinspector</module>
       </modules>
     </profile>
   </profiles>
@@ -59,15 +60,6 @@
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>com.github.spotbugs</groupId>
-          <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>3.1.9</version>
-          <configuration>
-            <!-- No spotbugs for contrib modules -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>

--- a/zookeeper-it/pom.xml
+++ b/zookeeper-it/pom.xml
@@ -33,16 +33,11 @@
     ZooKeeper system tests
   </description>
 
-  <profiles>
-    <profile>
-      <id>full-build</id>
-      <properties>
-         <skipTests>true</skipTests>
-         <spotbugs.skip>true</spotbugs.skip>
-	 <checkstyle.skip>true</checkstyle.skip>
-      </properties>
-    </profile>
-  </profiles>
+  <properties>
+    <skipTests>true</skipTests>
+    <spotbugs.skip>true</spotbugs.skip>
+    <checkstyle.skip>true</checkstyle.skip>
+  </properties>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Ensure apache-rat:check passes with and without -Pfull-build and/or -Pfatjar

Specifically, this change does:

1. Use wildcards for rat check excludes, so the build passes whether rat
   detects the fils at the build execution root or within the activated
   module, so the rat check works whether or not the full-build or
   fatjar profiles are activated.
2. Ensures properties set at zookeeper-contrib that control rat,
   spotbugs, and checkstyle, are properly passed down to the contrib
   submodules when fatjar is activated, by ensuring the intermediate
   parent pom for zookeeper-contrib is activated when any of its
   submodules are activated.
3. Also use version of spotbugs that works with newer JDKs so the full
   build, including rat checks, can be tested with newer JDKs.