### PR TITLE
ZOOKEEPER-3938: java client: upgrade jline from 2.x to 3.x and adapt Completer to the new API.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -439,7 +439,7 @@
     <jetty.version>9.4.24.v20191120</jetty.version>
     <jackson.version>2.10.3</jackson.version>
     <json.version>1.1.1</json.version>
-    <jline.version>3.6.2</jline.version>
+    <jline.version>3.16.0</jline.version>
     <snappy.version>1.1.7</snappy.version>
     <kerby.version>2.0.0</kerby.version>
     <bouncycastle.version>1.60</bouncycastle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -439,7 +439,7 @@
     <jetty.version>9.4.24.v20191120</jetty.version>
     <jackson.version>2.10.3</jackson.version>
     <json.version>1.1.1</json.version>
-    <jline.version>2.14.6</jline.version>
+    <jline.version>3.6.2</jline.version>
     <snappy.version>1.1.7</snappy.version>
     <kerby.version>2.0.0</kerby.version>
     <bouncycastle.version>1.60</bouncycastle.version>
@@ -635,7 +635,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>jline</groupId>
+        <groupId>org.jline</groupId>
         <artifactId>jline</artifactId>
         <version>${jline.version}</version>
       </dependency>

--- a/zookeeper-assembly/pom.xml
+++ b/zookeeper-assembly/pom.xml
@@ -104,7 +104,7 @@
       <artifactId>json-simple</artifactId>
     </dependency>
     <dependency>
-      <groupId>jline</groupId>
+      <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>

--- a/zookeeper-contrib/zookeeper-contrib-fatjar/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-fatjar/pom.xml
@@ -83,7 +83,7 @@
       <artifactId>json-simple</artifactId>
     </dependency>
     <dependency>
-      <groupId>jline</groupId>
+      <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -113,7 +113,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>jline</groupId>
+      <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/JLineZNodeCompleter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/JLineZNodeCompleter.java
@@ -18,13 +18,12 @@
 
 package org.apache.zookeeper;
 
+import java.util.Collections;
+import java.util.List;
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
 import org.jline.reader.ParsedLine;
