### PR TITLE
ZOOKEEPER-3811 : cleaning up code,static field be directly referred by its class name

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/RequestThrottler.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/RequestThrottler.java
@@ -100,8 +100,8 @@ public class RequestThrottler extends ZooKeeperCriticalThread {
 
     protected boolean shouldThrottleOp(Request request, long elapsedTime) {
         return request.isThrottlable()
-                && zks.getThrottledOpWaitTime() > 0
-                && elapsedTime > zks.getThrottledOpWaitTime();
+                && ZooKeeperServer.getThrottledOpWaitTime() > 0
+                && elapsedTime > ZooKeeperServer.getThrottledOpWaitTime();
     }
 
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerBean.java
@@ -316,11 +316,11 @@ public class ZooKeeperServerBean implements ZooKeeperServerMXBean, ZKMBeanInfo {
     ///////////////////////////////////////////////////////////////////////////
 
     public int getThrottledOpWaitTime() {
-        return zks.getThrottledOpWaitTime();
+        return ZooKeeperServer.getThrottledOpWaitTime();
     }
 
     public void setThrottledOpWaitTime(int val) {
-        zks.setThrottledOpWaitTime(val);
+        ZooKeeperServer.setThrottledOpWaitTime(val);
     }
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
optimized code,A static field should be directly referred by its class name