### PR TITLE
ZOOKEEPER-3526: data inconsistency due to mistaken TRUNC caused by maxCommittedLog is much less than minCommittedLog when in readonly mode

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.server;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.management.JMException;
 
@@ -124,7 +125,8 @@ public class ZooKeeperServerMain {
             // create a file logger url from the command line args
             txnLog = new FileTxnSnapLog(config.dataLogDir, config.dataDir);
             final ZooKeeperServer zkServer = new ZooKeeperServer(txnLog,
-                    config.tickTime, config.minSessionTimeout, config.maxSessionTimeout, null, QuorumPeerConfig.isReconfigEnabled());
+                    config.tickTime, config.minSessionTimeout, config.maxSessionTimeout, null,
+                    new AtomicLong(0), QuorumPeerConfig.isReconfigEnabled());
             txnLog.setServerStats(zkServer.serverStats());
 
             // Registers shutdown handler which will be used to know the

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.server.quorum;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jute.Record;
 import org.slf4j.Logger;
@@ -55,9 +56,9 @@ public class FollowerZooKeeperServer extends LearnerZooKeeperServer {
      * @throws IOException
      */
     FollowerZooKeeperServer(FileTxnSnapLog logFactory,QuorumPeer self,
-            ZKDatabase zkDb) throws IOException {
+            ZKDatabase zkDb, AtomicLong hzxid) throws IOException {
         super(logFactory, self.tickTime, self.minSessionTimeout,
-                self.maxSessionTimeout, zkDb, self);
+                self.maxSessionTimeout, zkDb, hzxid, self);
         this.pendingSyncs = new ConcurrentLinkedQueue<Request>();
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderZooKeeperServer.java
@@ -32,6 +32,7 @@ import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  *
@@ -53,8 +54,9 @@ public class LeaderZooKeeperServer extends QuorumZooKeeperServer {
      * @param dataDir
      * @throws IOException
      */
-    LeaderZooKeeperServer(FileTxnSnapLog logFactory, QuorumPeer self, ZKDatabase zkDb) throws IOException {
-        super(logFactory, self.tickTime, self.minSessionTimeout, self.maxSessionTimeout, zkDb, self);
+    LeaderZooKeeperServer(FileTxnSnapLog logFactory, QuorumPeer self, ZKDatabase zkDb, AtomicLong hzxid)
+        throws IOException {
+        super(logFactory, self.tickTime, self.minSessionTimeout, self.maxSessionTimeout, zkDb, hzxid, self);
     }
 
     public Leader getLeader(){

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerZooKeeperServer.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.server.quorum;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.server.DataTreeBean;
@@ -43,10 +44,10 @@ public abstract class LearnerZooKeeperServer extends QuorumZooKeeperServer {
 
     public LearnerZooKeeperServer(FileTxnSnapLog logFactory, int tickTime,
             int minSessionTimeout, int maxSessionTimeout,
-            ZKDatabase zkDb, QuorumPeer self)
+            ZKDatabase zkDb, AtomicLong hzxid, QuorumPeer self)
         throws IOException
     {
-        super(logFactory, tickTime, minSessionTimeout, maxSessionTimeout, zkDb, self);
+        super(logFactory, tickTime, minSessionTimeout, maxSessionTimeout, zkDb, hzxid, self);
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverZooKeeperServer.java
@@ -19,6 +19,7 @@ package org.apache.zookeeper.server.quorum;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,8 +52,8 @@ public class ObserverZooKeeperServer extends LearnerZooKeeperServer {
     ConcurrentLinkedQueue<Request> pendingSyncs = 
         new ConcurrentLinkedQueue<Request>();
 
-    ObserverZooKeeperServer(FileTxnSnapLog logFactory, QuorumPeer self, ZKDatabase zkDb) throws IOException {
-        super(logFactory, self.tickTime, self.minSessionTimeout, self.maxSessionTimeout, zkDb, self);
+    ObserverZooKeeperServer(FileTxnSnapLog logFactory, QuorumPeer self, ZKDatabase zkDb, AtomicLong hzxid) throws IOException {
+        super(logFactory, self.tickTime, self.minSessionTimeout, self.maxSessionTimeout, zkDb, hzxid, self);
         LOG.info("syncEnabled =" + syncRequestProcessorEnabled);
     }
     

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.server.quorum;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -44,9 +45,9 @@ public abstract class QuorumZooKeeperServer extends ZooKeeperServer {
 
     protected QuorumZooKeeperServer(FileTxnSnapLog logFactory, int tickTime,
             int minSessionTimeout, int maxSessionTimeout,
-            ZKDatabase zkDb, QuorumPeer self)
+            ZKDatabase zkDb, AtomicLong hzxid, QuorumPeer self)
     {
-        super(logFactory, tickTime, minSessionTimeout, maxSessionTimeout, zkDb, self.isReconfigEnabled());
+        super(logFactory, tickTime, minSessionTimeout, maxSessionTimeout, zkDb, hzxid, self.isReconfigEnabled());
         this.self = self;
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyZooKeeperServer.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server.quorum;
 
 import java.io.PrintWriter;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.server.DataTreeBean;
@@ -44,9 +45,9 @@ public class ReadOnlyZooKeeperServer extends ZooKeeperServer {
     private volatile boolean shutdown = false;
 
     ReadOnlyZooKeeperServer(FileTxnSnapLog logFactory, QuorumPeer self,
-                            ZKDatabase zkDb) {
+                            ZKDatabase zkDb, AtomicLong hzxid) {
         super(logFactory, self.tickTime, self.minSessionTimeout,
-              self.maxSessionTimeout, zkDb, self.isReconfigEnabled());
+              self.maxSessionTimeout, zkDb, hzxid, self.isReconfigEnabled());
         this.self = self;
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/CRCTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/CRCTest.java
@@ -29,6 +29,7 @@ import java.io.RandomAccessFile;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.Adler32;
 import java.util.zip.CheckedInputStream;
 
@@ -107,7 +108,7 @@ public class CRCTest extends ZKTestCase{
     public void testChecksums() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(150);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/FinalRequestProcessorTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/FinalRequestProcessorTest.java
@@ -39,6 +39,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -68,7 +69,7 @@ public class FinalRequestProcessorTest {
                 new ACL(ZooDefs.Perms.READ, new Id("world", "anyone"))
         ));
 
-        ZooKeeperServer zks = new ZooKeeperServer();
+        ZooKeeperServer zks = new ZooKeeperServer(new AtomicLong(0));
         ZKDatabase db = mock(ZKDatabase.class);
         String testPath = "/testPath";
         when(db.getNode(eq(testPath))).thenReturn(new DataNode());

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/PrepRequestProcessorTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/PrepRequestProcessorTest.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 
 public class PrepRequestProcessorTest extends ClientBase {
@@ -74,7 +75,7 @@ public class PrepRequestProcessorTest extends ClientBase {
     public void setup() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(100);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/PurgeTxnTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/PurgeTxnTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.zookeeper.data.Stat;
 
 import org.apache.zookeeper.CreateMode;
@@ -71,7 +72,7 @@ public class PurgeTxnTest extends ZKTestCase {
     public void testPurge() throws Exception {
         tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(100);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
@@ -118,7 +119,7 @@ public class PurgeTxnTest extends ZKTestCase {
     public void testPurgeWhenLogRollingInProgress() throws Exception {
         tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(30);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
@@ -453,7 +454,7 @@ public class PurgeTxnTest extends ZKTestCase {
         // Create Zookeeper and connect to it.
         tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
         f.startup(zks);
@@ -495,7 +496,7 @@ public class PurgeTxnTest extends ZKTestCase {
         PurgeTxnLog.purge(tmpDir, tmpDir, SNAP_RETAIN_COUNT);
 
         // Initialize Zookeeper again from the same dataDir.
-        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         f = ServerCnxnFactory.createFactory(PORT, -1);
         f.startup(zks);
         zk = ClientBase.createZKClient(HOSTPORT);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/SessionTrackerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/SessionTrackerTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 
 import org.apache.zookeeper.KeeperException;
@@ -119,7 +120,7 @@ public class SessionTrackerTest extends ZKTestCase {
     private ZooKeeperServer setupSessionTracker() throws IOException {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         zks.setupRequestProcessors();
         firstProcessor = new FirstProcessor(zks, null);
         zks.firstProcessor = firstProcessor;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerBeanTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jute.Record;
 import org.apache.zookeeper.ZooDefs;
@@ -54,7 +55,7 @@ public class ZooKeeperServerBeanTest {
         FileTxnSnapLog fileTxnSnapLog = new FileTxnSnapLog(new File(tmpDir, "data"),
                 new File(tmpDir, "data_txnlog"));
 
-        ZooKeeperServer zks = new ZooKeeperServer();
+        ZooKeeperServer zks = new ZooKeeperServer(new AtomicLong(0));
         zks.setTxnLogFactory(fileTxnSnapLog);
 
         ZooKeeperServerBean serverBean = new ZooKeeperServerBean(zks);
@@ -82,7 +83,7 @@ public class ZooKeeperServerBeanTest {
 
     @Test
     public void testGetSecureClientPort() throws IOException {
-        ZooKeeperServer zks = new ZooKeeperServer();
+        ZooKeeperServer zks = new ZooKeeperServer(new AtomicLong(0));
         /**
          * case 1: When secure client is not configured GetSecureClientPort
          * should return empty string
@@ -112,7 +113,7 @@ public class ZooKeeperServerBeanTest {
 
     @Test
     public void testGetSecureClientAddress() throws IOException {
-        ZooKeeperServer zks = new ZooKeeperServer();
+        ZooKeeperServer zks = new ZooKeeperServer(new AtomicLong(0));
         /**
          * case 1: When secure client is not configured getSecureClientAddress
          * should return empty string

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerMainTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerMainTest.java
@@ -26,6 +26,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -549,7 +550,7 @@ public class ZooKeeperServerMainTest extends ZKTestCase implements Watcher {
     private ServerCnxnFactory startServer(File tmpDir) throws IOException,
             InterruptedException {
         final int CLIENT_PORT = PortAssignment.unique();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(CLIENT_PORT, -1);
         f.startup(zks);
         Assert.assertNotNull("JMX initialization failed!", zks.jmxServerBean);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerStartupTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerStartupTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZKTestCase;
@@ -229,7 +230,7 @@ public class ZooKeeperServerStartupTest extends ZKTestCase {
 
         public SimpleZooKeeperServer(File snapDir, File logDir, int tickTime,
                 CountDownLatch startupDelayLatch) throws IOException {
-            super(snapDir, logDir, tickTime);
+            super(snapDir, logDir, tickTime, new AtomicLong(0));
             this.startupDelayLatch = startupDelayLatch;
         }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/CommitProcessorTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/CommitProcessorTest.java
@@ -218,7 +218,7 @@ public class CommitProcessorTest extends ZKTestCase {
 
         public TestZooKeeperServer(File snapDir, File logDir, int tickTime)
                 throws IOException {
-            super(snapDir, logDir, tickTime);
+            super(snapDir, logDir, tickTime, new AtomicLong(0));
         }
 
         public SessionTracker getSessionTracker() {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeDeletionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeDeletionTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
@@ -198,7 +199,7 @@ public class EphemeralNodeDeletionTest extends QuorumPeerTestBase {
         protected Follower makeFollower(FileTxnSnapLog logFactory)
                 throws IOException {
             return new Follower(this, new FollowerZooKeeperServer(logFactory,
-                    this, this.getZkDb())) {
+                    this, this.getZkDb(), new AtomicLong(0))) {
 
                 @Override
                 void readPacket(QuorumPacket pp) throws IOException {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
@@ -43,6 +43,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -83,7 +84,7 @@ public class LeaderBeanTest {
                 new File(tmpDir, "data_txnlog"));
         ZKDatabase zkDb = new ZKDatabase(fileTxnSnapLog);
 
-        zks = new LeaderZooKeeperServer(fileTxnSnapLog, qp, zkDb);
+        zks = new LeaderZooKeeperServer(fileTxnSnapLog, qp, zkDb, new AtomicLong(0));
         leader = new Leader(qp, zks);
         leaderBean = new LeaderBean(leader, zks);
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
@@ -51,7 +52,7 @@ public class LearnerTest extends ZKTestCase {
 
         public SimpleLearnerZooKeeperServer(FileTxnSnapLog ftsl, QuorumPeer self)
                 throws IOException {
-            super(ftsl, 2000, 2000, 2000, new ZKDatabase(ftsl), self);
+            super(ftsl, 2000, 2000, 2000, new ZKDatabase(ftsl), new AtomicLong(0), self);
         }
 
         @Override

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerMainTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerMainTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import javax.security.sasl.SaslException;
 
@@ -1447,6 +1448,8 @@ public class QuorumPeerMainTest extends QuorumPeerTestBase {
         private StartForwardingListener startForwardingListener;
         private BeginSnapshotListener beginSnapshotListener;
 
+	private AtomicLong hzxid = new AtomicLong(0);
+
         public CustomQuorumPeer(Context context)
                 throws SaslException {
             this.context = context;
@@ -1466,7 +1469,7 @@ public class QuorumPeerMainTest extends QuorumPeerTestBase {
         protected Follower makeFollower(FileTxnSnapLog logFactory)
                 throws IOException {
             return new Follower(this, new FollowerZooKeeperServer(logFactory,
-                    this, this.getZkDb())) {
+                    this, this.getZkDb(), hzxid)) {
 
                 @Override
                 void writePacket(QuorumPacket pp, boolean flush) throws IOException {
@@ -1484,7 +1487,7 @@ public class QuorumPeerMainTest extends QuorumPeerTestBase {
         @Override
         protected Leader makeLeader(FileTxnSnapLog logFactory) throws IOException, X509Exception {
             return new Leader(this, new LeaderZooKeeperServer(logFactory,
-                    this, this.getZkDb())) {
+                    this, this.getZkDb(), hzxid)) {
                 @Override
                 public long startForwarding(LearnerHandler handler,
                         long lastSeenZxid) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerReadOnlyTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerReadOnlyTest.java
@@ -1,0 +1,192 @@
+package org.apache.zookeeper.server.quorum;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.KeeperException.RuntimeInconsistencyException;
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.ZooKeeper.States;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QuorumPeerReadOnlyTest extends QuorumPeerTestBase {
+    
+    String prePropertyReadOnlyValue = null;
+    
+    @Before
+    public void setReadOnlySystemProperty() {
+        prePropertyReadOnlyValue = System.getProperty("readonlymode.enabled");
+        System.setProperty("readonlymode.enabled", "true");
+    }
+    
+    @After
+    public void restoreReadOnlySystemProperty() {
+        if (prePropertyReadOnlyValue == null) {
+            System.clearProperty("readonlymode.enabled");
+        } else {
+            System.setProperty("readonlymode.enabled", prePropertyReadOnlyValue);
+        }
+    }
+    
+    /**
+     * Test zxid is not set to a truncate value
+     */
+    @Test
+    public void testReadOnlyZxid() throws Exception {
+        ClientBase.setupTestEnv();
+        final int SERVER_COUNT = 3;
+        final int[] clientPorts = new int[SERVER_COUNT];
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            clientPorts[i] = PortAssignment.unique();
+            sb.append("server." + i + "=127.0.0.1:" + PortAssignment.unique() + ":" + PortAssignment.unique() + "\n");
+        }
+        String quorumCfgSection = sb.toString();
+
+        MainThread[] mt = new MainThread[SERVER_COUNT];
+        ZooKeeper[] zk = new ZooKeeper[SERVER_COUNT];
+        
+
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            mt[i] = new MainThread(i, clientPorts[i], quorumCfgSection + "\nclientPort=" + clientPorts[i]);
+            mt[i].start();
+            
+        }
+        
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            zk[i] = new ZooKeeper("127.0.0.1:" + clientPorts[i], ClientBase.CONNECTION_TIMEOUT, this, true);
+        }
+        
+        waitForAll(zk, States.CONNECTED);
+        
+        zk[0].create("/test", "Test".getBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+
+        // Shutdown all clients first, to ensure that the close zxid is seen and logged by all servers
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            zk[i].close();
+        }
+        // Shutdown all servers, before starting one again, as the commonly used data storage is cleaned
+        // up, when the first server is stopped
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            mt[i].shutdown();
+        }
+        
+        mt[SERVER_COUNT-1].start();
+        // Ensure that close will trigger a timeout
+        zk[SERVER_COUNT-1] = new ZooKeeper("127.0.0.1:" + clientPorts[SERVER_COUNT-1], ClientBase.CONNECTION_TIMEOUT, this, true) {
+//            @Override
+            public void close2() {
+                getTestable().injectSessionExpiration();
+                cnxn.disconnect();
+                try {
+                    Thread.sleep(ClientBase.CONNECTION_TIMEOUT * 2);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+        
+        waitForAll(new ZooKeeper[] {zk[SERVER_COUNT-1]}, States.CONNECTEDREADONLY);
+        
+        // Read some data
+        assertTrue(Arrays.equals(zk[SERVER_COUNT-1].getData("/test", false, null), "Test".getBytes()));
+        
+        // Kill the client, without notification
+        zk[SERVER_COUNT-1].close();
+       
+        // Start enough server for a quorum, but not all yet. Don't start any client, to avoid changing the zxid
+        for (int i=SERVER_COUNT-1; i >= ((SERVER_COUNT-1)/2); i--) {
+            if (i != SERVER_COUNT-1) {
+                mt[i].start();
+            }
+        }
+        ensureLeaderIsPresent(mt);
+
+        // Seems like without a waiting time, the test does succeeded sometimes without the fix applied
+        Thread.sleep(1000);
+        
+        // Start the remaining servers
+        for (int i = (SERVER_COUNT-1)/2-1; i >= 0; i--) {
+            mt[i].start();
+        }
+        ensureRemainingserversPresent(mt);
+
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            zk[i] = new ZooKeeper("127.0.0.1:" + clientPorts[i], ClientBase.CONNECTION_TIMEOUT, this, true);
+        }
+        waitForAll(zk, States.CONNECTED);
+
+        // Ensure that all clients can read the data
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            assertTrue(Arrays.equals(zk[i].getData("/test", false, null), "Test".getBytes()));
+        }
+        
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            zk[i].close();
+        }
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            mt[i].shutdown();
+        }
+    }
+    
+    private void waitForAll(ZooKeeper[] zks, States state) throws InterruptedException {
+        int iterations = ClientBase.CONNECTION_TIMEOUT / 1000;
+        boolean someoneNotConnected = true;
+        while (someoneNotConnected) {
+            if (iterations-- == 0) {
+                ClientBase.logAllStackTraces();
+                throw new RuntimeException("Waiting too long");
+            }
+
+            someoneNotConnected = false;
+            for (ZooKeeper zk : zks) {
+                if (zk.getState() != state) {
+                    someoneNotConnected = true;
+                    break;
+                }
+            }
+            Thread.sleep(1000);
+        }
+    }
+    
+    private void ensureLeaderIsPresent(MainThread[] mt) throws InterruptedException {
+        boolean leaderFound = false;
+        int searchCount = 0;
+        do {
+            Thread.sleep(100);
+            for (int i=mt.length-1; i >= ((mt.length-1)/2); i--) {
+                if (mt[i].main.quorumPeer.leader != null) {
+                    leaderFound = true;
+                    break;
+                }
+            }
+            if (searchCount++ >= 300) {
+                throw new RuntimeException("Waiting too long");
+            }
+        } while(!leaderFound);
+    }
+    
+    private void ensureRemainingserversPresent(MainThread[] mt) throws InterruptedException {
+        int searchCount = 0;
+        boolean missingConnection;
+        do {
+            Thread.sleep(100);
+            missingConnection = false;
+            for (int i = (mt.length-1)/2-1; i >= 0; i--) {
+                if (mt[i].main.quorumPeer.follower == null && mt[i].main.quorumPeer.leader == null) {
+                    missingConnection = true;
+                    break;
+                }
+            }
+            if (searchCount++ >= 300) {
+                throw new RuntimeException("Waiting too long");
+            }
+        } while(missingConnection);
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ReconfigDuringLeaderSyncTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ReconfigDuringLeaderSyncTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.PortAssignment;
@@ -206,6 +207,8 @@ public class ReconfigDuringLeaderSyncTest extends QuorumPeerTestBase {
 
     private static class CustomQuorumPeer extends QuorumPeer {
         private boolean newLeaderMessage = false;
+	
+	private final AtomicLong hzxid = new AtomicLong(0);
 
         public CustomQuorumPeer(Map<Long, QuorumServer> quorumPeers, File snapDir, File logDir, int clientPort,
                 int electionAlg, long myid, int tickTime, int initLimit, int syncLimit)
@@ -226,7 +229,7 @@ public class ReconfigDuringLeaderSyncTest extends QuorumPeerTestBase {
         @Override
         protected Follower makeFollower(FileTxnSnapLog logFactory) throws IOException {
 
-            return new Follower(this, new FollowerZooKeeperServer(logFactory, this, this.getZkDb())) {
+            return new Follower(this, new FollowerZooKeeperServer(logFactory, this, this.getZkDb(), hzxid)) {
 
                 @Override
                 void writePacket(QuorumPacket pp, boolean flush) throws IOException {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/WatchLeakTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/WatchLeakTest.java
@@ -45,6 +45,7 @@ import java.util.Random;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
@@ -129,7 +130,7 @@ public class WatchLeakTest {
 
         try {
             // Create a new follower
-            fzks = new FollowerZooKeeperServer(logfactory, quorumPeer, database);
+            fzks = new FollowerZooKeeperServer(logfactory, quorumPeer, database, new AtomicLong(0));
             fzks.startup();
             fzks.setServerCnxnFactory(serverCnxnFactory);
             quorumPeer.follower = new MyFollower(quorumPeer, fzks);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
@@ -41,6 +41,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
@@ -1201,7 +1202,7 @@ public class Zab1_0Test extends ZKTestCase {
         FileTxnSnapLog logFactory = new FileTxnSnapLog(tmpDir, tmpDir);
         peer.setTxnFactory(logFactory);
         ZKDatabase zkDb = new ZKDatabase(logFactory);
-        FollowerZooKeeperServer zk = new FollowerZooKeeperServer(logFactory, peer, zkDb);
+        FollowerZooKeeperServer zk = new FollowerZooKeeperServer(logFactory, peer, zkDb, new AtomicLong(0));
         peer.setZKDatabase(zkDb);
         return new ConversableFollower(peer, zk);
     }
@@ -1228,7 +1229,7 @@ public class Zab1_0Test extends ZKTestCase {
         FileTxnSnapLog logFactory = new FileTxnSnapLog(tmpDir, tmpDir);
         peer.setTxnFactory(logFactory);
         ZKDatabase zkDb = new ZKDatabase(logFactory);
-        ObserverZooKeeperServer zk = new ObserverZooKeeperServer(logFactory, peer, zkDb);
+        ObserverZooKeeperServer zk = new ObserverZooKeeperServer(logFactory, peer, zkDb, new AtomicLong(0));
         peer.setZKDatabase(zkDb);
         return new ConversableObserver(peer, zk);
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ZabUtils.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ZabUtils.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class ZabUtils {
 
@@ -91,7 +92,7 @@ public class ZabUtils {
         FileTxnSnapLog logFactory = new FileTxnSnapLog(tmpDir, tmpDir);
         peer.setTxnFactory(logFactory);
         ZKDatabase zkDb = new ZKDatabase(logFactory);
-        LeaderZooKeeperServer zk = new LeaderZooKeeperServer(logFactory, peer, zkDb);
+        LeaderZooKeeperServer zk = new LeaderZooKeeperServer(logFactory, peer, zkDb, new AtomicLong(0));
         return zk;
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ACLCountTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ACLCountTest.java
@@ -23,6 +23,7 @@ import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +63,7 @@ public class ACLCountTest extends ZKTestCase{
     public void testAclCount() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(1000);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ACLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ACLTest.java
@@ -23,6 +23,7 @@ import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +64,7 @@ public class ACLTest extends ZKTestCase implements Watcher {
     public void testDisconnectedAddAuth() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(1000);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
@@ -97,7 +98,7 @@ public class ACLTest extends ZKTestCase implements Watcher {
     public void testAcls() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(1000);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
@@ -138,7 +139,7 @@ public class ACLTest extends ZKTestCase implements Watcher {
                     ClientBase.waitForServerDown(HOSTPORT, CONNECTION_TIMEOUT));
         }
 
-        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         f = ServerCnxnFactory.createFactory(PORT, -1);
 
         f.startup(zks);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -418,7 +419,7 @@ public abstract class ClientBase extends ZKTestCase {
             InterruptedException {
         final int port = getPort(hostPort);
         LOG.info("STARTING server instance 127.0.0.1:{}", port);
-        ZooKeeperServer zks = new ZooKeeperServer(dataDir, dataDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(dataDir, dataDir, 3000, new AtomicLong(0));
         zks.setCreateSessionTrackerServerId(serverId);
         factory.startup(zks);
         Assert.assertTrue("waiting for server up", ClientBase.waitForServerUp(

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientPortBindTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientPortBindTest.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.Enumeration;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,7 +82,7 @@ public class ClientPortBindTest extends ZKTestCase{
         File tmpDir = ClientBase.createTmpDir();
 
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
 
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(
                 new InetSocketAddress(bindAddress, PORT), -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/EmptiedSnapshotRecoveryTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/EmptiedSnapshotRecoveryTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.CreateMode;
@@ -54,7 +55,7 @@ public class EmptiedSnapshotRecoveryTest extends ZKTestCase implements  Watcher 
         File tmpSnapDir = ClientBase.createTmpDir();
         File tmpLogDir  = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpSnapDir, tmpLogDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpSnapDir, tmpLogDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(SNAP_COUNT);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
@@ -76,7 +77,7 @@ public class EmptiedSnapshotRecoveryTest extends ZKTestCase implements  Watcher 
                 ClientBase.waitForServerDown(HOSTPORT, CONNECTION_TIMEOUT));
 
         // start server again with intact database
-        zks = new ZooKeeperServer(tmpSnapDir, tmpLogDir, 3000);
+        zks = new ZooKeeperServer(tmpSnapDir, tmpLogDir, 3000, new AtomicLong(0));
         zks.startdata();
         long zxid = zks.getZKDatabase().getDataTreeLastProcessedZxid();
         LOG.info("After clean restart, zxid = " + zxid);
@@ -100,7 +101,7 @@ public class EmptiedSnapshotRecoveryTest extends ZKTestCase implements  Watcher 
         }
 
         // start server again with corrupted database
-        zks = new ZooKeeperServer(tmpSnapDir, tmpLogDir, 3000);
+        zks = new ZooKeeperServer(tmpSnapDir, tmpLogDir, 3000, new AtomicLong(0));
         try {
             zks.startdata();
             long currentZxid = zks.getZKDatabase().getDataTreeLastProcessedZxid();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/GetProposalFromTxnTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/GetProposalFromTxnTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jute.Record;
 import org.apache.zookeeper.CreateMode;
@@ -61,7 +62,7 @@ public class GetProposalFromTxnTest extends ZKTestCase{
     public void testGetProposalFromTxn() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(100);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
@@ -92,7 +93,7 @@ public class GetProposalFromTxnTest extends ZKTestCase{
         zks.shutdown();
         Assert.assertTrue("waiting for server to shutdown",
                 ClientBase.waitForServerDown(HOSTPORT, CONNECTION_TIMEOUT));
-        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         zks.startdata();
 
         ZKDatabase db = zks.getZKDatabase();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/InvalidSnapshotTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/InvalidSnapshotTest.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.test;
 import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 
 import java.io.File;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZKTestCase;
@@ -83,7 +84,7 @@ public class InvalidSnapshotTest extends ZKTestCase{
     @Test
     public void testSnapshot() throws Exception {
         File snapDir = new File(testData, "invalidsnap");
-        ZooKeeperServer zks = new ZooKeeperServer(snapDir, snapDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(snapDir, snapDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(1000);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/LoadFromLogTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/LoadFromLogTest.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class LoadFromLogTest extends ClientBase {
     private static final int NUM_MESSAGES = 300;
@@ -254,7 +255,7 @@ public class LoadFromLogTest extends ClientBase {
         zks.shutdown();
         stopServer();
 
-        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         startServer();
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/OOMTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/OOMTest.java
@@ -23,6 +23,7 @@ import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -57,7 +58,7 @@ public class OOMTest extends ZKTestCase implements Watcher {
             }
         }
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
 
         final int PORT = PortAssignment.unique();
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/RecoveryTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/RecoveryTest.java
@@ -23,6 +23,7 @@ import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +67,7 @@ public class RecoveryTest extends ZKTestCase implements Watcher {
         File tmpDir = ClientBase.createTmpDir();
 
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
 
         int oldSnapCount = SyncRequestProcessor.getSnapCount();
         SyncRequestProcessor.setSnapCount(1000);
@@ -110,7 +111,7 @@ public class RecoveryTest extends ZKTestCase implements Watcher {
                        ClientBase.waitForServerDown(HOSTPORT,
                                           CONNECTION_TIMEOUT));
 
-            zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+            zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
             f = ServerCnxnFactory.createFactory(PORT, -1);
 
             startSignal = new CountDownLatch(1);
@@ -149,7 +150,7 @@ public class RecoveryTest extends ZKTestCase implements Watcher {
                        ClientBase.waitForServerDown(HOSTPORT,
                                           ClientBase.CONNECTION_TIMEOUT));
 
-            zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+            zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
             f = ServerCnxnFactory.createFactory(PORT, -1);
 
             startSignal = new CountDownLatch(1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/RepeatStartupTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/RepeatStartupTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.zookeeper.test;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooKeeper;
@@ -50,7 +52,7 @@ public class RepeatStartupTest extends ZKTestCase {
         QuorumBase.shutdown(qb.s5);
         String hp = qb.hostPort.split(",")[0];
         ZooKeeperServer zks = new ZooKeeperServer(qb.s1.getTxnFactory().getSnapDir(),
-                qb.s1.getTxnFactory().getDataDir(), 3000);
+                qb.s1.getTxnFactory().getDataDir(), 3000, new AtomicLong(0));
         final int PORT = Integer.parseInt(hp.split(":")[1]);
         ServerCnxnFactory factory = ServerCnxnFactory.createFactory(PORT, -1);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/RestoreCommittedLogTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/RestoreCommittedLogTest.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.test;
 
 import java.io.File;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.PortAssignment;
@@ -50,7 +51,8 @@ public class RestoreCommittedLogTest extends ZKTestCase{
     public void testRestoreCommittedLog() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000,
+            new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(100);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
@@ -72,7 +74,7 @@ public class RestoreCommittedLogTest extends ZKTestCase{
                 ClientBase.waitForServerDown(HOSTPORT, CONNECTION_TIMEOUT));
 
         // start server again
-        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         zks.startdata();
         List<Proposal> committedLog = zks.getZKDatabase().getCommittedLog();
         int logsize = committedLog.size();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SessionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SessionTest.java
@@ -26,6 +26,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +71,7 @@ public class SessionTest extends ZKTestCase {
         }
 
         ClientBase.setupTestEnv();
-        zs = new ZooKeeperServer(tmpDir, tmpDir, TICK_TIME);
+        zs = new ZooKeeperServer(tmpDir, tmpDir, TICK_TIME, new AtomicLong(0));
 
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         serverFactory = ServerCnxnFactory.createFactory(PORT, -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/StandaloneTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/StandaloneTest.java
@@ -23,6 +23,7 @@ import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.PortAssignment;
@@ -134,7 +135,7 @@ public class StandaloneTest extends QuorumPeerTestBase implements Watcher{
         final String HOSTPORT = "127.0.0.1:" + CLIENT_PORT;
 
         File tmpDir = ClientBase.createTmpDir();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
 
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(CLIENT_PORT, -1);
         f.startup(zks);


### PR DESCRIPTION
Use common zxid between all ZooKeeperServers used within a server instance