### PR TITLE
ZOOKEEPER-3953: Update hamcrest-library to version 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -433,7 +433,7 @@
     <junit-platform.version>1.6.2</junit-platform.version>
     <log4j.version>1.2.17</log4j.version>
     <mockito.version>2.27.0</mockito.version>
-    <hamcrest.version>1.3</hamcrest.version>
+    <hamcrest.version>2.2</hamcrest.version>
     <commons-cli.version>1.4</commons-cli.version>
     <netty.version>4.1.50.Final</netty.version>
     <jetty.version>9.4.24.v20191120</jetty.version>
@@ -459,7 +459,7 @@
     <dependencies>
       <dependency>
         <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-all</artifactId>
+        <artifactId>hamcrest-library</artifactId>
         <version>${hamcrest.version}</version>
       </dependency>
       <dependency>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
+      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
We use a really old version of hamcrest-library where we could use a newer one (version 2.2 instead of 1.3).
Time to update it.

Change-Id: I8d3d76b1b287610b58d4760a87428c41b43ef091