### PR TITLE
ZOOKEEPER-3800: improve the log printing the address when QuorumCnxManager#ListenerHandler's port binds

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -1090,7 +1090,7 @@ public class QuorumCnxManager {
                             break;
                         }
 
-                        LOG.error("Exception while listening", e);
+                        LOG.error("Exception while listening on port {}", address, e);
 
                         if (e instanceof SocketException) {
                             socketException.set(true);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -1090,7 +1090,7 @@ public class QuorumCnxManager {
                             break;
                         }
 
-                        LOG.error("Exception while listening on port {}", address, e);
+                        LOG.error("Exception while listening to address {}", address, e);
 
                         if (e instanceof SocketException) {
                             socketException.set(true);


### PR DESCRIPTION
As per [ZOOKEEPER-3800](https://issues.apache.org/jira/browse/ZOOKEEPER-3800), I updated the log message to print the address.

Please let me know if additional changes are required.