### PR TITLE
ZOOKEEPER-3863: Fix c client unit test (local session must be enabled for read only observers to work).

### DIFF
--- a/zookeeper-client/zookeeper-client-c/tests/zoo.cfg
+++ b/zookeeper-client/zookeeper-client-c/tests/zoo.cfg
@@ -3,6 +3,7 @@ initLimit=10
 syncLimit=5
 dataDir=TMPDIR/zkdata
 maxClientCnxns=MAXCLIENTCONNECTIONS
+localSessionsEnabled=true
 
 clientPort=CLIENTPORT
 secureClientPort=22281


### PR DESCRIPTION
Problem

ZOOKEEPER-3863 requires local session to be enabled for read only server to work. When merge ZOOKEEPER-3863 (in c47ef905e077184bc5b7f555a3e2dfeb6dc046e1), we only updated Java tests, and missed C tests. As a result, Jenkins build is broken.

Solution

Enable local session for C client tests.

Notes
This was not caught by Jenkins when we merge ZOOKEEPER-3863 because previous Jenkins was testing master branch (as discussed in https://github.com/apache/zookeeper/pull/1460). 