### PR TITLE
ZOOKEEPER-3955 added a shebang or a 'shell' directive to lastRevision.sh

### DIFF
--- a/zookeeper-server/src/main/resources/lastRevision.sh
+++ b/zookeeper-server/src/main/resources/lastRevision.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,6 +17,6 @@
 
 # Find the current revision, store it in a file
 FILE=$1
-LASTREV=`git rev-parse HEAD`
+LASTREV=$(git rev-parse HEAD)
 
-echo "lastRevision=${LASTREV}" > $FILE
+echo "lastRevision=${LASTREV}" > "$FILE"


### PR DESCRIPTION
1. Added the shebang
2. Added $(...) notation instead of legacy backticked `...`
3. Added double quote to prevent globbing and word splitting