### PR TITLE
ZOOKEEPER-3935: Handle float metrics in check_zookeeper

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-monitoring/check_zookeeper.py
+++ b/zookeeper-contrib/zookeeper-contrib-monitoring/check_zookeeper.py
@@ -311,10 +311,12 @@ class ZooKeeperServer(object):
         if not key:
             raise ValueError('The key is mandatory and should not be empty')
 
-        try:
-            value = int(value)
-        except (TypeError, ValueError):
-            pass
+        for typ in [int, float]:
+            try:
+                value = typ(value)
+                break
+            except (TypeError, ValueError):
+                pass
 
         return key, value
 


### PR DESCRIPTION
After upgrading to Zookeeper 3.6, Nagios tests for zk_avg_latency started failing due to floating point metrics being compared as strings.
