### PR TITLE
Extra horizontal lines

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache ZooKeeper
-Copyright 2009-2018 The Apache Software Foundation
+Copyright 2009-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/README_packaging.txt
+++ b/README_packaging.txt
@@ -13,8 +13,8 @@ yum install python-setuptools
 
 On Ubuntu:
 
-apt-get --install cppunit
-apt-get --install python-setuptools
+apt-get install cppunit
+apt-get install python-setuptools
 
 Package build command
 ---------------------

--- a/build.xml
+++ b/build.xml
@@ -75,7 +75,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
 
     <property environment="env"/>
     
-    <property name="version" value="3.4.15-SNAPSHOT" />
+    <property name="version" value="3.4.14" />
     <property name="final.name" value="${name}-${version}"/>
     <property name="revision.dir" value="${basedir}/.revision" />
     <property name="revision.properties" value="revision.properties" />

--- a/build.xml
+++ b/build.xml
@@ -748,6 +748,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle">
         </fileset>
         <fileset dir="${ivy.lib}">
           <exclude name="**/jsr305*.jar" />
+          <exclude name="**/spotbugs-annotations*.jar" />
         </fileset>
       </copy>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <groupId>org.apache.zookeeper</groupId>
   <artifactId>zookeeper</artifactId>
   <packaging>pom</packaging>
-  <version>3.4.14-SNAPSHOT</version>
+  <version>3.4.14</version>
   <name>Apache ZooKeeper</name>
   <description>
     ZooKeeper is a centralized service for maintaining configuration information, naming,

--- a/zookeeper-client/pom.xml
+++ b/zookeeper-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper</artifactId>
-    <version>3.4.14-SNAPSHOT</version>
+    <version>3.4.14</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/zookeeper-client/zookeeper-client-c/NOTICE.txt
+++ b/zookeeper-client/zookeeper-client-c/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache ZooKeeper
-Copyright 2009-2018 The Apache Software Foundation
+Copyright 2009-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/zookeeper-client/zookeeper-client-c/pom.xml
+++ b/zookeeper-client/zookeeper-client-c/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-client</artifactId>
-    <version>3.4.14-SNAPSHOT</version>
+    <version>3.4.14</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/zookeeper-contrib/pom.xml
+++ b/zookeeper-contrib/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper</artifactId>
-    <version>3.4.14-SNAPSHOT</version>
+    <version>3.4.14</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>

--- a/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-contrib</artifactId>
-    <version>3.4.14-SNAPSHOT</version>
+    <version>3.4.14</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-jute</artifactId>
-      <version>3.4.14-SNAPSHOT</version>
+      <version>3.4.14</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14-SNAPSHOT</version>
+      <version>3.4.14</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zookeeper-contrib/zookeeper-contrib-rest/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-rest/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-contrib</artifactId>
-    <version>3.4.14-SNAPSHOT</version>
+    <version>3.4.14</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
@@ -56,12 +56,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14-SNAPSHOT</version>
+      <version>3.4.14</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14-SNAPSHOT</version>
+      <version>3.4.14</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-contrib</artifactId>
-    <version>3.4.14-SNAPSHOT</version>
+    <version>3.4.14</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14-SNAPSHOT</version>
+      <version>3.4.14</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zookeeper-docs/pom.xml
+++ b/zookeeper-docs/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
-        <version>3.4.14-SNAPSHOT</version>
+        <version>3.4.14</version>
         <relativePath>..</relativePath>
     </parent>
 
   <groupId>org.apache.zookeeper</groupId>
   <artifactId>zookeeper-docs</artifactId>
-  <version>3.4.14-SNAPSHOT</version>
+  <version>3.4.14</version>
   <name>Apache ZooKeeper - Documentation</name>
   <description>Documentation</description>
 

--- a/zookeeper-docs/src/main/resources/markdown/releasenotes.md
+++ b/zookeeper-docs/src/main/resources/markdown/releasenotes.md
@@ -14,6 +14,48 @@ See the License for the specific language governing permissions and
 limitations under the License.
 //-->
 
