### PR TITLE
pom.xml: Fix-up the packaging type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </parent>
   <groupId>org.apache.zookeeper</groupId>
   <artifactId>parent</artifactId>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
   <!-- to change version: mvn -\-batch-mode release:update-versions -DdevelopmentVersion=3.6.0-SNAPSHOT -->
   <version>3.7.0-SNAPSHOT</version>
   <name>Apache ZooKeeper</name>


### PR DESCRIPTION
Since there is a `zookeeper.jar` artifact corresponding to this POM file
published, the packaging should be set to "jar".

Signed-off-by: Frank Viernau <frank.viernau@here.com>