### PR TITLE
ZOOKEEPER-3112: fix fd leak due to UnresolvedAddressException on conn…

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNIO.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNIO.java
@@ -26,6 +26,8 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
+import java.nio.channels.UnresolvedAddressException;
+import java.nio.channels.UnsupportedAddressTypeException;
 import java.util.Iterator;
 import java.util.Queue;
 import java.util.Set;
@@ -266,7 +268,7 @@ public class ClientCnxnSocketNIO extends ClientCnxnSocket {
         SocketChannel sock = createSock();
         try {
             registerAndConnect(sock, addr);
-        } catch (IOException e) {
+        } catch (UnresolvedAddressException | UnsupportedAddressTypeException | SecurityException | IOException e) {
             LOG.error("Unable to open socket to {}", addr);
             sock.close();
             throw e;


### PR DESCRIPTION
SocketChannel.connect() can throw different kind of exceptions but ClientCnxnSocketNIO.connect() handles only IOException. This could lead to FD leak when socked is opened but is not connected. We should handle some additional exception classes and close the socket.