### PR TITLE
Extra horizontal lines

### DIFF
--- a/README_packaging.txt
+++ b/README_packaging.txt
@@ -14,8 +14,8 @@ yum install python-setuptools
 
 On Ubuntu:
 
-apt-get --install cppunit
-apt-get --install python-setuptools
+apt-get install cppunit
+apt-get install python-setuptools
 
 Package build command
 ---------------------


### PR DESCRIPTION
I packaged zookeeper 3.4.14 by reading README_packaging.txt.
I found the two command have extra horizontal lines.
```
apt-get --install cppunit
apt-get --install python-setuptools
```
3.6.x and master are OK.
3.4.x and 3.5.x are wrong.
3.4.x pr: #1327