### PR TITLE
ZOOKEEPER-3919 : Added ARM64 support to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
     - os: linux
       jdk: openjdk11
     - os: linux
+      arch: arm64
+      jdk: openjdk11
+    - os: linux
       arch: s390x
       jdk: openjdk11
       addons:
@@ -25,6 +28,11 @@ addons:
   apt:
     packages:
     - libcppunit-dev
+
+install:
+  - if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+     sudo apt-get install maven;
+    fi
 
 script: mvn clean apache-rat:check verify -DskipTests spotbugs:check checkstyle:check -Pfull-build
 


### PR DESCRIPTION
1. Added ARM64 support with jdk 11
2. Installed maven if architecture is ARM64

Signed-off-by: odidev <odidev@puresoftware.com>