### PR TITLE
ZOOKEEPER-3831 - add a compatibility test module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <module>zookeeper-client</module>
     <module>zookeeper-recipes</module>
     <module>zookeeper-assembly</module>
-      <module>zookeeper-compatibility-tests</module>
+    <module>zookeeper-compatibility-tests</module>
   </modules>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <module>zookeeper-client</module>
     <module>zookeeper-recipes</module>
     <module>zookeeper-assembly</module>
+      <module>zookeeper-compatibility-tests</module>
   </modules>
 
   <scm>

--- a/zookeeper-compatibility-tests/pom.xml
+++ b/zookeeper-compatibility-tests/pom.xml
@@ -26,56 +26,17 @@
         <artifactId>parent</artifactId>
         <version>3.7.0-SNAPSHOT</version>
     </parent>
+    <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>zookeeper-compatibility-tests</artifactId>
 
+    <modules>
+        <module>zookeeper-compatibility-tests-curator</module>
+    </modules>
+
     <name>Apache ZooKeeper - Compatibility Tests</name>
     <description>Module for various compatibility tests</description>
-
-    <properties>
-        <apache-curator-version>5.0.0</apache-curator-version>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-recipes</artifactId>
-            <version>${apache-curator-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.zookeeper</groupId>
-                    <artifactId>zookeeper</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-test</artifactId>
-            <version>${apache-curator-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.zookeeper</groupId>
-                    <artifactId>zookeeper</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 
     <build>
         <plugins>

--- a/zookeeper-compatibility-tests/pom.xml
+++ b/zookeeper-compatibility-tests/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>parent</artifactId>
+        <version>3.7.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>zookeeper-compatibility-tests</artifactId>
+
+    <name>Apache ZooKeeper - Compatibility Tests</name>
+    <description>Module for various compatibility tests</description>
+
+    <properties>
+        <apache-curator-version>5.0.0</apache-curator-version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${apache-curator-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>${apache-curator-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/zookeeper-compatibility-tests/src/test/java/org/apache/zookeeper/compatibility/TestApacheCuratorCompatibility.java
+++ b/zookeeper-compatibility-tests/src/test/java/org/apache/zookeeper/compatibility/TestApacheCuratorCompatibility.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.compatibility;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingServer;
+import org.junit.Test;
+
+/**
+ * Make sure minimal Apache Curator APIs work correctly. As it's a widely used ZooKeeper
+ * client library we should not break it.
+ */
+public class TestApacheCuratorCompatibility {
+    private static final int TIMEOUT_MS = 5000;
+
+    @Test
+    public void testBasicUsageOfApisAndRecipes() throws Exception {
+        try (TestingServer server = new TestingServer()) {
+            RetryOneTime retryPolicy = new RetryOneTime(1);
+            try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), retryPolicy)) {
+                try (CuratorCache cache = CuratorCache.build(client, "/base/path")) {
+                    client.start();
+                    cache.start();
+
+                    BlockingQueue<String> paths = new LinkedBlockingQueue<>();
+                    cache.listenable().addListener((dummy1, dummy2, data) -> paths.add(data.getPath()));
+
+                    client.create().creatingParentsIfNeeded().forPath("/base/path/1");
+                    client.create().creatingParentsIfNeeded().forPath("/base/path/2");
+                    client.create().creatingParentsIfNeeded().forPath("/base/path/1/a");
+                    client.create().creatingParentsIfNeeded().forPath("/base/path/2/a");
+
+                    assertEquals("/base/path", poll(paths));
+                    assertEquals("/base/path/1", poll(paths));
+                    assertEquals("/base/path/2", poll(paths));
+                    assertEquals("/base/path/1/a", poll(paths));
+                    assertEquals("/base/path/2/a", poll(paths));
+                }
+            }
+        }
+    }
+
+    private String poll(BlockingQueue<String> queue) {
+        try {
+            String value = queue.poll(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            assertNotNull("Event poll timed out", value);
+            return value;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/zookeeper-compatibility-tests/zookeeper-compatibility-tests-curator/pom.xml
+++ b/zookeeper-compatibility-tests/zookeeper-compatibility-tests-curator/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper-compatibility-tests</artifactId>
+        <version>3.7.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>zookeeper-compatibility-tests-curator</artifactId>
+
+    <name>Apache ZooKeeper - Compatibility Tests - Curator</name>
+    <description>Module for Apache Curator compatibility tests</description>
+
+    <properties>
+        <apache-curator-version>5.0.0</apache-curator-version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${apache-curator-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>${apache-curator-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/zookeeper-compatibility-tests/zookeeper-compatibility-tests-curator/src/test/java/org/apache/zookeeper/compatibility/TestApacheCuratorCompatibility.java
+++ b/zookeeper-compatibility-tests/zookeeper-compatibility-tests-curator/src/test/java/org/apache/zookeeper/compatibility/TestApacheCuratorCompatibility.java
@@ -64,7 +64,7 @@ public class TestApacheCuratorCompatibility {
         }
     }
 
-    private String poll(BlockingQueue<String> queue) {
+    private static String poll(BlockingQueue<String> queue) {
         try {
             String value = queue.poll(TIMEOUT_MS, TimeUnit.MILLISECONDS);
             assertNotNull("Event poll timed out", value);


### PR DESCRIPTION
ZooKeeper has many external libraries that are dependent on staying compatible. For example, Apache Curator. This new module will be used to add compatibility tests for any third party library, tool, etc. that we want to ensure maintains compatibility. The module is configured with Maven not to install/deploy so it's only for testing purposes. An initial test using Apache Curator is added.