### PR TITLE
Shellcheck

### DIFF
--- a/zookeeper-server/src/main/resources/lastRevision.sh
+++ b/zookeeper-server/src/main/resources/lastRevision.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,6 +17,6 @@
 
 # Find the current revision, store it in a file
 FILE=$1
-LASTREV=`git rev-parse HEAD`
+LASTREV=$(git rev-parse HEAD)
 
-echo "lastRevision=${LASTREV}" > $FILE
+echo "lastRevision=${LASTREV}" > "$FILE"

--- a/zookeeper-server/src/test/resources/test-github-pr.sh
+++ b/zookeeper-server/src/test/resources/test-github-pr.sh
@@ -567,7 +567,7 @@ This message is automatically generated."
 
 ### Check if arguments to the script have been specified properly or not
 echo "----- Going to parser args -----"
-parseArgs $@
+parseArgs "$@"
 cd $BASEDIR
 
 echo "----- Parsed args, going to checkout -----"


### PR DESCRIPTION
Double quote array expansions to avoid re-splitting elements.