### PR TITLE
ZOOKEEPER-3893: Enhance documentation for property ssl.clientAuth

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1588,7 +1588,7 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
 
 * *ssl.clientAuth* and *ssl.quorum.clientAuth* :
     (Java system properties: **zookeeper.ssl.clientAuth** and **zookeeper.ssl.quorum.clientAuth**)
-    **New in 3.5.7:**
+    **Added in 3.5.5, but broken until 3.5.7:**
     Specifies options to authenticate ssl connections from clients. Valid values are
  
      * "none": server will not request client authentication 

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1588,8 +1588,14 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
 
 * *ssl.clientAuth* and *ssl.quorum.clientAuth* :
     (Java system properties: **zookeeper.ssl.clientAuth** and **zookeeper.ssl.quorum.clientAuth**)
-    **New in 3.5.5:**
-    TBD
+    **New in 3.5.7:**
+    Specifies options to authenticate ssl connections from clients. Valid values are
+ 
+     * "none": server will not request client authentication 
+     * "want": server will "request" client authentication 
+     * "need": server will "require" client authentication
+
+     Default: "need"
 
 * *ssl.handshakeDetectionTimeoutMillis* and *ssl.quorum.handshakeDetectionTimeoutMillis* :
     (Java system properties: **zookeeper.ssl.handshakeDetectionTimeoutMillis** and **zookeeper.ssl.quorum.handshakeDetectionTimeoutMillis**)


### PR DESCRIPTION
Currently, the documentation for this property just mentions TBD (check https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html). I believe this was ignored until versions 3.5.7 (https://issues.apache.org/jira/browse/ZOOKEEPER-3674) and a fix was made. It will be good to add some documentation around it. 