### PR TITLE
fix too many files open error

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNIO.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNIO.java
@@ -260,6 +260,8 @@ public class ClientCnxnSocketNIO extends ClientCnxnSocket {
         boolean immediateConnect = sock.connect(addr);
         if (immediateConnect) {
             sendThread.primeConnection();
+        } else {
+            sock.close();
         }
     }
 


### PR DESCRIPTION
in org.apache.zookeeper.ClientCnxnSocketNIO#registerAndConnect.
some situation. sock.connect(addr) may not throw IOException, just return false. it should close socket. if the client config an incoreect addr, it may lead socket files too much.
