### PR TITLE
ZOOKEEPER-3923: Retry following reader after connection read error

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -114,7 +114,7 @@ public class Learner {
      * Time to wait after connection attempt with the Leader or LearnerMaster before this
      * Learner tries to connect again.
      */
-    private static final int leaderConnectDelayDuringRetryMs = Integer.getInteger("zookeeper.leaderConnectDelayDuringRetryMs", 100);
+    protected static final int leaderConnectDelayDuringRetryMs = Integer.getInteger("zookeeper.leaderConnectDelayDuringRetryMs", 100);
 
     private static final boolean nodelay = System.getProperty("follower.nodelay", "true").equals("true");
 


### PR DESCRIPTION
Performs retries in syncing up with leader, in order to handle cases in which the TCP connection is established but immediately closed.