### PR TITLE
Add a shebang or a 'shell' directive to lastRevision.sh

### DIFF
--- a/zookeeper-server/src/main/resources/lastRevision.sh
+++ b/zookeeper-server/src/main/resources/lastRevision.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information


### PR DESCRIPTION
Solve Muse issue Shellcheck.
Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.