### PR TITLE
ZOOKEEPER-3857: ZooKeeper branch-3.6 doesn't build after Curator test committed

### DIFF
--- a/zookeeper-compatibility-tests/pom.xml
+++ b/zookeeper-compatibility-tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>parent</artifactId>
-        <version>3.7.0-SNAPSHOT</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>

--- a/zookeeper-compatibility-tests/zookeeper-compatibility-tests-curator/pom.xml
+++ b/zookeeper-compatibility-tests/zookeeper-compatibility-tests-curator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper-compatibility-tests</artifactId>
-        <version>3.7.0-SNAPSHOT</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Updated version number in two pom.xml files.

Change-Id: I71194499cac0275eb6068a9adee8920b3eeb8b11