+# Release Notes - ZooKeeper - Version 3.4.14
+
+## Task
+* [ZOOKEEPER-3062](https://issues.apache.org/jira/browse/ZOOKEEPER-3062) - introduce fsync.warningthresholdms constant for FileTxnLog LOG.warn message
+* [ZOOKEEPER-3120](https://issues.apache.org/jira/browse/ZOOKEEPER-3120) - add NetBeans nbproject directory to .gitignore
+* [ZOOKEEPER-925](https://issues.apache.org/jira/browse/ZOOKEEPER-925) - Consider maven site generation to replace our forrest site and documentation generation
+* [ZOOKEEPER-3230](https://issues.apache.org/jira/browse/ZOOKEEPER-3230) - Add Apache NetBeans Maven project files to .gitignore
+
+## Sub-task
+* [ZOOKEEPER-3155](https://issues.apache.org/jira/browse/ZOOKEEPER-3155) - ZOOKEEPER-925 Remove Forrest XMLs and their build process from the project
+* [ZOOKEEPER-3154](https://issues.apache.org/jira/browse/ZOOKEEPER-3154) - ZOOKEEPER-925 Update release process to use the MarkDown solution
+* [ZOOKEEPER-3153](https://issues.apache.org/jira/browse/ZOOKEEPER-3153) - ZOOKEEPER-925 Create MarkDown files and build process for them
+* [ZOOKEEPER-3022](https://issues.apache.org/jira/browse/ZOOKEEPER-3022) - ZOOKEEPER-3021 Step 1.1 - Create docs and it maven structure
+* [ZOOKEEPER-3033](https://issues.apache.org/jira/browse/ZOOKEEPER-3033) - ZOOKEEPER-3021 Step 1.2 - Create zk-recipes maven structure
+* [ZOOKEEPER-3030](https://issues.apache.org/jira/browse/ZOOKEEPER-3030) - ZOOKEEPER-3021 Step 1.3 - Create zk-contrib maven structure
+* [ZOOKEEPER-3031](https://issues.apache.org/jira/browse/ZOOKEEPER-3031) - ZOOKEEPER-3021 Step 1.4 - Create zk-client maven structure
+* [ZOOKEEPER-3080](https://issues.apache.org/jira/browse/ZOOKEEPER-3080) - ZOOKEEPER-3021 Step 1.5 - Separate jute structure
+* [ZOOKEEPER-3032](https://issues.apache.org/jira/browse/ZOOKEEPER-3032) - ZOOKEEPER-3021 Step 1.6 - Create zk-server maven structure
+* [ZOOKEEPER-3223](https://issues.apache.org/jira/browse/ZOOKEEPER-3223) - ZOOKEEPER-3021 Configure Spotbugs
+* [ZOOKEEPER-3256](https://issues.apache.org/jira/browse/ZOOKEEPER-3256) - ZOOKEEPER-3021 Enable OWASP checks to Maven build
+* [ZOOKEEPER-3029](https://issues.apache.org/jira/browse/ZOOKEEPER-3029) - ZOOKEEPER-3021 Create pom files for jute, server and client
+* [ZOOKEEPER-3225](https://issues.apache.org/jira/browse/ZOOKEEPER-3225) - ZOOKEEPER-3021 Create code coverage analysis with maven build
+* [ZOOKEEPER-3226](https://issues.apache.org/jira/browse/ZOOKEEPER-3226) - ZOOKEEPER-3021 Activate C Client with a profile, disabled by default
+* [ZOOKEEPER-3171](https://issues.apache.org/jira/browse/ZOOKEEPER-3171) - ZOOKEEPER-3021 Create pom.xml for recipes and contrib
+* [ZOOKEEPER-3122](https://issues.apache.org/jira/browse/ZOOKEEPER-3122) - ZOOKEEPER-3021 Verify build after maven migration and the end artifact
+
+## Improvement
+* [ZOOKEEPER-3262](https://issues.apache.org/jira/browse/ZOOKEEPER-3262) - Update dependencies flagged by OWASP report
+* [ZOOKEEPER-3021](https://issues.apache.org/jira/browse/ZOOKEEPER-3021) - Umbrella: Migrate project structure to Maven build
+* [ZOOKEEPER-3094](https://issues.apache.org/jira/browse/ZOOKEEPER-3094) - Make BufferSizeTest reliable
+* [ZOOKEEPER-3077](https://issues.apache.org/jira/browse/ZOOKEEPER-3077) - Build native C library outside of source directory
+
+## Bug
+* [ZOOKEEPER-3217](https://issues.apache.org/jira/browse/ZOOKEEPER-3217) - owasp job flagging slf4j on trunk
+* [ZOOKEEPER-3156](https://issues.apache.org/jira/browse/ZOOKEEPER-3156) - ZOOKEEPER-2184 causes kerberos principal to not have resolved host name
+* [ZOOKEEPER-3210](https://issues.apache.org/jira/browse/ZOOKEEPER-3210) - Typo in zookeeperInternals doc
+* [ZOOKEEPER-1392](https://issues.apache.org/jira/browse/ZOOKEEPER-1392) - Should not allow to read ACL when not authorized to read node
+* [ZOOKEEPER-3009](https://issues.apache.org/jira/browse/ZOOKEEPER-3009) - Potential NPE in NIOServerCnxnFactory
+* [ZOOKEEPER-3148](https://issues.apache.org/jira/browse/ZOOKEEPER-3148) - Fix Kerberos tests on branch 3.4 and JDK11
+* [ZOOKEEPER-3265](https://issues.apache.org/jira/browse/ZOOKEEPER-3265) - Build failure on branch-3.4
+* [ZOOKEEPER-3162](https://issues.apache.org/jira/browse/ZOOKEEPER-3162) - Broken lock semantics in C client lock-recipe
+
 # Release Notes - ZooKeeper - Version 3.4.13
 
 ## Sub-task

--- a/zookeeper-jute/pom.xml
+++ b/zookeeper-jute/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper</artifactId>
-    <version>3.4.14-SNAPSHOT</version>
+    <version>3.4.14</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/zookeeper-recipes/pom.xml
+++ b/zookeeper-recipes/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper</artifactId>
-    <version>3.4.14-SNAPSHOT</version>
+    <version>3.4.14</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>

--- a/zookeeper-recipes/zookeeper-recipes-election/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-election/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-recipes</artifactId>
-    <version>3.4.14-SNAPSHOT</version>
+    <version>3.4.14</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14-SNAPSHOT</version>
+      <version>3.4.14</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14-SNAPSHOT</version>
+      <version>3.4.14</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/zookeeper-recipes/zookeeper-recipes-lock/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-lock/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-recipes</artifactId>
-    <version>3.4.14-SNAPSHOT</version>
+    <version>3.4.14</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14-SNAPSHOT</version>
+      <version>3.4.14</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14-SNAPSHOT</version>
+      <version>3.4.14</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/zookeeper-recipes/zookeeper-recipes-queue/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-queue/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-recipes</artifactId>
-    <version>3.4.14-SNAPSHOT</version>
+    <version>3.4.14</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
@@ -43,12 +43,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14-SNAPSHOT</version>
+      <version>3.4.14</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14-SNAPSHOT</version>
+      <version>3.4.14</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper</artifactId>
-    <version>3.4.14-SNAPSHOT</version>
+    <version>3.4.14</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-jute</artifactId>
-      <version>3.4.14-SNAPSHOT</version>
+      <version>3.4.14</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/zookeeper-server/src/main/resources/NOTICE.txt
+++ b/zookeeper-server/src/main/resources/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache ZooKeeper
-Copyright 2009-2018 The Apache Software Foundation
+Copyright 2009-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
I packaged zookeeper 3.4.14 by reading README_packaging.txt.
I found the two command have extra horizontal lines.
```
apt-get --install cppunit
apt-get --install python-setuptools
```

Related PR: #1327

