### PR TITLE
ZOOKEEPER-3865: fix backward-compatibility for ZooKeeperServer constructor

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -151,7 +151,14 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
     }
 
     /**
-     * Creates a ZooKeeperServer instance. It sets everything up, but doesn't
+     * Keeping this constructor for backward compatibility
+     */
+    public ZooKeeperServer(FileTxnSnapLog txnLogFactory, int tickTime, int minSessionTimeout, int maxSessionTimeout, ZKDatabase zkDb) {
+        this(txnLogFactory, tickTime, minSessionTimeout, maxSessionTimeout, zkDb, QuorumPeerConfig.isReconfigEnabled());
+    }
+
+    /**
+     *  * Creates a ZooKeeperServer instance. It sets everything up, but doesn't
      * actually start listening for clients until run() is invoked.
      *
      * @param dataDir the directory to put the data


### PR DESCRIPTION
In the fix of ZOOKEEPER-3829 I accidentally changed a public constructor of ZooKeeper server. I didn’t realize Curator is using it for testing (and maybe other Apache projects are doing so as well). 

In this PR I restore the original constructor for branch-3.5 making it compatible with e.g. Curator 4.3.