### PR TITLE
ZOOKEEPER-3954: C client: GCC 10 compilation fixes

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/load_gen.c
+++ b/zookeeper-client/zookeeper-client-c/src/load_gen.c
@@ -27,8 +27,6 @@
 
 static zhandle_t *zh;
 
-static int shutdownThisThing=0;
-
 // *****************************************************************************
 //
 static pthread_cond_t cond=PTHREAD_COND_INITIALIZER;

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -1728,23 +1728,23 @@ void free_completions(zhandle_t *zh,int callCompletion,int reason)
             }
         }
     }
-    if (zoo_lock_auth(zh) == 0) {
-        a_list.completion = NULL;
-        a_list.next = NULL;
 
-        get_auth_completions(&zh->auth_h, &a_list);
-        zoo_unlock_auth(zh);
+    zoo_lock_auth(zh);
+    a_list.completion = NULL;
+    a_list.next = NULL;
+    get_auth_completions(&zh->auth_h, &a_list);
+    zoo_unlock_auth(zh);
 
-        a_tmp = &a_list;
-        // chain call user's completion function
-        while (a_tmp->completion != NULL) {
-            auth_completion = a_tmp->completion;
-            auth_completion(reason, a_tmp->auth_data);
-            a_tmp = a_tmp->next;
-            if (a_tmp == NULL)
-                break;
-        }
+    a_tmp = &a_list;
+    // chain call user's completion function
+    while (a_tmp->completion != NULL) {
+        auth_completion = a_tmp->completion;
+        auth_completion(reason, a_tmp->auth_data);
+        a_tmp = a_tmp->next;
+        if (a_tmp == NULL)
+            break;
     }
+
     free_auth_completion(&a_list);
 }
 

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -319,11 +319,13 @@ static socket_t zookeeper_connect(zhandle_t *, struct sockaddr_storage *, socket
 /*
  * abort due to the use of a sync api in a singlethreaded environment
  */
+#ifndef THREADED
 static void abort_singlethreaded(zhandle_t *zh)
 {
     LOG_ERROR(LOGCALLBACK(zh), "Sync completion used without threads");
     abort();
 }
+#endif /* ifndef THREADED */
 
 static sendsize_t zookeeper_send(socket_t s, const void* buf, size_t len)
 {


### PR DESCRIPTION
The most important change in this PR avoids a confusing and scary compilation issue [encountered by Michael Hudson-Doyle](https://issues.apache.org/jira/browse/ZOOKEEPER-3954) when building the C client with GCC 10 and "aggressive" optimization settings:

> `free_auth_completions` is being inlined into `free_completions`, and this lets gcc see that members of `a_list` are being accessed without initialization

This is (fortunately!) a red herring: what GCC doesn't see is that, in practice, `zoo_lock_auth` always returns zero, and that `a_list` is always initialized in the conditional block which follows it.

That issue is easily "fixed" by removing the `if`.  The rest of the client code doesn't check `zoo_lock_auth`'s return value--and we have bigger issues if unconditional locks start failing anyway.

The remaining changes get rid of a couple of innocuous warnings, to that the client can successfully build even when configured with `-Werror`.