### PR TITLE
ZOOKEEPER-3896. PollSCM hourly only to let previous builds to finish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     }
 
     triggers {
-        pollSCM 'H/10 * * * *'
+        pollSCM('@hourly')
         cron('@daily')
     }
 
@@ -68,4 +68,3 @@ pipeline {
         }
     }
 }
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,11 +39,11 @@ pipeline {
                     }
                 }
 
-			    tools {
-					// Install the Maven version configured as "M3" and add it to the path.
-					maven "Maven 3.5.4"
-					jdk "${JAVA_VERSION}"
-			    }
+                tools {
+                    // Install the Maven version configured as "M3" and add it to the path.
+                    maven "Maven 3.5.4"
+                    jdk "${JAVA_VERSION}"
+                }
 
                 stages {
                     stage('BuildAndTest') {
@@ -54,14 +54,14 @@ pipeline {
                             // Run Maven on a Unix agent.
                             sh "mvn verify spotbugs:check checkstyle:check -Pfull-build -Dsurefire-forkcount=4"
                         }
-            			post {
-				            // If Maven was able to run the tests, even if some of the test
-				            // failed, record the test results and archive the jar file.
-				            always {
-				               junit '**/target/surefire-reports/TEST-*.xml'
-				               archiveArtifacts '**/target/*.jar'
-				            }
-				        }
+                        post {
+                            // If Maven was able to run the tests, even if some of the test
+                            // failed, record the test results and archive the jar file.
+                            always {
+                               junit '**/target/surefire-reports/TEST-*.xml'
+                               archiveArtifacts '**/target/*.jar'
+                            }
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pipeline {
+   agent none
+
+    options {
+        buildDiscarder(logRotator(daysToKeepStr: '14'))
+    }
+
+    stages {
+        stage('BuildAndTest') {
+            matrix {
+                agent any
+                axes {
+                    axis {
+                        name 'JAVA_VERSION'
+                        values 'JDK 1.8 (latest)', 'JDK 11 (latest)'
+                    }
+                }
+
+			    tools {
+					// Install the Maven version configured as "M3" and add it to the path.
+					maven "Maven 3.5.4"
+					jdk "${JAVA_VERSION}"
+			    }
+
+                stages {
+                    stage('Build') {
+                        steps {
+                            // Get some code from a GitHub repository
+                            git 'https://github.com/apache/zookeeper'
+
+                            // Run Maven on a Unix agent.
+                            sh "mvn verify spotbugs:check checkstyle:check -Pfull-build -Dsurefire-forkcount=4"
+                        }
+            			post {
+				            // If Maven was able to run the tests, even if some of the test
+				            // failed, record the test results and archive the jar file.
+				            always {
+				               junit '**/target/surefire-reports/TEST-*.xml'
+				               archiveArtifacts 'target/*.jar'
+				            }
+				        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,11 @@ pipeline {
 					jdk "${JAVA_VERSION}"
 			    }
 
+			    triggers {
+                    pollSCM 'H/10 * * * *'
+                    cron('@daily')
+                }
+
                 stages {
                     stage('BuildAndTest') {
                         steps {
@@ -53,7 +58,7 @@ pipeline {
 				            // If Maven was able to run the tests, even if some of the test
 				            // failed, record the test results and archive the jar file.
 				            always {
-				               junit '**/target/surefire-reports/*.txt'
+				               junit '**/target/surefire-reports/TEST-*.xml'
 				               archiveArtifacts '**/target/*.jar'
 				            }
 				        }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,11 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '14'))
     }
 
+    triggers {
+        pollSCM 'H/10 * * * *'
+        cron('@daily')
+    }
+
     stages {
         stage('Prepare') {
             matrix {
@@ -39,11 +44,6 @@ pipeline {
 					maven "Maven 3.5.4"
 					jdk "${JAVA_VERSION}"
 			    }
-
-			    triggers {
-                    pollSCM 'H/10 * * * *'
-                    cron('@daily')
-                }
 
                 stages {
                     stage('BuildAndTest') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     }
 
     stages {
-        stage('BuildAndTest') {
+        stage('Prepare') {
             matrix {
                 agent any
                 axes {
@@ -41,7 +41,7 @@ pipeline {
 			    }
 
                 stages {
-                    stage('Build') {
+                    stage('BuildAndTest') {
                         steps {
                             // Get some code from a GitHub repository
                             git 'https://github.com/apache/zookeeper'
@@ -53,8 +53,8 @@ pipeline {
 				            // If Maven was able to run the tests, even if some of the test
 				            // failed, record the test results and archive the jar file.
 				            always {
-				               junit '**/target/surefire-reports/TEST-*.xml'
-				               archiveArtifacts 'target/*.jar'
+				               junit '**/target/surefire-reports/*.txt'
+				               archiveArtifacts '**/target/*.jar'
 				            }
 				        }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
 
                 tools {
                     // Install the Maven version configured as "M3" and add it to the path.
-                    maven "Maven 3.5.4"
+                    maven "Maven (latest)"
                     jdk "${JAVA_VERSION}"
                 }
 


### PR DESCRIPTION
Looks like that PollSCM trigger will trigger another build on the same ref if other builds haven't **completed** rather than haven't **started**.

I change the polling interval to hourly to let other builds finish in time.