### PR TITLE
ZOOKEEPER-3803 Prevent NPE on TestingServer close()

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -318,6 +318,10 @@ public class FileTxnSnapLog {
         DataTree dt,
         Map<Long, Integer> sessions,
         PlayBackListener listener) throws IOException {
+        // ZOOKEPER-3803: Prevents NPE on TestingServer close()
+        if (txnLog == null) {
+            return 0;
+        }
         TxnIterator itr = txnLog.read(dt.lastProcessedZxid + 1);
         long highestZxid = dt.lastProcessedZxid;
         TxnHeader hdr;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -318,7 +318,7 @@ public class FileTxnSnapLog {
         DataTree dt,
         Map<Long, Integer> sessions,
         PlayBackListener listener) throws IOException {
-        // ZOOKEPER-3803: Prevents NPE on TestingServer close()
+        // ZOOKEPER-3803: Prevents NPE on Curator's TestingServer close()
         if (txnLog == null) {
             return 0;
         }


### PR DESCRIPTION
Prevent NPE on TestingServer close()

When using TestingServer, close method triggers an unneed call to fastForwardFromEdits on FileTxnSnapLog instance that has been already closed throwing a NPE that is harmless but a bit annoying on development