-
-import java.util.Collections;
-import java.util.List;
 
 class JLineZNodeCompleter implements Completer {
     private ZooKeeper zk;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/JLineZNodeCompleter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/JLineZNodeCompleter.java
@@ -44,29 +44,37 @@ class JLineZNodeCompleter implements Completer {
         }
 
         if (token.startsWith("/")) {
-            int idx = token.lastIndexOf("/") + 1;
-            String prefix = token.substring(idx);
-            try {
-                // Only the root path can end in a /, so strip it off every other prefix
-                StringBuilder dir = new StringBuilder(idx == 1 ? "/" : token.substring(0, idx - 1));
-                List<String> children = zk.getChildren(dir.toString(), false);
-                for (String child : children) {
-                    if (child.startsWith(prefix)) {
-                        if (!dir.toString().endsWith("/")) {
-                            dir.append("/");
-                        }
-                        candidates.add(new Candidate(dir + child, child, null, null, null, null, true));
-                    }
-                }
-            } catch (InterruptedException | KeeperException e) {
-                // Ignore
-            }
-            Collections.sort(candidates);
+            completeZNode(candidates, token);
         } else {
-            for (String cmd : ZooKeeperMain.getCommands()) {
-                if (cmd.startsWith(token)) {
-                    candidates.add(new Candidate(cmd, cmd, null, null, null, null, true));
+            completeCommand(candidates, token);
+        }
+    }
+
+    private void completeZNode(List<Candidate> candidates, String token) {
+        int idx = token.lastIndexOf("/") + 1;
+        String prefix = token.substring(idx);
+        try {
+            // Only the root path can end in a /, so strip it off every other prefix
+            StringBuilder dir = new StringBuilder(idx == 1 ? "/" : token.substring(0, idx - 1));
+            List<String> children = zk.getChildren(dir.toString(), false);
+            for (String child : children) {
+                if (child.startsWith(prefix)) {
+                    if (!dir.toString().endsWith("/")) {
+                        dir.append("/");
+                    }
+                    candidates.add(new Candidate(dir + child, child, null, null, null, null, true));
                 }
+            }
+        } catch (InterruptedException | KeeperException e) {
+            // Ignore
+        }
+        Collections.sort(candidates);
+    }
+
+    private void completeCommand(List<Candidate> candidates, String token) {
+        for (String cmd : ZooKeeperMain.getCommands()) {
+            if (cmd.startsWith(token)) {
+                candidates.add(new Candidate(cmd, cmd, null, null, null, null, true));
             }
         }
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper;
 
 import java.io.IOException;
+import java.sql.SQLOutput;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -283,6 +284,7 @@ public class ZooKeeperMain {
     void run() throws IOException, InterruptedException {
         if (cl.getCommand() == null) {
             System.out.println("Welcome to ZooKeeper!");
+            System.out.println("JLine support is enabled");
 
             Terminal terminal = TerminalBuilder.builder().system(true).build();
             Completer znodeCompleter = new JLineZNodeCompleter(zk);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -286,7 +286,7 @@ public class ZooKeeperMain {
 
             Terminal terminal = TerminalBuilder.builder().system(true).build();
             Completer znodeCompleter = new JLineZNodeCompleter(zk);
-            String prompt = "[zkCli] ";
+            String prompt = getPrompt();
 
             LineReader lineReader = LineReaderBuilder.builder().terminal(terminal).completer(znodeCompleter).build();
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -287,15 +287,18 @@ public class ZooKeeperMain {
 
             Terminal terminal = TerminalBuilder.builder().system(true).build();
             Completer znodeCompleter = new JLineZNodeCompleter(zk);
-            String prompt = getPrompt();
 
             LineReader lineReader = LineReaderBuilder.builder().terminal(terminal).completer(znodeCompleter).build();
 
             String line;
-            while ((line = lineReader.readLine(prompt)) != null) {
-                executeLine(line);
+            try {
+                while ((line = lineReader.readLine(getPrompt())) != null) {
+                    executeLine(line);
+                }
+            } catch (UserInterruptException ex) {
+                // ignore exception
+                executeLine("quit");
             }
-
         } else {
             // Command line args non-null.  Run what was passed.
             processCmd(cl);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -18,11 +18,7 @@
 
 package org.apache.zookeeper;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -45,6 +45,7 @@ import org.apache.zookeeper.util.ServiceUtils;
 import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.UserInterruptException;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.slf4j.Logger;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -19,7 +19,6 @@
 package org.apache.zookeeper;
 
 import java.io.IOException;
-import java.sql.SQLOutput;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/zookeeper-server/src/main/resources/lib/jline-3.16.0.LICENSE.txt
+++ b/zookeeper-server/src/main/resources/lib/jline-3.16.0.LICENSE.txt
@@ -1,7 +1,7 @@
-Copyright (c) 2002-2017, the original author or authors.
+Copyright (c) 2002-2018, the original author or authors.
 All rights reserved.
 
-http://www.opensource.org/licenses/bsd-license.php
+https://opensource.org/licenses/BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or
 without modification, are permitted provided that the following

--- a/zookeeper-server/src/main/resources/lib/jline-3.6.2.LICENSE.txt
+++ b/zookeeper-server/src/main/resources/lib/jline-3.6.2.LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2002-2012, the original author or authors.
+Copyright (c) 2002-2017, the original author or authors.
 All rights reserved.
 
 http://www.opensource.org/licenses/bsd-license.php


### PR DESCRIPTION
There are several Jline 3.x versions. I think it's time to adapt new version jlines. I made some adjustments to the 'JLineZNodeCompleter.java' in this pr.

the result is as follows.
![image](https://user-images.githubusercontent.com/9931878/93433048-e2456d00-f8f8-11ea-8e5b-9703443ae938.png)

