### PR TITLE
ZOOKEEPER-3916: if zkServer is null, don't accept connection for wasting resource, until not null

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxnFactory.java
@@ -28,14 +28,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.slf4j.Logger;
@@ -183,6 +176,8 @@ public class NIOServerCnxnFactory extends ServerCnxnFactory {
                          *
                          */
                         if (zkServer == null) {
+                            Thread.sleep(5*1000);
+
                             continue;
                         }
 


### PR DESCRIPTION
## when leader is shutdown or not voted yet
```
Leader#shutdown ---> self.setZooKeeperServer(null) ---> NIOServerCnxnFactory.SelectorThread#run 
---> processAcceptedConnections ---> createConnection(zkServer=null) 
```

## when the client tries to connect that uninitialized server
* origin, accept the connections immediately. When reading data check whether the zkServer is null or not. If null, throws exceptions and closes connections, which wastes the resources.
```
NIOServerCnxn#doIO---> NIOServerCnxn#readLength ---> 
if (!isZKServerRunning()) ---> throw new IOException("ZooKeeperServer not running")
```
* current, precheck whether the zkServer is null or not. If null, not accept the connetion.
```
QuorumPeerMain#quorumPeer.start();--->QuorumPeer#startServerCnxnFactory();--->ServerCnxnFactory#start();--->
acceptThread.start(); then thread is running waiting for connection to accepted; 
--->AcceptThread#run, if (zkServer == null) continue; don't accept the connection, until zkServer is not null
```