### PR TITLE
ZOOKEEPER-3865: fix backward-compatibility for ZooKeeperServer constructor

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -301,7 +301,14 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
     }
 
     /**
-     * Creates a ZooKeeperServer instance. It sets everything up, but doesn't
+     * Keeping this constructor for backward compatibility
+     */
+    public ZooKeeperServer(FileTxnSnapLog txnLogFactory, int tickTime, int minSessionTimeout, int maxSessionTimeout, int clientPortListenBacklog, ZKDatabase zkDb, String initialConfig) {
+        this(txnLogFactory, tickTime, minSessionTimeout, maxSessionTimeout, clientPortListenBacklog, zkDb, initialConfig, QuorumPeerConfig.isReconfigEnabled());
+    }
+
+    /**
+     *  * Creates a ZooKeeperServer instance. It sets everything up, but doesn't
      * actually start listening for clients until run() is invoked.
      *
      */


### PR DESCRIPTION
In the fix of ZOOKEEPER-3829 I accidentally changed a public constructor of ZooKeeper server. I didn’t realize Curator is using it for testing (and maybe other Apache projects are doing so as well). 

In this PR I restore the original constructor for master and branch-3.6.

For branch-3.5 I will submit an other PR, that will make it compatible with e.g. Curator 4.3.