### PR TITLE
ZOOKEEPER-3896. Added cleanup bits to all ZK builds

### DIFF
--- a/Jenkinsfile-PreCommit
+++ b/Jenkinsfile-PreCommit
@@ -37,6 +37,7 @@ pipeline {
         stage('BuildAndTest') {
             steps {
                 git 'https://github.com/apache/zookeeper'
+                sh "git clean -fxd"
                 sh "mvn verify spotbugs:check checkstyle:check -Pfull-build -Dsurefire-forkcount=4"
             }
             post {


### PR DESCRIPTION
Recently I noticed some weird null pointer exception issues during compile in out new builds. I usually resolve this by a full "git clean" locally, so I added it to the Jenkinsfiles too.