### PR TITLE
ZOOKEEPER-3896. Remove badly behaving PollSCM trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,6 @@ pipeline {
     }
 
     triggers {
-        pollSCM('@hourly')
         cron('@daily')
     }
 


### PR DESCRIPTION
PollSCM trigger triggers a build every time it scans the ZooKeeper repo regardless the branch pointer has been changed or not. Instead, I try to use the built-in 'Scan Multibranch Pipeline' instead which should be good for the same purpose.