### PR TITLE
ZOOKEEPER-3944 Fix sasl memory leak

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -662,6 +662,7 @@ static void destroy(zhandle_t *zh)
 #ifdef HAVE_CYRUS_SASL_H
     if (zh->sasl_client) {
         zoo_sasl_client_destroy(zh->sasl_client);
+        free(zh->sasl_client);
         zh->sasl_client = NULL;
     }
 #endif /* HAVE_CYRUS_SASL_H */


### PR DESCRIPTION
Within ```zoo_sasl_client_destroy```, it carefully free all members of the sasl client, while here it doesn't free the struct itself before set it to NULL. This error is detected by leak sanitizer. 