### PR TITLE
[ZOOKEEPER-3915] Digest hash - use UTF_8 explicitly when converting path String to bytes

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DigestCalculator.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DigestCalculator.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.CRC32;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.StatPersisted;
@@ -95,7 +96,7 @@ public class DigestCalculator {
         bb.putLong(stat.getEphemeralOwner());
 
         CRC32 crc = new CRC32();
-        crc.update(path.getBytes());
+        crc.update(path.getBytes(StandardCharsets.UTF_8));
         if (data != null) {
             crc.update(data);
         }


### PR DESCRIPTION
Fixes a false Digest mismatch when participants are running in environments with different default locales.