### PR TITLE
Zookeeper 3112: fd leak due to UnresolvedAddressException on connect.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNIO.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNIO.java
@@ -289,6 +289,10 @@ public class ClientCnxnSocketNIO extends ClientCnxnSocket {
             LOG.error("Unable to open socket to " + addr);
             sock.close();
             throw e;
+        } catch (RuntimeException e) {
+            LOG.error("Unable to open socket to " + addr);
+            sock.close();
+            throw e;
         }
         initialized = false;
 


### PR DESCRIPTION
SocketChannel.connect() can throw different kind of exceptions but ClientCnxnSocketNIO.connect() handles only IOException. This could lead to FD leak when socked is opened but is not connected. We should handle some additional exception classes and close the socket.