### PR TITLE
ZOOKEEPER-3751: upgrade jackson-databind to 2.10 from 2.9

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -55,7 +55,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="javacc.version" value="5.0"/>
 
     <property name="jetty.version" value="9.4.17.v20190418"/>
-    <property name="jackson.version" value="2.9.10.3"/>
+    <property name="jackson.version" value="2.10.3"/>
     <property name="dependency-check-ant.version" value="5.2.4"/>
 
     <property name="commons-io.version" value="2.6"/>

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
     <commons-cli.version>1.2</commons-cli.version>
     <jetty.version>9.4.24.v20191120</jetty.version>
     <netty.version>4.1.48.Final</netty.version>
-    <jackson.version>2.9.10.3</jackson.version>
+    <jackson.version>2.10.3</jackson.version>
     <json.version>1.1.1</json.version>
     <jline.version>2.11</jline.version>
     <snappy.version>1.1.7</snappy.version>


### PR DESCRIPTION
The original PR (#1283) was only merged to 3.6+ as in 3.5 we also have to change the ant configs. I created a new PR to kick-in the CI also for branch 3.5.