### PR TITLE
ZOOKEEPER-3727: Fix 3.5 source tarball to represent the git repository

### DIFF
--- a/zookeeper-assembly/src/main/assembly/source-package.xml
+++ b/zookeeper-assembly/src/main/assembly/source-package.xml
@@ -101,7 +101,7 @@
         <include>ivysettings.xml</include>
         <include>excludeFindBugsFilter.xml</include>
         <include>owaspSuppressions.xml</include>
-        <include>checktyle.xml</include>
+        <include>checkstyle.xml</include>
         <include>checkstyleSuppressions.xml</include>
         <include>.travis.yml</include>
       </includes>


### PR DESCRIPTION
Comparing the 3.5 source tarball with the freshly cloned branch-3.5,
we see the following differences:

```
diff --brief --recursive ./tarball/ ./cloned/

Only in ./cloned: .git
Only in ./cloned: .gitattributes
Only in ./cloned: .gitignore
Only in ./cloned: checkstyle.xml
Only in ./tarball/zookeeper-server/src/main/java/org/apache/zookeeper/version: Info.java
Only in ./tarball/zookeeper-server/src/main/resources: git.properties
```

I added the `checkstyle.xml`, as it was missing due to a typo.

The git related files / folders are not present in the 3.6 releases either, so I don't think we 
should change the current behaviour on 3.5.

The `Info.java` and `git.properties` files are generated by the Git-Commit-Id-Plugin during
the build. We don't have these files generated on the 3.6 / master branches. I would suggest
to keep them in the source tarball, as users who use the source tarball will not have the
git commit info as they didn't clone the repo from git.