### PR TITLE
Add log for UnimplementedException on reconfig.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -419,7 +419,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             try {
                 lzks = (LeaderZooKeeperServer) zks;
             } catch (ClassCastException e) {
-                // standalone mode - reconfiguration currently not supported
+                LOG.error("Reconfig operation requested but this feature is currently not supported on standalone mode.”);
                 throw new KeeperException.UnimplementedException();
             }
             QuorumVerifier lastSeenQV = lzks.self.getLastSeenQuorumVerifier();


### PR DESCRIPTION
i have this problem and i see is for the standalone:
zcli only said:
```
2020-05-20 19:29:52,244 [myid:localhost:2181] - INFO  [main-SendThread(localhost:2181):ClientCnxn$SendThread@1420] - Session establishment complete on server localhost/127.0.0.1:2181, session id = 0x100007757090006, negotiated timeout = 30000

WATCHER::

WatchedEvent state:SyncConnected type:None path:null
KeeperErrorCode = Unimplemented
2020-05-20 19:29:52,264 [myid:] - ERROR [main:ServiceUtils@42] - Exiting JVM with code 1
```
also the server log:
```
zookeeper     | 2020-05-20 19:29:52,250 [myid:1] - INFO  [ProcessThread(sid:0 cport:2181)::PrepRequestProcessor@913] - Got user-level KeeperException when processing sessionid:0x100007757090006 type:reconfig cxid:0x1 zxid:0xa3 txntype:-1 reqpath:n/a Error Path:null Error:KeeperErrorCode = Unimplemented
```
is more easy to seen if we have a message log.