### PR TITLE
ZOOKEEPER-3896. PollSCM hourly only to let previous builds to finish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     }
 
     triggers {
-        pollSCM 'H/10 * * * *'
+        pollSCM('@hourly')
         cron('@daily')
     }
 
@@ -68,4 +68,3 @@ pipeline {
         }
     }
 }
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,38 +28,40 @@ pipeline {
         cron('@daily')
     }
 
-    stages {
-        stage('Prepare') {
-            matrix {
-                agent any
-                axes {
-                    axis {
-                        name 'JAVA_VERSION'
-                        values 'JDK 1.8 (latest)', 'JDK 11 (latest)'
-                    }
-                }
-
-                tools {
-                    // Install the Maven version configured as "M3" and add it to the path.
-                    maven "Maven (latest)"
-                    jdk "${JAVA_VERSION}"
-                }
-
-                stages {
-                    stage('BuildAndTest') {
-                        steps {
-                            // Get some code from a GitHub repository
-                            git 'https://github.com/apache/zookeeper'
-
-                            // Run Maven on a Unix agent.
-                            sh "mvn verify spotbugs:check checkstyle:check -Pfull-build -Dsurefire-forkcount=4"
+    timeout(59) {
+        stages {
+            stage('Prepare') {
+                matrix {
+                    agent any
+                    axes {
+                        axis {
+                            name 'JAVA_VERSION'
+                            values 'JDK 1.8 (latest)', 'JDK 11 (latest)'
                         }
-                        post {
-                            // If Maven was able to run the tests, even if some of the test
-                            // failed, record the test results and archive the jar file.
-                            always {
-                               junit '**/target/surefire-reports/TEST-*.xml'
-                               archiveArtifacts '**/target/*.jar'
+                    }
+
+                    tools {
+                        // Install the Maven version configured as "M3" and add it to the path.
+                        maven "Maven (latest)"
+                        jdk "${JAVA_VERSION}"
+                    }
+
+                    stages {
+                        stage('BuildAndTest') {
+                            steps {
+                                // Get some code from a GitHub repository
+                                git 'https://github.com/apache/zookeeper'
+
+                                // Run Maven on a Unix agent.
+                                sh "mvn verify spotbugs:check checkstyle:check -Pfull-build -Dsurefire-forkcount=4"
+                            }
+                            post {
+                                // If Maven was able to run the tests, even if some of the test
+                                // failed, record the test results and archive the jar file.
+                                always {
+                                   junit '**/target/surefire-reports/TEST-*.xml'
+                                   archiveArtifacts '**/target/*.jar'
+                                }
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,8 +28,8 @@ pipeline {
         cron('@daily')
     }
 
-    timeout(59) {
-        stages {
+    stages {
+        timeout(59) {
             stage('Prepare') {
                 matrix {
                     agent any


### PR DESCRIPTION
Looks like that PollSCM trigger will trigger another build on the same ref if other builds haven't completed rather than haven't started.

I change the polling interval to hourly to let other builds finish in time.