### PR TITLE
ZOOKEEPER-3954: C client: GCC 10 compilation fixes

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -1927,23 +1927,23 @@ void free_completions(zhandle_t *zh,int callCompletion,int reason)
             }
         }
     }
-    if (zoo_lock_auth(zh) == 0) {
-        a_list.completion = NULL;
-        a_list.next = NULL;
 
-        get_auth_completions(&zh->auth_h, &a_list);
-        zoo_unlock_auth(zh);
+    zoo_lock_auth(zh);
+    a_list.completion = NULL;
+    a_list.next = NULL;
+    get_auth_completions(&zh->auth_h, &a_list);
+    zoo_unlock_auth(zh);
 
-        a_tmp = &a_list;
-        // chain call user's completion function
-        while (a_tmp->completion != NULL) {
-            auth_completion = a_tmp->completion;
-            auth_completion(reason, a_tmp->auth_data);
-            a_tmp = a_tmp->next;
-            if (a_tmp == NULL)
-                break;
-        }
+    a_tmp = &a_list;
+    // chain call user's completion function
+    while (a_tmp->completion != NULL) {
+        auth_completion = a_tmp->completion;
+        auth_completion(reason, a_tmp->auth_data);
+        a_tmp = a_tmp->next;
+        if (a_tmp == NULL)
+            break;
     }
+
     free_auth_completion(&a_list);
 }
 


### PR DESCRIPTION
The in this PR avoids a confusing and scary compilation issue [encountered by Michael Hudson-Doyle](https://issues.apache.org/jira/browse/ZOOKEEPER-3954) when building the C client with GCC 10 and "aggressive" optimization settings:

> `free_auth_completions` is being inlined into `free_completions`, and this lets gcc see that members of `a_list` are being accessed without initialization

This is (fortunately!) a red herring: what GCC doesn't see is that, in practice, `zoo_lock_auth` always returns zero, and that `a_list` is always initialized in the conditional block which follows it.

That issue is easily "fixed" by removing the `if`.  The rest of the client code doesn't check `zoo_lock_auth`'s return value--and we have bigger issues if unconditional locks start failing anyway.

See also https://github.com/apache/zookeeper/pull/1481 and https://github.com/apache/zookeeper/pull/1486.