### PR TITLE
ZOOKEEPER-3916: if zkServer is null, don't accept connection for wasting resource

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxnFactory.java
@@ -178,6 +178,15 @@ public class NIOServerCnxnFactory extends ServerCnxnFactory {
             try {
                 while (!stopped && !acceptSocket.socket().isClosed()) {
                     try {
+                        /** if zkServer is null, don't accept the connection.
+                         *  if accept the connection, when reading data from socket, it will be closed by null of zkServer
+                         *
+                         */
+                        if (zkServer == null) {
+                            Thread.sleep(5*1000);
+                            continue;
+                        }
+
                         select();
                     } catch (RuntimeException e) {
                         LOG.warn("Ignoring unexpected runtime exception", e);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxnFactory.java
@@ -178,8 +178,9 @@ public class NIOServerCnxnFactory extends ServerCnxnFactory {
             try {
                 while (!stopped && !acceptSocket.socket().isClosed()) {
                     try {
-                        /** if zkServer is null, don't accept the connection.
-                         *  if accept the connection, when reading data from socket, it will be closed by null of zkServer
+                        /**
+                         * if zkServer is null, don't accept the connection.
+                         * if accept the connection, when reading data from socket, it will be closed by null of zkServer
                          *
                          */
                         if (zkServer == null) {


### PR DESCRIPTION
## when leader is shutdown or not voted yet
```
Leader#shutdown ---> self.setZooKeeperServer(null) ---> NIOServerCnxnFactory.SelectorThread#run 
---> processAcceptedConnections ---> createConnection(zkServer=null) 
```
## when the client tries to connect that uninitialized server
* origin, accept the connections immediately. When reading data check whether the zkServer is null or not. If null, throws exceptions and closes connections, which wastes the resources.
```
NIOServerCnxn#doIO---> NIOServerCnxn#readLength ---> 
if (!isZKServerRunning()) ---> throw new IOException("ZooKeeperServer not running")
```
* current, precheck whether the zkServer is null or not. If null, not accept the connetion.
```
QuorumPeerMain#quorumPeer.start();--->QuorumPeer#startServerCnxnFactory();--->ServerCnxnFactory#start();--->
acceptThread.start(); then thread is running waiting for connection to accepted; 
--->AcceptThread#run, if (zkServer == null) continue; don't accept the connection, until zkServer is not null
```