### PR TITLE
ZOOKEEPER-3526: data inconsistency due to mistaken TRUNC caused by maxCommittedLog is much less than minCommittedLog when in readonly mode

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.server;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.management.JMException;
 
@@ -102,7 +103,7 @@ public class ZooKeeperServerMain {
             // so rather than spawning another thread, we will just call
             // run() in this thread.
             // create a file logger url from the command line args
-            final ZooKeeperServer zkServer = new ZooKeeperServer();
+            final ZooKeeperServer zkServer = new ZooKeeperServer(new AtomicLong(0));
             // Registers shutdown handler which will be used to know the
             // server error or shutdown state changes.
             final CountDownLatch shutdownLatch = new CountDownLatch(1);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.server.quorum;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jute.Record;
 import org.slf4j.Logger;
@@ -59,9 +60,9 @@ public class FollowerZooKeeperServer extends LearnerZooKeeperServer {
      * @throws IOException
      */
     FollowerZooKeeperServer(FileTxnSnapLog logFactory,QuorumPeer self,
-            DataTreeBuilder treeBuilder, ZKDatabase zkDb) throws IOException {
+            DataTreeBuilder treeBuilder, ZKDatabase zkDb, AtomicLong hzxid) throws IOException {
         super(logFactory, self.tickTime, self.minSessionTimeout,
-                self.maxSessionTimeout, treeBuilder, zkDb, self);
+                self.maxSessionTimeout, treeBuilder, zkDb, hzxid, self);
         this.pendingSyncs = new ConcurrentLinkedQueue<Request>();
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderZooKeeperServer.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server.quorum;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.KeeperException.SessionExpiredException;
 import org.apache.zookeeper.jmx.MBeanRegistry;
@@ -47,9 +48,9 @@ public class LeaderZooKeeperServer extends QuorumZooKeeperServer {
      * @throws IOException
      */
     LeaderZooKeeperServer(FileTxnSnapLog logFactory, QuorumPeer self,
-            DataTreeBuilder treeBuilder, ZKDatabase zkDb) throws IOException {
+            DataTreeBuilder treeBuilder, ZKDatabase zkDb, AtomicLong hzxid) throws IOException {
         super(logFactory, self.tickTime, self.minSessionTimeout,
-                self.maxSessionTimeout, treeBuilder, zkDb, self);
+                self.maxSessionTimeout, treeBuilder, zkDb, hzxid, self);
     }
 
     public Leader getLeader(){

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerZooKeeperServer.java
@@ -19,6 +19,7 @@ package org.apache.zookeeper.server.quorum;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.server.DataTreeBean;
@@ -33,11 +34,11 @@ import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 public abstract class LearnerZooKeeperServer extends QuorumZooKeeperServer {    
     public LearnerZooKeeperServer(FileTxnSnapLog logFactory, int tickTime,
             int minSessionTimeout, int maxSessionTimeout,
-            DataTreeBuilder treeBuilder, ZKDatabase zkDb, QuorumPeer self)
+            DataTreeBuilder treeBuilder, ZKDatabase zkDb, AtomicLong hzxid, QuorumPeer self)
         throws IOException
     {
         super(logFactory, tickTime, minSessionTimeout, maxSessionTimeout,
-                treeBuilder, zkDb, self);
+                treeBuilder, zkDb, hzxid, self);
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverZooKeeperServer.java
@@ -19,6 +19,7 @@ package org.apache.zookeeper.server.quorum;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,9 +59,9 @@ public class ObserverZooKeeperServer extends LearnerZooKeeperServer {
         new ConcurrentLinkedQueue<Request>();
         
     ObserverZooKeeperServer(FileTxnSnapLog logFactory, QuorumPeer self,
-            DataTreeBuilder treeBuilder, ZKDatabase zkDb) throws IOException {
+            DataTreeBuilder treeBuilder, ZKDatabase zkDb, AtomicLong hzxid) throws IOException {
         super(logFactory, self.tickTime, self.minSessionTimeout,
-                self.maxSessionTimeout, treeBuilder, zkDb, self);
+                self.maxSessionTimeout, treeBuilder, zkDb, hzxid, self);
         LOG.info("syncEnabled =" + syncRequestProcessorEnabled);
     }
     

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
@@ -18,6 +18,7 @@
 package org.apache.zookeeper.server.quorum;
 
 import java.io.PrintWriter;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;
@@ -32,10 +33,10 @@ public abstract class QuorumZooKeeperServer extends ZooKeeperServer {
 
     protected QuorumZooKeeperServer(FileTxnSnapLog logFactory, int tickTime,
             int minSessionTimeout, int maxSessionTimeout,
-            DataTreeBuilder treeBuilder, ZKDatabase zkDb, QuorumPeer self)
+            DataTreeBuilder treeBuilder, ZKDatabase zkDb, AtomicLong hzxid, QuorumPeer self)
     {
         super(logFactory, tickTime, minSessionTimeout, maxSessionTimeout,
-                treeBuilder, zkDb);
+                treeBuilder, zkDb, hzxid);
         this.self = self;
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyZooKeeperServer.java
@@ -18,6 +18,8 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.server.DataTreeBean;
 import org.apache.zookeeper.server.FinalRequestProcessor;
@@ -40,9 +42,9 @@ public class ReadOnlyZooKeeperServer extends QuorumZooKeeperServer {
 
     private volatile boolean shutdown = false;
     ReadOnlyZooKeeperServer(FileTxnSnapLog logFactory, QuorumPeer self,
-            DataTreeBuilder treeBuilder, ZKDatabase zkDb) {
+            DataTreeBuilder treeBuilder, ZKDatabase zkDb, AtomicLong hzxid) {
         super(logFactory, self.tickTime, self.minSessionTimeout, self.maxSessionTimeout,
-                treeBuilder, zkDb, self);
+                treeBuilder, zkDb, hzxid, self);
     }
 
     @Override

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/CRCTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/CRCTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.Adler32;
 import java.util.zip.CheckedInputStream;
 
@@ -113,7 +114,7 @@ public class CRCTest extends ZKTestCase implements Watcher {
     public void testChecksums() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(150);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/FinalRequestProcessorTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/FinalRequestProcessorTest.java
@@ -39,6 +39,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -68,7 +69,7 @@ public class FinalRequestProcessorTest {
                 new ACL(ZooDefs.Perms.READ, new Id("world", "anyone"))
         ));
 
-        ZooKeeperServer zks = new ZooKeeperServer();
+        ZooKeeperServer zks = new ZooKeeperServer(new AtomicLong(0));
         ZKDatabase db = mock(ZKDatabase.class);
         String testPath = "/testPath";
         when(db.getNode(eq(testPath))).thenReturn(new DataNode());

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/PrepRequestProcessorTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/PrepRequestProcessorTest.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class PrepRequestProcessorTest extends ClientBase {
     private static final Logger LOG = LoggerFactory.getLogger(PrepRequestProcessorTest.class);
@@ -65,7 +66,7 @@ public class PrepRequestProcessorTest extends ClientBase {
     public void setup() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(100);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/PurgeTxnTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/PurgeTxnTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.zookeeper.data.Stat;
 
 import org.apache.zookeeper.CreateMode;
@@ -73,7 +74,7 @@ public class PurgeTxnTest extends ZKTestCase implements  Watcher {
     public void testPurge() throws Exception {
         tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(100);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
@@ -120,7 +121,7 @@ public class PurgeTxnTest extends ZKTestCase implements  Watcher {
     public void testPurgeWhenLogRollingInProgress() throws Exception {
         tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(30);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
@@ -455,7 +456,7 @@ public class PurgeTxnTest extends ZKTestCase implements  Watcher {
         // Create Zookeeper and connect to it.
         tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
         f.startup(zks);
@@ -497,7 +498,7 @@ public class PurgeTxnTest extends ZKTestCase implements  Watcher {
         PurgeTxnLog.purge(tmpDir, tmpDir, SNAP_RETAIN_COUNT);
 
         // Initialize Zookeeper again from the same dataDir.
-        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         f = ServerCnxnFactory.createFactory(PORT, -1);
         f.startup(zks);
         zk = ClientBase.createZKClient(HOSTPORT);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/SessionTrackerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/SessionTrackerTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import junit.framework.Assert;
 
@@ -119,7 +120,7 @@ public class SessionTrackerTest extends ZKTestCase {
     private ZooKeeperServer setupSessionTracker() throws IOException {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         zks.setupRequestProcessors();
         firstProcessor = new FirstProcessor(zks, null);
         zks.firstProcessor = firstProcessor;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerMainTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerMainTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -454,7 +455,7 @@ public class ZooKeeperServerMainTest extends ZKTestCase implements Watcher {
         private SimpleFinalRequestProcessor finalProcessor;
 
         SimpleZooKeeperServer(FileTxnSnapLog ftsl) throws IOException {
-            super(ftsl, 2000, 2000, 4000, null, new ZKDatabase(ftsl));
+            super(ftsl, 2000, 2000, 4000, null, new ZKDatabase(ftsl), new AtomicLong(0));
         }
 
         @Override
@@ -599,7 +600,7 @@ public class ZooKeeperServerMainTest extends ZKTestCase implements Watcher {
     private ServerCnxnFactory startServer(File tmpDir) throws IOException,
             InterruptedException {
         final int CLIENT_PORT = PortAssignment.unique();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(CLIENT_PORT, -1);
         f.startup(zks);
         Assert.assertNotNull("JMX initialization failed!", zks.jmxServerBean);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerStartupTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerStartupTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZKTestCase;
@@ -261,7 +262,7 @@ public class ZooKeeperServerStartupTest extends ZKTestCase {
 
         public SimpleZooKeeperServer(File snapDir, File logDir, int tickTime,
                 CountDownLatch startupDelayLatch) throws IOException {
-            super(snapDir, logDir, tickTime);
+            super(snapDir, logDir, tickTime, new AtomicLong(0));
             this.startupDelayLatch = startupDelayLatch;
         }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeDeletionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeDeletionTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.PortAssignment;
@@ -182,7 +183,7 @@ public class EphemeralNodeDeletionTest extends QuorumPeerTestBase {
                 throws IOException {
             return new Follower(this, new FollowerZooKeeperServer(logFactory,
                     this, null /*DataTreeBuilder is never used*/,
-                    this.getZkDb())) {
+                    this.getZkDb(), new AtomicLong(0))) {
 
                 @Override
                 void readPacket(QuorumPacket pp) throws IOException {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
@@ -35,6 +35,7 @@ import org.mockito.stubbing.Answer;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -60,7 +61,7 @@ public class LeaderBeanTest {
                 new File(tmpDir, "data_txnlog"));
         ZKDatabase zkDb = new ZKDatabase(fileTxnSnapLog);
 
-        zks = new LeaderZooKeeperServer(fileTxnSnapLog, qp, null, zkDb);
+        zks = new LeaderZooKeeperServer(fileTxnSnapLog, qp, null, zkDb, new AtomicLong(0));
         leader = new Leader(qp, zks);
         leaderBean = new LeaderBean(leader, zks);
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
@@ -54,7 +55,7 @@ public class LearnerTest extends ZKTestCase {
 		boolean startupCalled;
 		
 		public SimpleLearnerZooKeeperServer(FileTxnSnapLog ftsl, QuorumPeer self) throws IOException {
-			super(ftsl, 2000, 2000, 2000, null, new ZKDatabase(ftsl), self);
+			super(ftsl, 2000, 2000, 2000, null, new ZKDatabase(ftsl), new AtomicLong(0), self);
 		}
 		Learner learner;
 		@Override

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumCnxManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumCnxManagerTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.security.sasl.SaslException;
 
@@ -931,7 +932,8 @@ public class QuorumCnxManagerTest extends ZKTestCase {
         addrField.set(peer, new InetSocketAddress(PortAssignment.unique()));
         ZKDatabase zkDb = new ZKDatabase(logFactory);
         LeaderZooKeeperServer zk = new LeaderZooKeeperServer(logFactory, peer,
-                new ZooKeeperServer.BasicDataTreeBuilder(), zkDb);
+                new ZooKeeperServer.BasicDataTreeBuilder(), zkDb,
+                new AtomicLong(0));
         return zk;
     }
 
@@ -940,7 +942,8 @@ public class QuorumCnxManagerTest extends ZKTestCase {
 
         public SimpleLearnerZooKeeperServer(FileTxnSnapLog ftsl,
                 QuorumPeer self) throws IOException {
-            super(ftsl, 2000, 2000, 2000, null, new ZKDatabase(ftsl), self);
+            super(ftsl, 2000, 2000, 2000, null, new ZKDatabase(ftsl),
+                new AtomicLong(0), self);
         }
 
         Learner learner;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerReadOnlyTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerReadOnlyTest.java
@@ -1,0 +1,189 @@
+package org.apache.zookeeper.server.quorum;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.KeeperException.RuntimeInconsistencyException;
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.ZooKeeper.States;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QuorumPeerReadOnlyTest extends QuorumPeerTestBase {
+    
+    String prePropertyReadOnlyValue = null;
+    
+    @Before
+    public void setReadOnlySystemProperty() {
+        prePropertyReadOnlyValue = System.getProperty("readonlymode.enabled");
+        System.setProperty("readonlymode.enabled", "true");
+    }
+    
+    @After
+    public void restoreReadOnlySystemProperty() {
+        if (prePropertyReadOnlyValue == null) {
+            System.clearProperty("readonlymode.enabled");
+        } else {
+            System.setProperty("readonlymode.enabled", prePropertyReadOnlyValue);
+        }
+    }
+    
+    /**
+     * Test zxid is not set to a truncate value
+     */
+    @Test
+    public void testReadOnlyZxid() throws Exception {
+        ClientBase.setupTestEnv();
+        final int SERVER_COUNT = 3;
+        final int[] clientPorts = new int[SERVER_COUNT];
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            clientPorts[i] = PortAssignment.unique();
+            sb.append("server." + i + "=127.0.0.1:" + PortAssignment.unique() + ":" + PortAssignment.unique() + "\n");
+        }
+        String quorumCfgSection = sb.toString();
+
+        MainThread[] mt = new MainThread[SERVER_COUNT];
+        ZooKeeper[] zk = new ZooKeeper[SERVER_COUNT];
+        
+
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            mt[i] = new MainThread(i, clientPorts[i], quorumCfgSection + "\nclientPort=" + clientPorts[i]);
+            mt[i].start();
+            
+        }
+        
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            zk[i] = new ZooKeeper("127.0.0.1:" + clientPorts[i], ClientBase.CONNECTION_TIMEOUT, this, true);
+        }
+        
+        waitForAll(zk, States.CONNECTED);
+        
+        zk[0].create("/test", "Test".getBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+
+        // Shutdown all clients first, to ensure that the close zxid is seen and logged by all servers
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            zk[i].close();
+        }
+        // Shutdown all servers, before starting one again, as the commonly used data storage is cleaned
+        // up, when the first server is stopped
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            mt[i].shutdown();
+        }
+        
+        mt[SERVER_COUNT-1].start();
+        // Ensure that close will trigger a timeout
+        zk[SERVER_COUNT-1] = new ZooKeeper("127.0.0.1:" + clientPorts[SERVER_COUNT-1], ClientBase.CONNECTION_TIMEOUT, this, true) {
+//            @Override
+            public void close2() {
+                getTestable().injectSessionExpiration();
+                cnxn.disconnect();
+                try {
+                    Thread.sleep(ClientBase.CONNECTION_TIMEOUT * 2);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+        
+        waitForAll(new ZooKeeper[] {zk[SERVER_COUNT-1]}, States.CONNECTEDREADONLY);
+        
+        // Read some data
+        assertTrue(Arrays.equals(zk[SERVER_COUNT-1].getData("/test", false, null), "Test".getBytes()));
+        
+        // Kill the client, without notification
+        zk[SERVER_COUNT-1].close();
+       
+        // Start enough server for a quorum, but not all yet. Don't start any client, to avoid changing the zxid
+        for (int i=SERVER_COUNT-1; i >= ((SERVER_COUNT-1)/2); i--) {
+            if (i != SERVER_COUNT-1) {
+                mt[i].start();
+            }
+        }
+        ensureLeaderIsPresent(mt);
+        
+        // Start the remaining servers
+        for (int i = (SERVER_COUNT-1)/2-1; i >= 0; i--) {
+            mt[i].start();
+        }
+        ensureRemainingserversPresent(mt);
+                
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            zk[i] = new ZooKeeper("127.0.0.1:" + clientPorts[i], ClientBase.CONNECTION_TIMEOUT, this, true);
+        }
+        waitForAll(zk, States.CONNECTED);
+
+        // Ensure that all clients can read the data
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            assertTrue(Arrays.equals(zk[i].getData("/test", false, null), "Test".getBytes()));
+        }
+        
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            zk[i].close();
+        }
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            mt[i].shutdown();
+        }
+    }
+    
+    private void waitForAll(ZooKeeper[] zks, States state) throws InterruptedException {
+        int iterations = ClientBase.CONNECTION_TIMEOUT / 1000;
+        boolean someoneNotConnected = true;
+        while (someoneNotConnected) {
+            if (iterations-- == 0) {
+                ClientBase.logAllStackTraces();
+                throw new RuntimeException("Waiting too long");
+            }
+
+            someoneNotConnected = false;
+            for (ZooKeeper zk : zks) {
+                if (zk.getState() != state) {
+                    someoneNotConnected = true;
+                    break;
+                }
+            }
+            Thread.sleep(1000);
+        }
+    }
+    
+    private void ensureLeaderIsPresent(MainThread[] mt) throws InterruptedException {
+        boolean leaderFound = false;
+        int searchCount = 0;
+        do {
+            Thread.sleep(100);
+            for (int i=mt.length-1; i >= ((mt.length-1)/2); i--) {
+                if (mt[i].main.quorumPeer.leader != null) {
+                    leaderFound = true;
+                    break;
+                }
+            }
+            if (searchCount++ >= 300) {
+                throw new RuntimeException("Waiting too long");
+            }
+        } while(!leaderFound);
+    }
+    
+    private void ensureRemainingserversPresent(MainThread[] mt) throws InterruptedException {
+        int searchCount = 0;
+        boolean missingConnection;
+        do {
+            Thread.sleep(100);
+            missingConnection = false;
+            for (int i = (mt.length-1)/2-1; i >= 0; i--) {
+                if (mt[i].main.quorumPeer.follower == null && mt[i].main.quorumPeer.leader == null) {
+                    missingConnection = true;
+                    break;
+                }
+            }
+            if (searchCount++ >= 300) {
+                throw new RuntimeException("Waiting too long");
+            }
+        } while(missingConnection);
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/WatchLeakTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/WatchLeakTest.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
@@ -88,7 +89,7 @@ public class WatchLeakTest {
         FollowerZooKeeperServer fzks = null;
         try {
             fzks = new FollowerZooKeeperServer(logfactory, quorumPeer, null,
-                    database);
+                    database, new AtomicLong(0));
             fzks.startup();
             fzks.setServerCnxnFactory(serverCnxnFactory);
             quorumPeer.follower = new MyFollower(quorumPeer, fzks);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
@@ -40,6 +40,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
@@ -1299,7 +1300,7 @@ public class Zab1_0Test {
         FileTxnSnapLog logFactory = new FileTxnSnapLog(tmpDir, tmpDir);
         peer.setTxnFactory(logFactory);
         ZKDatabase zkDb = new ZKDatabase(logFactory);
-        FollowerZooKeeperServer zk = new FollowerZooKeeperServer(logFactory, peer, new ZooKeeperServer.BasicDataTreeBuilder(), zkDb);
+        FollowerZooKeeperServer zk = new FollowerZooKeeperServer(logFactory, peer, new ZooKeeperServer.BasicDataTreeBuilder(), zkDb, new AtomicLong(0));
         peer.setZKDatabase(zkDb);
         return new ConversableFollower(peer, zk);
     }
@@ -1327,7 +1328,7 @@ public class Zab1_0Test {
         peer.setTxnFactory(logFactory);
         DataTreeBuilder treeBuilder = new ZooKeeperServer.BasicDataTreeBuilder();
         ZKDatabase zkDb = new ZKDatabase(logFactory);
-        ObserverZooKeeperServer zk = new ObserverZooKeeperServer(logFactory, peer, treeBuilder, zkDb);
+        ObserverZooKeeperServer zk = new ObserverZooKeeperServer(logFactory, peer, treeBuilder, zkDb, new AtomicLong(0));
         peer.setZKDatabase(zkDb);
         return new ConversableObserver(peer, zk);
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ZabUtils.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ZabUtils.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class ZabUtils {
 
@@ -81,7 +82,7 @@ public class ZabUtils {
         addrField.setAccessible(true);
         addrField.set(peer, new InetSocketAddress(PortAssignment.unique()));
         ZKDatabase zkDb = new ZKDatabase(logFactory);
-        return new LeaderZooKeeperServer(logFactory, peer, new ZooKeeperServer.BasicDataTreeBuilder(), zkDb);
+        return new LeaderZooKeeperServer(logFactory, peer, new ZooKeeperServer.BasicDataTreeBuilder(), zkDb, new AtomicLong(0));
     }
 
     private static final class NullServerCnxnFactory extends ServerCnxnFactory {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ACLCountTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ACLCountTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +68,7 @@ public class ACLCountTest extends ZKTestCase implements Watcher {
     public void testAclCount() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(1000);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ACLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ACLTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +54,7 @@ public class ACLTest extends ZKTestCase implements Watcher {
     public void testDisconnectedAddAuth() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(1000);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
@@ -87,7 +88,7 @@ public class ACLTest extends ZKTestCase implements Watcher {
     public void testAcls() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(1000);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
@@ -128,7 +129,7 @@ public class ACLTest extends ZKTestCase implements Watcher {
         }
         startSignal = new CountDownLatch(1);
 
-        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         f = ServerCnxnFactory.createFactory(PORT, -1);
 
         f.startup(zks);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -401,7 +402,7 @@ public abstract class ClientBase extends ZKTestCase {
             InterruptedException {
         final int port = getPort(hostPort);
         LOG.info("STARTING server instance 127.0.0.1:{}", port);
-        ZooKeeperServer zks = new ZooKeeperServer(dataDir, dataDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(dataDir, dataDir, 3000, new AtomicLong(0));
         factory.startup(zks);
         Assert.assertTrue("waiting for server up", ClientBase.waitForServerUp(
                 "127.0.0.1:" + port, CONNECTION_TIMEOUT));

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientPortBindTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientPortBindTest.java
@@ -28,6 +28,7 @@ import java.net.SocketException;
 import java.util.Enumeration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,7 +89,7 @@ public class ClientPortBindTest extends ZKTestCase implements Watcher {
         File tmpDir = ClientBase.createTmpDir();
 
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
 
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(
                 new InetSocketAddress(bindAddress, PORT), -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/InvalidSnapshotTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/InvalidSnapshotTest.java
@@ -22,6 +22,7 @@ import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,7 +90,7 @@ public class InvalidSnapshotTest extends ZKTestCase implements Watcher {
     @Test
     public void testSnapshot() throws Exception {
         File snapDir = new File(testData, "invalidsnap");
-        ZooKeeperServer zks = new ZooKeeperServer(snapDir, snapDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(snapDir, snapDir, 3000, new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(1000);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/LoadFromLogTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/LoadFromLogTest.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class LoadFromLogTest extends ClientBase {
     private static final int NUM_MESSAGES = 300;
@@ -188,7 +189,7 @@ public class LoadFromLogTest extends ClientBase {
         zks.shutdown();
         stopServer();
 
-        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         startServer();
    }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/OOMTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/OOMTest.java
@@ -23,6 +23,7 @@ import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -57,7 +58,7 @@ public class OOMTest extends ZKTestCase implements Watcher {
             }
         }
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
 
         final int PORT = PortAssignment.unique();
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/RecoveryTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/RecoveryTest.java
@@ -23,6 +23,7 @@ import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +67,7 @@ public class RecoveryTest extends ZKTestCase implements Watcher {
         File tmpDir = ClientBase.createTmpDir();
 
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
 
         int oldSnapCount = SyncRequestProcessor.getSnapCount();
         SyncRequestProcessor.setSnapCount(1000);
@@ -110,7 +111,7 @@ public class RecoveryTest extends ZKTestCase implements Watcher {
                        ClientBase.waitForServerDown(HOSTPORT,
                                           CONNECTION_TIMEOUT));
 
-            zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+            zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
             f = ServerCnxnFactory.createFactory(PORT, -1);
 
             startSignal = new CountDownLatch(1);
@@ -149,7 +150,7 @@ public class RecoveryTest extends ZKTestCase implements Watcher {
                        ClientBase.waitForServerDown(HOSTPORT,
                                           ClientBase.CONNECTION_TIMEOUT));
 
-            zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+            zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
             f = ServerCnxnFactory.createFactory(PORT, -1);
 
             startSignal = new CountDownLatch(1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/RepeatStartupTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/RepeatStartupTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.zookeeper.test;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooKeeper;
@@ -50,7 +52,7 @@ public class RepeatStartupTest extends ZKTestCase {
         qb.shutdown(qb.s5);
         String hp = qb.hostPort.split(",")[0];
         ZooKeeperServer zks = new ZooKeeperServer(qb.s1.getTxnFactory().getSnapDir(),
-                qb.s1.getTxnFactory().getDataDir(), 3000);
+                qb.s1.getTxnFactory().getDataDir(), 3000, new AtomicLong(0));
         final int PORT = Integer.parseInt(hp.split(":")[1]);
         ServerCnxnFactory factory = ServerCnxnFactory.createFactory(PORT, -1);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/RestoreCommittedLogTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/RestoreCommittedLogTest.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.test;
 import java.io.File;
 import java.util.List;
 import java.util.LinkedList;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.CreateMode;
@@ -53,7 +54,8 @@ public class RestoreCommittedLogTest extends ZKTestCase implements  Watcher {
     public void testRestoreCommittedLog() throws Exception {
         File tmpDir = ClientBase.createTmpDir();
         ClientBase.setupTestEnv();
-        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(tmpDir, tmpDir, 3000,
+            new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(100);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);
@@ -75,7 +77,7 @@ public class RestoreCommittedLogTest extends ZKTestCase implements  Watcher {
                 ClientBase.waitForServerDown(HOSTPORT, CONNECTION_TIMEOUT));
 
         // start server again
-        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000);
+        zks = new ZooKeeperServer(tmpDir, tmpDir, 3000, new AtomicLong(0));
         zks.startdata();
         LinkedList<Proposal> committedLog = zks.getZKDatabase().getCommittedLog();
         int logsize = committedLog.size();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SessionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SessionTest.java
@@ -26,6 +26,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,7 +72,7 @@ public class SessionTest extends ZKTestCase {
         }
 
         ClientBase.setupTestEnv();
-        zs = new ZooKeeperServer(tmpDir, tmpDir, TICK_TIME);
+        zs = new ZooKeeperServer(tmpDir, tmpDir, TICK_TIME, new AtomicLong(0));
 
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         serverFactory = ServerCnxnFactory.createFactory(PORT, -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/UpgradeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/UpgradeTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +61,8 @@ public class UpgradeTest extends ZKTestCase implements Watcher {
         File upgradeDir = new File(testData, "upgrade");
         UpgradeMain upgrade = new UpgradeMain(upgradeDir, upgradeDir);
         upgrade.runUpgrade();
-        ZooKeeperServer zks = new ZooKeeperServer(upgradeDir, upgradeDir, 3000);
+        ZooKeeperServer zks = new ZooKeeperServer(upgradeDir, upgradeDir, 3000,
+            new AtomicLong(0));
         SyncRequestProcessor.setSnapCount(1000);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
         ServerCnxnFactory f = ServerCnxnFactory.createFactory(PORT, -1);


### PR DESCRIPTION
Use common zxid between all ZooKeeperServers used within a server instance