### PR TITLE
Added arm64 support to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ sudo: false
 matrix:
   include:
     - os: linux
+      arch: arm64
+      jdk: openjdk8
+    - os: linux
+      arch: arm64
+      jdk: openjdk11
+    - os: linux
       jdk: openjdk8
     - os: linux
       jdk: openjdk11
@@ -25,6 +31,11 @@ addons:
   apt:
     packages:
     - libcppunit-dev
+
+install:
+  - if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+     sudo apt-get install maven;
+    fi
 
 script: mvn clean apache-rat:check verify -DskipTests spotbugs:check checkstyle:check -Pfull-build
 


### PR DESCRIPTION
1. Added arm64 support with jdk 8 and 11
2. Installed maven if architecture is arm64

Signed-off-by: odidev <odidev@puresoftware.com>