### PR TITLE
Extra horizontal lines

### DIFF
--- a/README_packaging.txt
+++ b/README_packaging.txt
@@ -13,8 +13,8 @@ yum install python-setuptools
 
 On Ubuntu:
 
-apt-get --install cppunit
-apt-get --install python-setuptools
+apt-get install cppunit
+apt-get install python-setuptools
 
 Package build command
 ---------------------


### PR DESCRIPTION
I packaged zookeeper 3.4.14 by reading README_packaging.txt.
I found the two command have extra horizontal lines.
```
apt-get --install cppunit
apt-get --install python-setuptools
```