### PR TITLE
ZOOKEEPER-3962: Add an .asf.yaml file

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
+
+github:
+  description: "Apache ZooKeeper"
+  homepage: https://zookeeper.apache.org
+  labels:
+    - zookeeper
+    - database
+    - hacktoberfest
+  features:
+    wiki: false
+    issues: false
+    projects: false
+
+notifications:
+  jira_options: link label worklog
+  commits: commits@zookeeper.apache.org
+  issues: issues@zookeeper.apache.org
+  pullrequests: notifications@zookeeper.apache.org
+


### PR DESCRIPTION
Create an .asf.yaml file to specify certain github repository settings,
such as description, topic, URL, etc. and to configure notification
settings and JIRA integration.

This file can also be later used to add automation for building the
project's website, in whole or in part.

See https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
for more information on available features.