### PR TITLE
ZOOKEEPER-3964: Introduce RocksDB snap and implement change data capture to enable incremental snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,7 @@
     <json.version>1.1.1</json.version>
     <jline.version>2.14.6</jline.version>
     <snappy.version>1.1.7</snappy.version>
+    <rocksdb.version>6.4.6</rocksdb.version>
     <kerby.version>2.0.0</kerby.version>
     <bouncycastle.version>1.60</bouncycastle.version>
     <commons-collections.version>3.2.2</commons-collections.version>
@@ -650,6 +651,11 @@
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
         <version>${snappy.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.rocksdb</groupId>
+        <artifactId>rocksdbjni</artifactId>
+        <version>${rocksdb.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -176,6 +176,11 @@
       <artifactId>snappy-java</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.rocksdb</groupId>
+      <artifactId>rocksdbjni</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -59,6 +59,8 @@ import org.apache.zookeeper.common.PathTrie;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.data.StatPersisted;
+import org.apache.zookeeper.server.persistence.SnapShot;
+import org.apache.zookeeper.server.persistence.SnapshotFactory;
 import org.apache.zookeeper.server.watch.IWatchManager;
 import org.apache.zookeeper.server.watch.WatchManagerFactory;
 import org.apache.zookeeper.server.watch.WatcherMode;
@@ -69,6 +71,7 @@ import org.apache.zookeeper.server.watch.WatchesSummary;
 import org.apache.zookeeper.txn.CheckVersionTxn;
 import org.apache.zookeeper.txn.CloseSessionTxn;
 import org.apache.zookeeper.txn.CreateContainerTxn;
+import org.apache.zookeeper.txn.CreateSessionTxn;
 import org.apache.zookeeper.txn.CreateTTLTxn;
 import org.apache.zookeeper.txn.CreateTxn;
 import org.apache.zookeeper.txn.DeleteTxn;
@@ -165,6 +168,12 @@ public class DataTree {
 
     private final ReferenceCountedACLCache aclCache = new ReferenceCountedACLCache();
 
+    /**
+     * A list of all changes related to data nodes, acl lists and sessions
+     * made during the process of processing transactions.
+     */
+    private List<TransactionChangeRecord> changeList;
+
     // The maximum number of tree digests that we will keep in our history
     public static final int DIGEST_LOG_LIMIT = 1024;
 
@@ -234,6 +243,14 @@ public class DataTree {
         return result;
     }
 
+    public boolean nodesDigestEnabled() {
+        return ZooKeeperServer.isDigestEnabled();
+    }
+
+    public List<TransactionChangeRecord> getChangeList() {
+        return changeList;
+    }
+
     /**
      * Get the size of the nodes based on path and data length.
      *
@@ -283,6 +300,13 @@ public class DataTree {
     }
 
     DataTree(DigestCalculator digestCalculator) {
+        boolean shouldRecordTransactionChange = SnapshotFactory.shouldRecordTransactionChanges();
+        if (shouldRecordTransactionChange) {
+            changeList = new ArrayList<TransactionChangeRecord>();
+        } else {
+            changeList = null;
+        }
+
         this.digestCalculator = digestCalculator;
         nodes = new NodeHashMapImpl(digestCalculator);
 
@@ -474,6 +498,11 @@ public class DataTree {
             throw new KeeperException.NoNodeException();
         }
         synchronized (parent) {
+            Set<String> children = parent.getChildren();
+            if (children.contains(childName)) {
+                throw new KeeperException.NodeExistsException();
+            }
+
             // Add the ACL to ACL cache first, to avoid the ACL not being
             // created race condition during fuzzy snapshot sync.
             //
@@ -485,12 +514,7 @@ public class DataTree {
             // Later we can audit and delete all non-referenced ACLs from
             // ACL map when loading the snapshot/txns from disk, like what
             // we did for the global sessions.
-            Long longval = aclCache.convertAcls(acl);
-
-            Set<String> children = parent.getChildren();
-            if (children.contains(childName)) {
-                throw new KeeperException.NodeExistsException();
-            }
+            Long longval = aclCache.convertAcls(acl, changeList);
 
             nodes.preChange(parentName, parent);
             if (parentCVersion == -1) {
@@ -509,6 +533,12 @@ public class DataTree {
             DataNode child = new DataNode(data, longval, stat);
             parent.addChild(childName);
             nodes.postChange(parentName, parent);
+            if (changeList != null) {
+                changeList.add(new TransactionChangeRecord(TransactionChangeRecord.DATANODE,
+                        TransactionChangeRecord.ADD, path, child));
+                changeList.add(new TransactionChangeRecord(TransactionChangeRecord.DATANODE,
+                        TransactionChangeRecord.UPDATE, parentName, parent));
+            }
             nodeDataSize.addAndGet(getNodeSize(path, child.data));
             nodes.put(path, child);
             EphemeralType ephemeralType = EphemeralType.get(ephemeralOwner);
@@ -585,6 +615,11 @@ public class DataTree {
                 parent.stat.setPzxid(zxid);
             }
             nodes.postChange(parentName, parent);
+
+            if (changeList != null) {
+                changeList.add(new TransactionChangeRecord(TransactionChangeRecord.DATANODE,
+                        TransactionChangeRecord.UPDATE, parentName, parent));
+            }
         }
 
         DataNode node = nodes.get(path);
@@ -592,8 +627,12 @@ public class DataTree {
             throw new KeeperException.NoNodeException();
         }
         nodes.remove(path);
+        if (changeList != null) {
+            changeList.add(new TransactionChangeRecord(TransactionChangeRecord.DATANODE,
+                    TransactionChangeRecord.REMOVE, path, node));
+        }
         synchronized (node) {
-            aclCache.removeUsage(node.acl);
+            aclCache.removeUsage(node.acl, changeList);
             nodeDataSize.addAndGet(-getNodeSize(path, node.data));
         }
 
@@ -668,6 +707,10 @@ public class DataTree {
             n.stat.setVersion(version);
             n.copyStat(s);
             nodes.postChange(path, n);
+            if (changeList != null) {
+                changeList.add(new TransactionChangeRecord(TransactionChangeRecord.DATANODE,
+                        TransactionChangeRecord.UPDATE, path, n));
+            }
         }
         // now update if the path is in a quota subtree.
         String lastPrefix = getMaxPrefixWithQuota(path);
@@ -782,12 +825,16 @@ public class DataTree {
             throw new KeeperException.NoNodeException();
         }
         synchronized (n) {
-            aclCache.removeUsage(n.acl);
+            aclCache.removeUsage(n.acl, changeList);
             nodes.preChange(path, n);
             n.stat.setAversion(version);
-            n.acl = aclCache.convertAcls(acl);
+            n.acl = aclCache.convertAcls(acl, changeList);
             n.copyStat(stat);
             nodes.postChange(path, n);
+            if (changeList != null) {
+                changeList.add(new TransactionChangeRecord(TransactionChangeRecord.DATANODE,
+                        TransactionChangeRecord.UPDATE, path, n));
+            }
             return stat;
         }
     }
@@ -861,6 +908,12 @@ public class DataTree {
 
     }
 
+    private void resetChangeList() {
+        if (changeList != null) {
+            changeList.clear();
+        }
+    }
+
     public volatile long lastProcessedZxid = 0;
 
     public ProcessTxnResult processTxn(TxnHeader header, Record txn, TxnDigest digest) {
@@ -874,6 +927,10 @@ public class DataTree {
     }
 
     public ProcessTxnResult processTxn(TxnHeader header, Record txn, boolean isSubTxn) {
+        if (!isSubTxn) {
+            resetChangeList();
+        }
+
         ProcessTxnResult rc = new ProcessTxnResult();
 
         try {
@@ -963,6 +1020,10 @@ public class DataTree {
                 SetACLTxn setACLTxn = (SetACLTxn) txn;
                 rc.path = setACLTxn.getPath();
                 rc.stat = setACL(setACLTxn.getPath(), setACLTxn.getAcl(), setACLTxn.getVersion());
+                break;
+            case OpCode.createSession:
+                CreateSessionTxn createSessionTxn = (CreateSessionTxn) txn;
+                createSession(header.getClientId(), createSessionTxn.getTimeOut());
                 break;
             case OpCode.closeSession:
                 long sessionId = header.getClientId();
@@ -1137,7 +1198,18 @@ public class DataTree {
         return rc;
     }
 
+    void createSession(long id, int timeout) {
+        if (changeList != null) {
+            changeList.add(new TransactionChangeRecord(TransactionChangeRecord.SESSION,
+                    TransactionChangeRecord.ADD, id, timeout));
+        }
+    }
+
     void killSession(long session, long zxid) {
+        if (changeList != null) {
+            changeList.add(new TransactionChangeRecord(TransactionChangeRecord.SESSION,
+                    TransactionChangeRecord.REMOVE, session, null));
+        }
         // the list is already removed from the ephemerals
         // so we do not have to worry about synchronizing on
         // the list. This is only called from FinalRequestProcessor
@@ -1313,13 +1385,12 @@ public class DataTree {
      * this method uses a stringbuilder to create a new path for children. This
      * is faster than string appends ( str1 + str2).
      *
-     * @param oa
-     *            OutputArchive to write to.
-     * @param path
-     *            a string builder.
+     * @param snapLog the snapshot file to serialize to
+     * @param path the string builder representing the path to the node
+     *
      * @throws IOException
      */
-    void serializeNode(OutputArchive oa, StringBuilder path) throws IOException {
+    private void serializeNode(SnapShot snapLog, StringBuilder path) throws IOException {
         String pathString = path.toString();
         DataNode node = getNode(pathString);
         if (node == null) {
@@ -1336,7 +1407,7 @@ public class DataTree {
             Set<String> childs = node.getChildren();
             children = childs.toArray(new String[childs.size()]);
         }
-        serializeNodeData(oa, pathString, nodeCopy);
+        serializeNodeData(snapLog, pathString, nodeCopy);
         path.append('/');
         int off = path.length();
         for (String child : children) {
@@ -1345,43 +1416,40 @@ public class DataTree {
             // to truncate the previous bytes of string.
             path.delete(off, Integer.MAX_VALUE);
             path.append(child);
-            serializeNode(oa, path);
+            serializeNode(snapLog, path);
         }
     }
 
     // visiable for test
-    public void serializeNodeData(OutputArchive oa, String path, DataNode node) throws IOException {
-        oa.writeString(path, "path");
-        oa.writeRecord(node, "node");
+    public void serializeNodeData(final SnapShot snapLog, String path, DataNode node) throws IOException {
+        snapLog.writeNode(path, node);
     }
 
-    public void serializeAcls(OutputArchive oa) throws IOException {
-        aclCache.serialize(oa);
+    public void serializeNodes(SnapShot snapLog) throws IOException {
+        serializeNode(snapLog, new StringBuilder(""));
     }
 
-    public void serializeNodes(OutputArchive oa) throws IOException {
-        serializeNode(oa, new StringBuilder());
+    public void serialize(SnapShot snapLog, String tag) throws IOException {
+        serializeNodes(snapLog);
         // / marks end of stream
         // we need to check if clear had been called in between the snapshot.
         if (root != null) {
-            oa.writeString("/", "path");
+            snapLog.markEnd();
         }
     }
 
-    public void serialize(OutputArchive oa, String tag) throws IOException {
-        serializeAcls(oa);
-        serializeNodes(oa);
-    }
-
-    public void deserialize(InputArchive ia, String tag) throws IOException {
-        aclCache.deserialize(ia);
+    public void deserialize(SnapShot snapLog, String tag) throws IOException {
         nodes.clear();
         pTrie.clear();
         nodeDataSize.set(0);
-        String path = ia.readString("path");
-        while (!"/".equals(path)) {
+
+        String path;
+        while (true) {
             DataNode node = new DataNode();
-            ia.readRecord(node, "node");
+            path = snapLog.readNode(node);
+            if ("/".equals(path)) {
+                break;
+            }
             nodes.put(path, node);
             synchronized (node) {
                 aclCache.addUsage(node.acl);
@@ -1415,7 +1483,6 @@ public class DataTree {
                     list.add(path);
                 }
             }
-            path = ia.readString("path");
         }
         // have counted digest for root node with "", ignore here to avoid
         // counting twice for root node
@@ -1677,6 +1744,10 @@ public class DataTree {
     private void logZxidDigest(long zxid, long digest) {
         ZxidDigest zxidDigest = new ZxidDigest(zxid, digestCalculator.getDigestVersion(), digest);
         lastProcessedZxidDigest = zxidDigest;
+        if (changeList != null) {
+            changeList.add(new TransactionChangeRecord(TransactionChangeRecord.ZXIDDIGEST,
+                    TransactionChangeRecord.UPDATE, null, lastProcessedZxidDigest));
+        }
         if (zxidDigest.zxid % DIGEST_LOG_INTERVAL == 0) {
             synchronized (digestLog) {
                 digestLog.add(zxidDigest);
@@ -1868,6 +1939,17 @@ public class DataTree {
         return digestFromLoadedSnapshot;
     }
 
+    public ZxidDigest getBlankDigest() {
+        return new ZxidDigest();
+    }
+
+    public int getDigestVersion() {
+        return digestCalculator.getDigestVersion();
+    }
+
+    public void setZxidDigestFromLoadedSnapshot(ZxidDigest zxidDigest) {
+        this.digestFromLoadedSnapshot = zxidDigest;
+    }
     /**
      * Add digest mismatch event handler.
      *

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ReferenceCountedACLCache.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ReferenceCountedACLCache.java
@@ -18,17 +18,11 @@
 
 package org.apache.zookeeper.server;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
-import org.apache.jute.Index;
-import org.apache.jute.InputArchive;
-import org.apache.jute.OutputArchive;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
@@ -50,13 +44,19 @@ public class ReferenceCountedACLCache {
      */
     long aclIndex = 0;
 
+    // VisibleForTesting
+    public synchronized Long convertAcls(List<ACL> acls) {
+        return convertAcls(acls, null);
+    }
+
     /**
      * converts the list of acls to a long.
      * Increments the reference counter for this ACL.
      * @param acls
+     * @param changeList a list of in memory changes that will be applied to snapshot.
      * @return a long that map to the acls
      */
-    public synchronized Long convertAcls(List<ACL> acls) {
+    public synchronized Long convertAcls(List<ACL> acls, List<TransactionChangeRecord> changeList) {
         if (acls == null) {
             return OPEN_UNSAFE_ACL_ID;
         }
@@ -66,6 +66,10 @@ public class ReferenceCountedACLCache {
         if (ret == null) {
             ret = incrementIndex();
             longKeyMap.put(ret, acls);
+            if (changeList != null) {
+                changeList.add(new TransactionChangeRecord(TransactionChangeRecord.ACL,
+                    TransactionChangeRecord.ADD, ret, acls));
+            }
             aclKeyMap.put(acls, ret);
         }
 
@@ -99,67 +103,33 @@ public class ReferenceCountedACLCache {
         return ++aclIndex;
     }
 
-    public void deserialize(InputArchive ia) throws IOException {
-        clear();
-        int i = ia.readInt("map");
-
-        LinkedHashMap<Long, List<ACL>> deserializedMap = new LinkedHashMap<>();
-        // keep read operations out of synchronization block
-        while (i > 0) {
-            Long val = ia.readLong("long");
-            List<ACL> aclList = new ArrayList<ACL>();
-            Index j = ia.startVector("acls");
-            if (j == null) {
-                throw new RuntimeException("Incorrent format of InputArchive when deserialize DataTree - missing acls");
-            }
-            while (!j.done()) {
-                ACL acl = new ACL();
-                acl.deserialize(ia, "acl");
-                aclList.add(acl);
-                j.incr();
-            }
-
-            deserializedMap.put(val, aclList);
-            i--;
+    public synchronized void updateMaps(long val, List<ACL> aclList) {
+        if (aclIndex < val) {
+            aclIndex = val;
         }
 
-        synchronized (this) {
-            for (Map.Entry<Long, List<ACL>> entry : deserializedMap.entrySet()) {
-                Long val = entry.getKey();
-                List<ACL> aclList = entry.getValue();
-                if (aclIndex < val) {
-                    aclIndex = val;
-                }
-
-                longKeyMap.put(val, aclList);
-                aclKeyMap.put(aclList, val);
-                referenceCounter.put(val, new AtomicLongWithEquals(0));
-            }
-        }
+        longKeyMap.put(val, aclList);
+        aclKeyMap.put(aclList, val);
+        referenceCounter.put(val, new AtomicLongWithEquals(0));
     }
 
-    public void serialize(OutputArchive oa) throws IOException {
-        Map<Long, List<ACL>> clonedLongKeyMap;
-        synchronized (this) {
-            clonedLongKeyMap = new HashMap<>(longKeyMap);
-        }
-        oa.writeInt(clonedLongKeyMap.size(), "map");
-        for (Map.Entry<Long, List<ACL>> val : clonedLongKeyMap.entrySet()) {
-            oa.writeLong(val.getKey(), "long");
-            List<ACL> aclList = val.getValue();
-            oa.startVector(aclList, "acls");
-            for (ACL acl : aclList) {
-                acl.serialize(oa, "acl");
-            }
-            oa.endVector(aclList, "acls");
-        }
+    public synchronized HashMap<Long, List<ACL>> getLongKeyMap() {
+        return new HashMap<>(longKeyMap);
+    }
+
+    public synchronized Map<List<ACL>, Long> getAclKeyMap() {
+        return new HashMap<>(aclKeyMap);
+    }
+
+    public synchronized Map<Long, AtomicLongWithEquals> getReferenceCounter() {
+        return new HashMap<>(referenceCounter);
     }
 
     public int size() {
         return aclKeyMap.size();
     }
 
-    private void clear() {
+    public void clear() {
         aclKeyMap.clear();
         longKeyMap.clear();
         referenceCounter.clear();
@@ -183,7 +153,12 @@ public class ReferenceCountedACLCache {
         }
     }
 
+    // VisibleForTesting
     public synchronized void removeUsage(Long acl) {
+        removeUsage(acl, null);
+    }
+
+    public synchronized void removeUsage(Long acl, List<TransactionChangeRecord> changeList) {
         if (acl == OPEN_UNSAFE_ACL_ID) {
             return;
         }
@@ -198,6 +173,11 @@ public class ReferenceCountedACLCache {
             referenceCounter.remove(acl);
             aclKeyMap.remove(longKeyMap.get(acl));
             longKeyMap.remove(acl);
+
+            if (changeList != null) {
+                changeList.add(new TransactionChangeRecord(TransactionChangeRecord.ACL,
+                        TransactionChangeRecord.REMOVE, acl, null));
+            }
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
@@ -256,6 +256,10 @@ public final class ServerMetrics {
         WATCH_BYTES = metricsContext.getCounter("watch_bytes");
 
         JVM_PAUSE_TIME = metricsContext.getSummary("jvm_pause_time_ms", DetailLevel.ADVANCED);
+
+        ROCKSDB_SNAPSHOT_DESERIALIZATION_TIME = metricsContext.getSummary("rocksdb_snap_deserialization_time", DetailLevel.ADVANCED);
+        APPLY_TXN_TO_SNAPSHOT_TIME = metricsContext.getSummary("apply_txn_to_rocksdb_time", DetailLevel.ADVANCED);
+        ROCKSDB_FLUSH_TIME = metricsContext.getSummary("rocksdb_flush_time", DetailLevel.ADVANCED);
     }
 
     /**
@@ -502,6 +506,10 @@ public final class ServerMetrics {
     public final Counter WATCH_BYTES;
 
     public final Summary JVM_PAUSE_TIME;
+
+    public final Summary ROCKSDB_SNAPSHOT_DESERIALIZATION_TIME;
+    public final Summary ROCKSDB_FLUSH_TIME;
+    public final Summary APPLY_TXN_TO_SNAPSHOT_TIME;
 
     private final MetricsProvider metricsProvider;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/TransactionChangeRecord.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/TransactionChangeRecord.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server;
+
+public class TransactionChangeRecord {
+    public static final String DATANODE = "DataNode";
+    public static final String ACL = "ACL";
+    public static final String SESSION = "Session";
+    public static final String ZXIDDIGEST = "ZxidDigest";
+
+    public static final String ADD = "add";
+    public static final String UPDATE = "update";
+    public static final String REMOVE = "remove";
+
+    private String type;
+    private String operation;
+    private Object key;
+    private Object value;
+
+    public TransactionChangeRecord(String type, String operation, Object key, Object value) {
+        this.type = type;
+        this.operation = operation;
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public Object getKey() {
+        return key;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
@@ -47,8 +47,10 @@ import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.DataTree.ProcessTxnResult;
+import org.apache.zookeeper.server.persistence.FileSnap;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog.PlayBackListener;
+import org.apache.zookeeper.server.persistence.SnapShot;
 import org.apache.zookeeper.server.persistence.TxnLog.TxnIterator;
 import org.apache.zookeeper.server.quorum.Leader;
 import org.apache.zookeeper.server.quorum.Leader.Proposal;
@@ -479,7 +481,19 @@ public class ZKDatabase {
      * datatree/zkdatabase
      */
     public ProcessTxnResult processTxn(TxnHeader hdr, Record txn, TxnDigest digest) {
-        return dataTree.processTxn(hdr, txn, digest);
+        ProcessTxnResult rc = dataTree.processTxn(hdr, txn, digest);
+
+        if (dataTree.getChangeList() != null) {
+            try {
+                long start = Time.currentElapsedTime();
+                snapLog.getSnapshot().applyTxn(dataTree.getChangeList(), hdr.getZxid());
+                long elapsed = Time.currentElapsedTime() - start;
+                ServerMetrics.getMetrics().APPLY_TXN_TO_SNAPSHOT_TIME.add(elapsed);
+            } catch (IOException e) {
+                LOG.error("Failed to apply txns to Snapshot.");
+            }
+        }
+        return rc;
     }
 
     /**
@@ -617,7 +631,13 @@ public class ZKDatabase {
      */
     public void deserializeSnapshot(InputArchive ia) throws IOException {
         clear();
-        SerializeUtils.deserializeSnapshot(getDataTree(), ia, getSessionWithTimeOuts());
+        // Use the methods in FileSnap to deserialize a snapshot from an input archive,
+        // we are not reading from a file here.
+        SnapShot snap = new FileSnap(null, ia);
+        snap.deserializeSessions(getSessionWithTimeOuts());
+        DataTree dt = getDataTree();
+        snap.deserializeACL(dt.getReferenceCountedAclCache());
+        dt.deserialize(snap, "tree");
         initialized = true;
     }
 
@@ -628,7 +648,13 @@ public class ZKDatabase {
      * @throws InterruptedException
      */
     public void serializeSnapshot(OutputArchive oa) throws IOException, InterruptedException {
-        SerializeUtils.serializeSnapshot(getDataTree(), oa, getSessionWithTimeOuts());
+        // Use the methods in FileSnap to serialize the snapshot to an output archive,
+        // we are not writing to a file here.
+        SnapShot snap = new FileSnap(null, oa);
+        snap.serializeSessions(getSessionWithTimeOuts());
+        DataTree dt = getDataTree();
+        snap.serializeACL(dt.getReferenceCountedAclCache());
+        dt.serialize(snap, "tree");
     }
 
     /**
@@ -751,5 +777,17 @@ public class ZKDatabase {
 
     public boolean compareDigest(TxnHeader header, Record txn, TxnDigest digest) {
         return dataTree.compareDigest(header, txn, digest);
+    }
+
+    /**
+     * Take a snap shot of zk database.
+     *
+     * @param syncSnap Controls whether or not to do a full snap or
+     *                 incremental snap. When set to true, will do
+     *                 a full snap. When set to false, will do an
+     *                 incremental snap.
+     */
+    public void save(boolean syncSnap) throws IOException {
+        snapLog.save(dataTree, sessionsWithTimeouts, syncSnap);
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileSnap.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileSnap.java
@@ -18,20 +18,29 @@
 
 package org.apache.zookeeper.server.persistence;
 
+import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.zip.CheckedInputStream;
 import java.util.zip.CheckedOutputStream;
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
+import org.apache.jute.Index;
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
+import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.server.DataNode;
 import org.apache.zookeeper.server.DataTree;
-import org.apache.zookeeper.server.util.SerializeUtils;
+import org.apache.zookeeper.server.DataTree.ZxidDigest;
+import org.apache.zookeeper.server.ReferenceCountedACLCache;
+import org.apache.zookeeper.server.TransactionChangeRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +54,8 @@ public class FileSnap implements SnapShot {
 
     File snapDir;
     SnapshotInfo lastSnapshotInfo = null;
+    OutputArchive oa;
+    InputArchive ia;
     private volatile boolean close = false;
     private static final int VERSION = 2;
     private static final long dbId = -1;
@@ -55,6 +66,16 @@ public class FileSnap implements SnapShot {
 
     public FileSnap(File snapDir) {
         this.snapDir = snapDir;
+    }
+
+    public FileSnap(File snapDir, OutputArchive oa) {
+        this.snapDir = snapDir;
+        this.oa = oa;
+    }
+
+    public FileSnap(File snapDir, InputArchive ia) {
+        this.snapDir = snapDir;
+        this.ia = ia;
     }
 
     /**
@@ -85,7 +106,7 @@ public class FileSnap implements SnapShot {
             LOG.info("Reading snapshot {}", snap);
             snapZxid = Util.getZxidFromName(snap.getName(), SNAPSHOT_FILE_PREFIX);
             try (CheckedInputStream snapIS = SnapStream.getInputStream(snap)) {
-                InputArchive ia = BinaryInputArchive.getArchive(snapIS);
+                ia = BinaryInputArchive.getArchive(snapIS);
                 deserialize(dt, sessions, ia);
                 SnapStream.checkSealIntegrity(snapIS, ia);
 
@@ -95,7 +116,7 @@ public class FileSnap implements SnapShot {
                 //
                 // To check the intact, after adding digest we added another
                 // CRC check.
-                if (dt.deserializeZxidDigest(ia, snapZxid)) {
+                if (deserializeZxidDigest(dt)) {
                     SnapStream.checkSealIntegrity(snapIS, ia);
                 }
 
@@ -127,12 +148,44 @@ public class FileSnap implements SnapShot {
      * @throws IOException
      */
     public void deserialize(DataTree dt, Map<Long, Integer> sessions, InputArchive ia) throws IOException {
+        this.ia = ia;
         FileHeader header = new FileHeader();
         header.deserialize(ia, "fileheader");
         if (header.getMagic() != SNAP_MAGIC) {
             throw new IOException("mismatching magic headers " + header.getMagic() + " !=  " + FileSnap.SNAP_MAGIC);
         }
-        SerializeUtils.deserializeSnapshot(dt, ia, sessions);
+        deserializeSessions(sessions);
+        deserializeACL(dt.getReferenceCountedAclCache());
+        dt.deserialize(this, "tree");
+    }
+
+    public void serialize(DataTree dt, Map<Long, Integer> sessions, long lastZxid, boolean fsync)
+            throws IOException {
+        File snapshotFile = new File(snapDir, Util.makeSnapshotName(lastZxid));
+        try {
+            serialize(dt, sessions, snapshotFile, fsync);
+        } catch (IOException e) {
+            if (snapshotFile.length() == 0) {
+                /* This may be caused by a full disk. In such a case, the server
+                 * will get stuck in a loop where it tries to write a snapshot
+                 * out to disk, and ends up creating an empty file instead.
+                 * Doing so will eventually result in valid snapshots being
+                 * removed during cleanup. */
+                if (snapshotFile.delete()) {
+                    LOG.info("Deleted empty snapshot file: "
+                            + snapshotFile.getAbsolutePath());
+                } else {
+                    LOG.warn("Could not delete empty snapshot file: "
+                            + snapshotFile.getAbsolutePath());
+                }
+            } else {
+                /* Something else went wrong when writing the snapshot out to
+                 * disk. If this snapshot file is invalid, when restarting,
+                 * ZooKeeper will skip it, and find the last known good snapshot
+                 * instead. */
+            }
+            throw e;
+        }
     }
 
     /**
@@ -209,14 +262,12 @@ public class FileSnap implements SnapShot {
      * serialize the datatree and sessions
      * @param dt the datatree to be serialized
      * @param sessions the sessions to be serialized
-     * @param oa the output archive to serialize into
      * @param header the header of this snapshot
      * @throws IOException
      */
     protected void serialize(
         DataTree dt,
         Map<Long, Integer> sessions,
-        OutputArchive oa,
         FileHeader header) throws IOException {
         // this is really a programmatic error and not something that can
         // happen at runtime
@@ -224,7 +275,9 @@ public class FileSnap implements SnapShot {
             throw new IllegalStateException("Snapshot's not open for writing: uninitialized header");
         }
         header.serialize(oa, "fileheader");
-        SerializeUtils.serializeSnapshot(dt, oa, sessions);
+        serializeSessions(sessions);
+        serializeACL(dt.getReferenceCountedAclCache());
+        dt.serialize(this, "tree");
     }
 
     /**
@@ -240,10 +293,12 @@ public class FileSnap implements SnapShot {
         File snapShot,
         boolean fsync) throws IOException {
         if (!close) {
+            long lastZxid = Util.getZxidFromName(snapShot.getName(), SNAPSHOT_FILE_PREFIX);
+            LOG.info("Snapshotting: 0x{} to {}", Long.toHexString(lastZxid), snapShot);
             try (CheckedOutputStream snapOS = SnapStream.getOutputStream(snapShot, fsync)) {
-                OutputArchive oa = BinaryOutputArchive.getArchive(snapOS);
+                oa = BinaryOutputArchive.getArchive(snapOS);
                 FileHeader header = new FileHeader(SNAP_MAGIC, VERSION, dbId);
-                serialize(dt, sessions, oa, header);
+                serialize(dt, sessions, header);
                 SnapStream.sealStream(snapOS, oa);
 
                 // Digest feature was added after the CRC to make it backward
@@ -252,7 +307,7 @@ public class FileSnap implements SnapShot {
                 //
                 // To check the intact, after adding digest we added another
                 // CRC check.
-                if (dt.serializeZxidDigest(oa)) {
+                if (serializeZxidDigest(dt)) {
                     SnapStream.sealStream(snapOS, oa);
                 }
 
@@ -279,6 +334,143 @@ public class FileSnap implements SnapShot {
         if (val != checkSum) {
             throw new IOException("CRC corruption");
         }
+    }
+
+    public synchronized void serializeSessions(Map<Long, Integer> sessions) throws IOException {
+        HashMap<Long, Integer> sessSnap = new HashMap<Long, Integer>(sessions);
+        oa.writeInt(sessSnap.size(), "count");
+        for (Entry<Long, Integer> entry : sessSnap.entrySet()) {
+            oa.writeLong(entry.getKey().longValue(), "id");
+            oa.writeInt(entry.getValue().intValue(), "timeout");
+        }
+    }
+
+    public synchronized void deserializeSessions(Map<Long, Integer> sessions) throws IOException {
+        int count = ia.readInt("count");
+        while (count > 0) {
+            long id = ia.readLong("id");
+            int to = ia.readInt("timeout");
+            sessions.put(id, to);
+            count--;
+        }
+    }
+
+    public synchronized void serializeACL(ReferenceCountedACLCache aclCache) throws IOException {
+        oa.writeInt(aclCache.getLongKeyMap().size(), "map");
+        Set<Map.Entry<Long, List<ACL>>> set = aclCache.getLongKeyMap().entrySet();
+        for (Map.Entry<Long, List<ACL>> val : set) {
+            oa.writeLong(val.getKey(), "long");
+            List<ACL> aclList = val.getValue();
+            oa.startVector(aclList, "acls");
+            for (ACL acl : aclList) {
+                acl.serialize(oa, "acl");
+            }
+            oa.endVector(aclList, "acls");
+        }
+    }
+
+    public synchronized void deserializeACL(ReferenceCountedACLCache aclCache) throws IOException {
+        aclCache.clear();
+        int aclCount = ia.readInt("aclCount");
+        while (aclCount > 0) {
+            Long val = ia.readLong("long");
+            List<ACL> aclList = new ArrayList<ACL>();
+            Index j = ia.startVector("acls");
+            if (j == null) {
+                throw new RuntimeException("Incorrect format of InputArchive when deserialize DataTree - missing acls");
+            }
+            while (!j.done()) {
+                ACL acl = new ACL();
+                acl.deserialize(ia, "acl");
+                aclList.add(acl);
+                j.incr();
+            }
+            aclCache.updateMaps(val, aclList);
+            aclCount--;
+        }
+    }
+
+    public synchronized void writeNode(String pathString, DataNode node) throws IOException {
+        oa.writeString(pathString, "path");
+        oa.writeRecord(node, "node");
+    }
+
+    public synchronized void markEnd() throws IOException {
+        oa.writeString("/", "path");
+    }
+
+    public String readNode(DataNode node) throws IOException {
+        String path = ia.readString("path");
+        if (!"/".equals(path)) {
+            ia.readRecord(node, "node");
+        }
+        return path;
+    }
+
+    public synchronized boolean serializeZxidDigest(DataTree dt) throws IOException {
+        if (dt.nodesDigestEnabled()) {
+            ZxidDigest zxidDigest = dt.getLastProcessedZxidDigest();
+            if (zxidDigest == null) {
+                zxidDigest = dt.getBlankDigest();
+            }
+            zxidDigest.serialize(oa);
+            return true;
+        }
+        return false;
+    }
+
+    public synchronized boolean deserializeZxidDigest(DataTree dt) throws IOException {
+        if (dt.nodesDigestEnabled()) {
+            try {
+                ZxidDigest zxidDigest = dt.getBlankDigest();
+                zxidDigest.deserialize(ia);
+                if (zxidDigest.getZxid() > 0) {
+                    dt.setZxidDigestFromLoadedSnapshot(zxidDigest);
+                    LOG.info("The digest in the snapshot is {}, 0x{}, {}",
+                            zxidDigest.getDigestVersion(),
+                            Long.toHexString(zxidDigest.getZxid()),
+                            zxidDigest.getDigest());
+                } else {
+                    dt.setZxidDigestFromLoadedSnapshot(null);
+                    LOG.info("The digest value is empty in snapshot");
+                }
+
+                // There is possibility that the start zxid of a snapshot might
+                // be larger than the digest zxid in snapshot.
+                //
+                // Known cases:
+                //
+                // The new leader set the last processed zxid to be the new
+                // epoch + 0, which is not mapping to any txn, and it uses
+                // this to take snapshot, which is possible if we don't
+                // clean database before switching to LOOKING. In this case
+                // the currentZxidDigest will be the zxid of last epoch and
+                // it's smaller than the zxid of the snapshot file.
+                //
+                // It's safe to reset the targetZxidDigest to null and start
+                // to compare digest when replaying the first txn, since it's
+                // a non fuzzy snapshot.
+                if (zxidDigest != null && zxidDigest.getZxid() < dt.lastProcessedZxid) {
+                    LOG.info("The zxid of snapshot digest 0x{} is smaller "
+                                    + "than the known snapshot highest zxid, the snapshot "
+                                    + "started with zxid 0x{}. It will be invalid to use "
+                                    + "this snapshot digest associated with this zxid, will "
+                                    + "ignore comparing it.", Long.toHexString(zxidDigest.getZxid()),
+                            Long.toHexString(dt.lastProcessedZxid));
+                    dt.setZxidDigestFromLoadedSnapshot(null);
+                }
+
+                return true;
+            } catch (EOFException e) {
+                LOG.warn("Got EOF exception while reading the digest, likely due to the reading an older snapshot.");
+                return false;
+            }
+        }
+        return false;
+    }
+
+    public void applyTxn(List<TransactionChangeRecord> changeList, long zxid) throws IOException {
+        // do nothing because FileSnap does not need to apply txns
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileToRocksDBSnap.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileToRocksDBSnap.java
@@ -1,0 +1,105 @@
+package org.apache.zookeeper.server.persistence;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.zookeeper.server.DataNode;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.ReferenceCountedACLCache;
+import org.apache.zookeeper.server.TransactionChangeRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class implements the snapshot interface.
+ * It is responsible for reading a snapshot from
+ * file systems and taking a snapshot in RocksDB
+ */
+public class FileToRocksDBSnap implements SnapShot {
+    private static final Logger LOG = LoggerFactory.getLogger(FileToRocksDBSnap.class);
+
+    SnapShot fileSnapLog;
+    SnapShot rocksdbSnapLog;
+    // RocksDB will only take a full snapshot if this is true. When we are loading
+    // the database, we always need take a full snapshot in RocksDB.
+    private final boolean SYNC_SNAP = true;
+
+    public FileToRocksDBSnap(File snapDir) throws IOException {
+        this.fileSnapLog = new FileSnap(snapDir);
+        this.rocksdbSnapLog = new RocksDBSnap(snapDir);
+    }
+
+    public long deserialize(DataTree dt, Map<Long, Integer> sessions)
+            throws IOException {
+        long lastZxid = fileSnapLog.deserialize(dt, sessions);
+        // After deserializing the data from the snapshot in files, we need take
+        // a snapshot in RocksDB immediately, otherwise we won't have a RocksDB
+        // snapshot to apply transactions to when replaying the transactions in
+        // transaction logs.
+        serialize(dt, sessions, lastZxid, SYNC_SNAP);
+        return lastZxid;
+    }
+
+    public synchronized void serialize(DataTree dt, Map<Long, Integer> sessions, long lastZxid, boolean fsync)
+            throws IOException {
+        rocksdbSnapLog.serialize(dt, sessions, lastZxid, fsync);
+    }
+
+    public File findMostRecentSnapshot() throws IOException {
+        // do nothing, because in deserialization, this method is called in FileSnap.
+        return null;
+    }
+
+    public void serializeSessions(Map<Long, Integer> sessions) throws IOException {
+        // do nothing, because in serialization, this method is called in RocksDBSnap.
+    }
+
+    public void deserializeSessions(Map<Long, Integer> sessions) throws IOException {
+        // do nothing, because in deserialization, this method is called in FileSnap.
+    }
+
+    public void serializeACL(ReferenceCountedACLCache aclCache) throws IOException {
+        // do nothing, because in serialization, this method is called in RocksDBSnap.
+    }
+
+    public void deserializeACL(ReferenceCountedACLCache aclCache) throws IOException {
+        // do nothing, because in deserialization, this method is called in FileSnap.
+    }
+
+    public void writeNode(String pathString, DataNode node) throws IOException {
+        // do nothing, because in serialization, this method is called in RocksDBSnap.
+    }
+
+    public void markEnd() throws IOException {
+        // do nothing, because in serialization, this method is called in RocksDBSnap.
+    }
+
+    public String readNode(DataNode node) throws IOException {
+        // do nothing, because in deserialization, this method is called in FileSnap.
+        return null;
+    }
+
+    public boolean serializeZxidDigest(DataTree dt) throws IOException {
+        // do nothing, because in serialization, this method is called in RocksDBSnap.
+        return false;
+    }
+
+    public boolean deserializeZxidDigest(DataTree dt) throws IOException {
+        // do nothing, because in deserialization, this method is called in FileSnap.
+        return false;
+    }
+
+    public void applyTxn(List<TransactionChangeRecord> changeList, long zxid) throws IOException {
+        rocksdbSnapLog.applyTxn(changeList, zxid);
+    }
+
+    public void close() throws IOException {
+        fileSnapLog.close();
+        rocksdbSnapLog.close();
+    }
+
+    public SnapshotInfo getLastSnapshotInfo() {
+        return null;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -167,7 +167,7 @@ public class FileTxnSnapLog {
         }
 
         txnLog = new FileTxnLog(this.dataDir);
-        snapLog = new FileSnap(this.snapDir);
+        snapLog = SnapshotFactory.createSnapshot(this.snapDir);
 
         autoCreateDB = Boolean.parseBoolean(
             System.getProperty(ZOOKEEPER_DB_AUTOCREATE, ZOOKEEPER_DB_AUTOCREATE_DEFAULT));
@@ -227,6 +227,21 @@ public class FileTxnSnapLog {
      */
     public SnapshotInfo getLastSnapshotInfo() {
         return this.snapLog.getLastSnapshotInfo();
+    }
+
+    /**
+     * @return the snapshot log
+     */
+    public SnapShot getSnapshot() {
+        return snapLog;
+    }
+
+    /**
+     * @return true if we need record the changes in in-memory database
+     * when processing txns, false if not.
+     */
+    public boolean needRecordChanges() {
+        return (snapLog instanceof RocksDBSnap) || (snapLog instanceof FileToRocksDBSnap);
     }
 
     /**
@@ -332,10 +347,11 @@ public class FileTxnSnapLog {
                     //empty logs
                     return dt.lastProcessedZxid;
                 }
-                if (hdr.getZxid() < highestZxid && highestZxid != 0) {
-                    LOG.error("{}(highestZxid) > {}(next log) for type {}", highestZxid, hdr.getZxid(), hdr.getType());
+                long currentZxid = hdr.getZxid();
+                if (currentZxid < highestZxid && highestZxid != 0) {
+                    LOG.error("{}(highestZxid) > {}(next log) for type {}", highestZxid, currentZxid, hdr.getType());
                 } else {
-                    highestZxid = hdr.getZxid();
+                    highestZxid = currentZxid;
                 }
                 try {
                     processTransaction(hdr, dt, sessions, itr.getTxn());
@@ -348,6 +364,8 @@ public class FileTxnSnapLog {
                                           + e.getMessage(),
                                           e);
                 }
+                // TODO: better to use the same logic in ZKDatabase to process and apply txns
+                getSnapshot().applyTxn(dt.getChangeList(), currentZxid);
                 listener.onTxnLoaded(hdr, itr.getTxn(), itr.getDigest());
                 if (!itr.next()) {
                     break;
@@ -466,30 +484,7 @@ public class FileTxnSnapLog {
         ConcurrentHashMap<Long, Integer> sessionsWithTimeouts,
         boolean syncSnap) throws IOException {
         long lastZxid = dataTree.lastProcessedZxid;
-        File snapshotFile = new File(snapDir, Util.makeSnapshotName(lastZxid));
-        LOG.info("Snapshotting: 0x{} to {}", Long.toHexString(lastZxid), snapshotFile);
-        try {
-            snapLog.serialize(dataTree, sessionsWithTimeouts, snapshotFile, syncSnap);
-        } catch (IOException e) {
-            if (snapshotFile.length() == 0) {
-                /* This may be caused by a full disk. In such a case, the server
-                 * will get stuck in a loop where it tries to write a snapshot
-                 * out to disk, and ends up creating an empty file instead.
-                 * Doing so will eventually result in valid snapshots being
-                 * removed during cleanup. */
-                if (snapshotFile.delete()) {
-                    LOG.info("Deleted empty snapshot file: {}", snapshotFile.getAbsolutePath());
-                } else {
-                    LOG.warn("Could not delete empty snapshot file: {}", snapshotFile.getAbsolutePath());
-                }
-            } else {
-                /* Something else went wrong when writing the snapshot out to
-                 * disk. If this snapshot file is invalid, when restarting,
-                 * ZooKeeper will skip it, and find the last known good snapshot
-                 * instead. */
-            }
-            throw e;
-        }
+        snapLog.serialize(dataTree, sessionsWithTimeouts, lastZxid, syncSnap);
     }
 
     /**
@@ -513,7 +508,7 @@ public class FileTxnSnapLog {
                 // would have a big impact outside ZKDatabase as there are other
                 // objects holding a reference to this object.
                 txnLog = new FileTxnLog(dataDir);
-                snapLog = new FileSnap(snapDir);
+                snapLog = SnapshotFactory.createSnapshot(this.snapDir);
 
                 return truncated;
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/RocksDBSnap.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/RocksDBSnap.java
@@ -1,0 +1,547 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import org.apache.jute.BinaryInputArchive;
+import org.apache.jute.BinaryOutputArchive;
+import org.apache.jute.Index;
+import org.apache.zookeeper.common.Time;
+import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.server.DataNode;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.DataTree.ZxidDigest;
+import org.apache.zookeeper.server.ReferenceCountedACLCache;
+import org.apache.zookeeper.server.ServerMetrics;
+import org.apache.zookeeper.server.TransactionChangeRecord;
+import org.rocksdb.FlushOptions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class implements the snapshot interface.
+ * It is responsible for storing, serializing
+ * and deserializing the right snapshot in RocksDB,
+ * and provides access to the snapshots.
+ */
+public class RocksDBSnap implements SnapShot {
+    File snapDir;
+    RocksDB db;
+    Options options;
+    WriteOptions writeOpts;
+    RocksIterator rocksIterator;
+
+    private volatile boolean close = false;
+
+    private static final boolean SYNC_WRITE = false;
+    private static final boolean DISABLE_WAL = true;
+
+    //VisibleForTesting
+    public static final String ROCKSDB_WRITE_BUFFER_SIZE = "zookeeper.rocksdbWriteBufferSize";
+
+    private static final int PREFIX_STARTING_INDEX = 0;
+    private static final int PREFIX_ENDING_INDEX = 3;
+
+    private static final String SESSION_KEY_PREFIX = "S::";
+    private static final String DATATREE_KEY_PREFIX = "T::";
+    private static final String ACL_KEY_PREFIX = "A::";
+
+    private static final String ZXID_KEY = "Zxid";
+    private static final String ZXIDDIGEST_KEY = "ZxidDigest";
+
+    private static final long DEFAULT_ROCKSDB_WRITE_BUFFER_SIZE = 4096 * 1024 * 1024;
+
+    private static final Logger LOG = LoggerFactory.getLogger(RocksDBSnap.class);
+
+    /**
+     * The constructor which takes the snapDir. This class is instantiated
+     * via SnapshotFactory
+     *
+     * @param snapDir the snapshot directory
+     */
+    public RocksDBSnap(File snapDir) throws IOException {
+        RocksDB.loadLibrary();
+        if (snapDir == null) {
+            throw new IllegalArgumentException("Snap Directory can't be null!");
+        }
+
+        this.snapDir = snapDir;
+
+        long rocksdbWriteBufferSize = Long.getLong(
+                ROCKSDB_WRITE_BUFFER_SIZE, DEFAULT_ROCKSDB_WRITE_BUFFER_SIZE);
+        this.options = new Options()
+                .setCreateIfMissing(true)
+                .setCreateMissingColumnFamilies(true)
+                .setDbWriteBufferSize(rocksdbWriteBufferSize);
+
+        try {
+            this.db = RocksDB.open(options, snapDir.getAbsolutePath());
+        } catch (RocksDBException e) {
+            throw new IOException("Failed to open RocksDB. " + "error: " + e.getMessage(), e);
+        }
+        // setting Sync = true and DisableWAL = true will lead to writes failing
+        // and throwing an exception. So we set Sync = false here and let RocksDB
+        // flush after serialization.
+        this.writeOpts = new WriteOptions().setSync(SYNC_WRITE).setDisableWAL(DISABLE_WAL);
+    }
+
+    // VisibleForTesting
+    public void initializeIterator() {
+        rocksIterator = db.newIterator();
+        rocksIterator.seekToFirst();
+    }
+
+    // VisibleForTesting
+    public void closeIterator() {
+        rocksIterator.close();
+    }
+
+    public long deserialize(DataTree dt, Map<Long, Integer> sessions)
+            throws IOException {
+        File[] files = snapDir.listFiles();
+        if (files == null || files.length == 0) {
+            LOG.info("No snapshot found in {}", snapDir.getName());
+            return -1L;
+        }
+        long lastProcessedZxid;
+        long start = Time.currentElapsedTime();
+        try {
+            byte[] zxidBytes = db.get(ZXID_KEY.getBytes(StandardCharsets.UTF_8));
+            if (zxidBytes == null) {
+                // We didn't find zxid infomation in RocksDB, which means
+                // there is no RocksDB snapshot in the snapDir.
+                LOG.info("No snapshot found in {}", snapDir.getName());
+                return -1L;
+            }
+            lastProcessedZxid = Long.parseLong(new String(zxidBytes, StandardCharsets.UTF_8));
+        } catch (RocksDBException e) {
+            throw new IOException("Failed to deserialize last processed zxid in RocksDB. " + "error: " + e.getMessage(), e);
+        }
+        LOG.info("RocksDB: Reading snapshot 0x{} from {}", Long.toHexString(lastProcessedZxid), snapDir);
+        dt.lastProcessedZxid = lastProcessedZxid;
+
+        rocksIterator = db.newIterator();
+        rocksIterator.seekToFirst();
+        ByteArrayInputStream bais;
+        BinaryInputArchive bia;
+        while (rocksIterator.isValid()) {
+            String key = new String(rocksIterator.key(), StandardCharsets.UTF_8);
+            String prefix = key.substring(PREFIX_STARTING_INDEX, PREFIX_ENDING_INDEX);
+            switch (prefix) {
+                case SESSION_KEY_PREFIX:
+                    deserializeSessions(sessions);
+                    break;
+                case ACL_KEY_PREFIX:
+                    deserializeACL(dt.getReferenceCountedAclCache());
+                    break;
+                case DATATREE_KEY_PREFIX:
+                    dt.deserialize(this, "tree");
+                    break;
+                default:
+                    // last processed zxid or zxid digest
+                    rocksIterator.next();
+                    break;
+            }
+        }
+        rocksIterator.close();
+
+        deserializeZxidDigest(dt);
+        if (dt.getDigestFromLoadedSnapshot() != null) {
+            dt.compareSnapshotDigests(lastProcessedZxid);
+        }
+        long elapsed = Time.currentElapsedTime() - start;
+        LOG.info("RocksDBSnap deserialization takes " + elapsed + " ms");
+        ServerMetrics.getMetrics().ROCKSDB_SNAPSHOT_DESERIALIZATION_TIME.add(elapsed);
+        return lastProcessedZxid;
+    }
+
+    public synchronized void serialize(DataTree dt, Map<Long, Integer> sessions,
+                                       long lastZxid, boolean fsync) throws IOException {
+        if (close) {
+            return;
+        }
+        if (fsync) {
+            // take a full snapshot when snap sync with the leader
+
+            // close RocksDB for cleaning up the old snapshot,
+            // because destroyDB will fail if the RocksDB is open and locked
+            db.close();
+            // clean up the old snapshot
+            try {
+                RocksDB.destroyDB(snapDir.getAbsolutePath(), options);
+            } catch (RocksDBException e) {
+                throw new IOException("Failed to clean old data in RocksDB files: " + "error: " + e.getMessage(), e);
+            }
+            // re-open RocksDB for taking a new snapshot
+            try {
+                db = RocksDB.open(options, snapDir.getAbsolutePath());
+            } catch (RocksDBException e) {
+                throw new IOException("Failed to open RocksDB. " + "error: " + e.getMessage(), e);
+            }
+
+            LOG.info("RocksDB: Snapshotting: 0x{} to {}", Long.toHexString(lastZxid), snapDir);
+
+            updateLastProcessedZxid(lastZxid, null);
+            serializeSessions(sessions);
+            serializeACL(dt.getReferenceCountedAclCache());
+            dt.serialize(this, "tree");
+            serializeZxidDigest(dt);
+        }
+        flush();
+    }
+
+    public void flush() throws IOException {
+        long start = Time.currentElapsedTime();
+        try (final FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true)) {
+            db.flush(flushOptions);
+        } catch (RocksDBException e) {
+            throw new IOException("Failed to flush in RocksDB: " + "error: " + e.getMessage(), e);
+        }
+        long elapsed = Time.currentElapsedTime() - start;
+        ServerMetrics.getMetrics().ROCKSDB_FLUSH_TIME.add(elapsed);
+    }
+
+    public File findMostRecentSnapshot() throws IOException {
+        // In RocksDB, we always apply transactions to the current snapshot.
+        // So we only keep one single folder for the RocksDB snapshot. If
+        // this snapshot cannot be loaded because of corrupted data, we will
+        // sync with leader to get the latest data. Keeping multiple snapshots
+        // won't help here, since we still need to take snapshot syncing with
+        // the old snapshot, that's why we only keep one here.
+        return snapDir;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void applyTxn(List<TransactionChangeRecord> changeList, long zxid) throws IOException {
+        // We use RocksDB WriteBatch to make atomic updates.
+        // We didn't let applying client's requests wait until flush finished because
+        // flushing 200MB of data in memtables takes nearly 1.5 seconds, flushing 500MB
+        // of data takes 4.5 seconds, and flushing 1GB of data takes more than 10 seconds.
+        try (WriteBatch writeBatch = new WriteBatch()) {
+            // update sessions, ACL, DataTree and ZxidDigest in RocksDB
+            for (int i = 0; i < changeList.size(); i++) {
+                TransactionChangeRecord change = changeList.get(i);
+                switch (change.getType()) {
+                    case TransactionChangeRecord.DATANODE:
+                        String path = (String) change.getKey();
+                        DataNode node = (DataNode) change.getValue();
+                        String operation = change.getOperation();
+                        if (operation.equals(TransactionChangeRecord.ADD)
+                            || operation.equals(TransactionChangeRecord.UPDATE)) {
+                            addNode(path, node, writeBatch);
+                        } else {
+                            removeNode(path, writeBatch);
+                        }
+                        break;
+                    case TransactionChangeRecord.ACL:
+                        Long index = (Long) change.getKey();
+                        List<ACL> aclList = (List<ACL>) change.getValue();
+                        if (change.getOperation().equals(TransactionChangeRecord.ADD)) {
+                            addACLKeyValue(index, aclList, writeBatch);
+                        } else {
+                            removeACLKeyValue(index, writeBatch);
+                        }
+                        break;
+                    case TransactionChangeRecord.SESSION:
+                        Long id = (Long) change.getKey();
+                        Integer timeout = (Integer) change.getValue();
+                        if (change.getOperation().equals(TransactionChangeRecord.ADD)) {
+                            addSessionKeyValue(id, timeout, writeBatch);
+                        } else {
+                            removeSessionKeyValue(id, writeBatch);
+                        }
+                        break;
+                    case TransactionChangeRecord.ZXIDDIGEST:
+                        ZxidDigest zxidDigest = (ZxidDigest) change.getValue();
+                        if (change.getOperation().equals(TransactionChangeRecord.UPDATE)) {
+                            updateZxidDigest(zxidDigest, writeBatch);
+                        }
+                        break;
+                    default:
+                        LOG.warn("Unknown TransactionChangeRecord type {}", change);
+                        break;
+                }
+            }
+            // update the zxid in RocksDB
+            updateLastProcessedZxid(zxid, writeBatch);
+
+            // even if RocksDB's memTable is auto flushed, we always have consistent data and zxid digest.
+            db.write(writeOpts, writeBatch);
+        } catch (RocksDBException e) {
+            throw new IOException("Failed to apply txns to RocksDB " + "error: " + e.getMessage(), e);
+        }
+    }
+
+    private void updateLastProcessedZxid(long zxid, WriteBatch writeBatch) throws IOException {
+        try {
+            if (writeBatch != null) {
+                writeBatch.put(ZXID_KEY.getBytes(StandardCharsets.UTF_8),
+                        Long.toString(zxid).getBytes(StandardCharsets.UTF_8));
+            } else {
+                db.put(writeOpts, ZXID_KEY.getBytes(StandardCharsets.UTF_8),
+                        Long.toString(zxid).getBytes(StandardCharsets.UTF_8));
+            }
+        } catch (RocksDBException e) {
+            throw new IOException("Failed to serialize last processed zxid in RocksDB. "
+                    + "error: " + e.getMessage(), e);
+        }
+    }
+
+    public void serializeSessions(Map<Long, Integer> sessions) throws IOException {
+        HashMap<Long, Integer> sessSnap = new HashMap<Long, Integer>(sessions);
+        for (Entry<Long, Integer> entry : sessSnap.entrySet()) {
+            addSessionKeyValue(entry.getKey(), entry.getValue(), null);
+        }
+    }
+
+    private void addSessionKeyValue(Long id, Integer timeout, WriteBatch writeBatch) throws IOException {
+        try {
+            String key = SESSION_KEY_PREFIX + id;
+            if (writeBatch != null) {
+                writeBatch.put(key.getBytes(StandardCharsets.UTF_8),
+                        timeout.toString().getBytes(StandardCharsets.UTF_8));
+            } else {
+                db.put(writeOpts, key.getBytes(StandardCharsets.UTF_8),
+                        timeout.toString().getBytes(StandardCharsets.UTF_8));
+            }
+        } catch (RocksDBException e) {
+            throw new IOException("Failed to serialize sessions in RocksDB " + "error: " + e.getMessage(), e);
+        }
+    }
+
+    private void removeSessionKeyValue(Long id, WriteBatch writeBatch) throws IOException {
+        try {
+            String key = SESSION_KEY_PREFIX + id;
+            writeBatch.delete(key.getBytes(StandardCharsets.UTF_8));
+        } catch (RocksDBException e) {
+            throw new IOException("Failed to delete the session in RocksDB " + "error: " + e.getMessage(), e);
+        }
+    }
+
+    public void deserializeSessions(Map<Long, Integer> sessions) throws IOException {
+        while (rocksIterator.isValid()) {
+            String key = new String(rocksIterator.key(), StandardCharsets.UTF_8);
+            if (!key.startsWith(SESSION_KEY_PREFIX)) {
+                break;
+            }
+            key = key.substring(PREFIX_ENDING_INDEX);
+            long id = Long.parseLong(key);
+            int to = Integer.parseInt(new String(rocksIterator.value(), StandardCharsets.UTF_8));
+            sessions.put(id, to);
+            rocksIterator.next();
+        }
+    }
+
+    public synchronized void serializeACL(ReferenceCountedACLCache aclCache) throws IOException {
+        Set<Map.Entry<Long, List<ACL>>> set = aclCache.getLongKeyMap().entrySet();
+        for (Map.Entry<Long, List<ACL>> val : set) {
+            addACLKeyValue(val.getKey(), val.getValue(), null);
+        }
+    }
+
+    private void addACLKeyValue(Long index, List<ACL> aclList, WriteBatch writeBatch) throws IOException {
+        String key = ACL_KEY_PREFIX + index;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        BinaryOutputArchive boa = BinaryOutputArchive.getArchive(baos);
+        boa.startVector(aclList, "acls");
+        for (ACL acl : aclList) {
+            acl.serialize(boa, "acl");
+        }
+        boa.endVector(aclList, "acls");
+        ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray());
+        try {
+            if (writeBatch != null) {
+                writeBatch.put(key.getBytes(StandardCharsets.UTF_8), bb.array());
+            } else {
+                db.put(writeOpts, key.getBytes(StandardCharsets.UTF_8), bb.array());
+            }
+        } catch (RocksDBException e) {
+            throw new IOException("Failed to serialize ACL lists in RocksDB " + "error: " + e.getMessage(), e);
+        }
+    }
+
+    private void removeACLKeyValue(Long index, WriteBatch writeBatch) throws IOException {
+        try {
+            String key = ACL_KEY_PREFIX + index;
+            writeBatch.delete(key.getBytes(StandardCharsets.UTF_8));
+        } catch (RocksDBException e) {
+            throw new IOException("Failed to delete the ACL list in RocksDB " + "error: " + e.getMessage(), e);
+        }
+    }
+
+    public synchronized void deserializeACL(ReferenceCountedACLCache aclCache) throws IOException {
+        aclCache.clear();
+        ByteArrayInputStream bais;
+        BinaryInputArchive bia;
+        while (rocksIterator.isValid()) {
+            String key = new String(rocksIterator.key(), StandardCharsets.UTF_8);
+            if (!key.startsWith(ACL_KEY_PREFIX)) {
+                break;
+            }
+            key = key.substring(PREFIX_ENDING_INDEX);
+            long val = Long.parseLong(key);
+            List<ACL> aclList = new ArrayList<ACL>();
+            bais = new ByteArrayInputStream(rocksIterator.value());
+            bia = BinaryInputArchive.getArchive(bais);
+            Index j = bia.startVector("acls");
+            if (j == null) {
+                throw new RuntimeException("Incorrent format of InputArchive when deserialize DataTree - missing acls");
+            }
+            while (!j.done()) {
+                ACL acl = new ACL();
+                acl.deserialize(bia, "acl");
+                aclList.add(acl);
+                j.incr();
+            }
+            aclCache.updateMaps(val, aclList);
+            rocksIterator.next();
+        }
+    }
+
+    public void writeNode(String pathString, DataNode node) throws IOException {
+        addNode(pathString, node, null);
+    }
+
+    private void addNode(String pathString, DataNode node, WriteBatch writeBatch) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        BinaryOutputArchive boa = BinaryOutputArchive.getArchive(baos);
+        boa.writeRecord(node, "node");
+        ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray());
+        try {
+            pathString = DATATREE_KEY_PREFIX + pathString;
+            if (writeBatch != null) {
+                writeBatch.put(pathString.getBytes(StandardCharsets.UTF_8), bb.array());
+            } else {
+                db.put(writeOpts, pathString.getBytes(StandardCharsets.UTF_8), bb.array());
+            }
+        } catch (RocksDBException e) {
+            throw new IOException("Failed to serialize data node in RocksDB " + "error: " + e.getMessage(), e);
+        }
+    }
+
+    private void removeNode(String pathString, WriteBatch writeBatch) throws IOException {
+        try {
+            pathString = DATATREE_KEY_PREFIX + pathString;
+            writeBatch.delete(pathString.getBytes(StandardCharsets.UTF_8));
+        } catch (RocksDBException e) {
+            throw new IOException("Failed to delete the data node in RocksDB " + "error: " + e.getMessage(), e);
+        }
+    }
+
+    public void markEnd() throws IOException {
+        // nothing needs to be done here when taking a snapshot in RocksDB
+    }
+
+    public String readNode(DataNode node) throws IOException {
+        if (!rocksIterator.isValid()) {
+            // finished iterating over all data nodes in RocksDB snapshot
+            return "/";
+        }
+        String path = new String(rocksIterator.key(), StandardCharsets.UTF_8);
+        if (!path.startsWith(DATATREE_KEY_PREFIX)) {
+            // finished iterating over all data nodes in RocksDB snapshot
+            return "/";
+        }
+        path = path.substring(PREFIX_ENDING_INDEX);
+        ByteArrayInputStream bais = new ByteArrayInputStream(rocksIterator.value());
+        BinaryInputArchive bia = BinaryInputArchive.getArchive(bais);
+        bia.readRecord(node, "node");
+        rocksIterator.next();
+        return path;
+    }
+
+    public boolean serializeZxidDigest(DataTree dt) throws IOException {
+        if (dt.nodesDigestEnabled()) {
+            ZxidDigest zxidDigest = dt.getLastProcessedZxidDigest();
+            if (zxidDigest == null) {
+                zxidDigest = dt.getBlankDigest();
+            }
+            updateZxidDigest(zxidDigest, null);
+            return true;
+        }
+        return false;
+    }
+
+    private void updateZxidDigest(ZxidDigest zxidDigest, WriteBatch writeBatch) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        BinaryOutputArchive boa = BinaryOutputArchive.getArchive(baos);
+        zxidDigest.serialize(boa);
+        ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray());
+        try {
+            if (writeBatch != null) {
+                writeBatch.put(ZXIDDIGEST_KEY.getBytes(StandardCharsets.UTF_8), bb.array());
+            } else {
+                db.put(writeOpts, ZXIDDIGEST_KEY.getBytes(StandardCharsets.UTF_8), bb.array());
+            }
+        } catch (RocksDBException e) {
+            throw new IOException("Failed to serialize zxid digest in RocksDB " + "error: " + e.getMessage(), e);
+        }
+    }
+
+    public boolean deserializeZxidDigest(DataTree dt) throws IOException {
+        if (dt.nodesDigestEnabled()) {
+            try {
+                byte[] zxidDigestBytes = db.get(ZXIDDIGEST_KEY.getBytes(StandardCharsets.UTF_8));
+                ZxidDigest zxidDigest = dt.getBlankDigest();
+                ByteArrayInputStream bais = new ByteArrayInputStream(zxidDigestBytes);
+                BinaryInputArchive bia = BinaryInputArchive.getArchive(bais);
+                zxidDigest.deserialize(bia);
+                dt.setZxidDigestFromLoadedSnapshot(zxidDigest);
+            } catch (RocksDBException e) {
+                throw new IOException("Failed to deserialize zxid digest from RocksDB " + "error: " + e.getMessage(), e);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * synchronized close just so that if serialize is in place
+     * the close operation will block and will wait till serialize
+     * is done and will set the close flag
+     */
+    @Override
+    public synchronized void close() throws IOException {
+        close = true;
+        writeOpts.close();
+        db.close();
+        options.close();
+    }
+
+    public SnapshotInfo getLastSnapshotInfo() {
+        return null;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/RocksDBToFileSnap.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/RocksDBToFileSnap.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.zookeeper.server.DataNode;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.ReferenceCountedACLCache;
+import org.apache.zookeeper.server.TransactionChangeRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class implements the snapshot interface.
+ * It is responsible for reading a snapshot from
+ * RocksDB and taking a snapshot in files
+ */
+public class RocksDBToFileSnap implements SnapShot {
+    private static final Logger LOG = LoggerFactory.getLogger(RocksDBToFileSnap.class);
+
+    SnapShot fileSnapLog;
+    SnapShot rocksdbSnapLog;
+
+    public RocksDBToFileSnap(File snapDir) throws IOException {
+        this.fileSnapLog = new FileSnap(snapDir);
+        this.rocksdbSnapLog = new RocksDBSnap(snapDir);
+    }
+
+    public long deserialize(DataTree dt, Map<Long, Integer> sessions)
+            throws IOException {
+        return rocksdbSnapLog.deserialize(dt, sessions);
+    }
+
+    public synchronized void serialize(DataTree dt, Map<Long, Integer> sessions, long lastZxid, boolean fsync)
+            throws IOException {
+        fileSnapLog.serialize(dt, sessions, lastZxid, fsync);
+    }
+
+    public File findMostRecentSnapshot() throws IOException {
+        // do nothing, because in deserialization, this method is called in RocksDBSnap.
+        return null;
+    }
+
+    public void serializeSessions(Map<Long, Integer> sessions) throws IOException {
+        // do nothing, because in serialization, this method is called in FileSnap.
+    }
+
+    public void deserializeSessions(Map<Long, Integer> sessions) throws IOException {
+        // do nothing, because in deserialization, this method is called in RocksDBSnap.
+    }
+
+    public void serializeACL(ReferenceCountedACLCache aclCache) throws IOException {
+        // do nothing, because in serialization, this method is called in FileSnap.
+    }
+
+    public void deserializeACL(ReferenceCountedACLCache aclCache) throws IOException {
+        // do nothing, because in deserialization, this method is called in RocksDBSnap.
+    }
+
+    public void writeNode(String pathString, DataNode node) throws IOException {
+        // do nothing, because in serialization, this method is called in FileSnap.
+    }
+
+    public void markEnd() throws IOException {
+        // do nothing, because in serialization, this method is called in FileSnap.
+    }
+
+    public String readNode(DataNode node) throws IOException {
+        // do nothing, because in deserialization, this method is called in RocksDBSnap.
+        return null;
+    }
+
+    public boolean serializeZxidDigest(DataTree dt) throws IOException {
+        // do nothing, because in serialization, this method is called in FileSnap.
+        return false;
+    }
+
+    public boolean deserializeZxidDigest(DataTree dt) throws IOException {
+        // do nothing, because in deserialization, this method is called in RocksDBSnap.
+        return false;
+    }
+
+    public void applyTxn(List<TransactionChangeRecord> changeList, long zxid) throws IOException {
+        // do nothing because we don't apply transactions to the snapshot in files.
+    }
+
+    public void close() throws IOException {
+        fileSnapLog.close();
+        rocksdbSnapLog.close();
+    }
+
+    public SnapshotInfo getLastSnapshotInfo() {
+        return null;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapShot.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapShot.java
@@ -20,8 +20,12 @@ package org.apache.zookeeper.server.persistence;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
+import org.apache.zookeeper.server.DataNode;
 import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.ReferenceCountedACLCache;
+import org.apache.zookeeper.server.TransactionChangeRecord;
 
 /**
  * snapshot interface for the persistence layer.
@@ -33,7 +37,8 @@ public interface SnapShot {
     /**
      * deserialize a data tree from the last valid snapshot and
      * return the last zxid that was deserialized
-     * @param dt the datatree to be deserialized into
+     *
+     * @param dt       the datatree to be deserialized into
      * @param sessions the sessions to be deserialized into
      * @return the last zxid that was deserialized from the snapshot
      * @throws IOException
@@ -42,16 +47,18 @@ public interface SnapShot {
 
     /**
      * persist the datatree and the sessions into a persistence storage
-     * @param dt the datatree to be serialized
+     *
+     * @param dt       the datatree to be serialized
      * @param sessions the session timeouts to be serialized
-     * @param name the object name to store snapshot into
-     * @param fsync sync the snapshot immediately after write
+     * @param lastZxid the last processed zxid before serialization
+     * @param fsync    sync the snapshot immediately after write
      * @throws IOException
      */
-    void serialize(DataTree dt, Map<Long, Integer> sessions, File name, boolean fsync) throws IOException;
+    void serialize(DataTree dt, Map<Long, Integer> sessions, long lastZxid, boolean fsync) throws IOException;
 
     /**
      * find the most recent snapshot file
+     *
      * @return the most recent snapshot file
      * @throws IOException
      */
@@ -59,12 +66,97 @@ public interface SnapShot {
 
     /**
      * get information of the last saved/restored snapshot
+     *
      * @return info of last snapshot
      */
     SnapshotInfo getLastSnapshotInfo();
 
     /**
+     * serialize the sessions into a snapshot
+     *
+     * @param sessions the session timeouts to be serialized
+     * @throws IOException
+     */
+    void serializeSessions(Map<Long, Integer> sessions) throws IOException;
+
+    /**
+     * deserialize the sessions from the last valid snapshot
+     *
+     * @param sessions the session timeouts to be deserialized into
+     * @throws IOException
+     */
+    void deserializeSessions(Map<Long, Integer> sessions) throws IOException;
+
+    /**
+     * serialize the ACL lists into a snapshot
+     *
+     * @param aclCache the acl cache to be serialized
+     * @throws IOException
+     */
+    void serializeACL(ReferenceCountedACLCache aclCache) throws IOException;
+
+    /**
+     * deserialize the ACL lists from the last valid snapshot
+     *
+     * @param aclCache the acl cache to be deserialized into
+     * @throws IOException
+     */
+    void deserializeACL(ReferenceCountedACLCache aclCache) throws IOException;
+
+    /**
+     * serialize the nodes of data tree into a snapshot
+     *
+     * @param pathString the path of the node to be serialized
+     * @param node       the data tree node to be serialized
+     * @throws IOException
+     */
+    void writeNode(String pathString, DataNode node) throws IOException;
+
+    /**
+     * mark the end of the serialized data of the data tree
+     *
+     * @throws IOException
+     */
+    void markEnd() throws IOException;
+
+    /**
+     * deserialize the data tree node and its path from the last valid snapshot
+     *
+     * @param node the data tree node to be deserialized into
+     * @return the path of the node
+     * @throws IOException
+     */
+    String readNode(DataNode node) throws IOException;
+
+    /**
+     * Serialize the zxid digest of a data tree into a snapshot.
+     *
+     * @param dt The DataTree
+     * @return if ZxidDigest was serialized successfully
+     * @throws IOException
+     */
+    boolean serializeZxidDigest(DataTree dt) throws IOException;
+
+    /**
+     * Deserialize the zxid digest from the last valid snapshot
+     *
+     * @param dt The DataTree
+     * @return if ZxidDigest was deserialized successfully
+     * @throws IOException
+     */
+    boolean deserializeZxidDigest(DataTree dt) throws IOException;
+
+    /**
+     * apply all the changes in the txn to the snapshot
+     *
+     * @param changeList a list of changes of in memory database made by the txn
+     */
+    void applyTxn(List<TransactionChangeRecord> changeList, long zxid) throws IOException;
+
+
+    /**
      * free resources from this snapshot immediately
+     *
      * @throws IOException
      */
     void close() throws IOException;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapshotFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapshotFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import java.io.File;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SnapshotFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(SnapshotFactory.class);
+
+    public static final String ZOOKEEPER_SNAPSHOT_NAME = "zookeeper.snapshotName";
+
+    public static boolean shouldRecordTransactionChanges() {
+        String snapName = System.getProperty(ZOOKEEPER_SNAPSHOT_NAME);
+        if (snapName == null || snapName.equals(FileSnap.class.getName())) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public static SnapShot createSnapshot(File snapDir) throws IOException {
+        String snapshotName = System.getProperty(ZOOKEEPER_SNAPSHOT_NAME);
+        if (snapshotName == null) {
+            snapshotName = FileSnap.class.getName();
+        }
+
+        try {
+            SnapShot snapshot = (SnapShot) Class.forName(snapshotName).getConstructor(File.class).newInstance(snapDir);
+            LOG.info("Using {} to take snapshot", snapshotName);
+            return snapshot;
+        } catch (Exception e) {
+            IOException ioe = new IOException("Couldn't instantiate " + snapshotName);
+            ioe.initCause(e);
+            throw ioe;
+        }
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/SerializeUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/SerializeUtils.java
@@ -21,19 +21,13 @@ package org.apache.zookeeper.server.util;
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.InputArchive;
-import org.apache.jute.OutputArchive;
 import org.apache.jute.Record;
 import org.apache.zookeeper.ZooDefs.OpCode;
-import org.apache.zookeeper.server.DataTree;
 import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.TxnLogEntry;
 import org.apache.zookeeper.server.ZooKeeperServer;
-import org.apache.zookeeper.server.ZooTrace;
 import org.apache.zookeeper.server.persistence.Util;
 import org.apache.zookeeper.txn.CloseSessionTxn;
 import org.apache.zookeeper.txn.CreateContainerTxn;
@@ -142,33 +136,6 @@ public class SerializeUtils {
         }
 
         return new TxnLogEntry(txn, hdr, digest);
-    }
-
-    public static void deserializeSnapshot(DataTree dt, InputArchive ia, Map<Long, Integer> sessions) throws IOException {
-        int count = ia.readInt("count");
-        while (count > 0) {
-            long id = ia.readLong("id");
-            int to = ia.readInt("timeout");
-            sessions.put(id, to);
-            if (LOG.isTraceEnabled()) {
-                ZooTrace.logTraceMessage(
-                    LOG,
-                    ZooTrace.SESSION_TRACE_MASK,
-                    "loadData --- session in archive: " + id + " with timeout: " + to);
-            }
-            count--;
-        }
-        dt.deserialize(ia, "tree");
-    }
-
-    public static void serializeSnapshot(DataTree dt, OutputArchive oa, Map<Long, Integer> sessions) throws IOException {
-        HashMap<Long, Integer> sessSnap = new HashMap<Long, Integer>(sessions);
-        oa.writeInt(sessSnap.size(), "count");
-        for (Entry<Long, Integer> entry : sessSnap.entrySet()) {
-            oa.writeLong(entry.getKey().longValue(), "id");
-            oa.writeInt(entry.getValue().intValue(), "timeout");
-        }
-        dt.serialize(oa, "tree");
     }
 
     public static byte[] serializeRequest(Request request) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/DataTreeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/DataTreeTest.java
@@ -28,10 +28,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
@@ -49,8 +51,14 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.common.PathTrie;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.metrics.MetricsUtils;
+import org.apache.zookeeper.server.persistence.FileSnap;
+import org.apache.zookeeper.server.persistence.SnapShot;
+import org.apache.zookeeper.test.ClientBase;
+import org.apache.zookeeper.test.TestUtils;
 import org.apache.zookeeper.txn.CreateTxn;
 import org.apache.zookeeper.txn.TxnHeader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -59,6 +67,28 @@ import org.slf4j.LoggerFactory;
 public class DataTreeTest extends ZKTestCase {
 
     protected static final Logger LOG = LoggerFactory.getLogger(DataTreeTest.class);
+
+    private File tmpDir;
+    private static File snapDir;
+    public static final int VERSION = 2;
+    public static final String version = "version-";
+
+    @BeforeEach
+    private void setUp() throws IOException {
+        tmpDir = ClientBase.createEmptyTestDir();
+        File snapshotDir = new File(tmpDir, "snapdir");
+        snapDir = new File((new File(snapshotDir, version + VERSION).toString()));
+        snapDir.mkdirs();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (tmpDir != null) {
+            TestUtils.deleteFileRecursively(tmpDir);
+        }
+        this.tmpDir = null;
+        this.snapDir = null;
+    }
 
     /**
      * For ZOOKEEPER-1755 - Test race condition when taking dumpEphemerals and
@@ -228,7 +258,6 @@ public class DataTreeTest extends ZKTestCase {
     @Test
     @Timeout(value = 60)
     public void testPathTrieClearOnDeserialize() throws Exception {
-
         //Create a DataTree with quota nodes so PathTrie get updated
         DataTree dserTree = new DataTree();
 
@@ -242,12 +271,17 @@ public class DataTreeTest extends ZKTestCase {
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         BinaryOutputArchive oa = BinaryOutputArchive.getArchive(baos);
-        tree.serialize(oa, "test");
+        SnapShot snapLog = new FileSnap(null, oa);
+        tree.serialize(snapLog, "tree");
         baos.flush();
+        snapLog.close();
 
         ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
         BinaryInputArchive ia = BinaryInputArchive.getArchive(bais);
-        dserTree.deserialize(ia, "test");
+        SnapShot snapLogNew = new FileSnap(null, ia);
+        dserTree.deserialize(snapLogNew, "tree");
+        //snapLogNew.deserialize(dserTree, new HashMap<>());
+        snapLogNew.close();
 
         Field pfield = DataTree.class.getDeclaredField("pTrie");
         pfield.setAccessible(true);
@@ -301,7 +335,9 @@ public class DataTreeTest extends ZKTestCase {
             }
         };
 
-        tree.serialize(oa, "test");
+        SnapShot snapLog = new FileSnap(null, oa);
+        tree.serialize(snapLog, "tree");
+        snapLog.close();
 
         //Let's make sure that we hit the code that ran the real assertion above
         assertTrue(ranTestCase.get(), "Didn't find the expected node");
@@ -319,7 +355,9 @@ public class DataTreeTest extends ZKTestCase {
         DataOutputStream out = new DataOutputStream(baos);
         BinaryOutputArchive oa = new BinaryOutputArchive(out);
 
-        tree.serialize(oa, "test");
+        SnapShot snapLog = new FileSnap(null, oa);
+        tree.serialize(snapLog, "tree");
+        snapLog.close();
 
         DataTree tree2 = new DataTree();
         DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
@@ -353,7 +391,9 @@ public class DataTreeTest extends ZKTestCase {
             }
         };
 
-        tree2.deserialize(ia, "test");
+        SnapShot snapLog2 = new FileSnap(null, ia);
+        tree2.deserialize(snapLog2, "tree");
+        snapLog2.close();
 
         //Let's make sure that we hit the code that ran the real assertion above
         assertTrue(ranTestCase.get(), "Didn't find the expected node");
@@ -410,7 +450,9 @@ public class DataTreeTest extends ZKTestCase {
             }
         };
 
-        tree.serialize(oa, "test");
+        SnapShot snapLog = new FileSnap(null, oa);
+        tree.serialize(snapLog, "tree");
+        snapLog.close();
 
         //Let's make sure that we hit the code that ran the real assertion above
         assertTrue(ranTestCase.get(), "Didn't find the expected node");
@@ -432,12 +474,16 @@ public class DataTreeTest extends ZKTestCase {
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         BinaryOutputArchive oa = BinaryOutputArchive.getArchive(baos);
-        tree.serialize(oa, "test");
+        SnapShot snapLog = new FileSnap(snapDir, oa);
+        snapLog.serialize(tree, new HashMap<>(), 1, true);
+        snapLog.close();
         baos.flush();
 
         ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
         BinaryInputArchive ia = BinaryInputArchive.getArchive(bais);
-        tree.deserialize(ia, "test");
+        SnapShot snapLogNew = new FileSnap(snapDir, ia);
+        snapLogNew.deserialize(tree, new HashMap<>());
+        snapLogNew.close();
 
         assertEquals(1, tree.aclCacheSize(), "expected to have 1 acl in acl cache map");
         assertEquals(ZooDefs.Ids.OPEN_ACL_UNSAFE, tree.getACL("/bug", new Stat()), "expected to have the same acl");

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ReferenceCountedACLCacheTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ReferenceCountedACLCacheTest.java
@@ -23,18 +23,58 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
-import org.apache.jute.OutputArchive;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
+import org.apache.zookeeper.server.persistence.FileSnap;
+import org.apache.zookeeper.server.persistence.RocksDBSnap;
+import org.apache.zookeeper.server.persistence.SnapShot;
+import org.apache.zookeeper.server.persistence.SnapshotFactory;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ReferenceCountedACLCacheTest {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(ReferenceCountedACLCacheTest.class);
+    private File tmpDir;
+    private File snapDir;
+
+    public static Stream<Arguments> data() {
+        return Stream.of(
+                Arguments.of(FileSnap.class.getName()),
+                Arguments.of(RocksDBSnap.class.getName()));
+    }
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        tmpDir = ClientBase.createEmptyTestDir();
+        snapDir = new File(tmpDir, "snapdir");
+    }
+
+    public void setUp(String snapName) {
+        System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME, snapName);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        System.clearProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME);
+        tmpDir = null;
+        snapDir = null;
+    }
 
     @Test
     public void testSameACLGivesSameID() {
@@ -162,8 +202,10 @@ public class ReferenceCountedACLCacheTest {
          */
     }
 
-    @Test
-    public void testSerializeDeserialize() throws IOException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testSerializeDeserialize(String snapName) throws IOException {
+        setUp(snapName);
         ReferenceCountedACLCache cache = new ReferenceCountedACLCache();
 
         List<ACL> acl1 = createACL("one");
@@ -178,13 +220,9 @@ public class ReferenceCountedACLCacheTest {
         Long aclId4 = convertACLsNTimes(cache, acl4, 4);
         Long aclId5 = convertACLsNTimes(cache, acl5, 5);
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        BinaryOutputArchive archive = BinaryOutputArchive.getArchive(baos);
-        cache.serialize(archive);
-
-        BinaryInputArchive inArchive = BinaryInputArchive.getArchive(new ByteArrayInputStream(baos.toByteArray()));
         ReferenceCountedACLCache deserializedCache = new ReferenceCountedACLCache();
-        deserializedCache.deserialize(inArchive);
+        serializeAndDeserializeACL(cache, deserializedCache);
+
         callAddUsageNTimes(deserializedCache, aclId1, 1);
         callAddUsageNTimes(deserializedCache, aclId2, 2);
         callAddUsageNTimes(deserializedCache, aclId3, 3);
@@ -193,24 +231,23 @@ public class ReferenceCountedACLCacheTest {
         assertCachesEqual(cache, deserializedCache);
     }
 
-    @Test
-    public void testNPEInDeserialize() throws IOException {
-        ReferenceCountedACLCache serializeCache = new ReferenceCountedACLCache() {
-            @Override
-            public synchronized void serialize(OutputArchive oa) throws IOException {
-                oa.writeInt(1, "map");
-                oa.writeLong(1, "long");
-                oa.startVector(null, "acls");
-                oa.endVector(null, "acls");
-            }
-        };
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testNPEInDeserialize(String snapName) throws IOException {
+        setUp(snapName);
+        ReferenceCountedACLCache serializeCache = new ReferenceCountedACLCache();
+
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         BinaryOutputArchive archive = BinaryOutputArchive.getArchive(baos);
-        serializeCache.serialize(archive);
+        archive.writeInt(1, "map");
+        archive.writeLong(1, "long");
+        archive.startVector(null, "acls");
+        archive.endVector(null, "acls");
         BinaryInputArchive inArchive = BinaryInputArchive.getArchive(new ByteArrayInputStream(baos.toByteArray()));
         ReferenceCountedACLCache deserializedCache = new ReferenceCountedACLCache();
         try {
-            deserializedCache.deserialize(inArchive);
+            SnapShot snapLog = new FileSnap(null, inArchive);
+            snapLog.deserializeACL(deserializedCache);
         } catch (NullPointerException e) {
             fail("should not throw NPE while do deserialized");
         } catch (RuntimeException e) {
@@ -225,8 +262,10 @@ public class ReferenceCountedACLCacheTest {
         assertEquals(expected.referenceCounter, actual.referenceCounter);
     }
 
-    @Test
-    public void testPurgeUnused() throws IOException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testPurgeUnused(String snapName) throws IOException {
+        setUp(snapName);
         ReferenceCountedACLCache cache = new ReferenceCountedACLCache();
 
         List<ACL> acl1 = createACL("one");
@@ -241,13 +280,9 @@ public class ReferenceCountedACLCacheTest {
         Long aclId4 = convertACLsNTimes(cache, acl4, 4);
         Long aclId5 = convertACLsNTimes(cache, acl5, 5);
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        BinaryOutputArchive archive = BinaryOutputArchive.getArchive(baos);
-        cache.serialize(archive);
-
-        BinaryInputArchive inArchive = BinaryInputArchive.getArchive(new ByteArrayInputStream(baos.toByteArray()));
         ReferenceCountedACLCache deserializedCache = new ReferenceCountedACLCache();
-        deserializedCache.deserialize(inArchive);
+        serializeAndDeserializeACL(cache, deserializedCache);
+
         callAddUsageNTimes(deserializedCache, aclId1, 1);
         callAddUsageNTimes(deserializedCache, aclId2, 2);
         deserializedCache.purgeUnused();
@@ -282,6 +317,31 @@ public class ReferenceCountedACLCacheTest {
         List<ACL> acl1 = new ArrayList<ACL>();
         acl1.add(new ACL(ZooDefs.Perms.ADMIN, new Id("scheme", id)));
         return acl1;
+    }
+
+    private void serializeAndDeserializeACL(ReferenceCountedACLCache cache,
+                                            ReferenceCountedACLCache deserializedCache) throws IOException {
+        if (System.getProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME).equals(
+                FileSnap.class.getName())) {
+            LOG.info("Testing FileSnap:");
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            BinaryOutputArchive archive = BinaryOutputArchive.getArchive(baos);
+            FileSnap snapLog = new FileSnap(null, archive);
+            snapLog.serializeACL(cache);
+            BinaryInputArchive inArchive = BinaryInputArchive.getArchive(new ByteArrayInputStream(baos.toByteArray()));
+            snapLog = new FileSnap(null, inArchive);
+            snapLog.deserializeACL(deserializedCache);
+            snapLog.close();
+        } else {
+            LOG.info("Testing RocksDBSnap:");
+            RocksDBSnap snapLog = new RocksDBSnap(snapDir);
+            snapLog.serializeACL(cache);
+
+            snapLog.initializeIterator();
+            snapLog.deserializeACL(deserializedCache);
+            snapLog.closeIterator();
+            snapLog.close();
+        }
     }
 
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/FileToRocksDBSnapTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/FileToRocksDBSnapTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import java.io.File;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileToRocksDBSnapTest {
+    private static final Logger LOG = LoggerFactory.getLogger(FileToRocksDBSnapTest.class);
+
+    File tmpDir;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        tmpDir = ClientBase.createEmptyTestDir();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        tmpDir = null;
+    }
+
+    @Test
+    public void testMigrateFromFileToRocksDB() throws Exception {
+        ConcurrentHashMap<Long, Integer> sessions = new ConcurrentHashMap<Long, Integer>();
+        sessions.put((long) 1, 2001);
+        sessions.put((long) 2, 2002);
+        sessions.put((long) 3, 2003);
+        DataTree dt = new DataTree();
+        dt.createNode("/foo", "foof".getBytes(), null, 0, 0, 1, 1);
+
+        // Use FileSnap to take a snapshot in file systems
+        System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME,
+                "org.apache.zookeeper.server.persistence.FileSnap");
+        FileTxnSnapLog snapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        snapLog.save(dt, sessions, false);
+        snapLog.close();
+
+        // Use FileToRocksDBSnap to read the snapshot from file
+        System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME,
+                "org.apache.zookeeper.server.persistence.FileToRocksDBSnap");
+        sessions = new ConcurrentHashMap<Long, Integer>();
+        dt = new DataTree();
+        FileTxnSnapLog.PlayBackListener listener = mock(FileTxnSnapLog.PlayBackListener.class);
+        snapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        long result = snapLog.restore(dt, sessions, listener);
+
+        assertTrue(sessions.get((long) 1) == 2001);
+        assertTrue(sessions.get((long) 2) == 2002);
+        assertTrue(sessions.get((long) 3) == 2003);
+        assertTrue(sessions.keySet().size() == 3);
+        assertTrue((int) result == 0);
+
+        // Use FileToRocksDBSnap to take a snapshot in RocksDB
+        snapLog.save(dt, sessions, false);
+        snapLog.close();
+
+        // Use RocksDBSnap to read the snapshot
+        System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME,
+                "org.apache.zookeeper.server.persistence.RocksDBSnap");
+        snapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        sessions = new ConcurrentHashMap<Long, Integer>();
+        dt = new DataTree();
+        result = snapLog.restore(dt, sessions, listener);
+        snapLog.close();
+
+        assertTrue(sessions.get((long) 1) == 2001);
+        assertTrue(sessions.get((long) 2) == 2002);
+        assertTrue(sessions.get((long) 3) == 2003);
+        assertTrue(sessions.keySet().size() == 3);
+        assertTrue((int) result == 0);
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/RocksDBIncrementalSnapshotTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/RocksDBIncrementalSnapshotTest.java
@@ -1,0 +1,385 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.jute.BinaryOutputArchive;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.Request;
+import org.apache.zookeeper.server.ZKDatabase;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.apache.zookeeper.server.util.AssertEqual;
+import org.apache.zookeeper.server.util.ZxidUtils;
+import org.apache.zookeeper.test.ClientBase;
+import org.apache.zookeeper.txn.CreateTxn;
+import org.apache.zookeeper.txn.DeleteTxn;
+import org.apache.zookeeper.txn.MultiTxn;
+import org.apache.zookeeper.txn.SetACLTxn;
+import org.apache.zookeeper.txn.SetDataTxn;
+import org.apache.zookeeper.txn.Txn;
+import org.apache.zookeeper.txn.TxnHeader;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RocksDBIncrementalSnapshotTest {
+    private static final Logger LOG = LoggerFactory.getLogger(RocksDBIncrementalSnapshotTest.class);
+
+    private File tmpDir;
+    private FileTxnSnapLog snapLog;
+    private ZKDatabase zkDb;
+    private long zxid;
+    private final long DB_WRITE_BUFFER_SIZE = 1024 * 1024 * 1024;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        System.setProperty(RocksDBSnap.ROCKSDB_WRITE_BUFFER_SIZE, Long.toString(DB_WRITE_BUFFER_SIZE));
+        System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME, RocksDBSnap.class.getName());
+        ZooKeeperServer.setDigestEnabled(true);
+        tmpDir = ClientBase.createEmptyTestDir();
+        snapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        zkDb = new ZKDatabase(snapLog);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        zkDb.close();
+        tmpDir = null;
+    }
+
+    @Test
+    public void testCreateTxnSuccess() throws Exception {
+        zkDb.save(true);
+
+        zxid = ZxidUtils.makeZxid(1, 0);
+        TxnHeader txnHeader = new TxnHeader(1, 1, zxid, 2, ZooDefs.OpCode.create);
+        CreateTxn txn = new CreateTxn("/" + 1, "data".getBytes(StandardCharsets.UTF_8),
+            null, false, 1);
+        zkDb.processTxn(txnHeader, txn, null);
+
+        zxid = ZxidUtils.makeZxid(1, 1);
+        txnHeader = new TxnHeader(1, 2, zxid, 3, ZooDefs.OpCode.create2);
+        txn = new CreateTxn("/foo", "fooData".getBytes(StandardCharsets.UTF_8),
+            ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 1);
+        zkDb.processTxn(txnHeader, txn, null);
+        // This will flush instead of taking a full snapshot.
+        zkDb.save(false);
+
+        ConcurrentHashMap<Long, Integer> sessions = new ConcurrentHashMap<>();
+        DataTree dserTree = new DataTree();
+        snapLog.restore(dserTree, sessions, (hdr, rec, digest) -> {});
+
+        Assert.assertEquals("data", new String(dserTree.getNode("/" + 1).getData(),
+            StandardCharsets.UTF_8));
+        Assert.assertEquals("fooData", new String(dserTree.getNode("/foo").getData(),
+            StandardCharsets.UTF_8));
+        AssertEqual.assertDBEqual(zkDb.getDataTree(), dserTree);
+    }
+
+    @Test
+    public void testCreateTxnNodeExists() throws Exception {
+        zkDb.save(true);
+
+        zxid = ZxidUtils.makeZxid(1, 1);
+        TxnHeader txnHeader = new TxnHeader(1, 2, zxid, 3, ZooDefs.OpCode.create);
+        CreateTxn txn = new CreateTxn("/foo", "fooData".getBytes(StandardCharsets.UTF_8),
+            ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 1);
+        zkDb.processTxn(txnHeader, txn, null);
+
+        zxid = ZxidUtils.makeZxid(1, 2);
+        txnHeader = new TxnHeader(1, 3, zxid, 4, ZooDefs.OpCode.create);
+        txn = new CreateTxn("/foo", "bug".getBytes(StandardCharsets.UTF_8),
+            ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 1);
+        zkDb.processTxn(txnHeader, txn, null);
+        // This will flush instead of taking a full snapshot.
+        zkDb.save(false);
+        ConcurrentHashMap<Long, Integer> sessions = new ConcurrentHashMap<>();
+        DataTree dserTree = new DataTree();
+        snapLog.restore(dserTree, sessions, (hdr, rec, digest) -> {});
+
+        Assert.assertEquals("fooData", new String(dserTree.getNode("/foo").getData(),
+            StandardCharsets.UTF_8));
+        AssertEqual.assertDBEqual(zkDb.getDataTree(), dserTree);
+    }
+
+    @Test
+    public void testCreateTxnNoNode() throws Exception {
+        zkDb.save(true);
+
+        zxid = ZxidUtils.makeZxid(1, 1);
+        TxnHeader txnHeader = new TxnHeader(1, 2, zxid, 3, ZooDefs.OpCode.create);
+        CreateTxn txn = new CreateTxn("/foo/bug", "fooData".getBytes(StandardCharsets.UTF_8),
+            ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 1);
+        zkDb.processTxn(txnHeader, txn, null);
+        // This will flush instead of taking a full snapshot.
+        zkDb.save(false);
+
+        ConcurrentHashMap<Long, Integer> sessions = new ConcurrentHashMap<>();
+        DataTree dserTree = new DataTree();
+        snapLog.restore(dserTree, sessions, (hdr, rec, digest) -> {});
+        AssertEqual.assertDBEqual(zkDb.getDataTree(), dserTree);
+    }
+
+    @Test
+    public void testSetACLTxnSuccess() throws Exception {
+        zkDb.save(true);
+
+        zxid = ZxidUtils.makeZxid(1, 1);
+        TxnHeader txnHeader = new TxnHeader(1, 1, zxid, 2, ZooDefs.OpCode.create);
+        CreateTxn createTxn = new CreateTxn("/foo", "data".getBytes(StandardCharsets.UTF_8),
+            null, false, 1);
+        zkDb.processTxn(txnHeader, createTxn, null);
+
+        zxid = ZxidUtils.makeZxid(1, 2);
+        txnHeader = new TxnHeader(1, 2, zxid, 3, ZooDefs.OpCode.setACL);
+        SetACLTxn setACLTxn = new SetACLTxn("/foo", ZooDefs.Ids.OPEN_ACL_UNSAFE, -1);
+        zkDb.processTxn(txnHeader, setACLTxn, null);
+        // This will flush instead of taking a full snapshot.
+        zkDb.save(false);
+
+        ConcurrentHashMap<Long, Integer> sessions = new ConcurrentHashMap<>();
+        DataTree dserTree = new DataTree();
+        snapLog.restore(dserTree, sessions, (hdr, rec, digest) -> {});
+
+        AssertEqual.assertDBEqual(zkDb.getDataTree(), dserTree);
+    }
+
+    @Test
+    public void testDeleteTxnSuccess() throws Exception {
+        zkDb.save(true);
+
+        zxid = ZxidUtils.makeZxid(1, 1);
+        TxnHeader txnHeader = new TxnHeader(1, 1, zxid, 2, ZooDefs.OpCode.create);
+        CreateTxn createTxn = new CreateTxn("/foo", "data".getBytes(StandardCharsets.UTF_8),
+            ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 1);
+        zkDb.processTxn(txnHeader, createTxn, null);
+
+        zxid = ZxidUtils.makeZxid(1, 2);
+        txnHeader = new TxnHeader(1, 2, zxid, 3, ZooDefs.OpCode.delete);
+        DeleteTxn deleteTxn = new DeleteTxn("/foo");
+        zkDb.processTxn(txnHeader, deleteTxn, null);
+        // This will flush instead of taking a full snapshot.
+        zkDb.save(false);
+
+        ConcurrentHashMap<Long, Integer> sessions = new ConcurrentHashMap<>();
+        DataTree dserTree = new DataTree();
+        snapLog.restore(dserTree, sessions, (hdr, rec, digest) -> {});
+
+        Assert.assertEquals(null, dserTree.getNode("/foo"));
+        AssertEqual.assertDBEqual(zkDb.getDataTree(), dserTree);
+    }
+
+    @Test
+    public void testSetDataSuccess() throws Exception {
+        zkDb.save(true);
+
+        zxid = ZxidUtils.makeZxid(1, 2);
+        TxnHeader txnHeader = new TxnHeader(1, 1, zxid, 2, ZooDefs.OpCode.create);
+        CreateTxn createTxn = new CreateTxn("/foo", "data".getBytes(StandardCharsets.UTF_8),
+            ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 1);
+        zkDb.processTxn(txnHeader, createTxn, null);
+
+        zxid = ZxidUtils.makeZxid(1, 3);
+        txnHeader = new TxnHeader(1, 2, zxid, 3, ZooDefs.OpCode.setData);
+        SetDataTxn setDataTxn = new SetDataTxn("/foo",
+            "newData".getBytes(StandardCharsets.UTF_8), 2);
+        zkDb.processTxn(txnHeader, setDataTxn, null);
+        // This will flush instead of taking a full snapshot.
+        zkDb.save(false);
+
+        ConcurrentHashMap<Long, Integer> sessions = new ConcurrentHashMap<>();
+        DataTree dserTree = new DataTree();
+        snapLog.restore(dserTree, sessions, (hdr, rec, digest) -> {});
+
+        Assert.assertEquals("newData", new String(dserTree.getNode("/foo").getData(),
+            StandardCharsets.UTF_8));
+        AssertEqual.assertDBEqual(zkDb.getDataTree(), dserTree);
+    }
+
+    @Test
+    public void testMultiTxnSuccess() throws Exception {
+        zkDb.save(true);
+
+        zxid = ZxidUtils.makeZxid(1, 3);
+        TxnHeader txnHeader = new TxnHeader(1, 1, zxid, 2, ZooDefs.OpCode.multi);
+        List<Txn> txnList = new ArrayList<Txn>();
+
+        // Create node.
+        for (int i = 0; i < 5; i++) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            BinaryOutputArchive boa = BinaryOutputArchive.getArchive(baos);
+            CreateTxn createTxn = new CreateTxn("/znode-" + i, ("data-" + i).getBytes(),
+                ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 1);
+            createTxn.serialize(boa, "request");
+            ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray());
+            Txn txact = new Txn(ZooDefs.OpCode.create, bb.array());
+            txnList.add(txact);
+        }
+        MultiTxn multiTxn = new MultiTxn(txnList);
+        zkDb.processTxn(txnHeader, multiTxn, null);
+
+        zxid = ZxidUtils.makeZxid(1, 4);
+        txnHeader = new TxnHeader(2, 2, zxid, 3, ZooDefs.OpCode.multi);
+        // Set data.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        BinaryOutputArchive boa = BinaryOutputArchive.getArchive(baos);
+        SetDataTxn setDataTxn = new SetDataTxn("/znode-2", "newData".getBytes(), 2);
+        setDataTxn.serialize(boa, "request");
+        ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray());
+        Txn txact = new Txn(ZooDefs.OpCode.setData, bb.array());
+        txnList.add(txact);
+
+        // Delete node.
+        baos = new ByteArrayOutputStream();
+        boa = BinaryOutputArchive.getArchive(baos);
+        DeleteTxn deleteTxn = new DeleteTxn("/znode-3");
+        deleteTxn.serialize(boa, "request");
+        bb = ByteBuffer.wrap(baos.toByteArray());
+        txact = new Txn(ZooDefs.OpCode.delete, bb.array());
+        txnList.add(txact);
+
+        multiTxn = new MultiTxn(txnList);
+        zkDb.processTxn(txnHeader, multiTxn, null);
+
+        // This will flush instead of taking a full snapshot.
+        zkDb.save(false);
+
+        ConcurrentHashMap<Long, Integer> sessions = new ConcurrentHashMap<>();
+        DataTree dserTree = new DataTree();
+        snapLog.restore(dserTree, sessions, (hdr, rec, digest) -> {});
+
+        Assert.assertEquals("newData",
+            new String(dserTree.getNode("/znode-2").getData(), StandardCharsets.UTF_8));
+        Assert.assertEquals(null, dserTree.getNode("/znode-3"));
+        AssertEqual.assertDBEqual(zkDb.getDataTree(), dserTree);
+    }
+
+    @Test
+    public void testRocksDBApplyTxnWhenLoadingDatabase() throws Exception {
+        zkDb.save(true);
+
+        TxnHeader txnHeader = new TxnHeader(1, 1, 1, 2, ZooDefs.OpCode.create);
+        CreateTxn txn = new CreateTxn("/1", "data1".getBytes(StandardCharsets.UTF_8), null,
+            false, 1);
+        Request request = new Request(1, 1, 1, txnHeader, txn, 1);
+        zkDb.append(request);
+        zkDb.commit();
+
+        txnHeader = new TxnHeader(2, 2, 2, 3, ZooDefs.OpCode.create2);
+        txn = new CreateTxn("/2", "data2".getBytes(StandardCharsets.UTF_8),
+            ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 1);
+        request = new Request(1, 1, 1, txnHeader, txn, 1);
+        zkDb.append(request);
+        zkDb.commit();
+
+        txnHeader = new TxnHeader(3, 3, 3, 4, ZooDefs.OpCode.setData);
+        SetDataTxn setDataTxn = new SetDataTxn("/1",
+            "newData".getBytes(StandardCharsets.UTF_8), 2);
+        request = new Request(1, 1, 1, txnHeader, setDataTxn, 1);
+        zkDb.append(request);
+        zkDb.commit();
+
+        // When loading the database, in-memory data tree will be updated when the server processing
+        // transactions from the txnLog. The snapshot should also be updated because the server will
+        // apply all these transactions to the snapshot.
+        zkDb.loadDataBase();
+        // this will flush instead of taking a full snapshot.
+        zkDb.save(false);
+
+        ConcurrentHashMap<Long, Integer> sessions = new ConcurrentHashMap<>();
+        DataTree dserTree = new DataTree();
+        snapLog.getSnapshot().deserialize(dserTree, sessions);
+
+        Assert.assertEquals("newData", new String(dserTree.getNode("/1").getData(),
+            StandardCharsets.UTF_8));
+        Assert.assertEquals("data2", new String(dserTree.getNode("/2").getData(),
+            StandardCharsets.UTF_8));
+        AssertEqual.assertDBEqual(zkDb.getDataTree(), dserTree);
+    }
+
+    @Test
+    public void testFileToRocksDBSnapApplyTxnWhenLoadingDatabase() throws Exception {
+        zkDb.close();
+        System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME, FileSnap.class.getName());
+        snapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        zkDb = new ZKDatabase(snapLog);
+        // Take a snapshot in files.
+        zkDb.save(true);
+        zkDb.close();
+
+        // Start FileToRocksDBSnap.
+        System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME, FileToRocksDBSnap.class.getName());
+        snapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        zkDb = new ZKDatabase(snapLog);
+
+        TxnHeader txnHeader = new TxnHeader(1, 1, 1, 2, ZooDefs.OpCode.create);
+        CreateTxn txn = new CreateTxn("/1", "data1".getBytes(StandardCharsets.UTF_8),
+            null, false, 1);
+        Request request = new Request(1, 1, 1, txnHeader, txn, 1);
+        zkDb.append(request);
+        zkDb.commit();
+
+        txnHeader = new TxnHeader(2, 2, 2, 3, ZooDefs.OpCode.create2);
+        txn = new CreateTxn("/2", "data2".getBytes(StandardCharsets.UTF_8),
+            ZooDefs.Ids.OPEN_ACL_UNSAFE, false, 1);
+        request = new Request(1, 1, 1, txnHeader, txn, 1);
+        zkDb.append(request);
+        zkDb.commit();
+
+        txnHeader = new TxnHeader(3, 3, 3, 4, ZooDefs.OpCode.delete);
+        DeleteTxn deleteTxn = new DeleteTxn("/1");
+        request = new Request(1, 1, 1, txnHeader, deleteTxn, 1);
+        zkDb.append(request);
+        zkDb.commit();
+
+        // FileToRocksDBSnap will take a snapshot in RocksDB when loading the database then
+        // apply transactions to it.
+        zkDb.loadDataBase();
+        // This will flush instead of taking a full snapshot.
+        zkDb.save(false);
+
+        DataTree dataTree = zkDb.getDataTree();
+
+        // Use RocksDBSnap to deserialize the data tree from the snapshot.
+        zkDb.close();
+        System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME, RocksDBSnap.class.getName());
+        snapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        zkDb = new ZKDatabase(snapLog);
+
+        ConcurrentHashMap<Long, Integer> sessions = new ConcurrentHashMap<>();
+        DataTree dserTree = new DataTree();
+        snapLog.getSnapshot().deserialize(dserTree, sessions);
+
+        Assert.assertEquals(null, dserTree.getNode("/1"));
+        Assert.assertEquals("data2", new String(dserTree.getNode("/2").getData(),
+            StandardCharsets.UTF_8));
+        AssertEqual.assertDBEqual(dataTree, dserTree);
+    }
+}
+

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/RocksDBMultipleSnapshotsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/RocksDBMultipleSnapshotsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RocksDBMultipleSnapshotsTest {
+    private static final Logger LOG = LoggerFactory.getLogger(RocksDBMultipleSnapshotsTest.class);
+
+    @Test
+    public void testMultipleSaveAndRestore() throws Exception {
+        System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME, "org.apache.zookeeper.server.persistence.RocksDBSnap");
+        // first snapshot
+        ConcurrentHashMap<Long, Integer> sessions = new ConcurrentHashMap<Long, Integer>();
+        sessions.put((long) 1, 2001);
+        sessions.put((long) 2, 2002);
+        sessions.put((long) 3, 2003);
+        DataTree dt = new DataTree();
+        dt.createNode("/foo", "foof".getBytes(), null, 0, 0, 1, 1);
+
+        File tmpDir = ClientBase.createTmpDir();
+        FileTxnSnapLog snapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        snapLog.save(dt, sessions, true);
+
+        Map<Long, Integer> deserializedSessions = new HashMap<Long, Integer>();
+        DataTree deserializedDatatree = new DataTree();
+
+        FileTxnSnapLog.PlayBackListener listener = mock(FileTxnSnapLog.PlayBackListener.class);
+        long result = snapLog.restore(deserializedDatatree, deserializedSessions, listener);
+
+        assertTrue(deserializedSessions.get((long) 1) == 2001);
+        assertTrue(deserializedSessions.get((long) 2) == 2002);
+        assertTrue(deserializedSessions.get((long) 3) == 2003);
+        assertTrue(deserializedSessions.keySet().size() == 3);
+        assertTrue((int) result == 0);
+
+
+        // second snapshot
+        sessions = new ConcurrentHashMap<Long, Integer>();
+        sessions.put((long) 11, 21);
+        sessions.put((long) 22, 2002);
+        sessions.put((long) 33, 23);
+        dt = new DataTree();
+        dt.createNode("/foo", "foof".getBytes(), null, 0, 0, 1, 1);
+        snapLog.save(dt, sessions, true);
+
+        deserializedSessions = new HashMap<Long, Integer>();
+        deserializedDatatree = new DataTree();
+        result = snapLog.restore(deserializedDatatree, deserializedSessions, listener);
+        snapLog.close();
+
+        assertTrue(deserializedSessions.get((long) 11) == 21);
+        assertTrue(deserializedSessions.get((long) 22) == 2002);
+        assertTrue(deserializedSessions.get((long) 33) == 23);
+        assertTrue(deserializedSessions.keySet().size() == 3);
+        assertTrue((int) result == 0);
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/RocksDBSnapEndToEndTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/RocksDBSnapEndToEndTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.apache.zookeeper.server.util.AssertEqual;
+import org.apache.zookeeper.test.ClientBase;
+import org.apache.zookeeper.txn.CreateSessionTxn;
+import org.apache.zookeeper.txn.CreateTxn;
+import org.apache.zookeeper.txn.TxnHeader;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RocksDBSnapEndToEndTest extends ClientBase {
+  private static final Logger LOG = LoggerFactory.getLogger(RocksDBSnapEndToEndTest.class);
+
+  @Override
+  public void setUp() {
+  }
+
+  @Test
+  public void testCreateAndCloseSessionSuccess() throws Exception {
+    // Use FileToRocksDBSnap to deserialize the snapshot from file systems.
+    System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME, FileToRocksDBSnap.class.getName());
+    setUpWithServerId(1);
+    ZooKeeperServer zks = serverFactory.getZooKeeperServer();
+
+    // Take a snapshot in RocksDB.
+    zks.takeSnapshot();
+    stopServer();
+
+    // Use RocksDB to apply transactions.
+    System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME, RocksDBSnap.class.getName());
+    startServer();
+    zks = serverFactory.getZooKeeperServer();
+
+    long firstClientId = (long) 1;
+    long secondClientId = (long) 2;
+    long thirdClientId = (long) 3;
+    // Process the CreateSessionTxn.
+    TxnHeader txnHeader = new TxnHeader(firstClientId, 1414, 0, 55, ZooDefs.OpCode.createSession);
+    CreateSessionTxn cst = new CreateSessionTxn(20000);
+    zks.processTxn(txnHeader, cst); // request is null
+
+    txnHeader = new TxnHeader(secondClientId, 1414, 1, 55, ZooDefs.OpCode.createSession);
+    cst = new CreateSessionTxn(30000);
+    zks.processTxn(txnHeader, cst); // request is null
+
+    // create two nodes with the same clientID, they will be added to the same key under ephemerals
+    txnHeader = new TxnHeader(secondClientId, 2, 2, 2, ZooDefs.OpCode.create);
+    CreateTxn txn = new CreateTxn("/foo1", "data1".getBytes(StandardCharsets.UTF_8), ZooDefs.Ids.OPEN_ACL_UNSAFE, true, 1);
+    zks.processTxn(txnHeader, txn); // request is null
+
+    txnHeader = new TxnHeader(secondClientId, 3, 3, 3, ZooDefs.OpCode.create);
+    txn = new CreateTxn("/foo2", "data2".getBytes(StandardCharsets.UTF_8), ZooDefs.Ids.OPEN_ACL_UNSAFE, true, 1);
+    zks.processTxn(txnHeader, txn); // request is null
+
+    // Create a node with a different clientID.
+    txnHeader = new TxnHeader(thirdClientId, 4, 4, 4, ZooDefs.OpCode.create);
+    txn = new CreateTxn("/foo3", "data3".getBytes(StandardCharsets.UTF_8), ZooDefs.Ids.OPEN_ACL_UNSAFE, true, 1);
+    zks.processTxn(txnHeader, txn); // request is null
+
+    // Close the session, so the session will be removed and the two nodes with the same clientID (ephemeralOwner)
+    // will be deleted.
+    txnHeader = new TxnHeader(secondClientId, 1414, 5, 55, ZooDefs.OpCode.closeSession);
+    zks.processTxn(txnHeader, null); // request is null
+
+    // This will flush instead of taking a full snapshot.
+    zks.takeSnapshot();
+
+    DataTree dataTree = zks.getZKDatabase().getDataTree();
+    ConcurrentHashMap<Long, Integer> sessions = zks.getZKDatabase().getSessionWithTimeOuts();
+    // Get a copy of the in memory session to compare with the sessions gotten from RocksDB snapshot.
+    ConcurrentHashMap<Long, Integer> sessionCopy = new ConcurrentHashMap<Long, Integer>(sessions);
+
+    stopServer();
+
+    FileTxnSnapLog snapLogSpy = spy(new FileTxnSnapLog(tmpDir, tmpDir));
+    ConcurrentHashMap<Long, Integer> dserSessions = new ConcurrentHashMap<>();
+    DataTree dserTree = spy(new DataTree());
+    FileTxnSnapLog.PlayBackListener listener = mock(FileTxnSnapLog.PlayBackListener.class);
+    snapLogSpy.restore(dserTree, dserSessions, listener);
+
+    Assert.assertTrue(dserSessions.size() == 1);
+    Assert.assertTrue(dserSessions.get(firstClientId) == 20000);
+    Assert.assertEquals(new String(dserTree.getNode("/foo3").getData(), StandardCharsets.UTF_8),
+        "data3");
+    // The node is deleted in closeSession.
+    Assert.assertTrue(dserTree.getNode("/foo1") == null);
+    Assert.assertTrue(dserTree.getNode("/foo2") == null);
+    // Global sessions are the same.
+    Assert.assertEquals(sessionCopy, dserSessions);
+    // Data trees are the same.
+    AssertEqual.assertDBEqual(dataTree, dserTree);
+  }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/RocksDBToFileSnapTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/RocksDBToFileSnapTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import java.io.File;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RocksDBToFileSnapTest {
+    private static final Logger LOG = LoggerFactory.getLogger(RocksDBToFileSnapTest.class);
+
+    File tmpDir;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        tmpDir = ClientBase.createEmptyTestDir();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        tmpDir = null;
+    }
+
+    @Test
+    public void testMigrateFromFileToRocksDB() throws Exception {
+        ConcurrentHashMap<Long, Integer> sessions = new ConcurrentHashMap<Long, Integer>();
+        sessions.put((long) 1, 2001);
+        sessions.put((long) 2, 2002);
+        sessions.put((long) 3, 2003);
+        DataTree dt = new DataTree();
+        dt.createNode("/foo", "foof".getBytes(), null, 0, 0, 1, 1);
+
+        // Use RocksDBSnap to take a snapshot in RocksDB
+        System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME,
+                "org.apache.zookeeper.server.persistence.RocksDBSnap");
+        FileTxnSnapLog snapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        snapLog.save(dt, sessions, true);
+        snapLog.close();
+
+        // Use RocksDBToFileSnap to read the snapshot from RocksDB
+        System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME,
+                "org.apache.zookeeper.server.persistence.RocksDBToFileSnap");
+        sessions = new ConcurrentHashMap<Long, Integer>();
+        dt = new DataTree();
+        FileTxnSnapLog.PlayBackListener listener = mock(FileTxnSnapLog.PlayBackListener.class);
+        snapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        long result = snapLog.restore(dt, sessions, listener);
+
+        assertTrue(sessions.get((long) 1) == 2001);
+        assertTrue(sessions.get((long) 2) == 2002);
+        assertTrue(sessions.get((long) 3) == 2003);
+        assertTrue(sessions.keySet().size() == 3);
+        assertTrue((int) result == 0);
+
+        // Use RocksDBToFileSnap to take a snapshot in files
+        snapLog.save(dt, sessions, true);
+        snapLog.close();
+
+        // Use FileSnap to read the snapshot
+        System.setProperty(SnapshotFactory.ZOOKEEPER_SNAPSHOT_NAME,
+                "org.apache.zookeeper.server.persistence.FileSnap");
+        snapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        sessions = new ConcurrentHashMap<Long, Integer>();
+        dt = new DataTree();
+        result = snapLog.restore(dt, sessions, listener);
+        snapLog.close();
+
+        assertTrue(sessions.get((long) 1) == 2001);
+        assertTrue(sessions.get((long) 2) == 2002);
+        assertTrue(sessions.get((long) 3) == 2003);
+        assertTrue(sessions.keySet().size() == 3);
+        assertTrue((int) result == 0);
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/FuzzySnapshotRelatedTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/FuzzySnapshotRelatedTest.java
@@ -50,6 +50,7 @@ import org.apache.zookeeper.server.ServerMetrics;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.server.persistence.SnapShot;
 import org.apache.zookeeper.test.ClientBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -428,8 +429,8 @@ public class FuzzySnapshotRelatedTest extends QuorumPeerTestBase {
         SetDataTxnListener setListener;
 
         @Override
-        public void serializeNodeData(OutputArchive oa, String path, DataNode node) throws IOException {
-            super.serializeNodeData(oa, path, node);
+        public void serializeNodeData(final SnapShot snapLog, String path, DataNode node) throws IOException {
+            super.serializeNodeData(snapLog, path, node);
             NodeSerializeListener listener = listeners.get(path);
             if (listener != null) {
                 listener.nodeSerialized(path);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/util/AssertEqual.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/util/AssertEqual.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Set;
+import org.apache.zookeeper.data.StatPersisted;
+import org.apache.zookeeper.server.DataNode;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.ReferenceCountedACLCache;
+
+public class AssertEqual {
+
+  public static void assertDBEqual(DataTree expected, DataTree actual) {
+    // lastProcessedZxid
+    assertEquals(expected.lastProcessedZxid, actual.lastProcessedZxid);
+    // data nodes
+    assertEquals(expected.getNodeCount(), actual.getNodeCount());
+    assertDataTreeEqual(expected, actual, "/");
+    // ACL
+    assertCachesEqual(expected.getReferenceCountedAclCache(), actual.getReferenceCountedAclCache());
+  }
+
+  public static void assertDataTreeEqual(DataTree expected, DataTree actual, String name) {
+    DataNode nodeExpected = expected.getNode(name);
+    DataNode nodeActual = actual.getNode(name);
+    Set<String> childrenExpected;
+    Set<String> childrenActual;
+    assertStatEqual(nodeExpected.stat, nodeActual.stat);
+    assertEquals(new String(nodeActual.getData()), new String(nodeExpected.getData()));
+    childrenActual = nodeActual.getChildren();
+    childrenExpected = nodeExpected.getChildren();
+    for (String child : childrenActual) {
+      assertTrue(childrenExpected.contains(child));
+      String childName = name + (name.equals("/") ? "" : "/") + child;
+      assertDataTreeEqual(expected, actual, childName);
+    }
+  }
+
+  public static void assertStatEqual(StatPersisted expected, StatPersisted actual) {
+    assertEquals(expected.getCzxid(), actual.getCzxid());
+    assertEquals(expected.getCtime(), actual.getCtime());
+    assertEquals(expected.getMzxid(), actual.getMzxid());
+    assertEquals(expected.getMtime(), actual.getMtime());
+    assertEquals(expected.getPzxid(), actual.getPzxid());
+    assertEquals(expected.getCversion(), actual.getCversion());
+    assertEquals(expected.getVersion(), actual.getVersion());
+    assertEquals(expected.getAversion(), actual.getAversion());
+    assertEquals(expected.getEphemeralOwner(), actual.getEphemeralOwner());
+  }
+
+  public static void assertCachesEqual(ReferenceCountedACLCache expected, ReferenceCountedACLCache actual) {
+    assertEquals(expected.getAclKeyMap(), actual.getAclKeyMap());
+    assertEquals(expected.getLongKeyMap(), actual.getLongKeyMap());
+    assertEquals(expected.getReferenceCounter(), actual.getReferenceCounter());
+  }
+}


### PR DESCRIPTION
This is the first step of enabling on disk storage engine for ZooKeeper by extending the existing Snap interface and implement a RocksDB backed snapshot. Comparing to file based snapshot, RocksDB based snapshot is superior for big in memory data tree as it supports incremental snapshot by only serializing the changed data between snapshots. 

High level overview:

* Extend Snap interface so every thing that's need serialize has a presence on the interface.
* Implement RocksDB based snapshot, and bidirectional conversations between File based snapshot and RocksDB snapshot, for back / forward compatibility.
* Change data capture is implemented by buffering transactions applied to data tree, and applied to RocksDB when processing each transaction. An incremental snapshot thus only requires RocksDB flush. ZK will always do a full snapshot when first loading the data tree during the start process.
* By default, this feature is disabled. Users need opt in by explicitly specify a Java system property to instantiate RocksDBSnap at runtime.

This work is based on top of the patch attached to ZOOKEEPER-3783 (kudos to Fangmin and co at FB), with some bug / test fixes and adjustment so it can cleanly apply to master branch.