### PR TITLE
ZOOKEEPER-3931: "zkServer.sh version" returns a trailing dash

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
@@ -119,7 +119,7 @@ public class VerGen {
             w.write("public class " + VERSION_CLASS_NAME + " implements " + PACKAGE_NAME + ".Info {\n");
             w.write("    public static void main(String[] args) {\n");
             w.write("        final String VER_STRING = MAJOR + \".\" + MINOR + \".\" + MICRO +");
-            w.write("            (QUALIFIER == null ? \"\" : \"-\" + QUALIFIER)  + \" \" +");
+            w.write("            (QUALIFIER == null || QUALIFIER.isEmpty() ? \"\" : \"-\" + QUALIFIER)  + \" \" +");
             w.write("            BUILD_DATE;" + "\n");
             w.write("        System.out.println(\"Apache ZooKeeper, version \" + VER_STRING);\n");
             w.write("    }\n");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
@@ -119,7 +119,7 @@ public class VerGen {
             w.write("public class " + VERSION_CLASS_NAME + " implements " + PACKAGE_NAME + ".Info {\n");
             w.write("    public static void main(String[] args) {\n");
             w.write("        final String VER_STRING = MAJOR + \".\" + MINOR + \".\" + MICRO +");
-            w.write("            (QUALIFIER == null || QUALIFIER.isEmpty() ? \"\" : \"-\" + QUALIFIER)  + \" \" +");
+            w.write("            (QUALIFIER.isEmpty() ? \"\" : \"-\" + QUALIFIER)  + \" \" +");
             w.write("            BUILD_DATE;" + "\n");
             w.write("        System.out.println(\"Apache ZooKeeper, version \" + VER_STRING);\n");
             w.write("    }\n");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
@@ -119,7 +119,7 @@ public class VerGen {
             w.write("public class " + VERSION_CLASS_NAME + " implements " + PACKAGE_NAME + ".Info {\n");
             w.write("    public static void main(String[] args) {\n");
             w.write("        final String VER_STRING = MAJOR + \".\" + MINOR + \".\" + MICRO +");
-            w.write("            (QUALIFIER.isEmpty() ? \"\" : \"-\" + QUALIFIER)  + \" \" +");
+            w.write("            (QUALIFIER == null || QUALIFIER.isEmpty() ? \"\" : \"-\" + QUALIFIER)  + \" \" +");
             w.write("            BUILD_DATE;" + "\n");
             w.write("        System.out.println(\"Apache ZooKeeper, version \" + VER_STRING);\n");
             w.write("    }\n");


### PR DESCRIPTION
Problem:
The VersionInfoMain.java file generated by VerGen.java, which gets used by `bin/zkServer.sh version` print a trailing '-' when version qualifier is an empty string.

Fix:
Added a check to see if Qualifier is empty in the VerGen.java file

Test:
Tested manually by running the `bin/zkServer.sh version`
Before the change:
Apache ZooKeeper, version **3.6.2-** 09/13/2020 18:51 GMT
After the change:
Apache ZooKeeper, version **3.6.2** 09/13/2020 18:56 GMT

