### PR TITLE
ZOOKEEPER-3829: fix rolling restart when dynamic reconfig is disabled

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -129,6 +129,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
     }
     @Override
     public void run() {
+        LOG.info(String.format("PrepRequestProcessor (sid:%d) started, reconfigEnabled=%s", zks.getServerId(), zks.reconfigEnabled));
         try {
             while (true) {
                 Request request = submittedRequests.take();
@@ -423,7 +424,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
                 addChangeRecord(nodeRecord);
                 break;
             case OpCode.reconfig:
-                if (!QuorumPeerConfig.isReconfigEnabled()) {
+                if (!zks.isReconfigEnabled()) {
                     LOG.error("Reconfig operation requested but reconfig feature is disabled.");
                     throw new KeeperException.ReconfigDisabledException();
                 }
@@ -433,7 +434,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
                 }
 
                 zks.sessionTracker.checkSession(request.sessionId, request.getOwner());
-                ReconfigRequest reconfigRequest = (ReconfigRequest)record; 
+                ReconfigRequest reconfigRequest = (ReconfigRequest)record;
                 LeaderZooKeeperServer lzks;
                 try {
                     lzks = (LeaderZooKeeperServer)zks;
@@ -441,13 +442,13 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
                     // standalone mode - reconfiguration currently not supported
                     throw new KeeperException.UnimplementedException();
                 }
-                QuorumVerifier lastSeenQV = lzks.self.getLastSeenQuorumVerifier();                                                                                 
+                QuorumVerifier lastSeenQV = lzks.self.getLastSeenQuorumVerifier();
                 // check that there's no reconfig in progress
                 if (lastSeenQV.getVersion()!=lzks.self.getQuorumVerifier().getVersion()) {
-                       throw new KeeperException.ReconfigInProgress(); 
+                       throw new KeeperException.ReconfigInProgress();
                 }
                 long configId = reconfigRequest.getCurConfigId();
-  
+
                 if (configId != -1 && configId!=lzks.self.getLastSeenQuorumVerifier().getVersion()){
                    String msg = "Reconfiguration from version " + configId + " failed -- last seen version is " +
                            lzks.self.getLastSeenQuorumVerifier().getVersion();
@@ -455,54 +456,54 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
                 }
 
                 String newMembers = reconfigRequest.getNewMembers();
-                
-                if (newMembers != null) { //non-incremental membership change                  
+
+                if (newMembers != null) { //non-incremental membership change
                    LOG.info("Non-incremental reconfig");
-                
+
                    // Input may be delimited by either commas or newlines so convert to common newline separated format
                    newMembers = newMembers.replaceAll(",", "\n");
-                   
+
                    try{
-                       Properties props = new Properties();                        
+                       Properties props = new Properties();
                        props.load(new StringReader(newMembers));
                        request.qv = QuorumPeerConfig.parseDynamicConfig(props, lzks.self.getElectionType(), true, false);
                        request.qv.setVersion(request.getHdr().getZxid());
                    } catch (IOException | ConfigException e) {
                        throw new KeeperException.BadArgumentsException(e.getMessage());
                    }
-                } else { //incremental change - must be a majority quorum system   
+                } else { //incremental change - must be a majority quorum system
                    LOG.info("Incremental reconfig");
-                   
-                   List<String> joiningServers = null; 
+
+                   List<String> joiningServers = null;
                    String joiningServersString = reconfigRequest.getJoiningServers();
                    if (joiningServersString != null)
                    {
                        joiningServers = StringUtils.split(joiningServersString,",");
                    }
-                   
+
                    List<String> leavingServers = null;
                    String leavingServersString = reconfigRequest.getLeavingServers();
                    if (leavingServersString != null)
                    {
                        leavingServers = StringUtils.split(leavingServersString, ",");
                    }
-                   
+
                    if (!(lastSeenQV instanceof QuorumMaj)) {
                            String msg = "Incremental reconfiguration requested but last configuration seen has a non-majority quorum system";
                            LOG.warn(msg);
-                           throw new KeeperException.BadArgumentsException(msg);               
+                           throw new KeeperException.BadArgumentsException(msg);
                    }
                    Map<Long, QuorumServer> nextServers = new HashMap<Long, QuorumServer>(lastSeenQV.getAllMembers());
-                   try {                           
+                   try {
                        if (leavingServers != null) {
                            for (String leaving: leavingServers){
                                long sid = Long.parseLong(leaving);
                                nextServers.remove(sid);
-                           } 
+                           }
                        }
                        if (joiningServers != null) {
                            for (String joiner: joiningServers){
-                        	   // joiner should have the following format: server.x = server_spec;client_spec               
+                        	   // joiner should have the following format: server.x = server_spec;client_spec
                         	   String[] parts = StringUtils.split(joiner, "=").toArray(new String[0]);
                                if (parts.length != 2) {
                                    throw new KeeperException.BadArgumentsException("Wrong format of server string");
@@ -511,7 +512,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
                                Long sid = Long.parseLong(parts[0].substring(parts[0].lastIndexOf('.') + 1));
                                QuorumServer qs = new QuorumServer(sid, parts[1]);
                                if (qs.clientAddr == null || qs.electionAddr == null || qs.addr == null) {
-                                   throw new KeeperException.BadArgumentsException("Wrong format of server string - each server should have 3 ports specified"); 	   
+                                   throw new KeeperException.BadArgumentsException("Wrong format of server string - each server should have 3 ports specified");
                                }
 
                                // check duplication of addresses and ports
@@ -524,7 +525,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
 
                                nextServers.remove(qs.id);
                                nextServers.put(qs.id, qs);
-                           }  
+                           }
                        }
                    } catch (ConfigException e){
                        throw new KeeperException.BadArgumentsException("Reconfiguration failed");
@@ -540,21 +541,21 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
                    String msg = "Reconfig failed - new configuration must include at least 1 follower";
                    LOG.warn(msg);
                    throw new KeeperException.BadArgumentsException(msg);
-                }                           
-                   
+                }
+
                 if (!lzks.getLeader().isQuorumSynced(request.qv)) {
                    String msg2 = "Reconfig failed - there must be a connected and synced quorum in new configuration";
-                   LOG.warn(msg2);             
+                   LOG.warn(msg2);
                    throw new KeeperException.NewConfigNoQuorum();
                 }
-                
-                nodeRecord = getRecordForPath(ZooDefs.CONFIG_NODE);               
-                checkACL(zks, nodeRecord.acl, ZooDefs.Perms.WRITE, request.authInfo);                  
-                request.setTxn(new SetDataTxn(ZooDefs.CONFIG_NODE, request.qv.toString().getBytes(), -1));    
+
+                nodeRecord = getRecordForPath(ZooDefs.CONFIG_NODE);
+                checkACL(zks, nodeRecord.acl, ZooDefs.Perms.WRITE, request.authInfo);
+                request.setTxn(new SetDataTxn(ZooDefs.CONFIG_NODE, request.qv.toString().getBytes(), -1));
                 nodeRecord = nodeRecord.duplicate(request.getHdr().getZxid());
-                nodeRecord.stat.setVersion(-1);                
+                nodeRecord.stat.setVersion(-1);
                 addChangeRecord(nodeRecord);
-                break;                         
+                break;
             case OpCode.setACL:
                 zks.sessionTracker.checkSession(request.sessionId, request.getOwner());
                 SetACLRequest setAclRequest = (SetACLRequest)record;
@@ -753,7 +754,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
                 pRequest2Txn(request.type, zks.getNextZxid(), request, deleteRequest, true);
                 break;
             case OpCode.setData:
-                SetDataRequest setDataRequest = new SetDataRequest();                
+                SetDataRequest setDataRequest = new SetDataRequest();
                 pRequest2Txn(request.type, zks.getNextZxid(), request, setDataRequest, true);
                 break;
             case OpCode.reconfig:
@@ -762,11 +763,11 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
                 pRequest2Txn(request.type, zks.getNextZxid(), request, reconfigRequest, true);
                 break;
             case OpCode.setACL:
-                SetACLRequest setAclRequest = new SetACLRequest();                
+                SetACLRequest setAclRequest = new SetACLRequest();
                 pRequest2Txn(request.type, zks.getNextZxid(), request, setAclRequest, true);
                 break;
             case OpCode.check:
-                CheckVersionRequest checkRequest = new CheckVersionRequest();              
+                CheckVersionRequest checkRequest = new CheckVersionRequest();
                 pRequest2Txn(request.type, zks.getNextZxid(), request, checkRequest, true);
                 break;
             case OpCode.multi:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
@@ -31,6 +31,7 @@ import org.apache.zookeeper.server.admin.AdminServer.AdminServerException;
 import org.apache.zookeeper.server.admin.AdminServerFactory;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog.DatadirException;
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -123,7 +124,7 @@ public class ZooKeeperServerMain {
             // create a file logger url from the command line args
             txnLog = new FileTxnSnapLog(config.dataLogDir, config.dataDir);
             final ZooKeeperServer zkServer = new ZooKeeperServer(txnLog,
-                    config.tickTime, config.minSessionTimeout, config.maxSessionTimeout, null);
+                    config.tickTime, config.minSessionTimeout, config.maxSessionTimeout, null, QuorumPeerConfig.isReconfigEnabled());
             txnLog.setServerStats(zkServer.serverStats());
 
             // Registers shutdown handler which will be used to know the

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -212,7 +212,7 @@ public class Leader {
     /**
      * Returns true if a quorum in qv is connected and synced with the leader
      * and false otherwise
-     *  
+     *
      * @param qv, a QuorumVerifier
      */
     public boolean isQuorumSynced(QuorumVerifier qv) {
@@ -228,7 +228,7 @@ public class Leader {
        }
        return qv.containsQuorum(ids);
     }
-    
+
     private final ServerSocket ss;
 
     Leader(QuorumPeer self,LeaderZooKeeperServer zk) throws IOException {
@@ -358,17 +358,17 @@ public class Leader {
      * This message type informs observers of a committed proposal.
      */
     final static int INFORM = 8;
-    
+
     /**
      * Similar to COMMIT, only for a reconfig operation.
      */
     final static int COMMITANDACTIVATE = 9;
-    
+
     /**
      * Similar to INFORM, only for a reconfig operation.
      */
     final static int INFORMANDACTIVATE = 19;
-    
+
     final ConcurrentMap<Long, Proposal> outstandingProposals = new ConcurrentHashMap<Long, Proposal>();
 
     private final ConcurrentLinkedQueue<Proposal> toBeApplied = new ConcurrentLinkedQueue<Proposal>();
@@ -448,9 +448,9 @@ public class Leader {
     long epoch = -1;
     boolean waitingForNewEpoch = true;
 
-    // when a reconfig occurs where the leader is removed or becomes an observer, 
+    // when a reconfig occurs where the leader is removed or becomes an observer,
    // it does not commit ops after committing the reconfig
-    boolean allowedToCommit = true;     
+    boolean allowedToCommit = true;
     /**
      * This method is main function that is called to lead
      *
@@ -500,45 +500,46 @@ public class Leader {
             QuorumVerifier curQV = self.getQuorumVerifier();
             if (curQV.getVersion() == 0 && curQV.getVersion() == lastSeenQV.getVersion()) {
                 // This was added in ZOOKEEPER-1783. The initial config has version 0 (not explicitly
-                // specified by the user; the lack of version in a config file is interpreted as version=0). 
+                // specified by the user; the lack of version in a config file is interpreted as version=0).
                 // As soon as a config is established we would like to increase its version so that it
                 // takes presedence over other initial configs that were not established (such as a config
-                // of a server trying to join the ensemble, which may be a partial view of the system, not the full config). 
+                // of a server trying to join the ensemble, which may be a partial view of the system, not the full config).
                 // We chose to set the new version to the one of the NEWLEADER message. However, before we can do that
                 // there must be agreement on the new version, so we can only change the version when sending/receiving UPTODATE,
-                // not when sending/receiving NEWLEADER. In other words, we can't change curQV here since its the committed quorum verifier, 
-                // and there's still no agreement on the new version that we'd like to use. Instead, we use 
+                // not when sending/receiving NEWLEADER. In other words, we can't change curQV here since its the committed quorum verifier,
+                // and there's still no agreement on the new version that we'd like to use. Instead, we use
                 // lastSeenQuorumVerifier which is being sent with NEWLEADER message
-                // so its a good way to let followers know about the new version. (The original reason for sending 
+                // so its a good way to let followers know about the new version. (The original reason for sending
                 // lastSeenQuorumVerifier with NEWLEADER is so that the leader completes any potentially uncommitted reconfigs
-                // that it finds before starting to propose operations. Here we're reusing the same code path for 
+                // that it finds before starting to propose operations. Here we're reusing the same code path for
                 // reaching consensus on the new version number.)
-                
+
                 // It is important that this is done before the leader executes waitForEpochAck,
                 // so before LearnerHandlers return from their waitForEpochAck
                 // hence before they construct the NEWLEADER message containing
                 // the last-seen-quorumverifier of the leader, which we change below
                try {
+                   LOG.debug(String.format("set lastSeenQuorumVerifier to currentQuorumVerifier (%s)", curQV.toString()));
                    QuorumVerifier newQV = self.configFromString(curQV.toString());
                    newQV.setVersion(zk.getZxid());
-                   self.setLastSeenQuorumVerifier(newQV, true);    
+                   self.setLastSeenQuorumVerifier(newQV, true);
                } catch (Exception e) {
                    throw new IOException(e);
                }
             }
-            
+
             newLeaderProposal.addQuorumVerifier(self.getQuorumVerifier());
             if (self.getLastSeenQuorumVerifier().getVersion() > self.getQuorumVerifier().getVersion()){
                newLeaderProposal.addQuorumVerifier(self.getLastSeenQuorumVerifier());
             }
-            
+
             // We have to get at least a majority of servers in sync with
             // us. We do this by waiting for the NEWLEADER packet to get
             // acknowledged
-                       
+
              waitForEpochAck(self.getId(), leaderStateSummary);
-             self.setCurrentEpoch(epoch);    
-            
+             self.setCurrentEpoch(epoch);
+
              try {
                  waitForNewLeaderAck(self.getId(), zk.getZxid());
              } catch (InterruptedException e) {
@@ -550,14 +551,14 @@ public class Leader {
                      if (self.getQuorumVerifier().getVotingMembers().containsKey(f.getSid())){
                          followerSet.add(f.getSid());
                      }
-                 }    
+                 }
                  boolean initTicksShouldBeIncreased = true;
                  for (Proposal.QuorumVerifierAcksetPair qvAckset:newLeaderProposal.qvAcksetPairs) {
                      if (!qvAckset.getQuorumVerifier().containsQuorum(followerSet)) {
                          initTicksShouldBeIncreased = false;
                          break;
                      }
-                 }                  
+                 }
                  if (initTicksShouldBeIncreased) {
                      LOG.warn("Enough followers present. "+
                              "Perhaps the initTicks need to be increased.");
@@ -566,7 +567,7 @@ public class Leader {
              }
 
              startZkServer();
-             
+
             /**
              * WARNING: do not use this for anything other than QA testing
              * on a real cluster. Specifically to enable verification that quorum
@@ -712,39 +713,39 @@ public class Leader {
 
     /** In a reconfig operation, this method attempts to find the best leader for next configuration.
      *  If the current leader is a voter in the next configuartion, then it remains the leader.
-     *  Otherwise, choose one of the new voters that acked the reconfiguartion, such that it is as   
+     *  Otherwise, choose one of the new voters that acked the reconfiguartion, such that it is as
      * up-to-date as possible, i.e., acked as many outstanding proposals as possible.
-     *  
+     *
      * @param reconfigProposal
      * @param zxid of the reconfigProposal
      * @return server if of the designated leader
      */
-    
+
     private long getDesignatedLeader(Proposal reconfigProposal, long zxid) {
        //new configuration
-       Proposal.QuorumVerifierAcksetPair newQVAcksetPair = reconfigProposal.qvAcksetPairs.get(reconfigProposal.qvAcksetPairs.size()-1);        
-       
-       //check if I'm in the new configuration with the same quorum address - 
-       // if so, I'll remain the leader    
-       if (newQVAcksetPair.getQuorumVerifier().getVotingMembers().containsKey(self.getId()) && 
-               newQVAcksetPair.getQuorumVerifier().getVotingMembers().get(self.getId()).addr.equals(self.getQuorumAddress())){  
+       Proposal.QuorumVerifierAcksetPair newQVAcksetPair = reconfigProposal.qvAcksetPairs.get(reconfigProposal.qvAcksetPairs.size()-1);
+
+       //check if I'm in the new configuration with the same quorum address -
+       // if so, I'll remain the leader
+       if (newQVAcksetPair.getQuorumVerifier().getVotingMembers().containsKey(self.getId()) &&
+               newQVAcksetPair.getQuorumVerifier().getVotingMembers().get(self.getId()).addr.equals(self.getQuorumAddress())){
            return self.getId();
        }
-       // start with an initial set of candidates that are voters from new config that 
-       // acknowledged the reconfig op (there must be a quorum). Choose one of them as 
+       // start with an initial set of candidates that are voters from new config that
+       // acknowledged the reconfig op (there must be a quorum). Choose one of them as
        // current leader candidate
        HashSet<Long> candidates = new HashSet<Long>(newQVAcksetPair.getAckset());
        candidates.remove(self.getId()); // if we're here, I shouldn't be the leader
        long curCandidate = candidates.iterator().next();
-       
+
        //go over outstanding ops in order, and try to find a candidate that acked the most ops.
        //this way it will be the most up-to-date and we'll minimize the number of ops that get dropped
-       
+
        long curZxid = zxid + 1;
        Proposal p = outstandingProposals.get(curZxid);
-               
-       while (p!=null && !candidates.isEmpty()) {                              
-           for (Proposal.QuorumVerifierAcksetPair qvAckset: p.qvAcksetPairs){ 
+
+       while (p!=null && !candidates.isEmpty()) {
+           for (Proposal.QuorumVerifierAcksetPair qvAckset: p.qvAcksetPairs){
                //reduce the set of candidates to those that acknowledged p
                candidates.retainAll(qvAckset.getAckset());
                //no candidate acked p, return the best candidate found so far
@@ -752,18 +753,18 @@ public class Leader {
                //update the current candidate, and if it is the only one remaining, return it
                curCandidate = candidates.iterator().next();
                if (candidates.size() == 1) return curCandidate;
-           }      
+           }
            curZxid++;
            p = outstandingProposals.get(curZxid);
        }
-       
+
        return curCandidate;
     }
 
     /**
      * @return True if committed, otherwise false.
      **/
-    synchronized public boolean tryToCommit(Proposal p, long zxid, SocketAddress followerAddr) {       
+    synchronized public boolean tryToCommit(Proposal p, long zxid, SocketAddress followerAddr) {
        // make sure that ops are committed in order. With reconfigurations it is now possible
        // that different operations wait for different sets of acks, and we still want to enforce
        // that they are committed in order. Currently we only permit one outstanding reconfiguration
@@ -772,50 +773,52 @@ public class Leader {
        // for an operation without getting enough acks for preceding ops. But in the future if multiple
        // concurrent reconfigs are allowed, this can happen.
        if (outstandingProposals.containsKey(zxid - 1)) return false;
-       
+
        // in order to be committed, a proposal must be accepted by a quorum.
        //
        // getting a quorum from all necessary configurations.
         if (!p.hasAllQuorums()) {
-           return false;                 
+           return false;
         }
-        
+
         // commit proposals in order
-        if (zxid != lastCommitted+1) {    
+        if (zxid != lastCommitted+1) {
            LOG.warn("Commiting zxid 0x" + Long.toHexString(zxid)
                     + " from " + followerAddr + " not first!");
             LOG.warn("First is "
                     + (lastCommitted+1));
-        }     
-        
+        }
+
         outstandingProposals.remove(zxid);
-        
+
         if (p.request != null) {
              toBeApplied.add(p);
         }
 
         if (p.request == null) {
             LOG.warn("Going to commmit null: " + p);
-        } else if (p.request.getHdr().getType() == OpCode.reconfig) {                                   
-            LOG.debug("Committing a reconfiguration! " + outstandingProposals.size()); 
-                 
-            //if this server is voter in new config with the same quorum address, 
+        } else if (p.request.getHdr().getType() == OpCode.reconfig) {
+            LOG.debug("Committing a reconfiguration! " + outstandingProposals.size());
+
+            //if this server is voter in new config with the same quorum address,
             //then it will remain the leader
             //otherwise an up-to-date follower will be designated as leader. This saves
-            //leader election time, unless the designated leader fails                             
+            //leader election time, unless the designated leader fails
             Long designatedLeader = getDesignatedLeader(p, zxid);
             //LOG.warn("designated leader is: " + designatedLeader);
 
             QuorumVerifier newQV = p.qvAcksetPairs.get(p.qvAcksetPairs.size()-1).getQuorumVerifier();
-       
+
             self.processReconfig(newQV, designatedLeader, zk.getZxid(), true);
 
             if (designatedLeader != self.getId()) {
+                LOG.info(String.format("Committing a reconfiguration (reconfigEnabled=%s); this leader is not the designated "
+                        + "leader anymore, setting allowedToCommit=false", self.isReconfigEnabled()));
                 allowedToCommit = false;
             }
-                   
-            // we're sending the designated leader, and if the leader is changing the followers are 
-            // responsible for closing the connection - this way we are sure that at least a majority of them 
+
+            // we're sending the designated leader, and if the leader is changing the followers are
+            // responsible for closing the connection - this way we are sure that at least a majority of them
             // receive the commit message.
             commitAndActivate(zxid, designatedLeader);
             informAndActivate(p, designatedLeader);
@@ -828,12 +831,12 @@ public class Leader {
         if(pendingSyncs.containsKey(zxid)){
             for(LearnerSyncRequest r: pendingSyncs.remove(zxid)) {
                 sendSync(r);
-            }               
-        } 
-        
-        return  true;   
+            }
+        }
+
+        return  true;
     }
-    
+
     /**
      * Keep a count of acks that are received by the leader for a particular
      * proposal
@@ -842,9 +845,9 @@ public class Leader {
      * @param sid, the id of the server that sent the ack
      * @param followerAddr
      */
-    synchronized public void processAck(long sid, long zxid, SocketAddress followerAddr) {        
-        if (!allowedToCommit) return; // last op committed was a leader change - from now on 
-                                     // the new leader should commit        
+    synchronized public void processAck(long sid, long zxid, SocketAddress followerAddr) {
+        if (!allowedToCommit) return; // last op committed was a leader change - from now on
+                                     // the new leader should commit
         if (LOG.isTraceEnabled()) {
             LOG.trace("Ack zxid: 0x{}", Long.toHexString(zxid));
             for (Proposal p : outstandingProposals.values()) {
@@ -854,7 +857,7 @@ public class Leader {
             }
             LOG.trace("outstanding proposals all");
         }
-        
+
         if ((zxid & 0xffffffffL) == 0) {
             /*
              * We no longer process NEWLEADER ack with this method. However,
@@ -863,8 +866,8 @@ public class Leader {
              */
             return;
         }
-            
-            
+
+
         if (outstandingProposals.size() == 0) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("outstanding is 0");
@@ -885,13 +888,13 @@ public class Leader {
                     Long.toHexString(zxid), followerAddr);
             return;
         }
-        
-        p.addAck(sid);        
+
+        p.addAck(sid);
         /*if (LOG.isDebugEnabled()) {
             LOG.debug("Count for zxid: 0x{} is {}",
                     Long.toHexString(zxid), p.ackSet.size());
         }*/
-        
+
         boolean hasCommitted = tryToCommit(p, zxid, followerAddr);
 
         // If p is a reconfiguration, multiple other operations may be ready to be committed,
@@ -908,11 +911,11 @@ public class Leader {
            while (allowedToCommit && hasCommitted && p!=null){
                curZxid++;
                p = outstandingProposals.get(curZxid);
-               if (p !=null) hasCommitted = tryToCommit(p, curZxid, null);             
+               if (p !=null) hasCommitted = tryToCommit(p, curZxid, null);
            }
         }
     }
-    
+
     static class ToBeAppliedRequestProcessor implements RequestProcessor {
         private final RequestProcessor next;
 
@@ -1021,11 +1024,11 @@ public class Leader {
         synchronized(this){
             lastCommitted = zxid;
         }
-        
+
         byte data[] = new byte[8];
-        ByteBuffer buffer = ByteBuffer.wrap(data);                            
+        ByteBuffer buffer = ByteBuffer.wrap(data);
        buffer.putLong(designatedLeader);
-       
+
         QuorumPacket qp = new QuorumPacket(Leader.COMMITANDACTIVATE, zxid, data, null);
         sendPacket(qp);
     }
@@ -1039,17 +1042,17 @@ public class Leader {
         sendObserverPacket(qp);
     }
 
-    
+
     /**
      * Create an inform&activate packet and send it to all observers.
      */
     public void informAndActivate(Proposal proposal, long designatedLeader) {
        byte[] proposalData = proposal.packet.getData();
         byte[] data = new byte[proposalData.length + 8];
-        ByteBuffer buffer = ByteBuffer.wrap(data);                            
+        ByteBuffer buffer = ByteBuffer.wrap(data);
        buffer.putLong(designatedLeader);
        buffer.put(proposalData);
-       
+
         QuorumPacket qp = new QuorumPacket(Leader.INFORMANDACTIVATE, proposal.request.zxid, data, null);
         sendObserverPacket(qp);
     }
@@ -1097,19 +1100,19 @@ public class Leader {
 
         Proposal p = new Proposal();
         p.packet = pp;
-        p.request = request;                
-        
+        p.request = request;
+
         synchronized(this) {
            p.addQuorumVerifier(self.getQuorumVerifier());
-                   
+
            if (request.getHdr().getType() == OpCode.reconfig){
-               self.setLastSeenQuorumVerifier(request.qv, true);                       
+               self.setLastSeenQuorumVerifier(request.qv, true);
            }
-           
+
            if (self.getQuorumVerifier().getVersion()<self.getLastSeenQuorumVerifier().getVersion()) {
                p.addQuorumVerifier(self.getLastSeenQuorumVerifier());
            }
-                   
+
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Proposing:: " + request);
             }
@@ -1120,7 +1123,7 @@ public class Leader {
         }
         return p;
     }
-    
+
     public LearnerSnapshotThrottler getLearnerSnapshotThrottler() {
         return learnerSnapshotThrottler;
     }
@@ -1158,7 +1161,7 @@ public class Leader {
      *
      * @param handler handler of the follower
      * @return last proposed zxid
-     * @throws InterruptedException 
+     * @throws InterruptedException
      */
     synchronized public long startForwarding(LearnerHandler handler,
             long lastSeenZxid) {
@@ -1242,7 +1245,7 @@ public class Leader {
             }
             if (ss.getCurrentEpoch() != -1) {
                 if (ss.isMoreRecentThan(leaderStateSummary)) {
-                    throw new IOException("Follower is ahead of the leader, leader summary: " 
+                    throw new IOException("Follower is ahead of the leader, leader summary: "
                                                     + leaderStateSummary.getCurrentEpoch()
                                                     + " (current epoch), "
                                                     + leaderStateSummary.getLastZxid()
@@ -1270,9 +1273,9 @@ public class Leader {
             }
         }
     }
-    
+
     /**
-     * Return a list of sid in set as string  
+     * Return a list of sid in set as string
      */
     private String getSidSetString(Set<Long> sidSet) {
         StringBuilder sids = new StringBuilder();
@@ -1293,33 +1296,37 @@ public class Leader {
     private synchronized void startZkServer() {
         // Update lastCommitted and Db's zxid to a value representing the new epoch
         lastCommitted = zk.getZxid();
-        LOG.info("Have quorum of supporters, sids: [ "
-                + newLeaderProposal.ackSetsToString()
-                + " ]; starting up and setting last processed zxid: 0x{}",
+        LOG.info("Have quorum of supporters, sids: [{}]; starting up and setting last processed zxid: 0x{}",
+                newLeaderProposal.ackSetsToString(),
                 Long.toHexString(zk.getZxid()));
-        
-        /*
-         * ZOOKEEPER-1324. the leader sends the new config it must complete
-         *  to others inside a NEWLEADER message (see LearnerHandler where
-         *  the NEWLEADER message is constructed), and once it has enough
-         *  acks we must execute the following code so that it applies the
-         *  config to itself.
-         */
-        QuorumVerifier newQV = self.getLastSeenQuorumVerifier();
-        
-        Long designatedLeader = getDesignatedLeader(newLeaderProposal, zk.getZxid());                                         
 
-        self.processReconfig(newQV, designatedLeader, zk.getZxid(), true);
-        if (designatedLeader != self.getId()) {
-            allowedToCommit = false;
+        if (self.isReconfigEnabled()) {
+            /*
+             * ZOOKEEPER-1324. the leader sends the new config it must complete
+             *  to others inside a NEWLEADER message (see LearnerHandler where
+             *  the NEWLEADER message is constructed), and once it has enough
+             *  acks we must execute the following code so that it applies the
+             *  config to itself.
+             */
+            QuorumVerifier newQV = self.getLastSeenQuorumVerifier();
+
+            Long designatedLeader = getDesignatedLeader(newLeaderProposal, zk.getZxid());
+
+            self.processReconfig(newQV, designatedLeader, zk.getZxid(), true);
+            if (designatedLeader != self.getId()) {
+                LOG.warn("This leader is not the designated leader, it will be initialized with allowedToCommit = false");
+                allowedToCommit = false;
+            }
+        } else {
+            LOG.info("Dynamic reconfig feature is disabled, skip designatedLeader calculation and reconfig processing.");
         }
-        
+
         zk.startup();
         /*
          * Update the election vote here to ensure that all members of the
          * ensemble report the same vote to new servers that start up and
          * send leader election notifications to the ensemble.
-         * 
+         *
          * @see https://issues.apache.org/jira/browse/ZOOKEEPER-1732
          */
         self.updateElectionVote(getEpoch());
@@ -1411,7 +1418,7 @@ public class Leader {
         case COMMIT:
             return "COMMIT";
         case COMMITANDACTIVATE:
-            return "COMMITANDACTIVATE";           
+            return "COMMITANDACTIVATE";
         case PING:
             return "PING";
         case REVALIDATE:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -399,7 +399,7 @@ public class Learner {
                 // ZOOKEEPER-2819: overwrite config node content extracted
                 // from leader snapshot with local config, to avoid potential
                 // inconsistency of config node content during rolling restart.
-                if (!QuorumPeerConfig.isReconfigEnabled()) {
+                if (!self.isReconfigEnabled()) {
                     LOG.debug("Reset config node content from local config after deserialization of snapshot.");
                     zk.getZKDatabase().initConfigInZKDatabase(self.getQuorumVerifier());
                 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -1363,4 +1363,9 @@ public class QuorumCnxManager {
     public boolean connectedToPeer(long peerSid) {
         return senderWorkerMap.get(peerSid) != null;
     }
+
+    public boolean isReconfigEnabled() {
+        return self.isReconfigEnabled();
+    }
+
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
@@ -138,7 +138,7 @@ public class QuorumPeerMain {
           LOG.warn("Unable to register log4j JMX control", e);
       }
 
-      LOG.info("Starting quorum peer");
+      LOG.info("Starting quorum peer, myid=" + config.getServerId());
       try {
           ServerCnxnFactory cnxnFactory = null;
           ServerCnxnFactory secureCnxnFactory = null;
@@ -201,7 +201,7 @@ public class QuorumPeerMain {
           }
           quorumPeer.setQuorumCnxnThreadsSize(config.quorumCnxnThreadsSize);
           quorumPeer.initialize();
-          
+
           quorumPeer.start();
           quorumPeer.join();
       } catch (InterruptedException e) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
@@ -46,7 +46,7 @@ public abstract class QuorumZooKeeperServer extends ZooKeeperServer {
             int minSessionTimeout, int maxSessionTimeout,
             ZKDatabase zkDb, QuorumPeer self)
     {
-        super(logFactory, tickTime, minSessionTimeout, maxSessionTimeout, zkDb);
+        super(logFactory, tickTime, minSessionTimeout, maxSessionTimeout, zkDb, self.isReconfigEnabled());
         this.self = self;
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyZooKeeperServer.java
@@ -46,7 +46,7 @@ public class ReadOnlyZooKeeperServer extends ZooKeeperServer {
     ReadOnlyZooKeeperServer(FileTxnSnapLog logFactory, QuorumPeer self,
                             ZKDatabase zkDb) {
         super(logFactory, self.tickTime, self.minSessionTimeout,
-              self.maxSessionTimeout, zkDb);
+              self.maxSessionTimeout, zkDb, self.isReconfigEnabled());
         this.self = self;
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ReconfigRollingRestartCompatibilityTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ReconfigRollingRestartCompatibilityTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -28,7 +31,6 @@ import java.util.List;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.ArrayList;
-
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.test.ClientBase;
@@ -36,7 +38,6 @@ import org.apache.zookeeper.test.ReconfigTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 
 /**
  * ReconfigRollingRestartCompatibilityTest - we want to make sure that users
@@ -106,7 +107,7 @@ public class ReconfigRollingRestartCompatibilityTest extends QuorumPeerTestBase 
         }
 
         for (int i = 0; i < serverCount; i++) {
-            Assert.assertTrue("waiting for server " + i + " being up",
+            assertTrue("waiting for server " + i + " being up",
                     ClientBase.waitForServerUp("127.0.0.1:" + clientPorts.get(i),
                             CONNECTION_TIMEOUT));
             Assert.assertNull("static file backup (zoo.cfg.bak) shouldn't exist!",
@@ -114,7 +115,7 @@ public class ReconfigRollingRestartCompatibilityTest extends QuorumPeerTestBase 
             Assert.assertNull("dynamic configuration file (zoo.cfg.dynamic.*) shouldn't exist!",
                     mt[i].getFileByName(mt[i].getQuorumPeer().getNextDynamicConfigFilename()));
             staticFileContent[i] = Files.readAllLines(mt[i].confFile.toPath(), StandardCharsets.UTF_8).toString();
-            Assert.assertTrue("static config file should contain server entry " + serverAddress.get(i),
+            assertTrue("static config file should contain server entry " + serverAddress.get(i),
                     staticFileContent[i].contains(serverAddress.get(i)));
         }
 
@@ -141,7 +142,7 @@ public class ReconfigRollingRestartCompatibilityTest extends QuorumPeerTestBase 
         }
 
         for (int i = 0; i < serverCount; ++i) {
-            Assert.assertTrue("waiting for server " + i + " being up",
+            assertTrue("waiting for server " + i + " being up",
                     ClientBase.waitForServerUp("127.0.0.1:" + clientPorts.get(i),
                             CONNECTION_TIMEOUT));
         }
@@ -159,11 +160,11 @@ public class ReconfigRollingRestartCompatibilityTest extends QuorumPeerTestBase 
     }
 
     @Test(timeout = 90000)
-    // This test simulate the use case of change of membership through rolling
-    // restart. For a 3 node ensemble we expand it to a 5 node ensemble, verify
+    // This test simulate the use case of change of membership by starting new servers
+    // without dynamic reconfig. For a 3 node ensemble we expand it to a 5 node ensemble, verify
     // during the process each node has the expected configuration setting pushed
     // via updating local zoo.cfg file.
-    public void testRollingRestartWithMembershipChange() throws Exception {
+    public void testExtendingQuorumWithNewMembers() throws Exception {
         int serverCount = 3;
         String config = generateNewQuorumConfig(serverCount);
         QuorumPeerTestBase.MainThread mt[] = new QuorumPeerTestBase.MainThread[serverCount];
@@ -176,7 +177,7 @@ public class ReconfigRollingRestartCompatibilityTest extends QuorumPeerTestBase 
         }
 
         for (int i = 0; i < serverCount; ++i) {
-            Assert.assertTrue("waiting for server " + i + " being up",
+            assertTrue("waiting for server " + i + " being up",
                     ClientBase.waitForServerUp("127.0.0.1:" + clientPorts.get(i),
                             CONNECTION_TIMEOUT));
         }
@@ -188,10 +189,11 @@ public class ReconfigRollingRestartCompatibilityTest extends QuorumPeerTestBase 
 
         Map<Integer, String> oldServerAddress = new HashMap<>(serverAddress);
         List<String> newServers = new ArrayList<>(joiningServers);
-        config = updateExistingQuorumConfig(Arrays.asList(3, 4), new ArrayList<Integer>());
-        newServers.add(serverAddress.get(3)); newServers.add(serverAddress.get(4));
+        config = updateExistingQuorumConfig(Arrays.asList(3, 4), new ArrayList<>());
+        newServers.add(serverAddress.get(3));
+        newServers.add(serverAddress.get(4));
         serverCount = serverAddress.size();
-        Assert.assertEquals("Server count should be 5 after config update.", serverCount, 5);
+        assertEquals("Server count should be 5 after config update.", serverCount, 5);
 
         // We are adding two new servers to the ensemble. These two servers should have the config which includes
         // all five servers (the old three servers, plus the two servers added). The old three servers should only
@@ -202,7 +204,7 @@ public class ReconfigRollingRestartCompatibilityTest extends QuorumPeerTestBase 
             mt[i] = new QuorumPeerTestBase.MainThread(i, clientPorts.get(i),
                     config, false);
             mt[i].start();
-            Assert.assertTrue("waiting for server " + i + " being up",
+            assertTrue("waiting for server " + i + " being up",
                     ClientBase.waitForServerUp("127.0.0.1:" + clientPorts.get(i),
                             CONNECTION_TIMEOUT));
             verifyQuorumConfig(i, newServers, null);
@@ -225,6 +227,138 @@ public class ReconfigRollingRestartCompatibilityTest extends QuorumPeerTestBase 
         }
     }
 
+    @Test
+    public void testRollingRestartWithExtendedMembershipConfig() throws Exception {
+        // in this test we are performing rolling restart with extended quorum config, see ZOOKEEPER-3829
+
+        // Start a quorum with 3 members
+        int serverCount = 3;
+        String config = generateNewQuorumConfig(serverCount);
+        QuorumPeerTestBase.MainThread[] mt = new QuorumPeerTestBase.MainThread[serverCount];
+        List<String> joiningServers = new ArrayList<>();
+        for (int i = 0; i < serverCount; i++) {
+            mt[i] = new QuorumPeerTestBase.MainThread(i, clientPorts.get(i), config, false);
+            mt[i].start();
+            joiningServers.add(serverAddress.get(i));
+        }
+        for (int i = 0; i < serverCount; i++) {
+            assertTrue("waiting for server " + i + " being up", ClientBase.waitForServerUp("127.0.0.1:" + clientPorts.get(i), CONNECTION_TIMEOUT));
+        }
+        for (int i = 0; i < serverCount; i++) {
+            verifyQuorumConfig(i, joiningServers, null);
+            verifyQuorumMembers(mt[i]);
+        }
+
+        // Create updated config with 4 members
+        List<String> newServers = new ArrayList<>(joiningServers);
+        config = updateExistingQuorumConfig(Arrays.asList(3), new ArrayList<>());
+        newServers.add(serverAddress.get(3));
+        serverCount = serverAddress.size();
+        assertEquals("Server count should be 4 after config update.", serverCount, 4);
+
+        // We are adding one new server to the ensemble. The new server should be started with the new config
+        mt = Arrays.copyOf(mt, mt.length + 1);
+        mt[3] = new QuorumPeerTestBase.MainThread(3, clientPorts.get(3), config, false);
+        mt[3].start();
+        assertTrue("waiting for server 3 being up", ClientBase.waitForServerUp("127.0.0.1:" + clientPorts.get(3), CONNECTION_TIMEOUT));
+        verifyQuorumConfig(3, newServers, null);
+        verifyQuorumMembers(mt[3]);
+
+        // Now we restart the first 3 servers, one-by-one with the new config
+        for (int i = 0; i < 3; i++) {
+            mt[i].shutdown();
+
+            assertTrue(String.format("Timeout during waiting for server %d to go down", i),
+                       ClientBase.waitForServerDown("127.0.0.1:" + clientPorts.get(i), ClientBase.CONNECTION_TIMEOUT));
+
+            mt[i] = new QuorumPeerTestBase.MainThread(i, clientPorts.get(i), config, false);
+            mt[i].start();
+            assertTrue("waiting for server " + i + " being up", ClientBase.waitForServerUp("127.0.0.1:" + clientPorts.get(i), CONNECTION_TIMEOUT));
+            verifyQuorumConfig(i, newServers, null);
+            verifyQuorumMembers(mt[i]);
+        }
+
+        // now verify that all nodes can handle traffic
+        for (int i = 0; i < 4; ++i) {
+            ZooKeeper zk = ClientBase.createZKClient("127.0.0.1:" + clientPorts.get(i));
+            ReconfigTest.testNormalOperation(zk, zk, false);
+        }
+
+        for (int i = 0; i < 4; ++i) {
+            mt[i].shutdown();
+        }
+    }
+
+    @Test
+    public void testRollingRestartWithHostAddedAndRemoved() throws Exception {
+        // in this test we are performing rolling restart with a new quorum config,
+        // contains a deleted node and a new node
+
+        // Start a quorum with 3 members
+        int serverCount = 3;
+        String config = generateNewQuorumConfig(serverCount);
+        QuorumPeerTestBase.MainThread[] mt = new QuorumPeerTestBase.MainThread[serverCount];
+        List<String> originalServers = new ArrayList<>();
+        for (int i = 0; i < serverCount; i++) {
+            mt[i] = new QuorumPeerTestBase.MainThread(i, clientPorts.get(i), config, false);
+            mt[i].start();
+            originalServers.add(serverAddress.get(i));
+        }
+        for (int i = 0; i < serverCount; i++) {
+            assertTrue("waiting for server " + i + " being up", ClientBase.waitForServerUp("127.0.0.1:" + clientPorts.get(i), CONNECTION_TIMEOUT));
+        }
+        for (int i = 0; i < serverCount; i++) {
+            verifyQuorumConfig(i, originalServers, null);
+            verifyQuorumMembers(mt[i]);
+        }
+
+        // we are stopping the third server (myid=2)
+        mt[2].shutdown();
+        assertTrue(String.format("Timeout during waiting for server %d to go down", 2),
+                   ClientBase.waitForServerDown("127.0.0.1:" + clientPorts.get(2), ClientBase.CONNECTION_TIMEOUT));
+        String leavingServer = originalServers.get(2);
+
+        // Create updated config with the first 2 existing members, but we remove 3rd and add one with different myid
+        config = updateExistingQuorumConfig(Arrays.asList(3), Arrays.asList(2));
+        List<String> newServers = new ArrayList<>(serverAddress.values());
+        serverCount = serverAddress.size();
+        assertEquals("Server count should be 3 after config update.", serverCount, 3);
+
+
+        // We are adding one new server to the ensemble. The new server should be started with the new config
+        mt = Arrays.copyOf(mt, mt.length + 1);
+        mt[3] = new QuorumPeerTestBase.MainThread(3, clientPorts.get(3), config, false);
+        mt[3].start();
+        assertTrue("waiting for server 3 being up", ClientBase.waitForServerUp("127.0.0.1:" + clientPorts.get(3), CONNECTION_TIMEOUT));
+        verifyQuorumConfig(3, newServers, Arrays.asList(leavingServer));
+        verifyQuorumMembers(mt[3]);
+
+        // Now we restart the first 2 servers, one-by-one with the new config
+        for (int i = 0; i < 2; i++) {
+            mt[i].shutdown();
+
+            assertTrue(String.format("Timeout during waiting for server %d to go down", i),
+                       ClientBase.waitForServerDown("127.0.0.1:" + clientPorts.get(i), ClientBase.CONNECTION_TIMEOUT));
+
+            mt[i] = new QuorumPeerTestBase.MainThread(i, clientPorts.get(i), config, false);
+            mt[i].start();
+            assertTrue("waiting for server " + i + " being up", ClientBase.waitForServerUp("127.0.0.1:" + clientPorts.get(i), CONNECTION_TIMEOUT));
+            verifyQuorumConfig(i, newServers, null);
+            verifyQuorumMembers(mt[i]);
+        }
+
+        // now verify that all three nodes can handle traffic
+        for (int i : serverAddress.keySet()) {
+            ZooKeeper zk = ClientBase.createZKClient("127.0.0.1:" + clientPorts.get(i));
+            ReconfigTest.testNormalOperation(zk, zk, false);
+        }
+
+        for (int i : serverAddress.keySet()) {
+            mt[i].shutdown();
+        }
+    }
+
+
     // Verify each quorum peer has expected config in its config zNode.
     private void verifyQuorumConfig(int sid, List<String> joiningServers, List<String> leavingServers) throws Exception {
         ZooKeeper zk = ClientBase.createZKClient("127.0.0.1:" + clientPorts.get(sid));
@@ -246,12 +380,12 @@ public class ReconfigRollingRestartCompatibilityTest extends QuorumPeerTestBase 
         Map<Long, QuorumPeer.QuorumServer> members =
                 mt.getQuorumPeer().getQuorumVerifier().getAllMembers();
 
-        Assert.assertTrue("Quorum member should not change.",
+        assertTrue("Quorum member should not change.",
                 members.size() == expectedConfigs.size());
 
         for (QuorumPeer.QuorumServer qs : members.values()) {
             String actualConfig = qs.toString();
-            Assert.assertTrue("Unexpected config " + actualConfig + " found!",
+            assertTrue("Unexpected config " + actualConfig + " found!",
                     expectedConfigs.contains(actualConfig));
         }
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigExceptionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigExceptionTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.zookeeper.test;
 
+import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
-
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
@@ -66,7 +66,7 @@ public class ReconfigExceptionTest extends ZKTestCase {
         try {
             qu.startAll();
         } catch (IOException e) {
-            Assert.fail("Fail to start quorum servers.");
+            fail("Fail to start quorum servers.");
         }
 
         resetZKAdmin();
@@ -90,9 +90,19 @@ public class ReconfigExceptionTest extends ZKTestCase {
     @Test(timeout = 10000)
     public void testReconfigDisabled() throws InterruptedException {
         QuorumPeerConfig.setReconfigEnabled(false);
+
+        // for this test we need to restart the quorum peers to get the config change,
+        // as in the setup() we started the quorum with reconfigEnabled=true
+        qu.shutdownAll();
+        try {
+            qu.startAll();
+        } catch (IOException e) {
+            fail("Fail to start quorum servers.");
+        }
+
         try {
             reconfigPort();
-            Assert.fail("Reconfig should be disabled.");
+            fail("Reconfig should be disabled.");
         } catch (KeeperException e) {
             Assert.assertTrue(e.code() == KeeperException.Code.RECONFIGDISABLED);
         }
@@ -102,7 +112,7 @@ public class ReconfigExceptionTest extends ZKTestCase {
     public void testReconfigFailWithoutAuth() throws InterruptedException {
         try {
             reconfigPort();
-            Assert.fail("Reconfig should fail without auth.");
+            fail("Reconfig should fail without auth.");
         } catch (KeeperException e) {
             // However a failure is still expected as user is not authenticated, so ACL check will fail.
             Assert.assertTrue(e.code() == KeeperException.Code.NOAUTH);
@@ -115,7 +125,7 @@ public class ReconfigExceptionTest extends ZKTestCase {
             zkAdmin.addAuthInfo("digest", "super:test".getBytes());
             Assert.assertTrue(reconfigPort());
         } catch (KeeperException e) {
-            Assert.fail("Reconfig should not fail, but failed with exception : " + e.getMessage());
+            fail("Reconfig should not fail, but failed with exception : " + e.getMessage());
         }
     }
 
@@ -126,7 +136,7 @@ public class ReconfigExceptionTest extends ZKTestCase {
         try {
             zkAdmin.addAuthInfo("digest", "user:test".getBytes());
             reconfigPort();
-            Assert.fail("Reconfig should fail without a valid ACL associated with user.");
+            fail("Reconfig should fail without a valid ACL associated with user.");
         } catch (KeeperException e) {
             // Again failure is expected because no ACL is associated with this user.
             Assert.assertTrue(e.code() == KeeperException.Code.NOAUTH);
@@ -148,7 +158,7 @@ public class ReconfigExceptionTest extends ZKTestCase {
             resetZKAdmin();
             zkAdmin.addAuthInfo("digest", "user:test".getBytes());
             reconfigPort();
-            Assert.fail("Reconfig should fail with an ACL that is read only!");
+            fail("Reconfig should fail with an ACL that is read only!");
         } catch (KeeperException e) {
             Assert.assertTrue(e.code() == KeeperException.Code.NOAUTH);
         }
@@ -169,7 +179,7 @@ public class ReconfigExceptionTest extends ZKTestCase {
             zkAdmin.addAuthInfo("digest", "user:test".getBytes());
             Assert.assertTrue(reconfigPort());
         } catch (KeeperException e) {
-            Assert.fail("Reconfig should not fail, but failed with exception : " + e.getMessage());
+            fail("Reconfig should not fail, but failed with exception : " + e.getMessage());
         }
     }
 
@@ -186,14 +196,14 @@ public class ReconfigExceptionTest extends ZKTestCase {
             zkAdmin = new ZooKeeperAdmin(cnxString,
                     ClientBase.CONNECTION_TIMEOUT, watcher);
         } catch (IOException e) {
-            Assert.fail("Fail to create ZooKeeperAdmin handle.");
+            fail("Fail to create ZooKeeperAdmin handle.");
             return;
         }
 
         try {
             watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         } catch (InterruptedException | TimeoutException e) {
-            Assert.fail("ZooKeeper admin client can not connect to " + cnxString);
+            fail("ZooKeeper admin client can not connect to " + cnxString);
         }
     }
 


### PR DESCRIPTION
In four different Jira tickets (ZOOKEEPER-3829, ZOOKEEPER-3830, ZOOKEEPER-3814, ZOOKEEPER-3842) we saw different errors when dynamic reconfig was disabled and we used rolling restart to change the quorum membership configuration. These rolling restart sequences was working fine on 3.4 but caused errors in 3.5 or 3.6.

In worst case the rolling restart leads to the scenario that we had an elected leader which was up but unable to commit any changes. This happens, when the quorum is extended with a new member in the following sequence:
* start server.1, server.2, server.3 (with config: 1,2,3)
* start server.4 (with config 1,2,3,4)
* stop server.1, then restart it with config 1,2,3,4
* stop server.2, then restart it with config 1,2,3,4
* stop server.3, then restart it with config 1,2,3,4
* at this point leader is server.4, but it can not commit any transaction

An other error we saw was when we changed a host name of an existing member (removing server.5 and add a new host as server.6). In this case we found in the logs of the new server (server.6) that it is still tried to connect to the old invalid server (server.5), although it was missing from it's config. The same problem remained even after making a full rolling-restart on all the nodes.

In this patch I try to fix these issues without breaking anything. The patch contains the following changes:
* We are making sure that neither the committed, nor the last seen config gets updated if dynamic reconfig is disabled.
* It is not possible now to start the leader without the ability of committing transaction, when dynamic reconfig is disabled (this is only needed to avoid a reconfig edge-case).
* I added a testcase simulating the enablement of dynamic reconfig using rolling restart
* I added a few more unit tests to cover rolling restart scenarios. (the tests are failing without the patch but succeeding after applying it).
* The enablement / disablement of reconfig is getting initialized now in the QuorumPeer and gets propagated to the other classes. This was needed for the rolling restart tests to be able to enable/disable reconfig only for the newly created servers without affecting the servers running already in the same JVM.

I also tested the changes with docker, using: https://github.com/symat/zookeeper-docker-test

target branches: 3.5, 3.6, master