### PR TITLE
ZOOKEEPER-3813 FileChangeWatcherTest is broken on Mac

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/FileChangeWatcherTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/FileChangeWatcherTest.java
@@ -45,6 +45,8 @@ public class FileChangeWatcherTest extends ZKTestCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileChangeWatcherTest.class);
 
+    private static final long FS_TIMEOUT = 30000L;
+
     @BeforeClass
     public static void createTempFile() throws IOException {
         tempDir = ClientBase.createEmptyTestDir();
@@ -87,7 +89,7 @@ public class FileChangeWatcherTest extends ZKTestCase {
                 FileUtils.writeStringToFile(tempFile, "Hello world " + i + "\n", StandardCharsets.UTF_8, true);
                 synchronized (events) {
                     if (events.size() < i + 1) {
-                        events.wait(3000L);
+                        events.wait(FS_TIMEOUT);
                     }
                     assertEquals("Wrong number of events", i + 1, events.size());
                     WatchEvent<?> event = events.get(i);
@@ -128,7 +130,7 @@ public class FileChangeWatcherTest extends ZKTestCase {
             FileUtils.touch(tempFile);
             synchronized (events) {
                 if (events.isEmpty()) {
-                    events.wait(3000L);
+                    events.wait(FS_TIMEOUT);
                 }
                 assertFalse(events.isEmpty());
                 WatchEvent<?> event = events.get(0);
@@ -162,7 +164,7 @@ public class FileChangeWatcherTest extends ZKTestCase {
             tempFile2.deleteOnExit();
             synchronized (events) {
                 if (events.isEmpty()) {
-                    events.wait(3000L);
+                    events.wait(FS_TIMEOUT);
                 }
                 assertFalse(events.isEmpty());
                 WatchEvent<?> event = events.get(0);
@@ -201,7 +203,7 @@ public class FileChangeWatcherTest extends ZKTestCase {
             tempFile.delete();
             synchronized (events) {
                 if (events.isEmpty()) {
-                    events.wait(3000L);
+                    events.wait(FS_TIMEOUT);
                 }
                 assertFalse(events.isEmpty());
                 WatchEvent<?> event = events.get(0);
@@ -239,14 +241,14 @@ public class FileChangeWatcherTest extends ZKTestCase {
             FileUtils.writeStringToFile(tempFile, "Hello world\n", StandardCharsets.UTF_8, true);
             synchronized (callCount) {
                 while (callCount.get() == 0) {
-                    callCount.wait(3000L);
+                    callCount.wait(FS_TIMEOUT);
                 }
             }
             LOG.info("Modifying file again");
             FileUtils.writeStringToFile(tempFile, "Hello world again\n", StandardCharsets.UTF_8, true);
             synchronized (callCount) {
                 if (callCount.get() == 1) {
-                    callCount.wait(3000L);
+                    callCount.wait(FS_TIMEOUT);
                 }
             }
             // The value of callCount can exceed 1 only if the callback thread


### PR DESCRIPTION
This patch will increase the FS wait timeout to give Mac OSX longer time to detect file modifications.