### PR TITLE
ZOOKEEPER-3419: Backup and recovery support. 

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/OptionBuilder.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/OptionBuilder.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.cli;
+
+import org.apache.commons.cli.Option;
+
+/**
+ * Replacement class for OptionBuilder without the static access issues.
+ * This roughly mirrors the Option.Builder class available in commons-cli-1.3.SNAPSHOT
+ */
+public class OptionBuilder {
+    private final String shortName;
+    private String longName = null;
+    private String description = null;
+    private String argName = null;
+    private Class<?> argType = null;
+    private int args = 0;
+    private boolean isRequired = false;
+
+    public OptionBuilder(final String shortName) {
+        this.shortName = shortName;
+    }
+
+    public OptionBuilder() {
+        this(null);
+    }
+
+    public OptionBuilder longOpt(final String longName) {
+        this.longName = longName;
+        return this;
+    }
+
+    public OptionBuilder desc(final String description) {
+        this.description = description;
+        return this;
+    }
+
+    public OptionBuilder argName(final String argName) {
+        this.argName = argName;
+        return this;
+    }
+
+    public OptionBuilder type(final Class<?> type) {
+        this.argType = type;
+        return this;
+    }
+
+    public OptionBuilder hasArg() {
+        this.args = 1;
+        return this;
+    }
+
+    public OptionBuilder hasArgs() {
+        this.args = Option.UNLIMITED_VALUES;
+        return this;
+    }
+
+    public OptionBuilder required() {
+        this.isRequired = true;
+        return this;
+    }
+
+    public Option build() {
+        Option o = new Option(shortName, longName, args != 0, description);
+
+        o.setRequired(isRequired);
+
+        if (args != 0) {
+            o.setArgs(args);
+        }
+
+        if (argType != null) {
+            o.setType(argType);
+        }
+
+        if (argName != null) {
+            o.setArgName(argName);
+        }
+
+        return o;
+    }
+}
+    

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
@@ -1,0 +1,272 @@
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Optional;
+import com.twitter.util.Duration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.zookeeper.common.ConfigException;
+import org.apache.zookeeper.common.VerifyingFileFactory;
+
+public class BackupConfig {
+    public static final String PROP_BACKUP_ENABLED = "backup.enabled";
+    public static final String PROP_BACKUP_STATUS_DIR = "backup.statusDir";
+    public static final String PROP_BACKUP_TMP_DIR = "backup.tmpDir";
+    public static final String PROP_BACKUP_INTERVAL = "backup.interval";
+    public static final String PROP_BACKUP_HDFS_CONFIG = "backup.hdfsConfig";
+    public static final String PROP_BACKUP_HDFS_PATH = "backup.hdfsPath";
+    public static final String PROP_BACKUP_RETENTION_DAYS = "backup.retentionDays";
+    public static final String PROP_BACKUP_RETENTION_MAINTENANCE_INTERVAL_HOURS =
+        "backup.retentionMaintenanceIntervalHours";
+
+    public static final boolean DEFAULT_ENABLED = false;
+    public static final int DEFAULT_RETENTION_DAYS = 0;
+    public static final Duration DEFAULT_BACKUP_INTERVAL =
+        Duration.fromTimeUnit(15, TimeUnit.MINUTES);
+    public static final Duration DEFAULT_RETENTION_MAINTENANCE_INTERVAL =
+        Duration.fromTimeUnit(24, TimeUnit.HOURS);
+
+    private static final Logger LOG = LoggerFactory.getLogger(BackupConfig.class);
+
+    private final File statusDir;
+    private final File tmpDir;
+    private final Duration interval; // 15 minutes;
+    private final File hdfsConfig;
+    private final String hdfsPath;
+    private final Duration retentionPeriod; // Days = 0;
+    private final Duration retentionMaintenanceInterval; // Hours = 24;
+
+    public BackupConfig(Builder builder) {
+        this.statusDir = builder._statusDir.get();
+        this.tmpDir = builder._tmpDir.get();
+        this.interval = builder._interval.or(DEFAULT_BACKUP_INTERVAL);
+        this.hdfsConfig = builder._hdfsConfig.get();
+        this.hdfsPath = builder._hdfsPath.get();
+        this.retentionPeriod = Duration.fromTimeUnit(
+            builder._retentionDays.or(DEFAULT_RETENTION_DAYS),
+            TimeUnit.DAYS
+        );
+        this.retentionMaintenanceInterval = builder._retentionMaintenanceInterval.or(
+            DEFAULT_RETENTION_MAINTENANCE_INTERVAL);
+    }
+
+    public File getStatusDir() {
+        return statusDir;
+    }
+
+    public File getTmpDir() {
+        return tmpDir;
+    }
+
+    public Duration getInterval() {
+        return interval;
+    }
+
+    public File getHDFSConfig() {
+        return hdfsConfig;
+    }
+
+    public String getHDFSPath() {
+        return hdfsPath;
+    }
+
+    public Duration getRetentionPeriod() {
+        return retentionPeriod;
+    }
+
+    public Duration getRetentionMaintenanceInterval() {
+        return retentionMaintenanceInterval;
+    }
+
+    public static class Builder {
+        private static final VerifyingFileFactory vff = new VerifyingFileFactory.Builder(LOG)
+            .warnForRelativePath()
+            .build();
+
+        private Optional<Boolean> _enabled = Optional.absent();
+        private Optional<File> _statusDir = Optional.absent();
+        private Optional<File> _tmpDir = Optional.absent();
+        private Optional<Duration> _interval = Optional.absent();
+        private Optional<File> _hdfsConfig = Optional.absent();
+        private Optional<String> _hdfsPath = Optional.absent();
+        private Optional<Integer> _retentionDays = Optional.absent();
+        private Optional<Duration> _retentionMaintenanceInterval = Optional.absent();
+
+        public Builder() {
+        }
+
+        public Builder enabled(boolean enabled) {
+            this._enabled = Optional.of(enabled);
+            return this;
+        }
+
+        public Builder statusDir(File dir) {
+            this._statusDir = Optional.of(dir);
+            return this;
+        }
+
+        public Builder tmpDir(File dir) {
+            this._tmpDir = Optional.of(dir);
+            return this;
+        }
+
+        public Builder interval(Duration interval) {
+            this._interval = Optional.of(interval);
+            return this;
+        }
+
+        public Builder hdfsConfig(File file) {
+            this._hdfsConfig = Optional.of(file);
+            return this;
+        }
+
+        public Builder hdfsPath(String path) {
+            this._hdfsPath = Optional.of(path);
+            return this;
+        }
+
+        public Builder retentionDays(int days) {
+            this._retentionDays = Optional.of(days);
+            return this;
+        }
+
+        public Builder retentionMaintenanceInterval(Duration interval) {
+            this._retentionMaintenanceInterval = Optional.of(interval);
+            return this;
+        }
+
+        public Optional<BackupConfig> build() throws ConfigException {
+            final Optional<BackupConfig> result;
+            boolean enabled = _enabled.or(DEFAULT_ENABLED);
+            if (enabled) {
+                if (!_statusDir.isPresent()) {
+                    throw new ConfigException("BackupConfig statusDir not specified");
+                }
+                if (!_tmpDir.isPresent()) {
+                    throw new ConfigException("BackupConfig tmpDir not specified");
+                }
+                if (!_hdfsConfig.isPresent()) {
+                    throw new ConfigException("BackupConfig hdfsConfig not specified");
+                }
+                if (!_hdfsPath.isPresent()) {
+                    throw new ConfigException("BackupConfig hdfsPath not specified");
+                }
+
+                result = Optional.of(new BackupConfig(this));
+            } else {
+                result = Optional.absent();
+            }
+            return result;
+        }
+
+        public Builder withProperties(Properties properties) throws ConfigException {
+            return withProperties(properties, "");
+        }
+
+        public Builder withProperties(Properties properties, String prefix)
+            throws ConfigException {
+            {
+                String key = prefix + PROP_BACKUP_ENABLED;
+                String prop = properties.getProperty(key);
+                if (prop != null) {
+                    enabled(parseBoolean(key, prop));
+                }
+            }
+            {
+                String key = prefix + PROP_BACKUP_STATUS_DIR;
+                String prop = properties.getProperty(key);
+                if (prop != null) {
+                    statusDir(vff.create(prop));
+                }
+            }
+            {
+                String key = prefix + PROP_BACKUP_TMP_DIR;
+                String prop = properties.getProperty(key);
+                if (prop != null) {
+                    tmpDir(vff.create(prop));
+                }
+            }
+            {
+                String key = prefix + PROP_BACKUP_INTERVAL;
+                String prop = properties.getProperty(key);
+                if (prop != null) {
+                    long minutes = parseLong(key, prop);
+                    interval(Duration.fromTimeUnit(minutes, TimeUnit.MINUTES));
+                }
+            }
+            {
+                String key = prefix + PROP_BACKUP_HDFS_CONFIG;
+                String prop = properties.getProperty(key);
+                if (prop != null) {
+                    hdfsConfig(vff.create(prop));
+                }
+            }
+            {
+                String key = prefix + PROP_BACKUP_HDFS_PATH;
+                String prop = properties.getProperty(key);
+                if (prop != null) {
+                    hdfsPath(prop);
+                }
+            }
+            {
+                String key = prefix + PROP_BACKUP_RETENTION_DAYS;
+                String prop = properties.getProperty(key);
+                if (prop != null) {
+                    retentionDays(parseInt(key, prop));
+                }
+            }
+            {
+                String key = prefix + PROP_BACKUP_RETENTION_MAINTENANCE_INTERVAL_HOURS;
+                String prop = properties.getProperty(key);
+                if (prop != null) {
+                    int h = parseInt(key, prop);
+                    retentionMaintenanceInterval(Duration.fromTimeUnit(h, TimeUnit.HOURS));
+                }
+            }
+            return this;
+        }
+
+        protected Builder withProperty(String key, String val) throws ConfigException {
+            Properties properties = new Properties();
+            properties.setProperty(key, val);
+            return withProperties(properties);
+        }
+
+        private static long parseLong(String key, String value) throws ConfigException {
+            try {
+                return Long.parseLong(value);
+            } catch (NumberFormatException exc) {
+                throw new ConfigException(String.format("parsing %s", key), exc);
+            }
+        }
+
+        private static int parseInt(String key, String value) throws ConfigException {
+            try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException exc) {
+                throw new ConfigException(String.format("parsing %s", key), exc);
+            }
+        }
+
+        private static boolean parseBoolean(String key, String value) throws ConfigException {
+            boolean result;
+            switch (value.toLowerCase()) {
+                case "yes":
+                    result = true;
+                    break;
+                case "no":
+                    result = false;
+                    break;
+                default:
+                    result = Boolean.parseBoolean(value);
+                    break;
+            }
+            return result;
+        }
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupFileInfo.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupFileInfo.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+
+import com.google.common.collect.Range;
+
+import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
+import org.apache.zookeeper.server.backup.BackupUtil.ZxidPart;
+import org.apache.zookeeper.server.persistence.Util;
+
+/**
+ * Metadata for a file that has been backed-up
+ * Assumes that the name of the backed up file uses the format:
+ * prefix.lowzxid-highzxid where prefix is one of the standard snap or log file prefixes, or
+ * "lostLog".
+ */
+public class BackupFileInfo {
+    private final File backupFile;
+    private final File standardFile;
+    private final Range<Long> zxidRange;
+    private final BackupFileType fileType;
+    private final long modificationTime;
+    private final long size;
+
+    /**
+     * Constructor that pulls backup metadata based on the backed-up filename
+     * @param backedupFile the backed-up file with the name in the form prefix.lowzxid-highzxid
+     *                     for example snapshot.9a0000a344-9a0000b012
+     * @param modificationTime the file modification time
+     * @param size the size of the file in bytes
+     */
+    public BackupFileInfo(File backedupFile, long modificationTime, long size) {
+        this.backupFile = backedupFile;
+        this.modificationTime = modificationTime;
+        this.size = size;
+
+        String backedupFilename = this.backupFile.getName();
+
+        if (backedupFilename.startsWith(BackupUtil.LOST_LOG_PREFIX)) {
+            this.fileType = BackupFileType.LOSTLOG;
+            this.standardFile = this.backupFile;
+        } else if (backedupFilename.startsWith(Util.SNAP_PREFIX)) {
+            this.fileType = BackupFileType.SNAPSHOT;
+            this.standardFile =
+                    new File(this.backupFile.getParentFile(), backedupFilename.split("-")[0]);
+        } else if (backedupFilename.startsWith(Util.TXLOG_PREFIX)) {
+            this.fileType = BackupFileType.TXNLOG;
+            this.standardFile =
+                    new File(this.backupFile.getParentFile(), backedupFilename.split("-")[0]);
+        } else {
+            throw new IllegalArgumentException("Not a known backup file type: " + backedupFilename);
+        }
+
+        this.zxidRange = BackupUtil.getZxidRangeFromName(
+                backedupFilename,
+                BackupUtil.getPrefix(this.fileType));
+    }
+
+    /**
+     * Get the zxid range for the backed up file.
+     * @return the zxid range
+     */
+    public Range<Long> getZxidRange() {
+        return this.zxidRange;
+    }
+
+    /**
+     * Convenience method for getting a specific zxid part
+     * @param whichZxid which part to get
+     * @return the value of the requested zxid part
+     */
+    public long getZxid(ZxidPart whichZxid) {
+        return whichZxid == ZxidPart.MIN_ZXID
+                ? this.zxidRange.lowerEndpoint()
+                : this.zxidRange.upperEndpoint();
+    }
+
+    /**
+     * Get the backedup file
+     * @return the backedup file
+     */
+    public File getBackedUpFile() {
+        return this.backupFile;
+    }
+
+    /**
+     * Get the files corresponding to the standard name of the backed up file.  I.e. removes the
+     * high zxid from the filename.
+     * @return the standard file corresponding to the backed up file
+     */
+    public File getStandardFile() {
+        return this.standardFile;
+    }
+
+    /**
+     * Get the type of the file (snap, log, lostLog)
+     * @return the type of file that was backed up
+     */
+    public BackupFileType getFileType() {
+        return this.fileType;
+    }
+
+    /**
+     * Get the modification time for the file
+     * @return the modification time
+     */
+    public long getModificationTime() {
+        return this.modificationTime;
+    }
+
+    /**
+     * Get the file size in bytes
+     * @return file size in bytes
+     */
+    public long getSize() {
+        return this.size;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -1,0 +1,729 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang.NullArgumentException;
+import org.apache.commons.lang.time.StopWatch;
+import org.apache.zookeeper.metrics.MetricsReceiver;
+import org.apache.zookeeper.server.persistence.*;
+import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
+import org.apache.zookeeper.server.backup.BackupUtil.ZxidPart;
+import org.apache.zookeeper.server.util.ZxidUtils;
+import org.apache.zookeeper.txn.TxnHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * This class manages the backing up of txnlog and snap files to remote
+ * storage for longer term and durable retention than is possible on
+ * an ensemble server
+ */
+public class BackupManager {
+    private final Logger logger;
+    private final File snapDir;
+    private final File dataLogDir;
+    private final File tmpDir;
+    private final int backupIntervalInMilliseconds;
+    private final MetricsReceiver metricsReceiver;
+    private BackupProcess logBackup = null;
+    private BackupProcess snapBackup = null;
+
+    // backupStatus, backupLogZxid and backedupSnapZxid need to be access while synchronized
+    // on backupStatus.
+    private BackupStatus backupStatus;
+    private long backedupLogZxid;
+    private long backedupSnapZxid;
+
+    private BackupStorageProvider backupStorage;
+
+    /**
+     * Tracks a file that needs to be backed up, including temporary copies of the file
+     */
+    protected static class BackupFile {
+        private File file;
+        private boolean isTemporary;
+        private ZxidRange zxidRange;
+
+        /**
+         * Create an instance of a BackupFile for the given initial file and zxid range
+         * @param backupFile the initial/original file
+         * @param isTemporaryFile whether the file is a temporary file
+         * @param fileMinZxid the min zxid associated with this file
+         * @param fileMaxZxid the max zxid associated with this file
+         */
+        public BackupFile(File backupFile, boolean isTemporaryFile, long fileMinZxid, long fileMaxZxid) {
+            this(backupFile, isTemporaryFile, new ZxidRange(fileMinZxid, fileMaxZxid));
+        }
+
+        /**
+         * Create an instance of a BackupFile for the given initial file and zxid range
+         * @param backupFile the initial/original file
+         * @param isTemporaryFile whether the file is a temporary file
+         * @param zxidRange the zxid range associated with this file
+         */
+        public BackupFile(File backupFile, boolean isTemporaryFile, ZxidRange zxidRange) {
+            Preconditions.checkNotNull(zxidRange);
+            
+            if (!zxidRange.isHighPresent()) {
+                throw new IllegalArgumentException("ZxidRange must have a high value");
+            }
+
+            this.file = backupFile;
+            this.isTemporary = isTemporaryFile;
+            this.zxidRange = zxidRange;
+        }
+
+        /**
+         * Perform cleanup including deleting temporary files.
+         */
+        public void cleanup() {
+            if (isTemporary && exists()) {
+                file.delete();
+            }
+        }
+
+        /**
+         * Whether the file representing the zxids exists
+         * @return whether the file represented exists
+         */
+        public boolean exists() {
+            return file != null && file.exists();
+        }
+
+        /**
+         * Get the current file (topmost on the stack)
+         * @return the current file
+         */
+        public File getFile() { return file; }
+
+        /**
+         * Get the zxid range associated with this file
+         * @return the zxid range
+         */
+        public ZxidRange getZxidRange() {
+            return zxidRange;
+        }
+
+        /**
+         * Get the min zxid associated with this file
+         * @return the min associated zxid
+         */
+        public long getMinZxid() { return zxidRange.getLow(); }
+
+        /**
+         * Get the max zxid associated with this file
+         * @return the max associated zxid
+         */
+        public long getMaxZxid() { return zxidRange.getHigh(); }
+
+        @Override
+        public String toString() {
+            return String.format("%s : %s : %d - %d",
+                    file == null ? "[empty]" : file.getPath(),
+                    isTemporary ? "temp" : "perm",
+                    zxidRange.getLow(),
+                    zxidRange.getHigh());
+        }
+    }
+
+    /**
+     * Base class for the txnlog and snap back processes.
+     * Provides the main backup loop and copying to remote storage (via HDFS APIs)
+     */
+    public abstract class BackupProcess implements Runnable {
+        protected final Logger logger;
+        private volatile boolean isRunning = true;
+
+        /**
+         * Initialize starting backup point based on remote storage and backupStatus file
+         */
+        protected abstract void initialize() throws IOException;
+
+        /**
+         * Marks the start of a backup iteration.  A backup iteration is run every
+         * backup.interval.  This is called at the start of the iteration and before
+         * any calls to getNextFileToBackup
+         * @throws IOException
+         */
+        protected abstract void startIteration() throws IOException;
+
+        /**
+         * Marks the end of a backup iteration.  After this call there will be no more
+         * calls to getNextFileToBackup or backupComplete until startIteration is
+         * called again.
+         * @param errorFree whether the iteration was error free
+         * @throws IOException
+         */
+        protected abstract void endIteration(boolean errorFree);
+
+        /**
+         * Get the next file to backup
+         * @return the next file to copy to backup storage.
+         * @throws IOException
+         */
+        protected abstract BackupFile getNextFileToBackup() throws IOException;
+
+        /**
+         * Marks that the copy of the specified file to backup storage has completed
+         * @param file the file to backup
+         * @throws IOException
+         */
+        protected abstract void backupComplete(BackupFile file) throws IOException;
+
+        /**
+         * Create an instance of the backup process
+         * @param logger the logger to use for this process.
+         */
+        public BackupProcess(Logger logger) {
+            if (logger == null) {
+                throw new NullArgumentException("logger");
+            }
+
+            this.logger = logger;
+        }
+
+        /**
+         * Runs the main file based backup loop indefinitely.
+         */
+        public void run() {
+            run(0);
+        }
+
+        /**
+         * Runs the main file based backup loop the specified number of time.
+         * Calls methods implemented by derived classes to get the next file to copy.
+         */
+        public void run(int iterations) {
+            try {
+                boolean errorFree = true;
+                logger.debug("Thread starting.");
+
+                while (isRunning) {
+                    BackupFile fileToCopy;
+                    StopWatch sw = new StopWatch();
+
+                    sw.start();
+
+                    try {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Starting iteration");
+                        }
+
+                        // Cleanup any invalid backups that may have been left behind by the
+                        // previous failed iteration.
+                        // NOTE: Not done on first iteration (errorFree initialized to true) since
+                        //       initialize already does this.
+                        if (!errorFree) {
+                            backupStorage.cleanupInvalidFiles(null);
+                        }
+
+                        startIteration();
+
+                        while ((fileToCopy = getNextFileToBackup()) != null) {
+                            // Consider: compress file before sending to remote storage
+                            copyToRemoteStorage(fileToCopy);
+                            backupComplete(fileToCopy);
+                            fileToCopy.cleanup();
+                        }
+
+                        errorFree = true;
+                    } catch (IOException e) {
+                        errorFree = false;
+                        logger.warn("Exception hit during backup", e);
+                    }
+
+                    endIteration(errorFree);
+
+                    sw.stop();
+                    long elapsedTime = sw.getTime();
+
+                    logger.info("Completed backup iteration in {} milliseconds.  ErrorFree: {}.",
+                            elapsedTime, errorFree);
+
+                    if (iterations != 0) {
+                        iterations--;
+
+                        if (iterations < 1) {
+                            break;
+                        }
+                    }
+
+                    // Count elapsed time towards the backup interval
+                    long waitTime = backupIntervalInMilliseconds - elapsedTime;
+
+                    synchronized (this) {  // synchronized to get notification of termination
+                        if (waitTime > 0) {
+                            wait(waitTime);
+                        }
+                    }
+                }
+            } catch (InterruptedException e) {
+                logger.warn("Interrupted exception while waiting for backup interval.", e);
+            } catch (Exception e) {
+                logger.error("Hit unexpected exception", e);
+            }
+
+            logger.warn("Thread exited loop!");
+        }
+
+        /**
+         * Copy given file to remote storage via HDFS APIs.
+         * @param fileToCopy the file to copy
+         * @throws IOException
+         */
+        private void copyToRemoteStorage(BackupFile fileToCopy) throws IOException {
+            if (fileToCopy.getFile() == null) {
+                return;
+            }
+
+            // Use the file name to encode the max included zxid
+            String backedupName = BackupUtil.makeBackupName(
+                    fileToCopy.getFile().getName(), fileToCopy.getMaxZxid());
+
+            backupStorage.copyToBackupStorage(fileToCopy.getFile(), new File(backedupName));
+        }
+
+        /**
+         * Shutdown the backup process
+         */
+        public void shutdown() {
+            synchronized (this) {
+                isRunning = false;
+                notifyAll();
+            }
+        }
+    }
+
+    /**
+     * Implements txnlog specific logic for BackupProcess
+     */
+    protected class TxnLogBackup extends BackupProcess {
+        private long iterationEndPoint;
+        private FileTxnSnapLog snapLog;
+
+        /**
+         * Constructor for TxnLogBackup
+         * @param snapLog the FileTxnSnapLog object to use
+         */
+        public TxnLogBackup(FileTxnSnapLog snapLog) {
+            super(LoggerFactory.getLogger(TxnLogBackup.class));
+            this.snapLog = snapLog;
+        }
+
+        protected void initialize() throws IOException {
+            backupStorage.cleanupInvalidFiles(null);
+
+            BackupFileInfo latest =
+                    BackupUtil.getLatest(backupStorage, BackupFileType.TXNLOG, ZxidPart.MIN_ZXID);
+
+            long rZxid = latest == null
+                    ? BackupUtil.INVALID_LOG_ZXID
+                    : latest.getZxid(ZxidPart.MAX_ZXID);
+
+            logger.info("Latest Zxid from storage: {}  from status: {}",
+                    ZxidUtils.zxidToString(rZxid), ZxidUtils.zxidToString(backedupLogZxid));
+
+            if (rZxid != backedupLogZxid) {
+                synchronized (backupStatus) {
+                    backedupLogZxid = rZxid;
+                    backupStatus.update(backedupLogZxid, backedupSnapZxid);
+                }
+            }
+        }
+
+        protected void startIteration() {
+            // Store the current last logged zxid.  This becomes the stopping point
+            // for the current iteration so we don't keep chasing our own tail as
+            // new transactions get written.
+            iterationEndPoint = snapLog.getLastLoggedZxid();
+            getStats().setLastTxnLogBackupIterationStart();
+        }
+
+        protected void endIteration(boolean errorFree) {
+            iterationEndPoint = 0L;
+            getStats().txnLogIterationDone(errorFree);
+        }
+
+        /**
+         * Gets the next txnlog file to backup.  This is a temporary file created by copying
+         * all transaction from the previous backup point until the end zxid for this iteration, or
+         * a file indicating that some log records were lost.
+         * @return the file that needs to be backed-up.  The minZxid is the first
+         *      zxid contained in the file.  The maxZxid is the last zxid that is contained in the
+         *      file.
+         * @throws IOException
+         */
+        protected BackupFile getNextFileToBackup() throws IOException {
+            long startingZxid = backupStatus.read().getLogZxid() + 1;
+
+            // Don't keep chasing the tail so stop if past the last zxid at the time
+            // this iteration started.
+            if (startingZxid > iterationEndPoint) {
+                return null;
+            }
+
+            TxnLog.TxnIterator iter = null;
+            FileTxnLog newFile = null;
+            long lastZxid = -1;
+            int txnCopied = 0;
+            BackupFile ret = null;
+
+            logger.info("Creating backup file from zxid {}.", ZxidUtils.zxidToString(startingZxid));
+
+            try {
+                iter = snapLog.readTxnLog(startingZxid, true);
+
+                // Use a temp directory to avoid conflicts with live txnlog files
+                newFile = new FileTxnLog(tmpDir, metricsReceiver);
+
+                // Check for lost txnlogs; <=1 indicates that no backups have been done before so
+                // nothing can be considered lost.
+                // If a lost sequence is found then return a file whose name encodes the lost
+                // sequence and back that up so the backup store has a record of the lost sequence
+                if (startingZxid > 1 &&
+                    iter.getHeader() != null &&
+                    iter.getHeader().getZxid() > startingZxid) {
+
+                    logger.error("TxnLog backups lost.  Required starting zxid={}  First available zxid={}",
+                            ZxidUtils.zxidToString(startingZxid),
+                            ZxidUtils.zxidToString(iter.getHeader().getZxid()));
+
+                    String fileName = String.format("%s.%s",
+                            BackupUtil.LOST_LOG_PREFIX,
+                            Long.toHexString(startingZxid));
+                    File lostZxidFile = new File(tmpDir, fileName);
+                    lostZxidFile.createNewFile();
+
+                    return new BackupFile(lostZxidFile, true, startingZxid, iter.getHeader().getZxid() - 1);
+                }
+
+                while (iter.getHeader() != null) {
+                    TxnHeader hdr = iter.getHeader();
+
+                    if (hdr.getZxid() > iterationEndPoint) {
+                        break;
+                    }
+
+                    newFile.append(hdr, iter.getTxn());
+
+                    // update position and count only AFTER the record has been successfully
+                    // copied
+                    lastZxid = hdr.getZxid();
+                    txnCopied++;
+
+                    iter.next();
+                }
+
+                ret = makeBackupFileFromCopiedLog(newFile, lastZxid);
+
+                if (ret != null) {
+                    logger.info("Copied {} records starting at {} and ending at zxid {}.",
+                            txnCopied,
+                            ZxidUtils.zxidToString(ret.getMinZxid()),
+                            ZxidUtils.zxidToString(ret.getMaxZxid()));
+                }
+
+            } catch (IOException e) {
+                logger.warn("Hit exception after {} records.  Exception: {} ", txnCopied, e);
+
+                // If any records were copied return those and ignore the error.  Otherwise
+                // rethrow the error to be handled by the caller as a failed backup iteration.
+                if (txnCopied <= 0) {
+                    throw e;
+                }
+
+                ret = makeBackupFileFromCopiedLog(newFile, lastZxid);
+            } finally {
+                if (iter != null) {
+                    iter.close();
+                }
+
+                if (newFile != null) {
+                    newFile.close();
+                }
+            }
+
+            return ret;
+        }
+
+        private BackupFile makeBackupFileFromCopiedLog(FileTxnLog backupTxnLog, long lastZxid) {
+
+            if (backupTxnLog == null) {
+                return null;
+            }
+
+            File logFile = backupTxnLog.getCurrentFile();
+
+            if (logFile == null) {
+                return null;
+            }
+            
+            long firstZxid = Util.getZxidFromName(logFile.getName(), Util.TXLOG_PREFIX);
+
+            if (lastZxid == -1) {
+                lastZxid = firstZxid;
+            }
+
+            return new BackupFile(logFile, true, new ZxidRange(firstZxid, lastZxid));
+        }
+
+        protected void backupComplete(BackupFile file) throws IOException {
+            synchronized (backupStatus) {
+                backedupLogZxid = file.getMaxZxid();
+                backupStatus.update(backedupLogZxid, backedupSnapZxid);
+            }
+
+            if (file.exists()) {
+                getStats().updateTxnLogSent(file.getFile().length());
+            }
+
+            logger.info("Updated backedup tnxlog zxid to {}", ZxidUtils.zxidToString(backedupLogZxid));
+        }
+    }
+
+    /**
+     * Implements snapshot specific logic for BackupProcess
+     */
+    protected class SnapBackup extends BackupProcess {
+        private FileTxnSnapLog snapLog;
+        private List<BackupFile> filesToBackup = new ArrayList<BackupFile>();
+
+        /**
+         * Constructor for SnapBackup
+         * @param snapLog the FileTxnSnapLog object to use
+         */
+        public SnapBackup(FileTxnSnapLog snapLog) {
+            super(LoggerFactory.getLogger(SnapBackup.class));
+            this.snapLog = snapLog;
+        }
+
+        protected void initialize() throws IOException {
+            backupStorage.cleanupInvalidFiles(null);
+
+            BackupFileInfo latest =
+                    BackupUtil.getLatest(backupStorage, BackupFileType.SNAPSHOT, ZxidPart.MIN_ZXID);
+
+            long rZxid = latest == null
+                    ? BackupUtil.INVALID_SNAP_ZXID
+                    : latest.getZxid(ZxidPart.MIN_ZXID);
+
+            logger.info("Latest Zxid from storage: {}  from status: {}",
+                    ZxidUtils.zxidToString(rZxid), ZxidUtils.zxidToString(backedupLogZxid));
+
+            if (rZxid != backedupSnapZxid) {
+                synchronized (backupStatus) {
+                    backedupSnapZxid = rZxid;
+                    backupStatus.update(backedupLogZxid, backedupSnapZxid);
+                }
+            }
+        }
+
+        protected void startIteration() throws IOException {
+            getStats().setLastSnapBackupIterationStart();
+
+            filesToBackup.clear();
+
+            List<File> candidateSnapshots = snapLog.findValidSnapshots(0, backedupSnapZxid);
+            Collections.reverse(candidateSnapshots);
+
+            if (candidateSnapshots.size() == 0) {
+                return;
+            }
+
+            if (backedupSnapZxid == BackupUtil.INVALID_SNAP_ZXID) {
+                File f = candidateSnapshots.get(0);
+                ZxidRange zxidRange = Util.getZxidRangeFromName(f.getName(), Util.SNAP_PREFIX);
+
+                // Handle backwards compatibility for snapshots that use old style naming where
+                // only the starting zxid is included.
+                // TODO: Can be removed after all snapshots being produced have ending zxid --
+                // TODO: see COORD-1947
+                if (!zxidRange.isHighPresent()) {
+                    long latestZxid = snapLog.getLastLoggedZxid();
+                    long consistentAt = latestZxid == -1 ? zxidRange.getLow() : latestZxid;
+
+                    // Consistency point can be moved earlier if this is not the only file
+                    if (candidateSnapshots.size() > 1) {
+                        long nextSnapshotStartZxid =
+                            Util.getZxidFromName(
+                                candidateSnapshots.get(1).getName(),
+                                Util.SNAP_PREFIX);
+
+                        if (nextSnapshotStartZxid > zxidRange.getLow()) {
+                            consistentAt = nextSnapshotStartZxid - 1;
+                        }
+                    }
+
+                    zxidRange = new ZxidRange(zxidRange.getLow(), consistentAt);
+                }
+
+
+                filesToBackup.add(new BackupFile(f, false, zxidRange));
+            }
+
+            // Always include the last snapshot to be copied as long as it was not already added
+            // above and has not already been backed up.
+            if (backedupSnapZxid != BackupUtil.INVALID_SNAP_ZXID || candidateSnapshots.size() > 1) {
+                File f = candidateSnapshots.get(candidateSnapshots.size() - 1);
+                ZxidRange zxidRange = Util.getZxidRangeFromName(f.getName(), Util.SNAP_PREFIX);
+
+                // Handle backwards compatibility for snapshots that use old style naming where
+                // only the starting zxid is included.
+                // TODO: Can be removed after all snapshots being produced have ending zxid --
+                // TODO: see COORD-1947
+                if (!zxidRange.isHighPresent()) {
+                    long latestZxid = snapLog.getLastLoggedZxid();
+                    zxidRange = new ZxidRange(
+                        zxidRange.getLow(), latestZxid == -1 ? zxidRange.getLow() : latestZxid);
+                }
+
+                if (zxidRange.getLow() > backedupSnapZxid) {
+                    filesToBackup.add(new BackupFile(f, false, zxidRange));
+                }
+            }
+        }
+
+        protected void endIteration(boolean errorFree) {
+            filesToBackup.clear();
+            getStats().snapIterationDone(errorFree);
+        }
+
+        protected BackupFile getNextFileToBackup() throws IOException {
+            if (filesToBackup.isEmpty()) {
+                return null;
+            }
+
+            return filesToBackup.remove(0);
+        }
+
+        protected void backupComplete(BackupFile file) throws IOException {
+            synchronized (backupStatus) {
+                backedupSnapZxid = file.getMinZxid();
+                backupStatus.update(backedupLogZxid, backedupSnapZxid);
+            }
+
+            getStats().updateSnapSent(file.getFile().length());
+
+            logger.info("Updated backedup snap zxid to {}", ZxidUtils.zxidToString(backedupSnapZxid));
+        }
+    }
+
+
+    /**
+     * Constructor for the BackupManager.
+     * @param snapDir the snapshot directory
+     * @param dataLogDir the txnlog directory
+     * @param backupStatusDir the backup status directory
+     * @param tmpDir temporary directory
+     * @param backupIntervalInMinutes the interval backups should run at in minutes
+     */
+    public BackupManager(File snapDir, File dataLogDir, File backupStatusDir, File tmpDir, int backupIntervalInMinutes,
+                         BackupStorageProvider backupStorageProvider, MetricsReceiver metricsReceiver) throws IOException {
+        logger = LoggerFactory.getLogger(BackupManager.class);
+        logger.info("snapDir={}", snapDir.getPath());
+        logger.info("dataLogDir={}", dataLogDir.getPath());
+        logger.info("backupStatusDir={}", backupStatusDir.getPath());
+        logger.info("tmpDir={}", tmpDir.getPath());
+        logger.info("backupIntervalInMinutes={}", backupIntervalInMinutes);
+
+        this.snapDir = snapDir;
+        this.dataLogDir = dataLogDir;
+        this.tmpDir = tmpDir;
+        this.backupStatus = new BackupStatus(backupStatusDir);
+        this.backupIntervalInMilliseconds = backupIntervalInMinutes * 60 * 1000;
+        this.backupStorage = backupStorageProvider;
+        this.metricsReceiver = metricsReceiver;
+
+        initialize();
+    }
+
+    /**
+     * Start the backup processes.
+     * @throws IOException
+     */
+    public synchronized void start() throws IOException {
+        logger.info("BackupManager starting.");
+
+        getStats().updateBackupManagerState(true);
+
+        initialize();
+
+        (new Thread(logBackup)).start();
+        (new Thread(snapBackup)).start();
+    }
+
+    /**
+     * Stop the backup processes.
+     */
+    public void stop() {
+        logger.info("BackupManager shutting down.");
+
+        getStats().updateBackupManagerState(false);
+
+        synchronized (this) {
+            logBackup.shutdown();
+            snapBackup.shutdown();
+            logBackup = null;
+            snapBackup = null;
+        }
+    }
+
+    public BackupProcess getLogBackup() { return logBackup; }
+    public BackupProcess getSnapBackup() { return snapBackup; }
+
+    public long getBackedupLogZxid() {
+        synchronized (backupStatus) {
+            return backedupLogZxid;
+        }
+    }
+
+    public long getBackedupSnapZxid() {
+        synchronized (backupStatus) {
+            return backedupSnapZxid;
+        }
+    }
+
+    public synchronized void initialize() throws IOException {
+        synchronized (backupStatus) {
+            backupStatus.createIfNeeded();
+            BackupPoint bp = backupStatus.read();
+            backedupLogZxid = bp.getLogZxid();
+            backedupSnapZxid = bp.getSnapZxid();
+        }
+
+        if (!tmpDir.exists()) {
+            tmpDir.mkdirs();
+        }
+
+        logBackup = new TxnLogBackup(new FileTxnSnapLog(dataLogDir, snapDir, metricsReceiver));
+        snapBackup = new SnapBackup(new FileTxnSnapLog(dataLogDir, snapDir, metricsReceiver));
+
+        logBackup.initialize();
+        snapBackup.initialize();
+    }
+
+    public static BackupStats getStats() {
+        return BackupStats.getSingleton();
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupPoint.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupPoint.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+/**
+ * Describes the point to which backups of log and snap files have been completed.
+ */
+public class BackupPoint {
+    private Long logZxid;
+    private Long snapZxid;
+
+    /**
+     * Create an instance of a BackupPoint
+     * @param logZxid the highest log zxid that has been backed up
+     * @param snapZxid the start zxid of the latest snap that has been backedup
+     */
+    public BackupPoint(long logZxid, long snapZxid) {
+        this.logZxid = logZxid;
+        this.snapZxid = snapZxid;
+    }
+
+    /**
+     * Get the zxid up to which the log has been backed up.
+     * @return the highest zxid that has been backed up
+     */
+    public long getLogZxid() { return logZxid; }
+
+    /**
+     * Get the starting zxid of the latest backed up snap
+     * @return the starting zxid of the latest backed up snap
+     */
+    public long getSnapZxid() { return snapZxid; }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupStats.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupStats.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import com.twitter.common.stats.Histogram;
+import com.twitter.common.stats.Statistics;
+import com.twitter.common.stats.WindowedApproxHistogram;
+import com.twitter.common.stats.WindowedStatistics;
+
+import java.io.PrintWriter;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.zookeeper.server.StatsGroup;
+
+/**
+ * Backup process stats
+ */
+public class BackupStats {
+    private boolean isBackupManagerActive = false;
+    private long lastTxnLogBackupIterationStart = System.currentTimeMillis();
+    private long lastSnapBackupIterationStart = System.currentTimeMillis();
+
+    // Default last error free iteration to current time in order to trigger
+    // confusion and/or alerts between start-up and completion of the first
+    // backup iteration.
+    private long lastErrorFreeTxnLogBackupIteration = System.currentTimeMillis();
+    private long lastErrorFreeSnapBackupIteration = System.currentTimeMillis();
+
+    private WindowedStatistics txnLogSizeStats = new WindowedStatistics();
+    private WindowedStatistics snapSizeStats = new WindowedStatistics();
+    private WindowedStatistics txnLogIterationDurationStats = new WindowedStatistics();
+    private WindowedStatistics snapIterationDurationStats = new WindowedStatistics();
+
+    private static final BackupStats singleton = new BackupStats();
+
+    private BackupStats() {}
+
+    public static BackupStats getSingleton() {
+        return singleton;
+    }
+
+    // getters
+    synchronized public boolean isBackupManagerActive() { return isBackupManagerActive; }
+
+    synchronized public StatsGroup getTxnLogSizeGroup() {
+        return new StatsGroup(txnLogSizeStats, null);
+    }
+
+    synchronized public StatsGroup getTxnLogLatencyGroup() {
+        return new StatsGroup(txnLogIterationDurationStats, null);
+    }
+
+    synchronized public StatsGroup getSnapSizeGroup() {
+        return new StatsGroup(snapSizeStats, null);
+    }
+
+    synchronized public StatsGroup getSnapLatencyGroup() {
+        return new StatsGroup(snapIterationDurationStats, null);
+    }
+
+    synchronized public long getMinutesSinceLastTxnLogIterationStart() {
+        return (System.currentTimeMillis() - lastTxnLogBackupIterationStart) / (60 * 1000);
+    }
+    synchronized public long getMinutesSinceLastSnapIterationStart() {
+        return (System.currentTimeMillis() - lastSnapBackupIterationStart) / (60 * 1000);
+    }
+
+    synchronized public long getMinutesSinceLastErrorFreeTxnLogIteration() {
+        return (System.currentTimeMillis() - lastErrorFreeTxnLogBackupIteration) / (60 * 1000);
+    }
+    synchronized public long getMinutesSinceLastErrorFreeSnapIteration() {
+        return (System.currentTimeMillis() - lastErrorFreeSnapBackupIteration) / (60 * 1000);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Minutes since last txnlog iteration start: " +
+            getMinutesSinceLastTxnLogIterationStart());
+        sb.append("Minutes since last successful txnlog iteration: " +
+            getMinutesSinceLastErrorFreeTxnLogIteration());
+        sb.append("Minutes since last snap iteration start: " +
+            getMinutesSinceLastSnapIterationStart());
+        sb.append("Minutes since last successful snap iteration: " +
+            getMinutesSinceLastErrorFreeTxnLogIteration());
+
+        return sb.toString();
+    }
+
+    // mutators
+    synchronized void updateBackupManagerState(boolean state) { isBackupManagerActive = state; }
+
+    synchronized void setLastTxnLogBackupIterationStart() {
+        lastTxnLogBackupIterationStart = System.currentTimeMillis();
+    }
+    synchronized void setLastSnapBackupIterationStart() {
+        lastSnapBackupIterationStart = System.currentTimeMillis();
+    }
+
+    synchronized void updateTxnLogSent(long sizeInBytes) {
+        txnLogSizeStats.accumulate(sizeInBytes);
+    }
+
+    synchronized void updateSnapSent(long sizeInBytes) {
+        snapSizeStats.accumulate(sizeInBytes);
+    }
+
+    synchronized void txnLogIterationDone(boolean errorFree) {
+        long duration = System.currentTimeMillis() - lastTxnLogBackupIterationStart;
+        txnLogIterationDurationStats.accumulate(duration);
+
+        if (errorFree) {
+            lastErrorFreeTxnLogBackupIteration = System.currentTimeMillis();
+        }
+    }
+
+    synchronized void snapIterationDone(boolean errorFree) {
+        long duration = System.currentTimeMillis() - lastSnapBackupIterationStart;
+        snapIterationDurationStats.accumulate(duration);
+
+        if (errorFree) {
+            lastErrorFreeSnapBackupIteration = System.currentTimeMillis();
+        }
+    }
+
+    synchronized public void refresh() {
+        txnLogSizeStats.refresh();
+        snapSizeStats.refresh();
+        txnLogIterationDurationStats.refresh();
+        snapIterationDurationStats.refresh();
+    }
+
+    synchronized public void reset() {
+        txnLogSizeStats = new WindowedStatistics();
+        snapSizeStats = new WindowedStatistics();
+        txnLogIterationDurationStats = new WindowedStatistics();
+        snapIterationDurationStats = new WindowedStatistics();
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupStatus.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupStatus.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import org.apache.jute.BinaryInputArchive;
+import org.apache.jute.BinaryOutputArchive;
+import org.apache.jute.InputArchive;
+import org.apache.jute.OutputArchive;
+import org.apache.zookeeper.server.persistence.Util;
+
+import java.io.*;
+import java.nio.channels.FileLock;
+
+/**
+ * Coordinate the backup status among processes local to a server;
+ * coordination across servers is better served via either an extension
+ * to the ZAB protocol or by some external mechanism.
+ */
+public class BackupStatus {
+    /**
+     * The name for the backup status file.
+     */
+    public final static String STATUS_FILENAME = "zkBackupStatus";
+
+    private final static String BACKEDUP_ZXID_TAG = "backedupLogZxid";
+    private final static String BACKEDUP_SNAP_TAG = "backedupSnapZxid";
+    private File statusFile;
+
+    /**
+     * Create an instance of BackupStatus for reading and updating the
+     * status
+     * @param backupStatusDir the directory for the backup status file
+     * @throws IOException
+     */
+    public BackupStatus(File backupStatusDir) {
+        statusFile = null;
+
+        if (backupStatusDir != null) {
+            statusFile = new File(backupStatusDir, STATUS_FILENAME);
+        }
+    }
+
+    /**
+     * Create the backup status if it does not already exist;  Initializes backup
+     * point to 0L, 0L.  Otherwise returns the current backup point.
+     * @return the current backup point
+     * @throws IOException
+     */
+    public synchronized BackupPoint createIfNeeded() throws IOException {
+        if (statusFile == null) {
+            throw new IllegalArgumentException("A backup status directory has not been specified.");
+        }
+
+        if (!statusFile.getParentFile().exists()) {
+            statusFile.getParentFile().mkdirs();
+        }
+
+        if (!statusFile.exists()) {
+            update(BackupUtil.INVALID_LOG_ZXID, BackupUtil.INVALID_SNAP_ZXID);
+        }
+
+        return read();
+    }
+
+    /**
+     * Get the latest backup point
+     * @return the latest backup point, or MAX_VALUE, MAX_VALUE if the backup
+     *      status file does not exist
+     */
+    public synchronized BackupPoint read() throws IOException {
+        BackupPoint status = new BackupPoint(Long.MAX_VALUE, Long.MAX_VALUE);
+
+        if (statusFile != null && statusFile.exists()) {
+            FileInputStream is = null;
+            FileLock fileLock = null;
+
+            // Synchronize with writers from other processes
+            try {
+                is = new FileInputStream(statusFile);
+                InputArchive ia = BinaryInputArchive.getArchive(is);
+                fileLock = is.getChannel().lock(0L, Long.MAX_VALUE, true);
+                status = new BackupPoint(ia.readLong(BACKEDUP_ZXID_TAG), ia.readLong(BACKEDUP_SNAP_TAG));
+            } finally {
+                if (fileLock != null) {
+                    fileLock.release();
+                }
+
+                if (is != null) {
+                    is.close();
+                }
+            }
+        }
+
+        return status;
+    }
+
+    /**
+     * Update the backup point in the status file.  Creates the status file if needed.
+     * @param backupPoint the new backup point
+     * @throws IOException
+     */
+    public synchronized void update(BackupPoint backupPoint) throws IOException {
+        update(backupPoint.getLogZxid(), backupPoint.getSnapZxid());
+    }
+
+    /**
+     * Update the backup point in the status file, Creates the status file if needed.
+     * @param logZxid the latest backed up txn log zxid
+     * @param snapZxid the starting zxid of the latest backed up snapshot
+     * @throws IOException
+     */
+    public synchronized void update(long logZxid, long snapZxid) throws IOException {
+        if (statusFile == null) {
+            throw new IllegalArgumentException("A backup status file has not been specified.");
+        }
+
+        if (!statusFile.exists()) {
+            System.out.println("Creating file " + statusFile.getAbsolutePath());
+            statusFile.createNewFile();
+        }
+
+        FileOutputStream os = null;
+        FileLock fileLock = null;
+
+        try {
+            os = new FileOutputStream(statusFile, false);
+            OutputArchive oa = BinaryOutputArchive.getArchive(os);
+            // Synchronize with readers and writers from other processes
+            fileLock = os.getChannel().lock();
+            oa.writeLong(logZxid, BACKEDUP_ZXID_TAG);
+            oa.writeLong(snapZxid, BACKEDUP_SNAP_TAG);
+        } finally {
+            if (os != null) {
+                os.flush();
+            }
+
+            if (fileLock != null) {
+                fileLock.release();
+            }
+
+            if (os != null) {
+                os.close();
+            }
+        }
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupStorageProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupStorageProvider.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * Interface for a backup storage provider
+ */
+public interface BackupStorageProvider {
+
+    /**
+     * Get the metadata for a backed-up file with the given name.
+     * @param file the file name relative to the root of the backup storage provider
+     * @return the metadata for the backed-up file
+     * @throws IOException
+     */
+    BackupFileInfo getBackupFileInfo(File file) throws IOException;
+
+    /**
+     * Get the metadata for backedup files with the given prefix.
+     * @param path path relative to the root of the backup storage provider
+     * @param prefix The file prefix
+     * @return the list of files matching the prefix
+     * @throws IOException
+     */
+    List<BackupFileInfo> getBackupFileInfos(File path, String prefix) throws IOException;
+
+    /**
+     * Get the list of directories under the given path
+     * @param path the location from where to get the list of directories
+     * @return list of the full child directory names relative to the root of the storage provider
+     * @throws IOException
+     */
+    List<File> getDirectories(File path) throws IOException;
+
+    /**
+     * Open a file
+     * @param path the path of the file to open
+     * @return stream of the file
+     * @throws IOException
+     */
+    InputStream open(File path) throws IOException;
+
+    /**
+     * Copy a local file to backup storage.
+     * This method must guarantee a valid and transactional operation, or implement the operation
+     * in such a way that the {@link #cleanupInvalidFiles(File path) cleanup} method can cleanup
+     * after any interrupted operations.
+     * @param srcFile the local file
+     * @param destName the name to use in backup storage
+     * @throws IOException
+     */
+    void copyToBackupStorage(File srcFile, File destName) throws IOException;
+
+    /**
+     * Copy a file from backup storage to local storage
+     * @param srcName the name of the backup file to copy
+     * @param destFile the local file to which to copy the file
+     * @throws IOException
+     */
+    void copyToLocalStorage(File srcName, File destFile) throws IOException;
+
+    /**
+     * Delete a file from backup storage
+     * @param fileToDelete the name of the backup file to delete
+     * @throws IOException
+     */
+    void delete(File fileToDelete) throws IOException;
+
+    /**
+     * Cleanup any invalid files that may have been left behind by failed operations on the
+     * storage provider
+     * @throws IOException
+     */
+    void cleanupInvalidFiles(File path) throws IOException;
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
@@ -1,0 +1,343 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.*;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+
+import org.apache.zookeeper.server.persistence.Util;
+
+/**
+ * Utility methods related to backups
+ */
+public class BackupUtil {
+    // first valid tnxlog zxid is 1 while first valid zxid for snapshots is 0
+    public static final long INVALID_LOG_ZXID = 0;
+    public static final long INVALID_SNAP_ZXID = -1;
+    public static final String LOST_LOG_PREFIX = "lostLogs";
+
+    /**
+     * Identifiers for the two zxids in a backedup file name
+     */
+    public enum ZxidPart {
+        MIN_ZXID,
+        MAX_ZXID
+    }
+
+    /**
+     * Identifiers for the backup file types
+     */
+    public enum BackupFileType {
+        SNAPSHOT(Util.SNAP_PREFIX),
+        TXNLOG(Util.TXLOG_PREFIX),
+        LOSTLOG(BackupUtil.LOST_LOG_PREFIX);
+
+        private final String prefix;
+
+        BackupFileType(String prefix) {
+            this.prefix = prefix;
+        }
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        public static BackupFileType fromPrefix(String prefix) {
+            switch (prefix) {
+                case BackupUtil.LOST_LOG_PREFIX:
+                    return LOSTLOG;
+                default:
+                    return fromBaseFileType(Util.FileType.fromPrefix(prefix));
+            }
+        }
+
+        public static BackupFileType fromBaseFileType(Util.FileType type) {
+            switch (type) {
+                case SNAPSHOT:
+                    return BackupFileType.SNAPSHOT;
+                case TXNLOG:
+                    return BackupFileType.TXNLOG;
+                default:
+                    throw new IllegalArgumentException("Unknown base file type: " + type);
+            }
+        }
+
+        public static Util.FileType toBaseFileType(BackupFileType type) {
+            switch (type) {
+                case SNAPSHOT:
+                    return Util.FileType.SNAPSHOT;
+                case TXNLOG:
+                    return Util.FileType.TXNLOG;
+                default:
+                    throw new IllegalArgumentException("No matching base file type for: " + type);
+            }
+        }
+    }
+
+    /**
+     * Identifiers for sort direction
+     */
+    public enum SortOrder {
+        ASCENDING,
+        DESCENDING
+    }
+
+    private static class BackupFileComparator implements Comparator<BackupFileInfo>, Serializable
+    {
+        private static final long serialVersionUID = -2648639884525140318L;
+
+        private SortOrder sortOrder;
+        private ZxidPart whichZxid;
+
+        public BackupFileComparator(ZxidPart whichZxid, SortOrder sortOrder) {
+            this.sortOrder = sortOrder;
+            this.whichZxid = whichZxid;
+        }
+
+        public int compare(BackupFileInfo o1, BackupFileInfo o2) {
+            long z1 = o1.getZxid(whichZxid);
+            long z2 = o2.getZxid(whichZxid);
+
+            int result = Long.compare(z1, z2);
+
+            if (result == 0) {
+                File f1 = o1.getBackedUpFile();
+                File f2 = o2.getBackedUpFile();
+
+                result = f1.compareTo(f2);
+            }
+
+            return sortOrder == SortOrder.ASCENDING ? result : -result;
+        }
+    }
+
+    private static Function<BackupFileInfo, Range<Long>> zxidRangeExtractor =
+            new Function<BackupFileInfo, Range<Long>>() {
+                public Range<Long> apply(BackupFileInfo fileInfo) {
+                    return fileInfo.getZxidRange();
+                }
+            };
+
+    public static String makeBackupName(String standardName, long highZxid) {
+        return standardName.indexOf('-') >= 0
+            ? standardName
+            : String.format("%s-%x", standardName, highZxid);
+    }
+
+    /**
+     * Helper method for getting the proper file prefix for a backup file type.
+     * @param fileType the file type whose prefix to get
+     * @return the prefix for the file
+     */
+    public static String getPrefix(BackupFileType fileType) {
+        return fileType.getPrefix();
+    }
+
+    /**
+     * Sort a list of backup files based on the specified zxid in the requested sort order
+     * @param files the files to sort
+     * @param whichZxid which zxid to sort by
+     * @param sortOrder which direction in which to sort the zxid
+     */
+    public static void sort(List<BackupFileInfo> files, ZxidPart whichZxid, SortOrder sortOrder) {
+        Collections.sort(files, new BackupFileComparator(whichZxid, sortOrder));
+    }
+
+    /**
+     * Get an zxid range from the backup file name
+     * @param name the name of the file
+     * @param prefix the prefix to match
+     * @return return the zxid range for the file
+     */
+    public static Range<Long> getZxidRangeFromName(String name, String prefix) {
+        Range<Long> zxidRange = Range.singleton(-1L);
+        String nameParts[] = name.split("[\\.-]");
+
+        if (nameParts.length == 3 && nameParts[0].equals(prefix)) {
+            try {
+                zxidRange = Range.closed(Long.parseLong(nameParts[1], 16), Long.parseLong(nameParts[2], 16));
+            } catch (NumberFormatException e) { }
+        }
+
+        return zxidRange;
+    }
+
+    /**
+     * Sort backup files by the min zxid part in ascending order
+     * @param bsp the backup provide from which to get the files
+     * @param fileType the backup file to get
+     * @return the files listed in the specified order using the request zxid
+     */
+    public static List<BackupFileInfo> getBackupFilesByMin(BackupStorageProvider bsp, BackupFileType fileType)
+            throws IOException {
+        return getBackupFilesByMin(bsp, null, fileType);
+    }
+
+    /**
+     * Sort backup files by the min zxid part in ascending order
+     * @param bsp the backup provide from which to get the files
+     * @param fileType the backup file to get
+     * @return the files listed in the specified order using the request zxid
+     */
+    public static List<BackupFileInfo> getBackupFilesByMin(
+            BackupStorageProvider bsp,
+            File path,
+            BackupFileType fileType) throws IOException {
+
+        return getBackupFiles(bsp, path, fileType, ZxidPart.MIN_ZXID, SortOrder.ASCENDING);
+    }
+
+    /**
+     * Sort backup files by the specified zxid part
+     * @param bsp the backup provide from which to get the files
+     * @param fileType the backup file to get
+     * @param whichZxid which zxid to sort by
+     * @param sortOrder which direction to sort the zxid in
+     * @return the file info for the matching files sorted on the request zxid
+     */
+    public static List<BackupFileInfo> getBackupFiles(
+            BackupStorageProvider bsp,
+            BackupFileType fileType,
+            ZxidPart whichZxid,
+            SortOrder sortOrder) throws IOException {
+
+        return getBackupFiles(bsp, null, fileType, whichZxid, sortOrder);
+    }
+
+    /**
+     * Sort backup files by the specified zxid part
+     * @param bsp the backup provide from which to get the files
+     * @param fileType the backup file to get
+     * @param whichZxid which zxid to sort by
+     * @param sortOrder which direction to sort the zxid in
+     * @return the file info for the matching files sorted on the request zxid
+     */
+    public static List<BackupFileInfo> getBackupFiles(
+            BackupStorageProvider bsp,
+            File path,
+            BackupFileType fileType,
+            ZxidPart whichZxid, SortOrder
+            sortOrder) throws IOException {
+
+        return getBackupFiles(bsp, path, new BackupFileType[] { fileType }, whichZxid, sortOrder);
+    }
+
+    /**
+     * Sort the backup files of the requested types by the specified zxid part
+     * @param bsp the backup provide from which to get the files
+     * @param fileTypes the backup file types to get
+     * @param whichZxid which zxid to sort by
+     * @param sortOrder which direction in which to sort based on the requested zxid
+     * @return the file info for the matching files sorted on the request zxid
+     */
+    public static List<BackupFileInfo> getBackupFiles(
+            BackupStorageProvider bsp,
+            BackupFileType[] fileTypes,
+            ZxidPart whichZxid,
+            SortOrder sortOrder) throws IOException {
+
+        return getBackupFiles(bsp, null, fileTypes, whichZxid, sortOrder);
+    }
+
+    /**
+     * Sort the backup files of the requested types by the specified zxid part
+     * @param bsp the backup provide from which to get the files
+     * @param fileTypes the backup file types to get
+     * @param whichZxid which zxid to sort by
+     * @param sortOrder which direction in which to sort based on the requested zxid
+     * @return the file info for the matching files sorted on the request zxid
+     */
+    public static List<BackupFileInfo> getBackupFiles(
+            BackupStorageProvider bsp,
+            File path,
+            BackupFileType[] fileTypes,
+            ZxidPart whichZxid,
+            SortOrder sortOrder) throws IOException {
+
+        List<BackupFileInfo> files = new ArrayList<BackupFileInfo>();
+
+        if (fileTypes.length == 1) {
+            files = bsp.getBackupFileInfos(path, getPrefix(fileTypes[0]));
+        } else {
+            for (BackupFileType fileType : fileTypes) {
+                files.addAll(bsp.getBackupFileInfos(path, getPrefix(fileType)));
+            }
+        }
+
+        sort(files, whichZxid, sortOrder);
+        return files;
+    }
+
+    /**
+     * Get the latest backup file of the given type.
+     * @param bsp the backup storage provider
+     * @param fileType the file to get
+     * @param whichZxid sorted based on which zxid
+     * @return the latest backup file if one exists, null otherwise
+     * @throws IOException
+     */
+    public static BackupFileInfo getLatest(
+            BackupStorageProvider bsp,
+            BackupFileType fileType,
+            ZxidPart whichZxid) throws IOException {
+        List<BackupFileInfo> files = getBackupFiles(bsp, fileType, whichZxid, SortOrder.DESCENDING);
+
+        return files.isEmpty() ? null : files.get(0);
+    }
+
+    /**
+     * Get both the zxids for each of the files matching the prefix
+     * @param bsp the backup storage provide to get the files from
+     * @param fileType the backup file to get
+     * @return the list of zxid pairs
+     * @throws IOException
+     */
+    public static List<Range<Long>> getZxids(BackupStorageProvider bsp, BackupFileType fileType)
+            throws IOException {
+
+        return getZxids(bsp, null, fileType);
+    }
+
+    /**
+     * Get both the zxids for each of the files matching the prefix
+     * @param bsp the backup storage provide to get the files from
+     * @param fileType the backup file to get
+     * @return the list of zxid pairs
+     * @throws IOException
+     */
+    public static List<Range<Long>> getZxids(
+            BackupStorageProvider bsp,
+            File path,
+            BackupFileType fileType) throws IOException {
+
+        return Lists.newArrayList(
+                Lists.transform(
+                        getBackupFiles(bsp, path, fileType, ZxidPart.MIN_ZXID, SortOrder.ASCENDING),
+                        zxidRangeExtractor));
+    }
+
+    // Utility class
+    private BackupUtil() {}
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/HdfsBackupStorage.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/HdfsBackupStorage.java
@@ -1,0 +1,236 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.PathFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * HDFS implementation of BackupStorageProvider
+ */
+public class HdfsBackupStorage implements BackupStorageProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(HdfsBackupStorage.class);
+    public static final String TMP_FILE_PREFIX = "TMP_";
+
+    private final Path storagePath;
+    protected FileSystem store;
+    private final ReadWriteLock rwLock;
+    private final Lock sharedLock;
+    private final Lock exclusiveLock;
+
+    private static class PrefixFilter implements PathFilter {
+        private final String prefix;
+        public PrefixFilter(String prefix) { this.prefix = prefix; }
+        public boolean accept(Path path) {
+            return path.getName().startsWith(prefix);
+        }
+    }
+
+    /**
+     * @param hdfsConfig location of hdfs configuration files
+     * @param hdfsPath the path, relative to the home directory, to use as the as the base path in
+     *                 hdfs for the other interfaces
+     * @throws IOException
+     */
+    public HdfsBackupStorage(File hdfsConfig, String hdfsPath) throws IOException {
+        LOG.info("hdfsConfig={}", hdfsConfig);
+        LOG.info("hdfsPath={}", hdfsPath);
+
+        rwLock = new ReentrantReadWriteLock();
+        sharedLock = rwLock.readLock();
+        exclusiveLock = rwLock.writeLock();
+
+        store = FileSystem.get(buildHdfsConfiguration(hdfsConfig));
+        Path home = store.getHomeDirectory();
+        storagePath = new Path(home, hdfsPath);
+
+        LOG.info("Backup base storage path is {}", storagePath);
+
+        if (!store.exists(storagePath)) {
+            LOG.info("Creating path {}", storagePath);
+            store.mkdirs(storagePath);
+        }
+    }
+
+    @Override
+    public List<File> getDirectories(File path) throws IOException {
+        Path fullPath = fullPath(path);
+        FileStatus[] files = store.listStatus(fullPath);
+        ArrayList<File> dirs = new ArrayList<File>();
+
+        for (FileStatus status : files) {
+            if (status.isDirectory()) {
+                dirs.add(new File(path, status.getPath().getName()));
+            }
+        }
+
+        return dirs;
+    }
+
+    @Override
+    public BackupFileInfo getBackupFileInfo(File file) throws IOException {
+        Path fullPath = fullPath(file);
+        FileStatus status = store.getFileStatus(fullPath);
+        return new BackupFileInfo(file, status.getModificationTime(), status.getLen());
+    }
+
+    @Override
+    public List<BackupFileInfo> getBackupFileInfos(final File path, String prefix) throws IOException {
+        Path fullPath = fullPath(path);
+        FileStatus[] files = store.listStatus(fullPath, new PrefixFilter(prefix));
+
+        if (files.length == 0) {
+            return new ArrayList<BackupFileInfo>(0);
+        }
+
+        return Lists.newArrayList(
+                Lists.transform(Lists.newArrayList(files),
+                new Function<FileStatus, BackupFileInfo>() {
+                    public BackupFileInfo apply(FileStatus status) {
+                        return new BackupFileInfo(
+                                new File(path, status.getPath().getName()),
+                                status.getModificationTime(),
+                                status.getLen());
+                    }
+                }));
+    }
+
+    @Override
+    public InputStream open(File path) throws IOException {
+        Path fullPath = fullPath(path);
+        return store.open(fullPath);
+    }
+
+    @Override
+    public void copyToBackupStorage(File srcFile, File destFile) throws IOException {
+        Path src = new Path(srcFile.getAbsolutePath());
+        Path dest = fullPath(destFile);
+        Path destTmp = fullPath(tempName(destFile));
+
+        LOG.info("Copying file {} to remote storage as {} via {}",
+                srcFile.getAbsolutePath(),
+                dest,
+                destTmp);
+
+        sharedLock.lock();
+
+        try {
+            // First copy to a temporary file and then rename to simulate an atomic copy.
+            // cleanupInvalidFiles can be used to remove any failed copies.
+            // Note: move/rename is NOT atomic until Hadoop 2.0 but we're accepting the small
+            // chance of failure
+            store.copyFromLocalFile(src, destTmp);
+            store.rename(destTmp, dest);
+        } finally {
+            sharedLock.unlock();
+        }
+    }
+
+    @Override
+    public void copyToLocalStorage(File srcFile, File destFile) throws IOException {
+        Path dest = new Path(destFile.getAbsolutePath());
+        Path src = fullPath(srcFile);
+
+        LOG.info("Copying from {} to {}", src, dest);
+        store.copyToLocalFile(src, dest);
+    }
+
+    @Override
+    public void delete(File fileToDelete) throws IOException {
+        store.delete(fullPath(fileToDelete), false);
+    }
+
+    @Override
+    public void cleanupInvalidFiles(File path) throws IOException {
+        Path fullPath = fullPath(path);
+
+        exclusiveLock.lock();
+
+        try {
+            FileStatus[] files = store.listStatus(fullPath, new PrefixFilter(TMP_FILE_PREFIX));
+
+            for (FileStatus file : files) {
+                store.delete(file.getPath(), false /* not recursive */);
+            }
+        } finally {
+            exclusiveLock.unlock();
+        }
+    }
+
+    /**
+     * Create the full HDFS path given the relative path of the file.
+     * @param path the name of the file
+     * @return the full HDFS path that includes the storagePath and the path
+     */
+    private Path fullPath(File path) {
+        return path == null ? storagePath : new Path(storagePath, path.getPath());
+    }
+
+    /**
+     * Create a name to be used for a temporary copy of the specified file
+     * @param file the file for which to create a temporary name
+     * @return the temporary name
+     */
+    private File tempName(File file) {
+        Preconditions.checkArgument(!file.isDirectory());
+
+        String name = TMP_FILE_PREFIX + file.getName();
+        return new File(file.getParentFile(), name);
+    }
+
+    /**
+     * Build the configuration to use for HDFS access.
+     * Note that this falls back to the local filesystem if the hdfs configuration
+     * files do not exist.
+     *
+     * @param hdfsConfigDir the configuration directory.
+     * @return
+     */
+    private Configuration buildHdfsConfiguration(File hdfsConfigDir) {
+        Configuration config = new Configuration();
+
+        if (hdfsConfigDir != null) {
+            Path parentPath = new Path(hdfsConfigDir.getPath());
+            LOG.info("hdfs configuration path: {}", parentPath);
+            config.addResource(new Path(parentPath, "core-site.xml"));
+            config.addResource(new Path(parentPath, "hdfs-site.xml"));
+        }
+
+        return config;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/HdfsBackupTxnLogIterator.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/HdfsBackupTxnLogIterator.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.Range;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.zookeeper.server.persistence.FileStreamTxnIterator;
+
+public class HdfsBackupTxnLogIterator extends FileStreamTxnIterator {
+    private static final Logger LOG = LoggerFactory.getLogger(HdfsBackupTxnLogIterator.class);
+
+    HdfsBackupStorage storage;
+    Range<Long> zxidRange = Range.all();
+    List<BackupFileInfo> files;
+    int currentFile = -1;
+
+    /**
+     * Iterate over all txns in all log files
+     * @param storage hdfs storage provider to use
+     * @throws IOException
+     */
+    public HdfsBackupTxnLogIterator(HdfsBackupStorage storage) throws IOException {
+        this(storage, null, null);
+    }
+
+    /**
+     * Iterate over all txns in a single log file
+     * @param storage hdfs storage provider to use
+     * @param file the file to iterate over
+     * @throws IOException
+     */
+    public HdfsBackupTxnLogIterator(HdfsBackupStorage storage, File file) throws IOException {
+        this(storage, file, null);
+    }
+
+    /**
+     * Iterate over all txns in a given zxid range regardless of which file they are in
+     * @param storage hdfs storage provider to use
+     * @param zxidRange the range to iterate over.
+     * @throws IOException
+     */
+    public HdfsBackupTxnLogIterator(
+            HdfsBackupStorage storage,
+            Range<Long> zxidRange) throws IOException {
+
+        this(storage, null, zxidRange);
+    }
+
+    /**
+     * Iterate over all txns within an optional zxid range either in a single file or all files
+     * @param storage hdfs storage provider to use
+     * @param file the file to iterate over, if null all files in storage provider will be considered
+     * @param zxidRange the range to iterate over, if null all zxids will be considered
+     * @throws IOException
+     */
+    public HdfsBackupTxnLogIterator(
+            HdfsBackupStorage storage,
+            File file,
+            Range<Long> zxidRange) throws IOException {
+
+        super(LOG);
+
+        this.storage = storage;
+
+        if (zxidRange != null) {
+            this.zxidRange = zxidRange;
+        }
+
+        if (file == null) {
+            this.files = BackupUtil.getBackupFiles(
+                    storage,
+                    BackupUtil.BackupFileType.TXNLOG,
+                    BackupUtil.ZxidPart.MIN_ZXID,
+                    BackupUtil.SortOrder.ASCENDING);
+        } else {
+            this.files = new ArrayList<BackupFileInfo>();
+            this.files.add(storage.getBackupFileInfo(file));
+        }
+
+        if (this.zxidRange.hasUpperBound()) {
+            setMaxZxid(zxidRange.upperEndpoint());
+        }
+
+        goToNextLog();
+        next();
+
+        if (this.zxidRange.hasLowerBound()) {
+            fastForwardTo(zxidRange.lowerEndpoint());
+        }
+    }
+
+    public InputStream getNextLog() throws IOException {
+
+        for (currentFile++; currentFile < files.size(); currentFile++) {
+            BackupFileInfo file = files.get(currentFile);
+
+            if (zxidRange.isConnected(file.getZxidRange())) {
+                return storage.open(file.getBackedUpFile());
+            }
+        }
+
+        return null;
+    }
+
+    public String getCurrentLogFilePath() {
+        return currentFile >= 0 && currentFile < files.size()
+                ? files.get(currentFile).getBackedUpFile().getName()
+                : null;
+    }
+
+    public long getStorageSize() throws IOException {
+        long sum = 0;
+        int i = currentFile + 1;
+
+        if (currentFile >= 0 && currentFile < files.size() && getInputStream() != null) {
+            sum += files.get(currentFile).getSize() - getInputStream().getPosition();
+        }
+
+        while (i < files.size()) {
+            BackupFileInfo file = files.get(i);
+
+            if (zxidRange.isConnected(file.getZxidRange())) {
+                sum += file.getSize();
+            }
+        }
+
+        return sum;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RestoreFromBackupTool.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RestoreFromBackupTool.java
@@ -1,0 +1,436 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Range;
+
+import org.apache.zookeeper.metrics.NullMetricsReceiver;
+import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
+import org.apache.zookeeper.server.backup.BackupUtil.ZxidPart;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.server.util.ZxidUtils;
+
+/**
+ *  This is a tool to restore, from backup storage, a snapshot and set of transaction log files
+ *  that combine to represent a transactionally consistent image of a ZooKeeper ensemble at
+ *  some zxid.
+ */
+public class RestoreFromBackupTool {
+    private static final int MAX_RETRIES = 10;
+
+    BackupStorageProvider storage;
+
+    FileTxnSnapLog snapLog;
+    long zxidToRestore;
+    boolean dryRun = false;
+
+    List<BackupFileInfo> logs;
+    List<BackupFileInfo> snaps;
+    List<BackupFileInfo> filesToCopy;
+
+    int mostRecentLogNeededIndex;
+    int snapNeededIndex;
+    int oldestLogNeededIndex;
+
+    static public void main(String[] args) {
+        RestoreFromBackupTool tool = new RestoreFromBackupTool();
+
+        tool.parseArgs(args);
+
+        if (!tool.runWithRetries()) {
+            System.err.println("Restore failed. See log for details.");
+            System.exit(10);
+        }
+    }
+
+    public static void usage() {
+        System.out.println("Usage: RestoreFromBackupTool restore <restore_point> <backup_store> <data_destination> <log_destination>");
+        System.out.println("    restore_point: the point to restore to, either the string 'latest' or a zxid in hex format.");
+        System.out.println("    backup_store: the connection information for the backup store");
+        System.out.println("       For HDFS the format is: hdfs:<config_path>:<backup_path>");
+        System.out.println("           config_path: the path to the hdfs configuration");
+        System.out.println("           backup_path: the path within hdfs where the backups are stored");
+        System.out.println("    data_destination: local destination path for restored snapshots");
+        System.out.println("    log_destination: local destination path for restored txlogs");
+    }
+
+    /**
+     * Default constructor; requires using parseArgs to setup state.
+     */
+    public RestoreFromBackupTool() {
+        filesToCopy = new ArrayList<BackupFileInfo>();
+        snapNeededIndex = -1;
+        mostRecentLogNeededIndex = -1;
+        oldestLogNeededIndex = -1;
+    }
+
+    /**
+     * Constructor
+     * @param storageProvider the backup provider from which to restore the backups
+     * @param snapLog the snap and log provider to use
+     * @param zxidToRestore the zxid upto which to restore, or Long.MAX to restore to the latest
+     *                      available transactionally consistent zxid.
+     * @param dryRun whether this is a dryrun in which case no files are actually copied
+     */
+    public RestoreFromBackupTool(
+            BackupStorageProvider storageProvider,
+            FileTxnSnapLog snapLog,
+            long zxidToRestore,
+            boolean dryRun) {
+
+        this();
+
+        this.storage = storageProvider;
+        this.zxidToRestore = zxidToRestore;
+        this.snapLog = snapLog;
+        this.dryRun = dryRun;
+    }
+
+    /**
+     * Parse and validate arguments to the tool
+     * @param args the set of arguments
+     * @return true if the arguments parse correctly; false in all other cases.
+     * @throws IOException if the backup provider cannot be instantiated correctly.
+     */
+    public void parseArgs(String[] args) {
+        if (args.length < 1) {
+            System.err.println("Must specify a command to run");
+            usage();
+            System.exit(1);
+        }
+
+        if (!args[0].equals("restore")) {
+            System.err.println("Invalid command" + args[0]);
+            usage();
+            System.exit(2);
+        }
+
+        if (args.length != 5 && args.length != 6) {
+            System.err.println("Invalid number of arguments for restore command");
+            usage();
+            System.exit(3);
+        }
+
+        if (args[1].equals("latest")) {
+            zxidToRestore = Long.MAX_VALUE;
+        } else {
+            int base = 10;
+            String numStr = args[1];
+
+            if (args[1].startsWith("0x")) {
+                numStr = args[1].substring(2);
+                base = 16;
+            }
+
+            try {
+                zxidToRestore = Long.parseLong(numStr, base);
+            } catch (NumberFormatException nfe) {
+                System.err.println("Invalid number specified for restore point");
+                usage();
+                System.exit(4);
+            }
+        }
+
+        String[] providerParts = args[2].split(":");
+
+        if (providerParts.length != 3 || !providerParts[0].equals("hdfs")) {
+            System.err.println("HDFS is the only backup provider supported or the specification is incorrect.");
+            usage();
+            System.exit(5);
+        }
+
+        if (args.length == 6) {
+            if (!args[5].equals("-n")) {
+                System.err.println("Invalid argument: " + args[5]);
+                usage();
+                System.exit(6);
+            }
+
+            dryRun = true;
+        }
+
+        try {
+            storage = new HdfsBackupStorage(new File(providerParts[1]), providerParts[2]);
+        } catch (IOException ioe) {
+            System.err.println("Could not setup backup provider (HDFS)" + ioe);
+            System.exit(7);
+        }
+
+        try {
+            File snapDir = new File(args[3]);
+            File logDir = new File(args[4]);
+            snapLog = new FileTxnSnapLog(logDir, snapDir, NullMetricsReceiver.get());
+        } catch (IOException ioe) {
+            System.err.println("Could not setup transaction log utility." + ioe);
+            System.exit(8);
+        }
+    }
+
+    /**
+     * Attempts to perform a restore with up to MAX_RETRIES retries.
+     * @return true if the restore completed successfully, false in all other cases.
+     */
+    public boolean runWithRetries() {
+        int tries = 0;
+
+        if (dryRun) {
+            System.out.println("This is a DRYRUN, no files will actually be copied.");
+        }
+
+        while (tries < MAX_RETRIES) {
+            if (run()) {
+                return true;
+            }
+
+            if (tries >= MAX_RETRIES) {
+                break;
+            }
+
+            tries++;
+            System.err.println("Restore attempt failed; attempting again. "
+                    + tries + "/" + MAX_RETRIES);
+        }
+
+        System.err.println("Failed to restore after " + (tries + 1) + " attempts.");
+        return false;
+    }
+
+    /**
+     * Attempts to perform a restore.
+     * @return true if the restore completed successfully, false in all other cases.
+     */
+    public boolean run() {
+        try {
+            if (!findFilesToRestore()) {
+                System.err.println("Failed to find a valid snapshot and logs to restore.");
+                return false;
+            }
+
+            for (BackupFileInfo backedupFile : filesToCopy) {
+                String standardFilename = backedupFile.getStandardFile().getName();
+                File base = backedupFile.getFileType() == BackupFileType.SNAPSHOT
+                        ? snapLog.getSnapDir()
+                        : snapLog.getDataDir();
+                File destination = new File(base, standardFilename);
+
+                if (!destination.exists()) {
+                    System.out.println("Copying " + backedupFile.getBackedUpFile()
+                            + " to "+ destination.getPath() + ".");
+
+                    if (!dryRun) {
+                        storage.copyToLocalStorage(backedupFile.getBackedUpFile(), destination);
+                    }
+                } else {
+                    System.out.println("Skipping " + backedupFile.getBackedUpFile()
+                            + " because it already exists as " + destination.getPath() + ".");
+                }
+            }
+
+            if (zxidToRestore != Long.MAX_VALUE && !this.dryRun) {
+                snapLog.truncateLog(zxidToRestore);
+            }
+        } catch (IOException ioe) {
+            System.err.println("Hit exception when attempting to restore." + ioe.getMessage());
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Finds the set of files (snapshot and txlog) that are required to restore to a transactionally
+     * consistent point for the requested zxid.
+     * Note that when restoring to the latest zxid, the transactionally consistent point may NOT
+     * be the latest backed up zxid if logs have been lost in between; or if there is no
+     * transactionally consistent point in which nothing will be restored but the restored will
+     * be considered successful.
+     * @return true if a transactionally consistent set of files could be found for the requested
+     *         restore point; false in all other cases.
+     * @throws IOException
+     */
+    private boolean findFilesToRestore() throws IOException {
+        snaps = BackupUtil.getBackupFiles(
+                    storage,
+                    BackupFileType.SNAPSHOT,
+                    ZxidPart.MIN_ZXID,
+                    BackupUtil.SortOrder.DESCENDING);
+        logs = BackupUtil.getBackupFiles(
+                storage,
+                new BackupFileType[] { BackupFileType.TXNLOG, BackupFileType.LOSTLOG },
+                ZxidPart.MIN_ZXID,
+                BackupUtil.SortOrder.DESCENDING);
+        filesToCopy = new ArrayList<BackupFileInfo>();
+
+        snapNeededIndex = -1;
+
+        while (findNextPossibleSnapshot()) {
+            if (findLogRange()) {
+                filesToCopy.add(snaps.get(snapNeededIndex));
+                filesToCopy.addAll(logs.subList(mostRecentLogNeededIndex, oldestLogNeededIndex + 1));
+                return true;
+            }
+
+            if (zxidToRestore != Long.MAX_VALUE) {
+                break;
+            }
+        }
+
+        // Restoring to an empty data tree (i.e. no backup files) is valid for restoring to
+        // latest
+        if (zxidToRestore == Long.MAX_VALUE) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Find the next snapshot whose range is below the requested restore point.
+     * Note: in practice this only gets called once when zxidToRestore != Long.MAX
+     * @return true if a snapshot is found; false in all other cases.
+     */
+    private boolean findNextPossibleSnapshot() {
+        for (snapNeededIndex++; snapNeededIndex < snaps.size(); snapNeededIndex++) {
+            if (snaps.get(snapNeededIndex).getZxidRange().upperEndpoint() <= zxidToRestore) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Find the range of log files needed to make the current proposed snapshot transactionally
+     * consistent to the requested zxid.
+     * When zxidToRestore == Long.MAX the transaction log range terminates either on the most
+     * recent backedup txnlog OR the last txnlog prior to a lost log range (assuming that log
+     * still makes the snapshot transactionally consistent).
+     * @return true if a valid log range is found; false in all other cases.
+     */
+    private boolean findLogRange() {
+        Preconditions.checkState(snapNeededIndex >= 0 && snapNeededIndex < snaps.size());
+
+        if (logs.size() == 0) {
+            return false;
+        }
+
+        BackupFileInfo snap = snaps.get(snapNeededIndex);
+        Range<Long> snapRange = snap.getZxidRange();
+        oldestLogNeededIndex = logs.size() - 1;
+        mostRecentLogNeededIndex = 0;
+
+        // Find the first txlog that might make the snapshot valid, OR is a lost log
+        for (int i = 0; i < logs.size() - 1; i++) {
+            BackupFileInfo log = logs.get(i);
+            Range<Long> logRange = log.getZxidRange();
+
+            if (logRange.lowerEndpoint() <= snapRange.lowerEndpoint()) {
+                oldestLogNeededIndex = i;
+                break;
+            }
+        }
+
+        // Starting if the oldest log that might allow the snapshot to be valid, find the txnlog
+        // that includes the restore point, OR is a lost log
+        for (int i = oldestLogNeededIndex; i > 0; i--) {
+            BackupFileInfo log = logs.get(i);
+            Range<Long> logRange = log.getZxidRange();
+
+            if (log.getFileType() == BackupFileType.LOSTLOG
+                    || logRange.upperEndpoint() >= zxidToRestore) {
+
+                mostRecentLogNeededIndex = i;
+                break;
+            }
+        }
+
+        return validateLogRange();
+    }
+
+    private boolean validateLogRange() {
+        Preconditions.checkState(oldestLogNeededIndex >= 0);
+        Preconditions.checkState(oldestLogNeededIndex < logs.size());
+        Preconditions.checkState(mostRecentLogNeededIndex >= 0);
+        Preconditions.checkState(mostRecentLogNeededIndex < logs.size());
+        Preconditions.checkState(oldestLogNeededIndex >= mostRecentLogNeededIndex);
+        Preconditions.checkState(snapNeededIndex >= 0);
+        Preconditions.checkState(snapNeededIndex < snaps.size());
+
+        BackupFileInfo snap = snaps.get(snapNeededIndex);
+        BackupFileInfo oldestLog = logs.get(oldestLogNeededIndex);
+        BackupFileInfo newestLog = logs.get(mostRecentLogNeededIndex);
+
+        if (oldestLog.getFileType() == BackupFileType.LOSTLOG) {
+            System.err.println(
+                    "Could not find logs to make the snapshot '" + snap.getBackedUpFile()
+                    + "' valid. Lost logs at " + logs.get(oldestLogNeededIndex).getZxidRange());
+            return false;
+        }
+
+        if (newestLog.getFileType() == BackupFileType.LOSTLOG) {
+            if (zxidToRestore == Long.MAX_VALUE
+                    && oldestLogNeededIndex != mostRecentLogNeededIndex) {
+                // When restoring to the latest, we can use the last valid log prior to lost log
+                // range.
+                mostRecentLogNeededIndex++;
+            } else {
+                System.err.println(
+                        "Could not find logs to make the snapshot '" + snap.getBackedUpFile()
+                        + "' valid. Lost logs at "
+                        + logs.get(mostRecentLogNeededIndex).getZxidRange()
+                        + ".");
+                return false;
+            }
+        }
+
+        Range<Long> fullRange = oldestLog.getZxidRange().span(newestLog.getZxidRange());
+
+        if (fullRange.lowerEndpoint() > snap.getZxidRange().lowerEndpoint()) {
+            System.err.println(
+                    "Could not find logs to make snap '" + snap.getBackedUpFile()
+                    + "' valid. Logs start at zxid "
+                    + ZxidUtils.zxidToString(fullRange.lowerEndpoint())
+                    + ".");
+            return false;
+        }
+
+        if (fullRange.upperEndpoint() < snap.getZxidRange().upperEndpoint()) {
+            System.err.println("Could not find logs to make snap '" + snap.getBackedUpFile()
+                    + "' valid. Logs end at zxid "
+                    + ZxidUtils.zxidToString(fullRange.upperEndpoint())
+                    + ".");
+            return false;
+        }
+
+        if (zxidToRestore != Long.MAX_VALUE && fullRange.upperEndpoint() < zxidToRestore) {
+            System.err.println("Could not find logs to restore to zxid " + zxidToRestore
+                    + ". Logs end at zxid " + ZxidUtils.zxidToString(fullRange.upperEndpoint())
+                    + ".");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RetentionManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RetentionManager.java
@@ -1,0 +1,724 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Range;
+import com.twitter.finagle.stats.*;
+import org.apache.zookeeper.metrics.MetricsReceiver;
+import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
+import org.apache.zookeeper.server.backup.BackupUtil.SortOrder;
+import org.apache.zookeeper.server.backup.BackupUtil.ZxidPart;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.server.persistence.Util;
+import org.apache.zookeeper.server.util.ZxidUtils;
+import org.apache.zookeeper.twitter.metrics.FinagleStatsReceiverWrapper;
+import org.apache.zookeeper.twitter.server.metrics.JvmStatsRegisterer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Manages the retention policies for backup enabled hosts.
+ * Controls purging of local snapshot and txnlog files as well as the retention policies
+ * for backed-up files
+ */
+public class RetentionManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RetentionManager.class);
+
+    private final ArrayList<Timer> timers;
+    private final Configuration config;
+    private final StatsReceiver statsReceiver;
+
+    private volatile boolean isRunning;
+
+    /**
+     * Configuration for the Retention Manager
+     */
+    public static class Configuration {
+        public boolean dryRun;
+        public long localPurgeInterval;
+        public File snapDir;
+        public File txnlogDir;
+        public File backupStatusDir;
+        public int snapRetainCount;
+        public long hdfsRetentionMaintenanceInterval;
+        public File hdfsConfigDir;
+        public String hdfsPath;
+        public int hdfsRecursionDepth;
+        public int hdfsBackupRetentionDays;
+        public boolean hdfsUseAdaptiveSnapRetention;
+
+        /**
+         * Constructor
+         * @param dryRun whether to only report actions that will be taken
+         * @param localPurgeInterval the interval at which to run local purge, in milliseconds
+         * @param snapDir the location of the local snapshots directory
+         * @param txnlogDir the location of the local txnlog directory
+         * @param backupStatusDir the location of the local backup status directory
+         * @param snapRetainCount the minimum number of snapshots to retain locally
+         * @param hdfsRetentionMaintenanceInterval the interval at which to run hdfs retention
+         *                                         maintenance, in milliseconds
+         * @param hdfsConfigDir the location of hdfs configuration
+         * @param hdfsPath the path to the backups in hdfs
+         * @param hdfsRecursionDepth the depth to which to recurse from hdfsPath; each directory
+         *                           is treated individually for retention calculations
+         * @param hdfsBackupRetentionDays the retention period to for backups, in days
+         * @param hdfsUseAdaptiveSnapRetention whether to use adaptive retention for snapshots;
+         *                                     when true snapshots are pruned in a progressively
+         *                                     more aggresive manner as they age
+         */
+        public Configuration(
+                boolean dryRun,
+                long localPurgeInterval,
+                File snapDir,
+                File txnlogDir,
+                File backupStatusDir,
+                int snapRetainCount,
+                long hdfsRetentionMaintenanceInterval,
+                File hdfsConfigDir,
+                String hdfsPath,
+                int hdfsRecursionDepth,
+                int hdfsBackupRetentionDays,
+                boolean hdfsUseAdaptiveSnapRetention) {
+
+            this.dryRun = dryRun;
+            this.localPurgeInterval = localPurgeInterval;
+            this.snapDir = snapDir;
+            this.txnlogDir = txnlogDir;
+            this.backupStatusDir = backupStatusDir;
+            this.snapRetainCount = snapRetainCount;
+            this.hdfsRetentionMaintenanceInterval = hdfsRetentionMaintenanceInterval;
+            this.hdfsConfigDir = hdfsConfigDir;
+            this.hdfsPath = hdfsPath;
+            this.hdfsRecursionDepth = hdfsRecursionDepth;
+            this.hdfsBackupRetentionDays = hdfsBackupRetentionDays;
+            this.hdfsUseAdaptiveSnapRetention = hdfsUseAdaptiveSnapRetention;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder b = new StringBuilder();
+
+            buildLine(b, "LocalPurgeInterval", this.localPurgeInterval);
+            buildLine(b, "SnapDir", this.snapDir);
+            buildLine(b, "TxnLogDir", this.txnlogDir);
+            buildLine(b, "BackupStatusDir", this.backupStatusDir);
+            buildLine(b, "SnapRetainCount", this.snapRetainCount);
+            buildLine(b, "HdfsRetentionInterval", this.hdfsRetentionMaintenanceInterval);
+            buildLine(b, "HdfsConfigDir", this.hdfsConfigDir);
+            buildLine(b, "HdfsBasePath", this.hdfsPath);
+            buildLine(b, "HdfsRecursionDepth", this.hdfsRecursionDepth);
+            buildLine(b, "HdfsRetentionDays", this.hdfsBackupRetentionDays);
+            buildLine(b, "HdfsUseAdaptiveSnapRetention", this.hdfsUseAdaptiveSnapRetention);
+
+            return b.toString();
+        }
+
+        private void buildLine(StringBuilder b, String tag, Object value) {
+            b.append(tag);
+            b.append(": ");
+            b.append(value);
+            b.append("\n");
+        }
+    }
+
+    public RetentionManager(Configuration config, StatsReceiver statsReceiver) {
+        this.config = config;
+        this.timers = new ArrayList<Timer>();
+        this.isRunning = false;
+        this.statsReceiver = statsReceiver.scope("RetentionManager");
+    }
+
+    /**
+     * Start the tasks and wait for them to be stopped.
+     * @throws InterruptedException
+     * @throws IOException
+     */
+    public synchronized void run() throws InterruptedException, IOException {
+        if (!isRunning) {
+            start();
+        }
+
+        while (isRunning) {
+            this.wait();
+        }
+    }
+
+    /**
+     * Start the retention manager tasks if applicable.
+     * @throws IOException
+     */
+    public synchronized void start() throws IOException {
+        if (config.localPurgeInterval > 0) {
+            Timer timer = new Timer("RetentionManager_LocalPurgeTask", true);
+            MetricsReceiver metricsReceiver = new FinagleStatsReceiverWrapper(statsReceiver);
+            JvmStatsRegisterer.register(metricsReceiver);
+            TimerTask task = new LocalPurgeTask(
+                config.dryRun,
+                new FileTxnSnapLog(config.txnlogDir, config.snapDir, metricsReceiver),
+                config.backupStatusDir,
+                config.snapRetainCount,
+                statsReceiver);
+
+            timer.scheduleAtFixedRate(task, 0, config.localPurgeInterval);
+            timers.add(timer);
+
+            LOG.info("Added LocalPurgeTask.");
+        } else {
+            LOG.info("Not starting LocalPurgeTask since purge interval is undefined.");
+        }
+
+        if (config.hdfsBackupRetentionDays > 0 && config.hdfsRetentionMaintenanceInterval > 0) {
+
+            Timer timer = new Timer("RetentionManager_HdfsRetentionMaintenance", true);
+            TimerTask task = new BackupStorageRetentionTask(
+                    config.dryRun,
+                    new HdfsBackupStorage(config.hdfsConfigDir, config.hdfsPath),
+                    config.hdfsRecursionDepth,
+                    config.hdfsBackupRetentionDays,
+                    config.hdfsUseAdaptiveSnapRetention,
+                    statsReceiver);
+
+            timer.scheduleAtFixedRate(task, 0, config.hdfsRetentionMaintenanceInterval);
+            timers.add(timer);
+
+            LOG.info("Added HdfsRetentionTask.");
+        } else {
+            LOG.info("Not starting HdfsRetentionTask (retentionDays={}, interval={}).",
+                    config.hdfsBackupRetentionDays, config.hdfsRetentionMaintenanceInterval);
+        }
+
+        if (timers.isEmpty()) {
+            LOG.info("No tasks to run; not starting RetentionManager.");
+            return;
+        }
+
+        isRunning = true;
+        LOG.info("Started RetentionManager.");
+    }
+
+    /**
+     * Stop the retention manager tasks
+     */
+    public synchronized void stop() {
+        for (Timer timer : timers) {
+            timer.cancel();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Cancelled timer: {}.", timer);
+            }
+        }
+
+        timers.clear();
+        isRunning = false;
+        LOG.info("Stopped RetentionManager.");
+        this.notifyAll();
+    }
+
+    /**
+     * Equivalent of PurgeTxnLog task but handles coordination with the backup service
+     * Will not delete snapshots and txnlog files locally until they have been backed-up.
+     */
+    public static class LocalPurgeTask extends TimerTask {
+        private final boolean dryRun;
+        private final FileTxnSnapLog snapLog;
+        private final File backupStatusDir;
+        private final int snapRetainCount;
+
+        private final Counter iterations;
+        private final Stat iterationDuration;
+        private final StatsReceiver deletedScope;
+
+        private final Gauge snapsRemainingCount;
+        private final Gauge snapsRemainingBytes;
+        private final Gauge txnLogRemainingCount;
+        private final Gauge txnLogRemainingBytes;
+
+        /**
+         * Constructor
+         * @param snapLog snapshot and txnlog manager
+         * @param backupStatusDir location of the backup status file
+         * @param snapRetainCount minimum number of snapshots to always retain locally
+         */
+        public LocalPurgeTask(
+                boolean dryRun,
+                FileTxnSnapLog snapLog,
+                File backupStatusDir,
+                int snapRetainCount,
+                StatsReceiver statsReceiver) {
+
+            this.dryRun = dryRun;
+            this.snapLog = snapLog;
+            this.snapRetainCount = snapRetainCount;
+            this.backupStatusDir = backupStatusDir;
+
+            StatsReceiver taskScope = statsReceiver.scope("local_purge_task");
+            StatsReceiver iterationScope = taskScope.scope("iterations");
+            this.iterations = iterationScope.counter0("count");
+            this.iterationDuration = iterationScope.stat0("duration");
+
+            this.deletedScope = taskScope.scope("purged");
+
+            StatsReceiver liveFiles = taskScope.scope("live");
+            StatsReceiver snapsRemaining = liveFiles.scope("snap");
+            this.snapsRemainingCount =
+                    StatsReceivers.addGauge(snapsRemaining, this.countSnaps, "count");
+            this.snapsRemainingBytes =
+                    StatsReceivers.addGauge(snapsRemaining, this.countSnapBytes, "bytes");
+
+            StatsReceiver txnLogsRemaining = liveFiles.scope("txnlog");
+            this.txnLogRemainingCount =
+                    StatsReceivers.addGauge(txnLogsRemaining, this.countTxnLogs, "count");
+            this.txnLogRemainingBytes =
+                    StatsReceivers.addGauge(txnLogsRemaining, this.countTxnLogBytes, "bytes");
+        }
+
+        private final Callable<Float> countSnaps = new Callable<Float>() {
+            @Override
+            public Float call() {
+                try {
+                    return (float)snapLog.findNRecentSnapshots(Integer.MAX_VALUE).size();
+                } catch (IOException e) {
+                    return -1f;
+                }
+            }
+        };
+
+        private final Callable<Float> countSnapBytes = new Callable<Float>() {
+            @Override
+            public Float call() {
+                try {
+                    float size = 0;
+
+                    for (File f : snapLog.findNRecentSnapshots(Integer.MAX_VALUE)) {
+                        size += f.length();
+                    }
+
+                    return size;
+                } catch (IOException e) {
+                    return -1f;
+                }
+            }
+        };
+
+        private final Callable<Float> countTxnLogs = new Callable<Float>() {
+            @Override
+            public Float call() {
+                return (float)snapLog.getSnapshotLogs(Long.MIN_VALUE).length;
+            }
+        };
+
+        private final Callable<Float> countTxnLogBytes = new Callable<Float>() {
+            @Override
+            public Float call() {
+                float size = 0;
+
+                for (File f : snapLog.getSnapshotLogs(Long.MIN_VALUE)) {
+                    size += f.length();
+                }
+
+                return size;
+            }
+        };
+
+        @Override
+        public void run() {
+            long startTime = System.currentTimeMillis();
+            LOG.info("Local purge task started.");
+            iterations.incr();
+
+            try {
+                BackupStatus backupStatus = new BackupStatus(backupStatusDir);
+                BackupPoint backedupIds = backupStatus.read();
+                long backupZxid =
+                        Math.min(backedupIds.getLogZxid(), backedupIds.getSnapZxid());
+
+                LOG.info("Backedup zxid: {}", ZxidUtils.zxidToString(backupZxid));
+
+                for (File file : snapLog.getFilesEligibleForDeletion(snapRetainCount, backupZxid)) {
+                    Optional<String[]> parts = Util.getFilenameParts(file.getName());
+                    long fileSize = file.getTotalSpace();
+
+                    if (!parts.isPresent()) {
+                        throw new IllegalArgumentException("Unknow filetype: " + file.getName());
+                    }
+
+                    String filePrefix = parts.get()[0];
+
+                    LOG.info("Removing file {} with last modified time of {}.",
+                            file.getPath(),
+                            DateFormat.getDateTimeInstance().format(file.lastModified()));
+
+                    if (!dryRun) {
+                        if (file.delete()) {
+                            StatsReceiver statScope = deletedScope.scope(filePrefix);
+                            statScope.counter0("count").incr();
+                            statScope.stat0("bytes").add(fileSize);
+                        } else {
+                            LOG.warn("Could not delete file {}.", file.getPath());
+                        }
+                    }
+                }
+
+                LOG.info("Local purge task completed successfully.");
+
+            } catch (Exception e) {
+                LOG.error("Local purge task completed with an error.", e);
+            }
+
+            long endTime = System.currentTimeMillis();
+
+            iterationDuration.add(endTime - startTime);
+        }
+    }
+
+    /**
+     * Manages retention of files backedup to a backup storage provider.
+     * All snapshots less than retentionDays olds are kept plus one additional one (in order to
+     * always have a full retentionDays worth of starting points for restores).
+     * All logs and lostlog files that are required for the retained snapshots are also kept.
+     * All other files are deleted.
+     */
+    public static class BackupStorageRetentionTask extends TimerTask {
+        private final boolean dryRun;
+        private final int retentionDays;
+        private final BackupStorageProvider storage;
+        private int recursionDepth;
+        private final long asOfTime;
+        private final boolean useAdaptiveSnapRetention;
+        private final long lowLatencyRecoveryThreshold;
+        private final long mediumLatencyRecoveryThreshold;
+
+        private final StatsReceiver statsReceiver;
+
+        private enum AdaptiveSnapMinInterval {
+            LOW_LATENCY(TimeUnit.MINUTES.toMillis(15)),
+            MEDIUM_LATENCY(TimeUnit.MINUTES.toMillis(60)),
+            HIGH_LATENCY(TimeUnit.HOURS.toMillis(6));
+
+            private long interval;
+
+            AdaptiveSnapMinInterval(long interval) {
+                this.interval = interval;
+            }
+
+            public long getInterval() {
+                return this.interval;
+            }
+        }
+
+        /**
+         * Constructor
+         * @param storage the backup storage provider where to perform retention maintenance
+         * @param recursionDepth the depth to recurse to; each directory is processed independently
+         * @param retentionDays the number of days to retain backups
+         */
+        public BackupStorageRetentionTask(
+                boolean dryRun,
+                BackupStorageProvider storage,
+                int recursionDepth,
+                int retentionDays,
+                boolean useAdaptiveSnapRetention,
+                StatsReceiver statsReceiver) throws IOException {
+
+            this(dryRun,
+                    storage,
+                    recursionDepth,
+                    retentionDays,
+                    useAdaptiveSnapRetention,
+                    0,
+                    statsReceiver);
+        }
+
+        /**
+         * Constructor
+         * @param storage the backup storage provider where to perform retention maintenance
+         * @param recursionDepth the depth to recurse to; each directory is processed independently
+         * @param retentionDays the number of days to retain backups
+         * @param asOfTime perform retention as if running at this point in time; 0 mean current
+         *                 time
+         */
+        public BackupStorageRetentionTask(
+                boolean dryRun,
+                BackupStorageProvider storage,
+                int recursionDepth,
+                int retentionDays,
+                boolean useAdaptiveSnapRetention,
+                long asOfTime,
+                StatsReceiver statsReceiver) throws IOException {
+
+            this.dryRun = dryRun;
+            this.storage = storage;
+            this.recursionDepth = recursionDepth;
+            this.retentionDays = retentionDays;
+            this.asOfTime = asOfTime;
+            this.useAdaptiveSnapRetention = useAdaptiveSnapRetention;
+            this.statsReceiver = statsReceiver.scope("backup_retention_manager");
+
+            long lowLatDays = 2;
+            long medLatDays = Math.max((long) Math.ceil(retentionDays * 0.50), lowLatDays + 1);
+            this.lowLatencyRecoveryThreshold = TimeUnit.DAYS.toMillis(lowLatDays);
+            this.mediumLatencyRecoveryThreshold = TimeUnit.DAYS.toMillis(medLatDays);
+
+            if (useAdaptiveSnapRetention) {
+                LOG.info("Using low latency recovery threshold of {} ({} days) and medium "
+                                + "latency recovery threshold of {} ({} days).",
+                        this.lowLatencyRecoveryThreshold,
+                        lowLatDays,
+                        this.mediumLatencyRecoveryThreshold,
+                        medLatDays);
+            }
+        }
+
+        @Override
+        public void run() {
+            LOG.info("Backup storage retention maintenance starting.");
+
+            long startTime = System.currentTimeMillis();
+            StatsReceiver iterationsScope = statsReceiver.scope("iterations");
+            iterationsScope.counter0("count").incr();
+
+            try {
+                long currentTime = asOfTime == 0 ? System.currentTimeMillis() : asOfTime;
+                long retentionCutoffTime = currentTime - TimeUnit.DAYS.toMillis(retentionDays);
+
+                LOG.info("Backup retention cutoff time is: {}.",
+                        DateFormat.getDateTimeInstance().format(retentionCutoffTime));
+
+                int remainingDepth = this.recursionDepth;
+                Queue<File> currentLevel = new LinkedList<File>();
+                processDirectory(null, currentTime, retentionCutoffTime);
+                currentLevel.add(null);
+
+                while (!currentLevel.isEmpty() && remainingDepth > 0) {
+                    Queue<File> nextLevel = new LinkedList<File>();
+
+                    while(!currentLevel.isEmpty()) {
+                        File current = currentLevel.remove();
+                        List<File> childDirs = storage.getDirectories(current);
+
+                        for (File childDir : childDirs) {
+                            nextLevel.add(childDir);
+                            processDirectory(childDir, currentTime, retentionCutoffTime);
+                        }
+                    }
+
+                    currentLevel = nextLevel;
+                    remainingDepth--;
+                }
+
+                LOG.info("Backup storage retention maintenance completed successfully.");
+
+            } catch (Exception e) {
+                LOG.error("Backup storage retention maintenance completed with an error.", e);
+            }
+
+            iterationsScope.stat0("duration").add(System.currentTimeMillis() - startTime);
+        }
+
+
+        private void processDirectory(
+                File childDir,
+                long currentTime,
+                long retentionCutoffTime) throws IOException {
+
+            String childName = childDir == null ? "base" : childDir.getPath().replace("/", "\\");
+            StatsReceiver clusterScope = statsReceiver.scope(childName);
+            StatsReceiver iterationsScope = clusterScope.scope("iterations");
+            StatsReceiver purgedScope = clusterScope.scope("purged");
+            long startTime = System.currentTimeMillis();
+            ArrayList<BackupFileInfo> filesToDelete = new ArrayList<BackupFileInfo>();
+
+            LOG.info("Processing {}", childDir == null ? "<hdfsBaseDir>" : childDir.toString());
+            iterationsScope.counter0("count").incr();
+
+            List<BackupFileInfo> logs = BackupUtil.getBackupFiles(
+                    storage,
+                    childDir,
+                    BackupFileType.TXNLOG,
+                    ZxidPart.MIN_ZXID,
+                    SortOrder.ASCENDING);
+            List<BackupFileInfo> lostLogs = BackupUtil.getBackupFiles(
+                    storage,
+                    childDir,
+                    BackupFileType.LOSTLOG,
+                    ZxidPart.MIN_ZXID,
+                    SortOrder.ASCENDING);
+            List<BackupFileInfo> snaps = BackupUtil.getBackupFiles(
+                    storage,
+                    childDir,
+                    BackupFileType.SNAPSHOT,
+                    ZxidPart.MIN_ZXID,
+                    SortOrder.ASCENDING);
+
+            // This is the zxid of the first snap that does NOT get deleted due to
+            // age
+            long cutoffZxid = snaps.isEmpty()
+                    ? Long.MAX_VALUE
+                    : snaps.get(0).getZxid(ZxidPart.MIN_ZXID);
+            Optional<BackupFileInfo> lastNotDeleted = Optional.absent();
+
+            // Find all snapshot that can be deleted neither because they fall outside of the
+            // retention period or because they can be pruned based on the recovery latency sla
+            for (int i = 0; i < snaps.size() - 1; i++) {
+                BackupFileInfo current = snaps.get(i);
+                BackupFileInfo next = snaps.get(i + 1);
+                Boolean deleteCurrent;
+
+                if (isSnapOutsideOfRetentionPeriod(current, next, retentionCutoffTime)) {
+                    deleteCurrent = true;
+                    cutoffZxid = next.getZxid(ZxidPart.MIN_ZXID);
+                } else {
+                    deleteCurrent =
+                            !isSnapNeededForRecoveryLatencySla(
+                                    current,
+                                    next,
+                                    lastNotDeleted,
+                                    currentTime,
+                                    lostLogs);
+                }
+
+                if (deleteCurrent) {
+                    filesToDelete.add(current);
+                } else {
+                    lastNotDeleted = Optional.fromNullable(current);
+                }
+            }
+
+
+            // Gather the log and lostlog files that are no longer needed for restoring any
+            // of the retained snapshots and that are older than the cutoff time
+            for (BackupFileInfo bfi : logs) {
+
+                if (bfi.getZxid(ZxidPart.MAX_ZXID) >= cutoffZxid
+                        || bfi.getModificationTime() >= retentionCutoffTime) {
+                    break;
+                }
+
+                filesToDelete.add(bfi);
+            }
+
+            // Gather the log and lostlog files that are no longer needed for restoring any
+            // of the retained snapshots and that are older than the cutoff time
+            for (BackupFileInfo bfi : lostLogs) {
+
+                if (bfi.getZxid(ZxidPart.MAX_ZXID) >= cutoffZxid
+                        || bfi.getModificationTime() >= retentionCutoffTime) {
+                    break;
+                }
+
+                filesToDelete.add(bfi);
+            }
+
+            for (BackupFileInfo bfi : filesToDelete) {
+                LOG.info("Deleting file {} with modification time {} from backup storage.",
+                        bfi.getBackedUpFile(),
+                        DateFormat.getDateTimeInstance().format(bfi.getModificationTime()));
+
+                if (!dryRun) {
+                    StatsReceiver fileTypeScope =
+                            purgedScope.scope(BackupUtil.getPrefix(bfi.getFileType()));
+                    long fileSize = bfi.getSize();
+
+                    storage.delete(bfi.getBackedUpFile());
+
+                    fileTypeScope.counter0("count").incr();
+                    fileTypeScope.stat0("bytes").add(fileSize);
+                }
+            }
+
+            iterationsScope.stat0("duration").add(System.currentTimeMillis() - startTime);
+        }
+
+        private boolean isSnapOutsideOfRetentionPeriod(
+                BackupFileInfo currentSnap,
+                BackupFileInfo nextSnap,
+                long retentionCutoffTime) {
+
+            return currentSnap.getModificationTime() < retentionCutoffTime &&
+                    nextSnap.getModificationTime() < retentionCutoffTime;
+        }
+
+        private boolean isSnapNeededForRecoveryLatencySla(
+                BackupFileInfo currentSnap,
+                BackupFileInfo nextSnap,
+                Optional<BackupFileInfo> lastRetainedSnap,
+                long currentTime,
+                List<BackupFileInfo> lostLogs) {
+
+            if (!useAdaptiveSnapRetention) {
+                return true;
+            }
+
+            AdaptiveSnapMinInterval adaptiveInterval =
+                    getAdaptiveInterval(currentTime, nextSnap.getModificationTime());
+            long lastRetainedTime = lastRetainedSnap.isPresent()
+                    ? lastRetainedSnap.get().getModificationTime()
+                    : 0;
+            long timeBetweenPreviousAndNext = nextSnap.getModificationTime() - lastRetainedTime;
+
+            if (timeBetweenPreviousAndNext < adaptiveInterval.getInterval()) {
+                long start = lastRetainedSnap.isPresent()
+                        ? lastRetainedSnap.get().getZxid(ZxidPart.MAX_ZXID)
+                        : Long.MIN_VALUE;
+                Range<Long> range = Range.closed(start, currentSnap.getZxid(ZxidPart.MAX_ZXID));
+
+                return doesRangeContainLostLogs(range, lostLogs);
+            }
+
+            return true;
+        }
+
+        private AdaptiveSnapMinInterval getAdaptiveInterval(long currentTime, long fileTime) {
+            long timeDiff = currentTime - fileTime;
+
+            if (timeDiff <= lowLatencyRecoveryThreshold) {
+                return AdaptiveSnapMinInterval.LOW_LATENCY;
+            } else if (timeDiff <= mediumLatencyRecoveryThreshold) {
+                return AdaptiveSnapMinInterval.MEDIUM_LATENCY;
+            } else {
+                return AdaptiveSnapMinInterval.HIGH_LATENCY;
+            }
+        }
+
+        private boolean doesRangeContainLostLogs(Range<Long> range, List<BackupFileInfo> lostLogs) {
+
+            for(BackupFileInfo current : lostLogs) {
+                if (current.getZxid(ZxidPart.MIN_ZXID) > range.upperEndpoint()) {
+                    break;
+                }
+
+                if (range.isConnected(current.getZxidRange())) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RetentionManagerTool.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RetentionManagerTool.java
@@ -1,0 +1,374 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Optional;
+import com.twitter.finagle.Http$;
+import com.twitter.finagle.http.HttpMuxer;
+import com.twitter.finagle.stats.DefaultStatsReceiver;
+import com.twitter.finagle.stats.MetricsExporter;
+import com.twitter.finagle.stats.NullStatsReceiver;
+import com.twitter.finagle.tracing.NullTracer;
+import com.twitter.server.handler.HeapResourceHandler;
+import com.twitter.server.handler.ProfileResourceHandler;
+import com.twitter.util.Closable;
+import com.twitter.util.Closable$;
+import org.apache.commons.cli.BasicParser;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import org.apache.zookeeper.cli.OptionBuilder;
+
+/**
+ * Tool for running the retention manager as a daemon
+ */
+public class RetentionManagerTool {
+    private static final String LOCAL_PURGER = "local-purger";
+    private static final String LOCAL_PURGER_INTERVAL = LOCAL_PURGER + "-interval";
+    private static final String LOCAL_PURGER_SNAP_DIR = LOCAL_PURGER + "-snap-dir";
+    private static final String LOCAL_PURGER_TXLOG_DIR = LOCAL_PURGER + "-txlog-dir";
+    private static final String LOCAL_PURGER_BACKUP_STATUS_DIR = LOCAL_PURGER + "-backup-status-dir";
+    private static final String LOCAL_PURGER_SNAP_RETAIN_COUNT = LOCAL_PURGER + "-snap-retain-count";
+
+    private static final String HDFS_PURGER = "hdfs-purger";
+    private static final String HDFS_PURGER_INTERVAL = HDFS_PURGER + "-interval";
+    private static final String HDFS_PURGER_RETENTION_PERIOD = HDFS_PURGER + "-retention-period";
+    private static final String HDFS_PURGER_CONFIG_DIR = HDFS_PURGER + "-config-dir";
+    private static final String HDFS_PURGER_BASE_PATH = HDFS_PURGER + "-base-path";
+    private static final String HDFS_PURGER_RECURSION_DEPTH = HDFS_PURGER + "-recursion-depth";
+    private static final String HDFS_PURGER_USE_ADAPTIVE_SNAP_RETENTION = HDFS_PURGER + "-adaptive-snap-retention";
+
+    private static final String VERBOSE = "verbose";
+    private static final String VERBOSE_SHORT = "v";
+    private static final String ADMIN_PORT = "admin_port";
+    private static final String ADMIN_PORT_SHORT = "p";
+    private static final String DRYRUN = "n";
+
+    private static final String ADMIN_METRICS          = "/admin/metrics.json";
+    private static final String ADMIN_PPROF_HEAP       = "/admin/pprof/heap";
+    private static final String ADMIN_PPROF_PROFILE    = "/admin/pprof/profile";
+    private static final String ADMIN_PPROF_CONTENTION = "/admin/pprof/contention";
+
+    private static List<Option> base;
+    private static List<Option> local;
+    private static List<Option> hdfs;
+
+    private static RetentionManager.Configuration config;
+    private static Optional<Integer> adminPort = Optional.absent();
+
+    static {
+        base = new ArrayList<>();
+        base.add(new Option("h", "help", false, "Print usage."));
+
+        base.add(new OptionBuilder()
+                    .longOpt(LOCAL_PURGER_INTERVAL)
+                    .desc("The interval, in minutes, at which to run the local snap and "
+                            + "txnlog purger")
+                    .argName("MINUTES")
+                    .type(Number.class)
+                    .hasArg()
+                    .build());
+        base.add(new OptionBuilder()
+                    .longOpt(HDFS_PURGER_INTERVAL)
+                    .desc(
+                            "The interval, in hours, at which to run the backup cleanup.")
+                    .argName("HOURS")
+                    .type(Number.class)
+                    .hasArg()
+                    .build());
+        base.add(new OptionBuilder(VERBOSE_SHORT).longOpt(VERBOSE).build());
+        base.add(new OptionBuilder(ADMIN_PORT_SHORT)
+                    .longOpt(ADMIN_PORT)
+                    .desc("The port to use for the admin server")
+                    .argName("PORT")
+                    .type(Number.class)
+                    .hasArg()
+                    .build());
+        base.add(new Option("n",
+                "Dryrun -- report actions that would be taken but do not take them."));
+
+        local = new ArrayList<>();
+        local.add(new OptionBuilder()
+                    .longOpt(LOCAL_PURGER_SNAP_DIR)
+                    .desc("The location for ZooKeeper snapshots")
+                    .argName("PATH")
+                    .type(File.class)
+                    .hasArg()
+                    .required()
+                    .build());
+        local.add(new OptionBuilder()
+                    .longOpt(LOCAL_PURGER_TXLOG_DIR)
+                    .desc("The location for ZooKeeper transaction logs")
+                    .argName("PATH")
+                    .type(File.class)
+                    .hasArg()
+                    .build());
+        local.add(new OptionBuilder()
+                    .longOpt(LOCAL_PURGER_BACKUP_STATUS_DIR)
+                    .desc("The location for the backup status file")
+                    .argName("PATH")
+                    .type(File.class)
+                    .hasArg()
+                    .required()
+                    .build());
+        local.add(new OptionBuilder()
+                    .longOpt(LOCAL_PURGER_SNAP_RETAIN_COUNT)
+                    .desc("Minimum number of snaps to retain")
+                    .argName("SNAPS")
+                    .type(Number.class)
+                    .hasArg()
+                    .required()
+                    .build());
+
+        hdfs = new ArrayList<>();
+        hdfs.add(new OptionBuilder()
+                    .longOpt(HDFS_PURGER_RETENTION_PERIOD)
+                    .desc("The duration for which backups should be retained")
+                    .argName("DAYS")
+                    .type(Number.class)
+                    .hasArg()
+                    .required()
+                    .build());
+        hdfs.add(new OptionBuilder()
+                    .longOpt(HDFS_PURGER_CONFIG_DIR)
+                    .desc("The hdfs config locations")
+                    .argName("PATH")
+                    .type(File.class)
+                    .hasArg()
+                    .required()
+                    .build());
+        hdfs.add(new OptionBuilder()
+                    .longOpt(HDFS_PURGER_BASE_PATH)
+                    .desc("The hdfs base path for the backups")
+                    .argName("RELATIVE-PATH")
+                    .hasArg()
+                    .required()
+                    .build());
+        hdfs.add(new OptionBuilder()
+                    .longOpt(HDFS_PURGER_RECURSION_DEPTH)
+                    .desc("The depth to recurse into directories")
+                    .argName("DEPTH")
+                    .type(Number.class)
+                    .hasArg()
+                    .required()
+                    .build());
+        hdfs.add(new OptionBuilder()
+                    .longOpt(HDFS_PURGER_USE_ADAPTIVE_SNAP_RETENTION)
+                    .desc("Use adaptive snap retention intervals")
+                    .build());
+    }
+
+    /**
+     * Main entry point
+     * @param args arguments; only one expected: the location of the ZooKeeper configuration file.
+     * @throws IOException
+     */
+    public static void main(String[] args) throws IOException {
+        parseArgs(args);
+        RetentionManager mgr = new RetentionManager(config, DefaultStatsReceiver.self());
+
+        // Admin
+        Closable adminServer;
+
+        if (adminPort.isPresent()) {
+            System.out.println("Starting admin server on port " + adminPort.get());
+            HttpMuxer muxerSvc = new HttpMuxer()
+                .withHandler(ADMIN_METRICS, new MetricsExporter())
+                .withHandler(ADMIN_PPROF_HEAP, new HeapResourceHandler())
+                .withHandler(ADMIN_PPROF_PROFILE,
+                    new ProfileResourceHandler(Thread.State.RUNNABLE))
+                .withHandler(ADMIN_PPROF_CONTENTION,
+                    new ProfileResourceHandler(Thread.State.BLOCKED));
+            adminServer = Http$.MODULE$.server()
+                .withTracer(new NullTracer())
+                .withStatsReceiver(NullStatsReceiver.get())
+                .withLabel("admin")
+                .serve(new InetSocketAddress(adminPort.get()), muxerSvc);
+        } else {
+            adminServer = Closable$.MODULE$.nop();
+        }
+
+        try {
+            mgr.run();
+        } catch (Exception e) {
+            System.err.println("Retention manager failed with an exception: " + e.getMessage());
+            System.exit(1);
+        } finally {
+            adminServer.close();
+        }
+    }
+
+    /**
+     * Parse the arguments configuration.
+     * @param args command line arguments
+     * @return the parsed ZooKeeper quorum peer configuration
+     */
+    public static void parseArgs(String[] args) {
+        try {
+            long localPurgerInterval = 0;
+            File localPurgerSnapDir = null;
+            File localPurgerTxlogDir = null;
+            File localPurgerBackupStatusDir = null;
+            int localPurgerSnapRetainCount = Integer.MAX_VALUE;
+
+            long hdfsPurgerInterval = 0;
+            File hdfsPurgerConfigDir = null;
+            String hdfsPurgerBasePath = null;
+            int hdfsPurgerRecursionDepth = 0;
+            int hdfsPurgerRetentionDays = Integer.MAX_VALUE;
+            boolean hdfsPurgerUseAdaptiveSnapRetention = false;
+
+            boolean dryRun = false;
+
+            BasicParser parser = new BasicParser();
+            Options options = new Options();
+
+            addOptions(options, base);
+
+            // First parse the base options to determine which tasks to run; this will not
+            // fail on unknown options
+            CommandLine cl = parser.parse(options, args, true);
+
+            if (cl.hasOption(ADMIN_PORT)) {
+                adminPort = Optional.of(((Number)cl.getParsedOptionValue(ADMIN_PORT)).intValue());
+            }
+
+            if (cl.hasOption(LOCAL_PURGER_INTERVAL)) {
+                localPurgerInterval = TimeUnit.MINUTES.toMillis(
+                        ((Number) cl.getParsedOptionValue(LOCAL_PURGER_INTERVAL)).longValue());
+            }
+
+            if (cl.hasOption(HDFS_PURGER_INTERVAL)) {
+                hdfsPurgerInterval = TimeUnit.HOURS.toMillis(
+                        ((Number) cl.getParsedOptionValue(HDFS_PURGER_INTERVAL)).longValue());
+            }
+
+            if (cl.hasOption(DRYRUN)) {
+                dryRun = true;
+            }
+
+            if (localPurgerInterval > 0) {
+                addOptions(options, local);
+            }
+
+            if (hdfsPurgerInterval > 0) {
+                addOptions(options, hdfs);
+            }
+
+            // Now parse with the required options for each of the requested tasks; this validates
+            // that all options are legal
+            cl = parser.parse(options, args);
+
+            if (localPurgerInterval > 0) {
+                localPurgerSnapDir = (File)cl.getParsedOptionValue(LOCAL_PURGER_SNAP_DIR);
+                localPurgerTxlogDir = localPurgerSnapDir;
+
+                if (cl.hasOption(LOCAL_PURGER_TXLOG_DIR)) {
+                    localPurgerTxlogDir = (File)cl.getParsedOptionValue(LOCAL_PURGER_TXLOG_DIR);
+                }
+
+                localPurgerBackupStatusDir =
+                    (File)cl.getParsedOptionValue(LOCAL_PURGER_BACKUP_STATUS_DIR);
+                localPurgerSnapRetainCount =
+                    ((Number)cl.getParsedOptionValue(LOCAL_PURGER_SNAP_RETAIN_COUNT)).intValue();
+            }
+
+            if (hdfsPurgerInterval > 0) {
+                hdfsPurgerConfigDir = (File)cl.getParsedOptionValue(HDFS_PURGER_CONFIG_DIR);
+                hdfsPurgerBasePath = cl.getOptionValue(HDFS_PURGER_BASE_PATH);
+                hdfsPurgerRetentionDays =
+                    ((Number)cl.getParsedOptionValue(HDFS_PURGER_RETENTION_PERIOD)).intValue();
+                hdfsPurgerRecursionDepth =
+                    ((Number)cl.getParsedOptionValue(HDFS_PURGER_RECURSION_DEPTH)).intValue();
+
+                if (cl.hasOption(HDFS_PURGER_USE_ADAPTIVE_SNAP_RETENTION)) {
+                    hdfsPurgerUseAdaptiveSnapRetention = true;
+                }
+            }
+
+            if (cl.hasOption("h") || cl.hasOption("help")) {
+                printHelp();
+            }
+
+            config = new RetentionManager.Configuration(
+                        dryRun,
+                        localPurgerInterval,
+                        localPurgerSnapDir,
+                        localPurgerTxlogDir,
+                        localPurgerBackupStatusDir,
+                        localPurgerSnapRetainCount,
+                        hdfsPurgerInterval,
+                        hdfsPurgerConfigDir,
+                        hdfsPurgerBasePath,
+                        hdfsPurgerRecursionDepth,
+                        hdfsPurgerRetentionDays,
+                        hdfsPurgerUseAdaptiveSnapRetention);
+
+            if (cl.hasOption("v") || cl.hasOption("verbose")) {
+                System.out.println("Configuration:");
+                System.out.println(config);
+            }
+
+        } catch (ParseException pe) {
+            System.err.println(pe.getMessage());
+            printHelp();
+            System.exit(2);
+        }
+    }
+
+    private static void addOptions(Options target, List<Option> options) {
+        for (Option o : options) {
+            target.addOption(o);
+        }
+    }
+
+    private static void printHelp() {
+        Options full = new Options();
+        HelpFormatter help = new HelpFormatter();
+
+        addOptions(full, base);
+        addOptions(full, local);
+        addOptions(full, hdfs);
+
+        String header = "Options starting with " + LOCAL_PURGER
+                + "- are required if --" + LOCAL_PURGER_INTERVAL
+                + " specifies a value greater than 0.\n"
+                + "Options starting with " + HDFS_PURGER
+                + "- are required if --" + HDFS_PURGER_INTERVAL
+                + " specifies a value greater than 0.";
+
+        help.printHelp(
+                120,
+                "java -cp <class-path> " + RetentionManagerTool.class.getName(),
+                header,
+                full,
+                "NOTE: Console output may include logging output.");
+
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileStreamTxnIterator.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileStreamTxnIterator.java
@@ -1,0 +1,251 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import java.io.BufferedInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.Adler32;
+import java.util.zip.Checksum;
+
+import org.apache.jute.BinaryInputArchive;
+import org.apache.jute.InputArchive;
+import org.apache.jute.Record;
+import org.apache.zookeeper.server.TxnLogEntry;
+import org.apache.zookeeper.server.util.SerializeUtils;
+import org.apache.zookeeper.txn.TxnDigest;
+import org.apache.zookeeper.txn.TxnHeader;
+import org.slf4j.Logger;
+
+public abstract class FileStreamTxnIterator implements TxnLog.TxnIterator {
+    protected final Logger log;
+
+    private long maxZxid = Long.MAX_VALUE;
+    private PositionInputStream inputStream = null;
+    private InputArchive ia;
+    private FileHeader fileHdr;
+    private TxnHeader hdr;
+    private Record record;
+    private TxnDigest digest;
+    private int recordSize;
+
+    static final String CRC_ERROR = "CRC check failed";
+
+    public FileStreamTxnIterator(Logger logger) {
+        this.log = logger;
+    }
+
+    public abstract String getCurrentLogFilePath();
+
+    public abstract InputStream getNextLog() throws IOException;
+
+    public void fastForwardTo(long zxid) throws IOException {
+        if (hdr != null) {
+            while (hdr.getZxid() < zxid) {
+                if (!next()) {
+                    break;
+                }
+            }
+        }
+    }
+
+    public void setMaxZxid(long zxid) {
+        maxZxid = zxid;
+    }
+
+    /**
+     * go to the next logfile
+     * @return true if there is one and false if there is no
+     * new file to be read
+     * @throws IOException
+     */
+    protected boolean goToNextLog() throws IOException {
+        try {
+            InputStream in = getNextLog();
+            
+            if (in != null) {
+                ia = createInputArchive(in);
+                return true;
+            }
+        } catch (EOFException eof) {
+        }
+
+        return false;
+    }
+
+    /**
+     * Invoked to indicate that the input stream has been created.
+     * @param logStream the logStream to create an archive for
+     * @throws IOException
+     **/
+    protected InputArchive createInputArchive(InputStream logStream) throws IOException {
+        if (inputStream == null){
+            inputStream = new PositionInputStream(new BufferedInputStream(logStream));
+
+            if (log.isDebugEnabled()) {
+                log.debug("Created new input stream {}", getCurrentLogFilePath());
+            }
+
+            ia  = BinaryInputArchive.getArchive(inputStream);
+            inStreamCreated();
+
+            if (log.isDebugEnabled()) {
+                log.debug("Created new input archive {}", getCurrentLogFilePath());
+            }
+        }
+        return ia;
+    }
+
+    /**
+     * read the header from the inputarchive
+     * @throws IOException
+     */
+    protected void inStreamCreated() throws IOException{
+        fileHdr = new FileHeader();
+        fileHdr.deserialize(ia, "fileheader");
+        if (fileHdr.getMagic() != FileTxnLog.TXNLOG_MAGIC) {
+            throw new IOException("Transaction log: " + getCurrentLogFilePath() + " has invalid magic number "
+                    + fileHdr.getMagic()
+                    + " != " + FileTxnLog.TXNLOG_MAGIC);
+        }
+    }
+
+    protected PositionInputStream getInputStream() {
+        return inputStream;
+    }
+
+    /**
+     * Return the file header for the current file
+     * @return current file's header
+     */
+    public FileHeader getFileHeader() {
+        return fileHdr;
+    }
+
+    /**
+     * reutrn the current header
+     * @return the current header that
+     * is read
+     */
+    public TxnHeader getHeader() {
+        return hdr;
+    }
+
+    /**
+     * return the current transaction
+     * @return the current transaction
+     * that is read
+     */
+    public Record getTxn() {
+        return record;
+    }
+
+    public int getTxnSize() {
+        return recordSize;
+    }
+
+    /**
+     * create a checksum algorithm
+     * @return the checksum algorithm
+     */
+    protected Checksum makeChecksumAlgorithm(){
+        return new Adler32();
+    }
+
+    /**
+     * the iterator that moves to the next transaction
+     * @return true if there is more transactions to be read
+     * false if not.
+     */
+    public boolean next() throws IOException {
+        if (ia == null) {
+            return false;
+        }
+
+        try {
+            long crcValue = ia.readLong("crcvalue");
+            byte[] bytes = Util.readTxnBytes(ia);
+
+            // Since we preallocate, we define EOF to be an
+            if (bytes == null || bytes.length == 0) {
+                throw new EOFException("Failed to read " + getCurrentLogFilePath());
+            }
+
+            // EOF or corrupted record
+            // validate CRC
+            Checksum crc = makeChecksumAlgorithm();
+            crc.update(bytes, 0, bytes.length);
+
+            if (crcValue != crc.getValue()) {
+                throw new IOException(CRC_ERROR);
+            }
+
+            if (bytes == null || bytes.length == 0) {
+                return false;
+            }
+
+            TxnLogEntry logEntry = SerializeUtils.deserializeTxn(bytes);
+            hdr = logEntry.getHeader();
+            record = logEntry.getTxn();
+            digest = logEntry.getDigest();
+            recordSize = bytes.length;
+
+            if (hdr.getZxid() > maxZxid) {
+                hdr = null;
+                record = null;
+                return false;
+            }
+
+        } catch (EOFException e) {
+            inputStream.close();
+            inputStream = null;
+            ia = null;
+            hdr = null;
+
+            // this means that the file has ended
+            // we should go to the next file
+            if (!goToNextLog()) {
+                return false;
+            }
+
+            // if we went to the next log file, we should call next() again
+            return next();
+        } catch (IOException e) {
+            inputStream.close();
+            throw e;
+        }
+
+        return true;
+    }
+
+    /**
+     * close the iterator
+     * and release the resources.
+     */
+    public void close() throws IOException {
+        if (inputStream != null) {
+            inputStream.close();
+        }
+    }
+
+    public TxnDigest getDigest() {
+        return digest;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/PositionInputStream.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/PositionInputStream.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * a class that keeps track of the position
+ * in the input stream. The position points to offset
+ * that has been consumed by the applications. It can
+ * wrap buffered input streams to provide the right offset
+ * for the application.
+ */
+public class PositionInputStream extends FilterInputStream {
+    private long position;
+
+    /**
+     * Create a positioned input stream as a wrapper over a generic input stream
+     * @param in underlying input stream
+     */
+    public PositionInputStream(InputStream in) {
+        super(in);
+        position = 0;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int rc = super.read();
+        if (rc > -1) {
+            position++;
+        }
+        return rc;
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        int rc = super.read(b);
+        if (rc > 0) {
+            position += rc;
+        }
+        return rc;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int rc = super.read(b, off, len);
+        if (rc > 0) {
+            position += rc;
+        }
+        return rc;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        long rc = super.skip(n);
+        if (rc > 0) {
+            position += rc;
+        }
+        return rc;
+    }
+    public long getPosition() {
+        return position;
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    @Override
+    public void mark(int readLimit) {
+        throw new UnsupportedOperationException("mark");
+    }
+
+    @Override
+    public void reset() {
+        throw new UnsupportedOperationException("reset");
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/ZxidRange.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/ZxidRange.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Range;
+
+/**
+ * A range of Zxids with an optional high zxid.
+ */
+public class ZxidRange {
+    public static final ZxidRange INVALID = new ZxidRange(-1L, Optional.of(-1L), true);
+
+    private long low;
+    private Optional<Long> high;
+
+    private ZxidRange(long low, Optional<Long> high, boolean allowNeg) {
+        Preconditions.checkNotNull(high);
+        Preconditions.checkArgument(allowNeg || low >= 0, "Zxid must be 0 or greater");
+        Preconditions.checkArgument(allowNeg || !high.isPresent() || high.get() >= 0,
+            "Zxid must be 0 or greater");
+        Preconditions.checkArgument(!high.isPresent() || low <= high.get(),
+            "Invalid zxid range, low must not be greater than high");
+
+        this.low = low;
+        this.high = high;
+    }
+
+    public ZxidRange(long low, long high) {
+        this(low, Optional.of(high), false);
+    }
+
+    public ZxidRange(long low) {
+        this(low, Optional.<Long>absent(), false);
+    }
+
+    public ZxidRange(Range<Long> range) {
+        this(range.lowerEndpoint(), range.upperEndpoint());
+    }
+
+    public static ZxidRange parse(String value) {
+        String[] zxidParts = value.split("-");
+
+        if (zxidParts.length == 1 && !value.endsWith("-")) {
+            try {
+                return new ZxidRange(Long.parseLong(zxidParts[0], 16));
+            } catch (NumberFormatException e) { }
+        } else if (zxidParts.length == 2) {
+            try {
+                return new ZxidRange(Long.parseLong(zxidParts[0], 16), Long.parseLong(zxidParts[1], 16));
+            } catch (NumberFormatException e) { }
+        }
+
+        return ZxidRange.INVALID;
+    }
+
+    public Range<Long> toRange() {
+        return Range.closed(low, high.isPresent() ? high.get() : Long.MAX_VALUE);
+    }
+
+    public long getLow() {
+        return low;
+    }
+
+    public long getHigh() {
+        Preconditions.checkState(high.isPresent());
+        return high.get();
+    }
+
+    public boolean isHighPresent() {
+        return high.isPresent();
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -106,6 +106,15 @@ public class QuorumPeerConfig {
     protected int purgeInterval = 0;
     protected boolean syncEnabled = true;
 
+    protected boolean backupEnabled = false;
+    protected File backupStatusDir;
+    protected File backupTmpDir;
+    protected int backupIntervalInMinutes = 15;
+    protected File backupHdfsConfig;
+    protected String backupHdfsPath;
+    protected int backupRetentionDays = 0;
+    protected int backupRetentionMaintenanceIntervalHours = 24;
+
     protected String initialConfig;
 
     protected LearnerType peerType = LearnerType.PARTICIPANT;
@@ -343,7 +352,30 @@ public class QuorumPeerConfig {
                 snapRetainCount = Integer.parseInt(value);
             } else if (key.equals("autopurge.purgeInterval")) {
                 purgeInterval = Integer.parseInt(value);
-            } else if (key.equals("standaloneEnabled")) {
+            } else if (key.equals("backup.enabled")) {
+                if (value.toLowerCase().equals("true")) {
+                    backupEnabled = true;
+                } else if (value.toLowerCase().equals("false")) {
+                    backupEnabled = false;
+                } else {
+                    throw new ConfigException("Invalid option for backup.enabled mode. Choose 'true' or 'false.'");
+                }
+            } else if (key.equals("backup.statusDir")) {
+                backupStatusDir = vff.create(value);
+            } else if (key.equals("backup.tmpDir")) {
+                backupTmpDir = vff.create(value);
+            } else if (key.equals("backup.interval")) {
+                backupIntervalInMinutes = Integer.parseInt(value);
+            } else if (key.equals("backup.hdfsConfig")) {
+                backupHdfsConfig = vff.create(value);
+            } else if (key.equals("backup.hdfsPath")) {
+                backupHdfsPath = value;
+            } else if (key.equals("backup.retentionDays")) {
+                backupRetentionDays = Integer.parseInt(value);
+            } else if (key.equals("backup.retentionMaintenanceIntervalHours")) {
+                backupRetentionMaintenanceIntervalHours = Integer.parseInt(value);
+            }
+            else if (key.equals("standaloneEnabled")) {
                 setStandaloneEnabled(parseBoolean(key, value));
             } else if (key.equals("reconfigEnabled")) {
                 setReconfigEnabled(parseBoolean(key, value));

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupConfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupConfigTest.java
@@ -1,0 +1,201 @@
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.zookeeper.common.ConfigException;
+import org.junit.Test;
+
+import com.twitter.util.Duration;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BackupConfigTest {
+    private static final File DEFAULT_STATUS_DIR = new File("/backup/status");
+    private static final File DEFAULT_TMP_DIR = new File("/tmp/backup");
+    private static final File DEFAULT_HDFS_CONFIG = new File("/hdfs/config");
+    private static final String DEFAULT_HDFS_PATH = "/hdfs/path";
+
+    @Test
+    public void testEnabled() throws Exception {
+        assertFalse(new BackupConfig.Builder().build().isPresent());
+        assertTrue(builder().build().isPresent());
+        assertFalse(builder()
+            .withProperty(BackupConfig.PROP_BACKUP_ENABLED, "false")
+            .build().isPresent());
+        assertTrue(builder()
+            .withProperty(BackupConfig.PROP_BACKUP_ENABLED, "true")
+            .build().isPresent());
+    }
+
+    @Test
+    public void testStatusDir() throws Exception {
+        try {
+            new BackupConfig.Builder()
+                .enabled(true)
+                .tmpDir(DEFAULT_TMP_DIR)
+                .hdfsConfig(DEFAULT_HDFS_CONFIG)
+                .hdfsPath(DEFAULT_HDFS_PATH)
+                .build();
+            assertTrue(false);
+        } catch (ConfigException exc) {
+            assertTrue(true);
+        }
+
+        assertEquals(DEFAULT_STATUS_DIR, builder()
+            .build().get()
+            .getStatusDir());
+        File expected = new File("/expected");
+        assertEquals(expected, builder()
+            .statusDir(expected)
+            .build().get()
+            .getStatusDir());
+        assertEquals(expected, builder()
+            .withProperty(BackupConfig.PROP_BACKUP_STATUS_DIR, expected.getAbsolutePath())
+            .build().get()
+            .getStatusDir());
+    }
+
+    @Test
+    public void testTmpDir() throws Exception {
+        try {
+            new BackupConfig.Builder()
+                .enabled(true)
+                .statusDir(DEFAULT_STATUS_DIR)
+                .hdfsConfig(DEFAULT_HDFS_CONFIG)
+                .hdfsPath(DEFAULT_HDFS_PATH)
+                .build();
+            assertTrue(false);
+        } catch (ConfigException exc) {
+            assertTrue(true);
+        }
+
+        assertEquals(DEFAULT_TMP_DIR, builder()
+            .build().get()
+            .getTmpDir());
+        File expected = new File("/expected");
+        assertEquals(expected, builder()
+            .tmpDir(expected)
+            .build().get()
+            .getTmpDir());
+        assertEquals(expected, builder()
+            .withProperty(BackupConfig.PROP_BACKUP_TMP_DIR, expected.getAbsolutePath())
+            .build().get()
+            .getTmpDir());
+    }
+
+    @Test
+    public void testInterval() throws Exception {
+        assertEquals(BackupConfig.DEFAULT_BACKUP_INTERVAL, builder()
+            .build().get()
+            .getInterval());
+        Duration expected = Duration.fromTimeUnit(3, TimeUnit.MINUTES);
+        assertEquals(expected, builder()
+            .interval(expected)
+            .build().get()
+            .getInterval());
+        assertEquals(expected, builder()
+            .withProperty(BackupConfig.PROP_BACKUP_INTERVAL, "3")
+            .build().get()
+            .getInterval());
+    }
+
+    @Test
+    public void testHDFSConfig() throws Exception {
+        try {
+            new BackupConfig.Builder()
+                .enabled(true)
+                .statusDir(DEFAULT_STATUS_DIR)
+                .tmpDir(DEFAULT_TMP_DIR)
+                .hdfsPath(DEFAULT_HDFS_PATH)
+                .build();
+            assertTrue(false);
+        } catch (ConfigException exc) {
+            assertTrue(true);
+        }
+
+        assertEquals(DEFAULT_HDFS_CONFIG, builder()
+            .build().get()
+            .getHDFSConfig());
+        File expected = new File("/expected");
+        assertEquals(expected, builder()
+            .hdfsConfig(expected)
+            .build().get()
+            .getHDFSConfig());
+        assertEquals(expected, builder()
+            .withProperty(BackupConfig.PROP_BACKUP_HDFS_CONFIG, expected.getAbsolutePath())
+            .build().get()
+            .getHDFSConfig());
+
+    }
+
+    @Test
+    public void testHDFSPath() throws Exception {
+        try {
+            new BackupConfig.Builder()
+                .enabled(true)
+                .statusDir(DEFAULT_STATUS_DIR)
+                .tmpDir(DEFAULT_TMP_DIR)
+                .hdfsConfig(DEFAULT_HDFS_CONFIG)
+                .build();
+            assertTrue(false);
+        } catch (ConfigException exc) {
+            assertTrue(true);
+        }
+
+        assertEquals(DEFAULT_HDFS_PATH, builder()
+            .build().get()
+            .getHDFSPath());
+        String expected = "/expected";
+        assertEquals(expected, builder()
+            .hdfsPath(expected)
+            .build().get()
+            .getHDFSPath());
+        assertEquals(expected, builder()
+            .withProperty(BackupConfig.PROP_BACKUP_HDFS_PATH, expected)
+            .build().get()
+            .getHDFSPath());
+    }
+
+    @Test
+    public void testRetentionPeriod() throws Exception {
+        assertEquals(BackupConfig.DEFAULT_RETENTION_DAYS, builder()
+            .build().get()
+            .getRetentionPeriod().inDays());
+        int expected = 100;
+        assertEquals(expected, builder()
+            .retentionDays(expected)
+            .build().get()
+            .getRetentionPeriod().inDays());
+        assertEquals(expected, builder()
+            .withProperty(BackupConfig.PROP_BACKUP_RETENTION_DAYS, "100")
+            .build().get()
+            .getRetentionPeriod().inDays());
+    }
+
+    @Test
+    public void testRetentionMaintenanceInterval() throws Exception {
+        assertEquals(BackupConfig.DEFAULT_RETENTION_MAINTENANCE_INTERVAL, builder()
+            .build().get()
+            .getRetentionMaintenanceInterval());
+        Duration expected = Duration.fromTimeUnit(3, TimeUnit.HOURS);
+        assertEquals(expected, builder()
+            .retentionMaintenanceInterval(expected)
+            .build().get()
+            .getRetentionMaintenanceInterval());
+        assertEquals(expected, builder()
+            .withProperty(BackupConfig.PROP_BACKUP_RETENTION_MAINTENANCE_INTERVAL_HOURS, "3")
+            .build().get()
+            .getRetentionMaintenanceInterval());
+    }
+
+    private BackupConfig.Builder builder() {
+        return new BackupConfig.Builder()
+            .enabled(true)
+            .statusDir(DEFAULT_STATUS_DIR)
+            .tmpDir(DEFAULT_TMP_DIR)
+            .hdfsConfig(DEFAULT_HDFS_CONFIG)
+            .hdfsPath(DEFAULT_HDFS_PATH);
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/HdfsBackupTxnLogIteratorTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/HdfsBackupTxnLogIteratorTest.java
@@ -1,0 +1,207 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Range;
+
+import org.apache.zookeeper.server.FileStreamTxnIteratorTestBase;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test the behavior of the hdfs txn log iterator
+ */
+public class HdfsBackupTxnLogIteratorTest extends FileStreamTxnIteratorTestBase {
+    private static final Logger LOG = LoggerFactory.getLogger(HdfsBackupTxnLogIteratorTest.class);
+
+    private static List<BackupFileInfo> backupFiles = new ArrayList<>(3);
+
+    private class MyBackupStorage extends HdfsBackupStorage {
+
+        private Map<String, BackupFileInfo> backupFiles = new HashMap<String, BackupFileInfo>();
+
+        public MyBackupStorage(List<BackupFileInfo> files) throws IOException {
+            super(logDir, logDir.getPath());
+
+            if (files != null) {
+                for (BackupFileInfo bfi : files) {
+                    String name = bfi.getBackedUpFile().getName();
+                    backupFiles.put(name, bfi);
+                    LOG.info("Adding entry with key '{}' to backup file list", name);
+                }
+            }
+        }
+
+        @Override
+        public BackupFileInfo getBackupFileInfo(File file) throws IOException {
+            LOG.info("Getting backup file info for file: {} ({})", file, file.getName());
+            return backupFiles.get(file.getName());
+        }
+
+        @Override
+        public List<BackupFileInfo> getBackupFileInfos(File path, String prefix) throws IOException {
+            List<BackupFileInfo> files = new ArrayList<BackupFileInfo>();
+
+            LOG.info("Getting backup file infos for path: {} prefix: {}", path, prefix);
+
+            for (Map.Entry<String, BackupFileInfo> kv : backupFiles.entrySet()) {
+                if (kv.getKey().startsWith(prefix)) {
+                    files.add(kv.getValue());
+                    LOG.info("Return includes: {}", kv.getValue().getBackedUpFile());
+                }
+            }
+
+            return files;
+        }
+
+        @Override
+        public List<File> getDirectories(File path) throws IOException {
+            return new ArrayList<>();
+        }
+
+        @Override
+        public InputStream open(File path) throws IOException {
+            BackupFileInfo bfi = backupFiles.get(path.getName());
+            InputStream stream = null;
+
+            LOG.info("Opening file: {}", path);
+
+            if (bfi != null) {
+                stream = new FileInputStream(bfi.getBackedUpFile());
+            } else {
+                LOG.info("File not found: {}", path);
+            }
+
+            return stream;
+        }
+
+        @Override
+        public void copyToBackupStorage(File srcFile, File destName) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void copyToLocalStorage(File srcName, File destFile) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void delete(File fileToDelete) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void cleanupInvalidFiles(File path) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static void createBackupFiles() throws IOException {
+        addBackupFile(logFiles.get(0), 10);
+        addBackupFile(logFiles.get(1), 219);
+        addBackupFile(logFiles.get(2), 229);
+
+        Assert.assertEquals(3, backupFiles.size());
+        Assert.assertEquals(1, backupFiles.get(0).getZxid(BackupUtil.ZxidPart.MIN_ZXID));
+        Assert.assertEquals(10, backupFiles.get(0).getZxid(BackupUtil.ZxidPart.MAX_ZXID));
+        Assert.assertEquals(110, backupFiles.get(1).getZxid(BackupUtil.ZxidPart.MIN_ZXID));
+        Assert.assertEquals(219, backupFiles.get(1).getZxid(BackupUtil.ZxidPart.MAX_ZXID));
+        Assert.assertEquals(220, backupFiles.get(2).getZxid(BackupUtil.ZxidPart.MIN_ZXID));
+
+        for (BackupFileInfo bfi : backupFiles) {
+            LOG.info("Standard: {}  Backedup: {}  Range: {}  Size: {}  ModificationTime: {}",
+                bfi.getStandardFile(),
+                bfi.getBackedUpFile(),
+                bfi.getZxidRange(),
+                bfi.getSize(),
+                bfi.getModificationTime());
+        }
+    }
+
+    private static void addBackupFile(File logFile, long highZxid) {
+        File backedupName =
+            new File(logFile.getParent(), BackupUtil.makeBackupName(logFile.getName(), highZxid));
+        logFile.renameTo(backedupName);
+        BackupFileInfo bfi =
+            new BackupFileInfo(backedupName, System.currentTimeMillis(), logFile.length());
+
+        backupFiles.add(bfi);
+    }
+
+    @BeforeClass
+    public static void setupClass() throws IOException {
+        logDir = ClientBase.createTmpDir();
+        createTxnLogFiles(logDir);
+        createBackupFiles();
+    }
+
+    @Test
+    public void testSingleFileIteration() throws Exception {
+        MyBackupStorage backupStorage = new MyBackupStorage(backupFiles);
+        HdfsBackupTxnLogIterator iter =
+                new HdfsBackupTxnLogIterator(backupStorage, backupFiles.get(1).getBackedUpFile());
+
+        long startingZxid = 110;
+        long endingZxid = 119;
+
+        checkRange(iter, startingZxid, endingZxid);
+    }
+
+    @Test
+    public void testAllFilesIteration() throws Exception {
+        MyBackupStorage backupStorage = new MyBackupStorage(backupFiles);
+        HdfsBackupTxnLogIterator iter = new HdfsBackupTxnLogIterator(backupStorage);
+
+        long startingZxid = 1;
+        long endingZxid = 229;
+
+        checkRange(iter, startingZxid, endingZxid);
+    }
+
+    @Test
+    public void testZxidRangeIteration() throws Exception {
+        MyBackupStorage backupStorage = new MyBackupStorage(backupFiles);
+        Range<Long> zxidRange = Range.closed(5L, 114L);
+        HdfsBackupTxnLogIterator iter = new HdfsBackupTxnLogIterator(backupStorage, zxidRange);
+
+
+        checkRange(iter, zxidRange.lowerEndpoint(), zxidRange.upperEndpoint());
+    }
+
+    @Test
+    public void testEmptyStorage() throws Exception {
+        MyBackupStorage backupStorage = new MyBackupStorage(null);
+        HdfsBackupTxnLogIterator iter = new HdfsBackupTxnLogIterator(backupStorage);
+
+        Assert.assertNull(iter.getHeader());
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/BackupManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/BackupManagerTest.java
@@ -1,0 +1,587 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.Range;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.metrics.NullMetricsReceiver;
+import org.apache.zookeeper.server.ServerCnxn;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.SyncRequestProcessor;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.apache.zookeeper.server.backup.BackupFileInfo;
+import org.apache.zookeeper.server.backup.BackupManager;
+import org.apache.zookeeper.server.backup.BackupPoint;
+import org.apache.zookeeper.server.backup.BackupStatus;
+import org.apache.zookeeper.server.backup.BackupUtil;
+import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
+import org.apache.zookeeper.server.backup.HdfsBackupStorage;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.server.persistence.Util;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BackupManagerTest extends ZKTestCase implements Watcher {
+
+    private static String HOSTPORT = "127.0.0.1:" + PortAssignment.unique();
+    private static final int CONNECTION_TIMEOUT = 300000;
+    private static final Logger LOG = LoggerFactory.getLogger(BackupManagerTest.class);
+
+    private ZooKeeper connection;
+    private File dataDir;
+    private File backupStatusDir;
+    private File backupTmpDir;
+    private File backupDir;
+    private ZooKeeperServer zks;
+    private ServerCnxnFactory serverCnxnFactory;
+    private HdfsBackupStorage backupStorage;
+    private BackupManager backupManager;
+    private BackupStatus backupStatus;
+    private FileTxnSnapLog snapLog;
+    private int createdNodeCount = 0;
+
+    @Before
+    public void setup() throws Exception {
+        setupZk();
+        connection = createConnection();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        closeConnection(connection);
+        connection = null;
+        cleanupZk();
+    }
+
+    @Test
+    public void testEmptyDirectory() throws Exception {
+        File dataDir = ClientBase.createTmpDir();
+        File backupTmpDir = ClientBase.createTmpDir();
+        File backupDir = ClientBase.createTmpDir();
+
+        BackupManager bm = new BackupManager(dataDir, dataDir, dataDir, backupTmpDir, 15,
+                new HdfsBackupStorage(dataDir, backupDir.getPath()), NullMetricsReceiver.get());
+        bm.initialize();
+
+        bm.getLogBackup().run(1);
+        bm.getSnapBackup().run(1);
+
+        Assert.assertFalse("No files should have been backed up.", backupDir.list() == null);
+        Assert.assertFalse("No temporary files should have been created.",
+                backupTmpDir.list() == null);
+        BackupStatus bs = new BackupStatus(dataDir);
+        BackupPoint bp = bs.read();
+        Assert.assertEquals("backupStatus should be set to min for log",
+                bp.getLogZxid(), BackupUtil.INVALID_LOG_ZXID);
+        Assert.assertEquals("backupStatus should be set to min for snap",
+                bp.getSnapZxid(), BackupUtil.INVALID_SNAP_ZXID);
+    }
+
+    @Test
+    public void testSwitchToNewBackupNode() throws Exception {
+        createNodes(connection, 1000);
+        backupManager.getLogBackup().run(1);
+        backupManager.getSnapBackup().run(1);
+
+        BackupPoint bp = backupStatus.read();
+        String[] filesOrig = getBackupFiles(backupDir);
+        Assert.assertEquals("backup status and backupmanager must match log",
+                bp.getLogZxid(), backupManager.getBackedupLogZxid());
+        Assert.assertEquals("backup status and backupmanager must match snap",
+                bp.getSnapZxid(), backupManager.getBackedupSnapZxid());
+
+        File backupStatusFile = new File(backupStatusDir, BackupStatus.STATUS_FILENAME);
+        backupStatusFile.delete();
+
+        backupManager.initialize();
+        BackupPoint bp2 = backupStatus.read();
+        Assert.assertEquals(
+                "backup status and backupmanager must match log after switch to new backup node",
+                bp2.getLogZxid(),
+                backupManager.getBackedupLogZxid());
+        Assert.assertEquals(
+                "backup status and backupmanager must match snap after switch to new backup node",
+                bp2.getSnapZxid(),
+                backupManager.getBackedupSnapZxid());
+        Assert.assertEquals("backup point must match prior backup point -- snap",
+                bp.getLogZxid(), bp2.getLogZxid());
+        Assert.assertEquals("backup point must match prior backup point -- snap",
+                bp.getSnapZxid(), bp2.getSnapZxid());
+
+        backupManager.getLogBackup().run(1);
+        backupManager.getSnapBackup().run(1);
+
+        String[] filesPost = getBackupFiles(backupDir);
+        Assert.assertArrayEquals("files before and after switch to new backup node",
+                filesOrig, filesPost);
+
+        createNodes(connection, 1000);
+        backupManager.getLogBackup().run(1);
+        backupManager.getSnapBackup().run(1);
+
+        String[] filesPostCreates = getBackupFiles(backupDir);
+        List<Range<Long>> zxids = BackupUtil.getZxids(backupStorage, BackupFileType.TXNLOG);
+
+        Assert.assertTrue("must have more backups", filesPostCreates.length > filesPost.length);
+
+        for (int i = 0; i < zxids.size(); i++) {
+            LOG.info("zxids[{}]: {}", i, zxids.get(i));
+        }
+
+        for (int i = 0; i < zxids.size() - 1; i++) {
+            Assert.assertEquals("max of previous must be one less than next min",
+                    (zxids.get(i).upperEndpoint() + 1), zxids.get(i + 1).lowerEndpoint().longValue());
+        }
+    }
+
+    @Test
+    public void testBackupManager() throws Exception {
+        backupManager.initialize();
+
+        backupManager.getSnapBackup().run(1);
+
+        String[] files = getBackupFiles(backupDir);
+        Assert.assertTrue("Must have some snapshots", files != null);
+
+        Assert.assertEquals("Must have just a single snapshot", 1, files.length);
+        Assert.assertEquals("File must be called snapshot.0-0",
+                Util.SNAP_PREFIX + ".0-0", files[0]);
+
+        BackupPoint bp;
+
+        createNodes(connection, 1);
+        backupManager.getLogBackup().run(1);
+        bp = backupStatus.read();
+
+        Assert.assertEquals("Must have copied last txn",
+                bp.getLogZxid(), zks.getTxnLogFactory().getLastLoggedZxid());
+        List<Range<Long>> zxids = BackupUtil.getZxids(backupStorage, BackupFileType.TXNLOG);
+        Range<Long> lastZxid = zxids.get(zxids.size() - 1);
+
+        Assert.assertEquals("last log must be 1-2", lastZxid, Range.closed(1L, 2L));
+
+        createNodes(connection, 1);
+        backupManager.getLogBackup().run(1);
+        zxids = BackupUtil.getZxids(backupStorage, BackupFileType.TXNLOG);
+        int count = zxids.size();
+        lastZxid = zxids.get(zxids.size() - 1);
+
+        Assert.assertEquals("last log must be 3-3", lastZxid, Range.closed(3L, 3L));
+
+        backupManager.getLogBackup().run(1);
+        zxids = BackupUtil.getZxids(backupStorage, BackupFileType.TXNLOG);
+        lastZxid = zxids.get(zxids.size() - 1);
+        int count2 = zxids.size();
+
+        Assert.assertEquals("last log must be 3-3", lastZxid, Range.closed(3L, 3L));
+        Assert.assertEquals("no new files", count, count2);
+
+        createNodes(connection, 1);
+        backupManager.getLogBackup().run(1);
+        zxids = BackupUtil.getZxids(backupStorage, BackupFileType.TXNLOG);
+        lastZxid = zxids.get(zxids.size() - 1);
+
+        Assert.assertEquals("last log must be 4-4", lastZxid, Range.closed(4L, 4L));
+
+        createNodes(connection, 1000);
+        backupManager.getLogBackup().run(1);
+        backupManager.getSnapBackup().run(1);
+
+        FileTxnSnapLog snapLog = new FileTxnSnapLog(dataDir, dataDir, NullMetricsReceiver.get());
+        List<File> snaps = snapLog.findNRecentSnapshots(100);
+        Collections.reverse(snaps);
+        List<BackupFileInfo> backupFiles = BackupUtil.getBackupFiles(
+                backupStorage,
+                BackupFileType.SNAPSHOT,
+                BackupUtil.ZxidPart.MIN_ZXID,
+                BackupUtil.SortOrder.ASCENDING);
+
+        Assert.assertEquals("must have only two snapshots", 2, backupFiles.size());
+        long firstSnapZxid = Util.getZxidFromName(snaps.get(0).getName(), Util.SNAP_PREFIX);
+        long firstBackupZxid = backupFiles.get(0).getZxidRange().lowerEndpoint();
+        long lastSnapZxid = Util.getZxidFromName(
+                snaps.get(snaps.size() - 1).getName(), Util.SNAP_PREFIX);
+        long lastBackupZxid = backupFiles.get(1).getZxidRange().lowerEndpoint();
+
+        Assert.assertEquals("first snapshot starting zxid must match",
+                firstSnapZxid, firstBackupZxid);
+        Assert.assertEquals("last snapshot starting zxid must match",
+                lastSnapZxid, lastBackupZxid);
+    }
+
+    @Test
+    public void restorabilityTest() throws Exception {
+        String[] nodeNames = {"/firstNode", "/secondNode", "/thirdNode", "/fourthNode"};
+
+        createNode(connection, nodeNames[0]);
+        backupManager.getSnapBackup().run(1);
+        backupManager.getLogBackup().run(1);
+
+        createNode(connection, nodeNames[1]);
+        backupManager.getSnapBackup().run(1);
+        backupManager.getLogBackup().run(1);
+
+        deleteNode(connection, nodeNames[1]);
+        backupManager.getSnapBackup().run(1);
+        backupManager.getLogBackup().run(1);
+
+        createNode(connection, nodeNames[2]);
+        backupManager.getSnapBackup().run(1);
+        backupManager.getLogBackup().run(1);
+
+        createNode(connection, nodeNames[3]);
+
+        closeConnection(connection);
+
+        boolean[][] expectedByLog = new boolean[][]{
+                {true, false, false, false},
+                {true, true, false, false},
+                {true, false, false, false},
+                {true, false, true, false}
+        };
+
+        for (int log = 0; log < 4; log++) {
+            restoreAndValidate(0, log, nodeNames, expectedByLog[log]);
+        }
+    }
+
+    @Test
+    public void testBackupFileMerge() throws Exception {
+        createNode(connection, "/fooBar");
+        backupManager.getLogBackup().run(1);
+
+        String[] backupFiles = getBackupFiles(backupDir);
+        Assert.assertEquals("Should have one backed up file", 1, backupFiles.length);
+
+        zks.getTxnLogFactory().rollLog();
+        createNode(connection, "/foo1");
+        long zxid1 = zks.getTxnLogFactory().getLastLoggedZxid();
+        createNode(connection, "/foo2");
+
+        zks.getTxnLogFactory().rollLog();
+        createNode(connection, "/foo3");
+        createNode(connection, "/foo4");
+        zks.getTxnLogFactory().rollLog();
+        createNode(connection, "/foo5");
+        createNode(connection, "/foo6");
+
+        File[] logs = snapLog.getSnapshotLogs(0);
+        Assert.assertEquals("Should have four log files.", 4, logs.length);
+        Assert.assertEquals("Should have zero additional txn in first file beyond backup point",
+                backupManager.getBackedupLogZxid() + 1, zxid1);
+        Assert.assertEquals("Zxid of second file must be backup point plus 1",
+                backupManager.getBackedupLogZxid() + 1,
+                Util.getZxidFromName(logs[1].getName(), Util.TXLOG_PREFIX));
+
+        backupManager.getLogBackup().run(1);
+        backupFiles = getBackupFiles(backupDir);
+
+        Assert.assertEquals("Should have two backed up files even with multiple log files",
+                2, backupFiles.length);
+    }
+
+    @Test
+    public void testBackupWithNoNewRecords() throws Exception {
+        createNode(connection, "/foo");
+        backupManager.getLogBackup().run(1);
+        long backedUpLog1 = backupManager.getBackedupLogZxid();
+        backupManager.getLogBackup().run(1);
+        Assert.assertEquals("Backup point cannot have moved #1",
+                backedUpLog1, backupManager.getBackedupLogZxid());
+        backupManager.getLogBackup().run(1);
+        Assert.assertEquals("Backup point cannot have moved #2",
+                backedUpLog1, backupManager.getBackedupLogZxid());
+    }
+
+    @Test
+    public void testLostLogs() throws Exception {
+        createNode(connection, "/foo");
+        backupManager.getLogBackup().run(1);
+        createNode(connection, "/foobar");
+        createNode(connection, "/foobar2");
+        zks.getTxnLogFactory().rollLog();
+        createNode(connection, "/foobar3");
+        createNode(connection, "/foobar4");
+        zks.getTxnLogFactory().rollLog();
+        createNode(connection, "/foobar5");
+
+        File[] logs = snapLog.getSnapshotLogs(0);
+
+        for (int f = 0; f < logs.length; f++) {
+            LOG.info("File {}: {}", f, logs[f].getPath());
+        }
+
+        Assert.assertEquals("Should have three log files", 3, logs.length);
+        logs[0].delete();
+        logs[1].delete();
+        backupManager.getLogBackup().run(1);
+        backupManager.getLogBackup().run(1);
+        backupManager.getLogBackup().run(1);
+
+        String[] backupFiles = getBackupFiles(backupDir);
+        Assert.assertEquals("Should have three files in backup dir", 3, backupFiles.length);
+
+        boolean lostLogsFileFound = false;
+        for (String s : backupFiles) {
+            LOG.info("backupFile: {}", s);
+            if (s.equals("lostLogs.3-6")) {
+                lostLogsFileFound = true;
+                break;
+            }
+        }
+
+        Assert.assertTrue("Must have a lostLogs.3-6 file", lostLogsFileFound);
+    }
+
+    @Test
+    public void testCleanupOfInvalidFilesOnStartUp() throws Exception {
+        createNodes(connection, 110);
+        backupManager.getSnapBackup().run(1);
+        backupManager.getLogBackup().run(1);
+        createNodes(connection, 110);
+        backupManager.getSnapBackup().run(1);
+        backupManager.getLogBackup().run(1);
+        createNodes(connection, 110);
+        backupManager.getSnapBackup().run(1);
+        backupManager.getLogBackup().run(1);
+        createNodes(connection, 110);
+        backupManager.getSnapBackup().run(1);
+        backupManager.getLogBackup().run(1);
+
+        String[] expectedBackupFiles = getBackupFiles(backupDir);
+
+        backupManager.initialize();
+
+        String[] actualBackupFiles = getBackupFiles(backupDir);
+
+        Assert.assertArrayEquals("no files should have been deleted",
+                expectedBackupFiles, actualBackupFiles);
+
+        // Add some invalid files
+        File badFile = new File(
+                backupDir,
+                makeTmpName(BackupUtil.makeBackupName(Util.makeSnapshotName(1000), 1010)));
+        badFile.createNewFile();
+
+        badFile = new File(
+                backupDir,
+                makeTmpName(BackupUtil.makeBackupName(Util.makeSnapshotName(1100), 1110)));
+        badFile.createNewFile();
+
+        badFile = new File(
+                backupDir,
+                makeTmpName(BackupUtil.makeBackupName(Util.makeLogName(1000), 1200)));
+        badFile.createNewFile();
+
+        backupManager.initialize();
+
+        actualBackupFiles = getBackupFiles(backupDir);
+
+        Assert.assertArrayEquals("bad files were should have been deleted",
+                expectedBackupFiles, actualBackupFiles);
+    }
+
+    private String makeTmpName(String filename) {
+        return HdfsBackupStorage.TMP_FILE_PREFIX + filename;
+    }
+
+    private void restoreAndValidate(int startingSnap, int endIndex, String[] nodeNames, boolean[] expectedExistence) throws Exception {
+        ZooKeeper c = null;
+
+        try {
+            c = closeRestoreRestartGetConnection(startingSnap, endIndex);
+
+            for (int n = 0; n < nodeNames.length && n < expectedExistence.length; n++) {
+                String msg = "Node " + nodeNames[n] + " existence after restore from snap "
+                        + startingSnap + " and ending with log " + endIndex + ".";
+                Assert.assertEquals(msg, expectedExistence[n], exists(c, nodeNames[n]));
+                LOG.info("PASSED: " + msg);
+            }
+        } finally {
+            closeConnection(c);
+        }
+    }
+
+    private ZooKeeper closeRestoreRestartGetConnection(int startingSnap, int endIndex) throws Exception {
+        closeZk();
+        deleteDataFiles();
+        restoreFromBackup(startingSnap, endIndex);
+        startZk();
+        return createConnection();
+    }
+
+    private void deleteDataFiles() {
+        for (File f : snapLog.getSnapDir().listFiles()) {
+            LOG.info("Deleting file {}", f.getPath());
+            f.delete();
+        }
+        for (File f : snapLog.getDataDir().listFiles()) {
+            LOG.info("Deleting file {}", f.getPath());
+            f.delete();
+        }
+    }
+
+    private void restoreFromBackup(int startingSnap, int endPoint) throws Exception {
+        LOG.info("Restoring from backup: Snap {}  Log {}", startingSnap, endPoint);
+
+        List<BackupFileInfo> snaps = BackupUtil.getBackupFilesByMin(backupStorage, BackupFileType.SNAPSHOT);
+        List<BackupFileInfo> logs = BackupUtil.getBackupFilesByMin(backupStorage, BackupFileType.TXNLOG);
+
+        copyToLocal(snaps.get(startingSnap), snapLog.getSnapDir());
+
+        for (int i = startingSnap; i <= endPoint; i++) {
+            copyToLocal(logs.get(i), snapLog.getDataDir());
+        }
+    }
+
+    private void copyToLocal(BackupFileInfo src, File destDir) throws IOException {
+        String name = src.getStandardFile().getName();
+        File dest = new File(destDir, name);
+
+        LOG.info("Copying from {} to {}", src.getBackedUpFile(), dest);
+        backupStorage.copyToLocalStorage(src.getBackedUpFile(), dest);
+    }
+
+    private void setupZk() throws Exception {
+        LOG.info("Setting up directories");
+
+        dataDir = ClientBase.createTmpDir();
+        backupStatusDir = ClientBase.createTmpDir();
+        backupTmpDir = ClientBase.createTmpDir();
+        backupDir = ClientBase.createTmpDir();
+        backupStorage = new HdfsBackupStorage(null, backupDir.getPath());
+        ClientBase.setupTestEnv();
+
+        startZk();
+        snapLog = new FileTxnSnapLog(dataDir, dataDir, NullMetricsReceiver.get());
+    }
+
+    private void startZk() throws Exception {
+        LOG.info("Starting Zk");
+
+        zks = new ZooKeeperServer(dataDir, dataDir, 3000);
+        SyncRequestProcessor.setSnapCount(100);
+        final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
+        serverCnxnFactory = ServerCnxnFactory.createFactory(PORT, -1);
+        serverCnxnFactory.startup(zks);
+
+        LOG.info("Waiting for server startup");
+
+        Assert.assertTrue("waiting for server being up ",
+                ClientBase.waitForServerUp(HOSTPORT, CONNECTION_TIMEOUT));
+
+        backupManager = new BackupManager(dataDir, dataDir, backupStatusDir, backupTmpDir, 15,
+                backupStorage, NullMetricsReceiver.get());
+        backupManager.initialize();
+        backupStatus = new BackupStatus(backupStatusDir);
+    }
+
+    private void closeZk() throws Exception {
+        LOG.info("Closing Zk");
+
+        if (serverCnxnFactory != null) {
+            serverCnxnFactory.closeAll(ServerCnxn.DisconnectReason.SERVER_SHUTDOWN);
+            serverCnxnFactory.shutdown();
+            serverCnxnFactory = null;
+        }
+
+        if (zks != null) {
+            zks.getZKDatabase().close();
+            zks.shutdown();
+            zks = null;
+        }
+
+        Assert.assertTrue("waiting for server to shutdown",
+                ClientBase.waitForServerDown(HOSTPORT, CONNECTION_TIMEOUT));
+    }
+
+    private void cleanupZk() throws Exception {
+        LOG.info("Closing and cleaning up Zk");
+
+        closeZk();
+        backupManager = null;
+        backupStatus = null;
+        serverCnxnFactory = null;
+        zks = null;
+        snapLog = null;
+    }
+
+    private ZooKeeper createConnection() throws IOException {
+        return new ZooKeeper(HOSTPORT, CONNECTION_TIMEOUT, this);
+    }
+
+    private void closeConnection(ZooKeeper zk) throws InterruptedException {
+        if (zk != null) {
+            zk.close();
+        }
+    }
+
+    private void createNodes(ZooKeeper zk, int count) throws Exception {
+        int last = createdNodeCount + count;
+        for (; createdNodeCount < last; createdNodeCount++) {
+            zk.create("/invalidsnap-" + createdNodeCount, new byte[0], Ids.OPEN_ACL_UNSAFE,
+                    CreateMode.PERSISTENT);
+        }
+    }
+
+    private void createNode(ZooKeeper zk, String path) throws Exception {
+        zk.create(path, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    }
+
+    private void deleteNode(ZooKeeper zk, String path) throws Exception {
+        zk.delete(path, -1);
+    }
+
+    private boolean exists(ZooKeeper zk, String path) throws Exception {
+        return zk.exists(path, false) != null;
+    }
+
+    private String[] getBackupFiles(File path) {
+        FilenameFilter filter = new FilenameFilter() {
+            public boolean accept(File dir, String name) {
+                return name.startsWith(Util.SNAP_PREFIX)
+                        || name.startsWith(Util.TXLOG_PREFIX)
+                        || name.startsWith(BackupUtil.LOST_LOG_PREFIX);
+            }
+        };
+
+        return path.list(filter);
+    }
+
+    public void process(WatchedEvent event) {
+        // do nothing
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/BackupRetentionManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/BackupRetentionManagerTest.java
@@ -1,0 +1,469 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Lists;
+
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.server.backup.BackupFileInfo;
+import org.apache.zookeeper.server.backup.BackupUtil;
+import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
+import org.apache.zookeeper.server.backup.RetentionManager.BackupStorageRetentionTask;
+import org.apache.zookeeper.server.persistence.Util;
+import org.apache.zookeeper.test.TestBackupProvider.BackupInfoLists;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.twitter.finagle.stats.InMemoryStatsReceiver;
+import com.twitter.finagle.stats.ReadableCounter;
+import com.twitter.finagle.stats.StatsReceiver;
+
+/**
+ * Tests the backup storage retention manager
+ */
+public class BackupRetentionManagerTest extends ZKTestCase {
+    private static final Logger LOG = LoggerFactory.getLogger(BackupRetentionManagerTest.class);
+    private static final long retentionAsOfTime = System.currentTimeMillis();
+
+    public void testNoFilesYoungerThanRetentionPeriod() throws Exception {
+        run(
+            backupState(s(100, -5), s(200, -4), l(100, -5), l(200, -4), ll(50, -7)),
+            10,
+            BackupInfoLists.EMPTY);
+    }
+
+    @Test
+    public void testRetentionOfLastSnapBeforeCutoff() throws Exception {
+        run(
+            backupState(s(100, -5), s(200, -4), l(100, -5), l(200, -4), ll(50, -7)),
+            4,
+            expectedDeletions(ll(50, -7)));
+    }
+
+    @Test
+    public void testAllFilesOlderThanCutOff() throws Exception {
+        run(
+            backupState(s(100, -5), s(200, -4), l(100, -5), l(200, -4), ll(50, -7)),
+            2,
+            expectedDeletions(s(100, -5), l(100, -5), ll(50, -7)));
+    }
+
+    @Test
+    public void testNoSnapsAndOtherFilesYoungerThanCutOff() throws Exception {
+        run(
+            backupState(l(100, -5), l(200, -4), ll(50, -7)),
+            10,
+            BackupInfoLists.EMPTY);
+    }
+
+    @Test
+    public void testCommonCase() throws Exception {
+        run(
+            backupState(
+                    s(50, -20), s(100, -15), s(200, -10), s(300, -5), s(400, -2),
+                    l(49, -20), l(75, -15), l(104, -15), l(150, -15), l(200, -14),
+                    l(300, -4), l(340, -2), l(500, -1),
+                    ll(30, -25), ll(600, 0)),
+            14,
+            expectedDeletions(s(50, -20), l(49, -20), l(75, -15), ll(30, -25)));
+    }
+
+    @Test
+    public void testChildDirectoriesFullDepth() throws Exception {
+        BackupInfoLists state = new BackupInfoLists();
+        BackupInfoLists deletions = new BackupInfoLists();
+        
+        File[] dirs = new File[] { null, new File("z2"), new File("z1/c1"), new File("z1/c2"),
+                new File("z2/c1"), new File("z3/sz/c1"), new File("z3/sz/c2") };
+        
+        for (File dir : dirs) {
+            state.add(
+                backupState(
+                    s(dir, 50, -20), s(dir, 100, -15), s(dir, 200, -10), s(dir, 300, -5),
+                    s(dir, 400, -2),
+                    l(dir, 49, -20), l(dir, 75, -15), l(dir, 104, -15), l(dir, 150, -15),
+                    l(dir, 200, -14), l(dir, 300, -4), l(dir, 340, -2), l(dir, 500, -1),
+                    ll(dir, 30, -25), ll(dir, 600, 0)));
+            deletions.add(
+                expectedDeletions(
+                    s(dir, 50, -20), l(dir, 49, -20), l(dir, 75, -15), ll(dir, 30, -25)));
+        }
+
+        File dir = new File("z1/c3");
+        state.add(
+            backupState(
+                s(dir, 100, -10), s(dir, 150, -4),
+                l(dir, 100, -10), l(dir, 150, -4),
+                ll(dir, 50, -12)));
+
+        dir = new File("z2/c2");
+        state.add(
+            backupState(
+                s(dir, 10, -21), s(dir, 50, -20), s(dir, 100, -15), s(dir, 200, -10),
+                s(dir, 300, -5), s(dir, 400, -2), s(dir, 500, -1),
+                l(dir, 10, -21), l(dir, 49, -20), l(dir, 75, -15), l(dir, 104, -15),
+                l(dir, 150, -15), l(dir, 200, -14), l(dir, 300, -4), l(dir, 340, -2),
+                l(dir, 500, -1), l(dir, 600, -1),
+                ll(dir, 5, -26), ll(dir, 30, -25), ll(dir, 600, 0)));
+        deletions.add(
+            expectedDeletions(
+                s(dir, 10, -21), s(dir, 50, -20),
+                l(dir, 10, -21), l(dir, 49, -20), l(dir, 75, -15),
+                ll(dir, 5, -26), ll(dir, 30, -25)));
+
+        run(state, 5, 14, false, deletions);
+    }
+
+    @Test
+    public void testChildDirectoriesPartialDepth() throws Exception {
+        BackupInfoLists state = new BackupInfoLists();
+        BackupInfoLists deletions = new BackupInfoLists();
+
+        File[] dirs = new File[] { new File("z1/c1"), new File("z1/c2"), new File("z2/c1"),
+                new File("z2/sz/c1"), new File("z2/sz/c2") };
+        File[] deletionDirs = new File[] { new File("z1/c1"), new File("z1/c2"), new File("z2/c1")};
+
+        for (File dir : dirs) {
+            state.add(
+                backupState(
+                    s(dir, 50, -20), s(dir, 100, -15), s(dir, 200, -10), s(dir, 300, -5),
+                    s(dir, 400, -2),
+                    l(dir, 49, -20), l(dir, 75, -15), l(dir, 104, -15), l(dir, 150, -15),
+                    l(dir, 200, -14), l(dir, 300, -4), l(dir, 340, -2), l(dir, 500, -1),
+                    ll(dir, 30, -25), ll(dir, 600, 0)));
+        }
+
+        for (File dir : deletionDirs) {
+            deletions.add(
+                expectedDeletions(
+                    s(dir, 50, -20), l(dir, 49, -20), l(dir, 75, -15), ll(dir, 30, -25)));
+        }
+
+        run(state, 2, 14, false, deletions);
+    }
+
+    @Test
+    public void testRecursionDepthOfZero() throws Exception {
+        File c1 = new File("c1");
+
+        run(
+            backupState(
+                s(100, -5), s(200, -4), l(100, -5), l(200, -4), ll(50, -7),
+                s(c1, 100, -5), s(c1, 200, -4), l(c1, 100, -5), l(c1, 200, -4), ll(c1, 50, -7)),
+            0,
+            expectedDeletions(
+                s(100, -5), l(100, -5), ll(50, -7)));
+    }
+
+    @Test
+    public void testAdaptiveSnapRetention() throws Exception {
+        
+        // With a 10 day retention period, the interval cut-offs are at 2 days and 5 days
+        // We'll have a bunch of snaps in each interval, some of which can be removed, others
+        // which cannot.
+
+        run(
+            backupState(
+                // low latency period
+                sm(544, nt(0, 0, 1)), sm(528, nt(0, 0, 10)), sm(512, nt(0, 0, 40)),
+                sm(496, nt(0, 1, 0)), sm(480, nt(0, 1, 5)), sm(464, nt(0, 1, 10)),
+                sm(448, nt(0, 1, 12)), sm(432, nt(0, 1, 15)), sm(416, nt(0, 1, 30)),
+                sm(400, nt(0, 1, 46)), sm(384, nt(1, 20, 30)), sm(368, nt(1, 23, 55)),
+                // medium latency period
+                sm(352, nt(2, 0, 15)), sm(336, nt(2, 0, 30)), sm(320, nt(2, 0, 45)),
+                sm(304, nt(2, 1, 0)), sm(288, nt(2, 1, 15)), sm(272, nt(3, 12, 0)),
+                sm(256, nt(3, 12, 15)), sm(240, nt(3, 12, 30)), sm(224, nt(3, 16, 0)),
+                sm(208, nt(4, 23, 30)),
+                // long latency period
+                sm(192, nt(5, 0, 15)), sm(176, nt(5, 1, 30)), sm(160, nt(5, 2, 30)),
+                sm(144, nt(5, 3, 30)), sm(128, nt(5, 4, 30)), sm(112, nt(6, 10, 0)),
+                sm(96, nt(9, 15, 0)), sm(80, nt(9, 16, 0)), sm(64, nt(9, 20, 0)),
+                // outside of retention period
+                sm(48, nt(10, 0, 5)), sm(32, nt(10, 8, 0)), sm(16, nt(12, 0, 0))),
+            0, // no recursion
+            10,
+            true, // use adaptive snap retention
+            expectedDeletions(
+                    // low latency period deletions
+                    sm(464, nt(0, 1, 10)), sm(448, nt(0, 1, 12)),
+                    // medium latency period deletions
+                    sm(320, nt(2, 0, 45)), sm(304, nt(2, 1, 0)), sm(256, nt(3, 12, 15)),
+                    // high latency period deletions
+                    sm(176, nt(5, 1, 30)), sm(160, nt(5, 2, 30)), sm(144, nt(5, 3, 30)),
+                    sm(80, nt(9, 16, 0)),
+                    // outside of retention period deletions
+                    sm(32, nt(10, 8, 0)), sm(16, nt(12, 0, 0))));
+    }
+
+    @Test
+    public void testAdaptiveSnapRetentionWithLostLogs() throws Exception {
+        run(
+            backupState(
+                // low latency period
+                sm(544, nt(0, 0, 1)), sm(528, nt(0, 0, 10)), sm(512, nt(0, 0, 40)),
+                sm(496, nt(0, 1, 0)), sm(480, nt(0, 1, 5)), sm(464, nt(0, 1, 10)),
+                sm(448, nt(0, 1, 12)), sm(432, nt(0, 1, 15)), sm(416, nt(0, 1, 30)),
+                sm(400, nt(0, 1, 46)), sm(384, nt(1, 20, 30)), sm(368, nt(1, 23, 55)),
+                // medium latency period
+                sm(352, nt(2, 0, 15)), sm(336, nt(2, 0, 30)), sm(320, nt(2, 0, 45)),
+                sm(304, nt(2, 1, 0)), sm(288, nt(2, 1, 15)), sm(272, nt(3, 12, 0)),
+                sm(256, nt(3, 12, 15)), sm(240, nt(3, 12, 30)), sm(224, nt(3, 16, 0)),
+                sm(208, nt(4, 23, 30)),
+                // long latency period
+                sm(192, nt(5, 0, 15)), sm(176, nt(5, 1, 30)), sm(160, nt(5, 2, 30)),
+                sm(144, nt(5, 3, 30)), sm(128, nt(5, 4, 30)), sm(112, nt(6, 10, 0)),
+                sm(96, nt(9, 15, 0)), sm(80, nt(9, 16, 0)), sm(64, nt(9, 20, 0)),
+                // outside of retention period
+                sm(48, nt(10, 0, 5)), sm(32, nt(10, 8, 0)), sm(16, nt(12, 0, 0)),
+                llm(36, nt(10, 6, 0)), llm(144, nt(5, 3, 30)), llm(464, nt(0, 1, 10))),
+            0, // no recursion
+            10,
+            true, // use adaptive snap retention
+            expectedDeletions(
+                    // low latency period deletions
+                    sm(448, nt(0, 1, 12)),
+                    // medium latency period deletions
+                    sm(320, nt(2, 0, 45)), sm(304, nt(2, 1, 0)), sm(256, nt(3, 12, 15)),
+                    // high latency period deletions
+                    sm(176, nt(5, 1, 30)), sm(80, nt(9, 16, 0)),
+                    // outside of retention period deletions
+                    sm(32, nt(10, 8, 0)), sm(16, nt(12, 0, 0)),
+                    // lostLogs
+                    llm(36, nt(10, 6, 0))));
+    }
+
+    /**
+     * Helper method for building the list of files that exist in the backup provider
+     * @param descriptions the descriptions of the individual files
+     * @return the lists of backup files separated by type
+     */
+    private BackupInfoLists backupState(BackupFileInfo... descriptions) {
+        return BackupInfoLists.buildLists(Lists.newArrayList(descriptions));
+    }
+
+    /**
+     * Helper method for building the list of files that are expected to be deleted by the retention
+     * manager
+     * @param descriptions the descriptions of the individual files
+     * @return the lists of restored files separated by type
+     */
+    private BackupInfoLists expectedDeletions(BackupFileInfo... descriptions) {
+        return backupState(descriptions);
+    }
+
+    /**
+     * Helper method for creating a description of a snap in the test cases
+     * @param path the path for the file
+     * @param low the starting zxid for the snap
+     * @param modDateOffsetDays modification date adjustment from current time, in days
+     * @return the backup file info for the described snap
+     */
+    private BackupFileInfo s(File path, long low, long modDateOffsetDays) {
+        return createFile(path, Util.SNAP_PREFIX, low, TimeUnit.DAYS.toMillis(modDateOffsetDays));
+    }
+
+    private BackupFileInfo s(long low, long modDateOffsetDays) {
+        return s(null, low, modDateOffsetDays);
+    }
+
+    private BackupFileInfo sm(File path, long low, long timeOffset) {
+        return createFile(path, Util.SNAP_PREFIX, low, timeOffset);
+    }
+
+    private BackupFileInfo sm(long low, long timeOffset) {
+        return sm(null, low, timeOffset);
+    }
+
+    private long t(int days, int hours, int minutes) {
+        return TimeUnit.DAYS.toMillis(days)
+                + TimeUnit.HOURS.toMillis(hours)
+                + TimeUnit.MINUTES.toMillis(minutes);
+    }
+
+    private long nt(int days, int hours, int minutes) {
+        return -t(days, hours, minutes);
+    }
+
+    /**
+     * Helper method for creating a description of a txlog in the test cases
+     * @param path the path for the file
+     * @param low the starting zxid for the log
+     * @param modDateOffsetDays modification date adjustment from current time, in days
+     * @return the backup file info for the described log
+     */
+    private BackupFileInfo l(File path, long low, long modDateOffsetDays) {
+        return createFile(path, Util.TXLOG_PREFIX, low, TimeUnit.DAYS.toMillis(modDateOffsetDays));
+    }
+
+    private BackupFileInfo l(long low, long modDateOffsetDays) {
+        return l(null, low, modDateOffsetDays);
+    }
+
+    /**
+     * Helper method for creating a description of a lost log range in the test cases
+     * @param path the path for the file
+     * @param low the first zxid of the range that has been lost
+     * @param modDateOffsetDays modification date adjustment from current time, in days
+     * @return the backup file info for the described lost log range
+     */
+    private BackupFileInfo ll(File path, long low, long modDateOffsetDays) {
+        return createFile(
+                path,
+                BackupUtil.LOST_LOG_PREFIX,
+                low,
+                TimeUnit.DAYS.toMillis(modDateOffsetDays));
+    }
+
+    private BackupFileInfo ll(long low, long modDateOffsetDays) {
+        return ll(null, low, modDateOffsetDays);
+    }
+
+    private BackupFileInfo llm(long low, long timeOffset) {
+        return createFile(null, BackupUtil.LOST_LOG_PREFIX, low, timeOffset);
+    }
+
+    private BackupFileInfo createFile(File path, String prefix, long zxid, long timeOffset) {
+        return new BackupFileInfo(
+                new File(path, TestBackupProvider.backupName(prefix, zxid, zxid)),
+                retentionAsOfTime + timeOffset,
+                100);
+    }
+
+    private void printList(String title, List<BackupFileInfo> list) {
+        LOG.info(title);
+
+        if (list.isEmpty()) {
+            LOG.info("EMPTY");
+            return;
+        }
+
+        for(BackupFileInfo bfi : list) {
+            LOG.info(bfi.getBackedUpFile().toString());
+        }
+    }
+
+    private void run(BackupInfoLists startingBackupState,
+                     int retentionDays,
+                     BackupInfoLists expectedDeletions) throws IOException {
+        run(startingBackupState, 0, retentionDays, false, expectedDeletions);
+    }
+
+    private void run(BackupInfoLists startingBackupState,
+                     int recursionDepth,
+                     int retentionDays,
+                     boolean useAdaptiveSnapRetention,
+                     BackupInfoLists expectedDeletions) throws IOException {
+
+        TestBackupProvider storage = new TestBackupProvider();
+        storage.setAvailableBackups(startingBackupState);
+
+        InMemoryStatsReceiver statsReceiver = new InMemoryStatsReceiver();
+        StatsReceiver brmScope = statsReceiver.scope("backup_retention_manager");
+
+        BackupStorageRetentionTask retentionTask =
+                new BackupStorageRetentionTask(
+                        false, /* not dry run */
+                        storage,
+                        recursionDepth,
+                        retentionDays,
+                        useAdaptiveSnapRetention,
+                        retentionAsOfTime,
+                        statsReceiver);
+
+        retentionTask.run();
+
+        BackupInfoLists deletedFiles = storage.getDeletedLists();
+
+        Assert.assertEquals(1, rc(brmScope, "iterations", "count").apply());
+
+        printList("Expected deleted snaps:", expectedDeletions.snaps);
+        printList("Actual deleted snaps:", deletedFiles.snaps);
+        Assert.assertArrayEquals("Snaps",
+                TestBackupProvider.getBackupNames(expectedDeletions.snaps),
+                TestBackupProvider.getBackupNames(deletedFiles.snaps));
+        assertStatCountsPerDir(expectedDeletions.snaps, brmScope, BackupFileType.SNAPSHOT);
+
+        printList("Expected deleted logs:", expectedDeletions.logs);
+        printList("Actual deleted logs:", deletedFiles.logs);
+        Assert.assertArrayEquals("Logs",
+                TestBackupProvider.getBackupNames(expectedDeletions.logs),
+                TestBackupProvider.getBackupNames(deletedFiles.logs));
+        assertStatCountsPerDir(expectedDeletions.logs, brmScope, BackupFileType.TXNLOG);
+
+        printList("Expected deleted lostLogs:", expectedDeletions.lostLogs);
+        printList("Actual deleted lostLogs:", deletedFiles.lostLogs);
+        Assert.assertArrayEquals("LostLogs",
+                TestBackupProvider.getBackupNames(expectedDeletions.lostLogs),
+                TestBackupProvider.getBackupNames(deletedFiles.lostLogs));
+        assertStatCountsPerDir(expectedDeletions.lostLogs, brmScope, BackupFileType.LOSTLOG);
+    }
+
+    private void assertStatCountsPerDir(
+            List<BackupFileInfo> expectedDeletions,
+            StatsReceiver statsReceiver,
+            BackupFileType fileType) {
+
+        HashMap<String, Integer> countsPerDir = new HashMap<>();
+
+        for (BackupFileInfo bfi : expectedDeletions) {
+            String parent = bfi.getBackedUpFile().getParent();
+            parent = parent == null ? "base" : parent.replace("/", "\\");
+
+            if (!countsPerDir.containsKey(parent)) {
+                countsPerDir.put(parent, 1);
+            } else {
+                countsPerDir.put(parent, countsPerDir.get(parent) + 1);
+            }
+        }
+
+        for (Map.Entry<String, Integer> e : countsPerDir.entrySet()) {
+            StatsReceiver purgedScope = statsReceiver.scope(e.getKey()).scope("purged");
+
+            Assert.assertEquals(
+                    "childDir: " + e.getKey(),
+                    (int)e.getValue(),
+                    rcv(purgedScope, fileType, "count"));
+        }
+    }
+
+    private long rcv(StatsReceiver stats, BackupFileType fileType, String name) {
+        return rc(stats, fileType, name).apply();
+    }
+
+    private ReadableCounter rc(StatsReceiver stats, BackupFileType fileType, String name) {
+        return rc(stats, BackupUtil.getPrefix(fileType), name);
+    }
+
+    private ReadableCounter rc(StatsReceiver stats, String scope, String name) {
+        return rc(stats.scope(scope), name);
+    }
+
+    private ReadableCounter rc(StatsReceiver stats, String name) {
+        return (ReadableCounter)stats.counter0(name);
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/PersistenceUtilTests.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/PersistenceUtilTests.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.server.persistence.Util;
+import org.apache.zookeeper.server.persistence.ZxidRange;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test server/persistence/Util.java methods
+ */
+public class PersistenceUtilTests extends ZKTestCase {
+    @Test
+    public void testShortLogName() {
+        testDataFileName(Util.makeLogName(10), Util.TXLOG_PREFIX, new ZxidRange(10));
+    }
+
+    @Test
+    public void testShortSnapName() {
+        testDataFileName(Util.makeSnapshotName(55), Util.SNAP_PREFIX, new ZxidRange(55));
+    }
+
+    @Test
+    public void testLongSnapName() {
+        testDataFileName(Util.makeSnapshotName(100, 160), Util.SNAP_PREFIX, new ZxidRange(100, 160));
+    }
+
+    private void testDataFileName(String name, String prefix, ZxidRange expected) {
+
+        long zxid = Util.getZxidFromName(name, prefix);
+        ZxidRange zr = Util.getZxidRangeFromName(name, prefix);
+
+        Assert.assertEquals(expected.getLow(), zxid);
+        Assert.assertEquals(expected.getLow(), zr.getLow());
+        Assert.assertEquals(expected.isHighPresent(), zr.isHighPresent());
+
+        if (expected.isHighPresent()) {
+            Assert.assertEquals(expected.getHigh(), zr.getHigh());
+        }
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/PurgeTxnWithBackupTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/PurgeTxnWithBackupTest.java
@@ -1,0 +1,233 @@
+package org.apache.zookeeper.test;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+
+import org.apache.zookeeper.metrics.NullMetricsReceiver;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.backup.BackupPoint;
+import org.apache.zookeeper.server.backup.BackupStatus;
+import org.apache.zookeeper.server.backup.BackupUtil;
+import org.apache.zookeeper.server.backup.RetentionManager;
+import org.apache.zookeeper.server.persistence.FileSnap;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.server.persistence.SnapStream;
+import org.apache.zookeeper.server.persistence.Util;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.twitter.finagle.stats.InMemoryStatsReceiver;
+import com.twitter.finagle.stats.ReadableCounter;
+import com.twitter.finagle.stats.StatsReceiver;
+
+public class PurgeTxnWithBackupTest {
+    private static final Logger LOG = LoggerFactory.getLogger(PurgeTxnWithBackupTest.class);
+
+
+    @Test
+    public void testUseRetainSnapCountOverBackupStatus() throws Exception {
+        run(snapsAndLogs(s(100), s(200), s(300), s(400), l(99), l(200), l(300)),
+            b(500, 500),
+            3,
+            snapsAndLogs(s(200), s(300), s(400), l(200), l(300)));
+    }
+
+    @Test
+    public void testBackupStatusAtBeginningOfLogFile() throws Exception {
+        run(snapsAndLogs(
+                s(50), s(100), s(200), s(300), s(400), s(600),
+                l(50), l(99), l(150), l(200), l(300), l(450), l(480)),
+            b(150, 500),
+            3,
+            snapsAndLogs(
+                s(100), s(200), s(300), s(400), s(600),
+                l(99), l(150), l(200), l(300), l(450), l(480)));
+    }
+
+    @Test
+    public void testBackupStatusAtEndOfLogFile() throws Exception {
+        run(snapsAndLogs(
+                s(50), s(100), s(200), s(300), s(400), s(600),
+                l(50), l(99), l(150), l(200), l(300)),
+            b(199, 500),
+            3,
+            snapsAndLogs(s(200), s(300), s(400), s(600), l(200), l(300)));
+    }
+
+    @Test
+    public void testBackupStatusInMiddleOfLogFile() throws Exception {
+        run(snapsAndLogs(
+                s(50), s(100), s(200), s(300), s(400), s(600),
+                l(50), l(99), l(150), l(200), l(300), l(450), l(480)),
+            b(165, 500),
+            3,
+            snapsAndLogs(
+                s(100), s(200), s(300), s(400), s(600),
+                l(99), l(150), l(200), l(300), l(450), l(480)));
+    }
+
+    @Test
+    public void testBackupStatusAtBeginningOfSnapFile() throws Exception {
+        run(snapsAndLogs(
+                s(50), s(100), s(200), s(300), s(400), s(600),
+                l(50), l(99), l(150), l(200), l(300), l(450), l(480)),
+            b(700, 100),
+            3,
+            snapsAndLogs(
+                s(100), s(200), s(300), s(400), s(600),
+                l(99), l(150), l(200), l(300), l(450), l(480)));
+    }
+
+    @Test
+    public void testBackupStatusAtEndOfSnapFile() throws Exception {
+        run(snapsAndLogs(
+                s(50), s(100), s(200), s(300), s(400), s(600),
+                l(50), l(99), l(150), l(200), l(300), l(450), l(480)),
+            b(700, 199),
+            3,
+            snapsAndLogs(
+                s(200), s(300), s(400), s(600),
+                l(200), l(300), l(450), l(480)));
+    }
+
+    @Test
+    public void testBackupStatusInMiddleOfSnapFile() throws Exception {
+        run(snapsAndLogs(
+                s(50), s(100), s(200), s(300), s(400), s(600),
+                l(50), l(99), l(150), l(200), l(300), l(450), l(480)),
+            b(700, 250),
+            3,
+            snapsAndLogs(
+                s(200), s(300), s(400), s(600),
+                l(200), l(300), l(450), l(480)));
+    }
+
+    private String s(long zxid) {
+        return Util.makeSnapshotName(zxid);
+    }
+
+    private String l(long zxid) {
+        return Util.makeLogName(zxid);
+    }
+
+    private BackupPoint b(long logZxid, long snapZxid) {
+        return new BackupPoint(logZxid, snapZxid);
+    }
+
+    private String[] snapsAndLogs(String... files) {
+        return files;
+    }
+
+    private class DataFileNameComparator implements Comparator<String> {
+        @Override
+        public int compare(String s, String s2) {
+            String[] parts = s.split("\\.");
+            String[] parts2 = s2.split("\\.");
+
+            int result = parts[0].compareTo(parts2[0]);
+
+            if (result == 0) {
+                result = new Long(Long.parseLong(parts[1], 16)).compareTo(Long.parseLong(parts2[1], 16));
+            }
+
+            return result;
+        }
+    }
+
+    private void run(String[] dataFiles,
+                     BackupPoint backupPoint,
+                     int snapRetainCount,
+                     String[] expected) throws IOException {
+
+        File tmpDir = null;
+        File backupStatusDir = null;
+
+        try {
+            tmpDir = ClientBase.createTmpDir();
+            backupStatusDir = ClientBase.createTmpDir();
+
+            File versionedTmpDir = Util.makeVersionedFile(tmpDir);
+            versionedTmpDir.mkdirs();
+
+            for (String file : dataFiles) {
+                FileSnap snap = new FileSnap(tmpDir);
+                File fullName = new File(versionedTmpDir, file);
+
+                if (file.startsWith(Util.SNAP_PREFIX)) {
+                    snap.serialize(new DataTree(), new HashMap<Long, Integer>(), fullName, false);
+                    Assert.assertTrue(SnapStream.isValidSnapshot(fullName));
+                } else {
+                    fullName.createNewFile();
+                }
+            }
+
+            FilenameFilter fileFilter = new FilenameFilter() {
+                @Override
+                public boolean accept(File file, String s) {
+                    return s.startsWith(Util.TXLOG_PREFIX)
+                            || s.startsWith(Util.SNAP_PREFIX)
+                            || s.startsWith(BackupUtil.LOST_LOG_PREFIX);
+                }
+            };
+
+            InMemoryStatsReceiver statsReceiver = new InMemoryStatsReceiver();
+            StatsReceiver taskScope = statsReceiver.scope("local_purge_task");
+            BackupStatus status = new BackupStatus(backupStatusDir);
+            status.createIfNeeded();
+            status.update(backupPoint);
+
+            String[] startingFiles = versionedTmpDir.list(fileFilter);
+
+            RetentionManager.LocalPurgeTask purgeTask = new RetentionManager.LocalPurgeTask(
+                    false, /* not dry run */
+                    new FileTxnSnapLog(tmpDir, tmpDir, NullMetricsReceiver.get()),
+                    backupStatusDir,
+                    snapRetainCount,
+                    statsReceiver);
+            purgeTask.run();
+
+            Assert.assertEquals(1, rcv(taskScope, "iterations", "count"));
+
+            String[] remainingFiles = versionedTmpDir.list(fileFilter);
+
+            Arrays.sort(remainingFiles, new DataFileNameComparator());
+            Arrays.sort(expected, new DataFileNameComparator());
+
+            LOG.info("Remaining files");
+            for (String file : remainingFiles) {
+                LOG.info(file);
+            }
+            LOG.info("Expected files");
+            for (String file : expected) {
+                LOG.info(file);
+            }
+
+            Assert.assertArrayEquals(expected, remainingFiles);
+
+            StatsReceiver purgedScope = taskScope.scope("purged");
+            Assert.assertEquals(startingFiles.length - remainingFiles.length,
+                    rcv(purgedScope, Util.SNAP_PREFIX, "count") +
+                        rcv(purgedScope, Util.TXLOG_PREFIX, "count"));
+
+        } finally {
+            if (tmpDir != null) {
+                ClientBase.recursiveDelete(tmpDir);
+            }
+
+            if (backupStatusDir != null) {
+                ClientBase.recursiveDelete(backupStatusDir);
+            }
+        }
+    }
+
+    private long rcv(StatsReceiver stats, String scope, String name) {
+        return ((ReadableCounter)stats.scope(scope).counter0(name)).apply();
+    }
+
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/RestoreToolTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/RestoreToolTest.java
@@ -1,0 +1,382 @@
+package org.apache.zookeeper.test;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.google.common.collect.Lists;
+
+import org.apache.zookeeper.metrics.NullMetricsReceiver;
+import org.apache.zookeeper.server.backup.BackupFileInfo;
+import org.apache.zookeeper.server.backup.BackupUtil;
+import org.apache.zookeeper.server.backup.RestoreFromBackupTool;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.server.persistence.Util;
+import org.apache.zookeeper.test.TestBackupProvider.BackupInfoLists;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for validating funcationality of the RestoreFromBackupTool
+ *
+ * The initial state and expected outcome of test cases are specified using help methods that
+ * build the necessary objects.
+ * The test cases expect:
+ *  - the zxid up to which to restore (or Long.MAX_VALUE to restore to latest possible zxid)
+ *  - a list of files that exist in the backup store -- uses the 'backupState' helper method
+ *  - a list of files that are expected to be copied -- uses the 'expectedCopies' helper method
+ *  - whether the tool should succeed or not
+ *
+ * Note that the backupState and expectedCopies helper methods are the exact same except for their names, two methods
+ * are used to allow for better distinction in the test cases.
+ *
+ * The list of backed-up and/or copied files are specified using a sequence of objects created
+ * by the following help methods:
+ *  - s(long, long)  : creates a snap with the given starting zxid and zxid required for consistency
+ *  - l(long, long)  : creates a log with the given starting and ending zxids
+ *  - ll(long, long) : creates a range in which logs where lost
+ *
+ *  The s, l, and ll methods can be called in any order and the restore tool should work with any
+ *  order, but by convention they are listed in increasing zxid order of the first zxid for each
+ *  file.
+ *  This makes it easier to see the state that the testcase is testing.
+ */
+public class RestoreToolTest {
+    /**
+     * Custom implementation of FileTxnSnapLog in order to override and track calls to
+     * truncate
+      */
+    private static class TestFileTxnSnapLog extends FileTxnSnapLog {
+        long truncationZxid = -1;
+
+        public TestFileTxnSnapLog(File snapDir, File logDir) throws IOException {
+            super(logDir, snapDir, NullMetricsReceiver.get());
+        }
+
+        public boolean truncateLog(long zxid) {
+            Assert.assertEquals("Should not truncate multiple times", -1, truncationZxid);
+            Assert.assertTrue("Truncation zxid must be valid", zxid >= 1);
+            Assert.assertTrue("Cannot truncate to infinity", zxid != Long.MAX_VALUE);
+            truncationZxid = zxid;
+            return true;
+        }
+
+        public long getTruncationZxid() { return truncationZxid; }
+    }
+
+    static File tmpDir;
+
+    @BeforeClass
+    public static void classBefore() throws IOException {
+        tmpDir = ClientBase.createTmpDir();
+    }
+
+    @AfterClass
+    public static void classAfter() {
+        ClientBase.recursiveDelete(tmpDir);
+    }
+
+    @Test
+    public void restoreToLatest_noBackups() throws IOException {
+        run(true, BackupInfoLists.EMPTY, BackupInfoLists.EMPTY);
+    }
+
+    @Test
+    public void restoreToLatest_snapOnly() throws IOException {
+        run(true, backupState(s(100, 200)), BackupInfoLists.EMPTY);
+    }
+
+    @Test
+    public void restoreToLatest_logOnly() throws IOException {
+        run(true, backupState(l(100, 200)), BackupInfoLists.EMPTY);
+    }
+
+    @Test
+    public void restoreToLatest_matchingSnapAndLog() throws IOException {
+        run(true,
+            backupState(
+                    s(100, 200),
+                    l(100, 200)),
+            expectedCopies(
+                    s(100, 200),
+                    l(100, 200)));
+    }
+
+    @Test
+    public void restoreToLatest_additionalLog() throws IOException {
+        run(true,
+            backupState(
+                    s(100, 200),
+                    s(50, 55),
+                    l(100, 200),
+                    l(201, 205)),
+            expectedCopies(
+                    s(100, 200),
+                    l(100, 200),
+                    l(201, 205)));
+    }
+
+    @Test
+    public void restoreToLatest_validWithLostLogBothSides() throws IOException {
+        run(true,
+            backupState(
+                    s(100, 200),
+                    s(50, 55),
+                    ll(55, 99),
+                    l(100, 200),
+                    l(201, 205),
+                    ll(206, 210)),
+            expectedCopies(
+                    s(100, 200),
+                    l(100, 200),
+                    l(201, 205)));
+    }
+
+    @Test
+    public void restoreToLatest_needOlderSnapDueToLostLog() throws IOException {
+        run(true,
+            backupState(
+                    s(100, 200),
+                    s(400, 500),
+                    l(50, 249),
+                    l(250, 400),
+                    ll(401, 410),
+                    l(450, 600)),
+            expectedCopies(
+                    s(100, 200),
+                    l(50, 249),
+                    l(250, 400)));
+    }
+
+    @Test
+    public void restoreToLatest_needOlderSnapDueToConsistency() throws IOException {
+        run(true,
+            backupState(
+                    s(100, 200),
+                    s(400, 500),
+                    l(50, 249),
+                    l(250, 450)),
+            expectedCopies(
+                    s(100, 200),
+                    l(50, 249),
+                    l(250, 450)));
+    }
+
+    @Test
+    public void restoreToLatest_useUptoLostLog() throws IOException {
+        run(true,
+            backupState(
+                    s(97, 200),
+                    l(45, 48),
+                    l(50, 99),
+                    l(100, 165),
+                    l(170, 210),
+                    l(215, 250),
+                    l(251, 400),
+                    ll(410, 450),
+                    l(500, 700)),
+            expectedCopies(
+                    s(97, 200),
+                    l(50, 99),
+                    l(100, 165),
+                    l(170, 210),
+                    l(215, 250),
+                    l(251, 400)));
+    }
+
+    @Test
+    public void restoreToZxid_priorToEarliestSnap() throws IOException {
+        run(35,
+            false,
+            backupState(
+                    s(50, 100),
+                    l(50, 100)),
+            BackupInfoLists.EMPTY);
+    }
+
+    @Test
+    public void restoreToZxid_pointInLatestSnap() throws IOException {
+        run(335,
+            true,
+            backupState(
+                    l(45, 48),
+                    l(49, 50),
+                    l(50, 75),
+                    s(50, 100),
+                    l(75, 150),
+                    l(150, 350),
+                    s(300, 400),
+                    l(370, 401),
+                    l(450, 500)),
+            expectedCopies(
+                    l(50, 75),
+                    s(50, 100),
+                    l(75, 150),
+                    l(150, 350)));
+    }
+
+    @Test
+    public void restoreToZxid_IgnoreLostLogsOutOfScope() throws IOException {
+        run(500,
+            true,
+            backupState(
+                    ll(50, 250),
+                    l(251, 500),
+                    s(300, 400),
+                    ll(501, 600)),
+            expectedCopies(
+                    l(251, 500),
+                    s(300, 400)));
+    }
+
+    @Test
+    public void restoreToZxid_OnLowerEdgeOfLog() throws IOException {
+        run(501,
+            true,
+            backupState(
+                    l(50, 250),
+                    l(251, 500),
+                    s(300, 400),
+                    l(501, 600),
+                    l(600, 700)),
+            expectedCopies(
+                    l(251, 500),
+                    s(300, 400),
+                    l(501, 600)));
+    }
+
+    /**
+     * Helper method for building the list of files that exist in the backup provider
+     * @param descriptions the descriptions of the individual files
+     * @return the lists of backup files separated by type
+     */
+    private BackupInfoLists backupState(BackupFileInfo... descriptions) {
+        return BackupInfoLists.buildLists(Lists.newArrayList(descriptions));
+    }
+
+    /**
+     * Helper method for building the list of files that are expected to be copied by the restore
+     * tool
+     * <NOTE>Same as 'backupState' but with 'expectedCopies' representing expected to the two are easier to distinguish
+     * in the test cases.</NOTE>
+     * @param descriptions the descriptions of the individual files
+     * @return the lists of restored files separated by type
+     */
+    private BackupInfoLists expectedCopies(BackupFileInfo... descriptions) {
+        return backupState(descriptions);
+    }
+
+    /**
+     * Helper method for creating a description of a snap in the test cases
+     * @param low the starting zxid for the snap
+     * @param high the zxid needed for transactional consistency
+     * @return the backup file info for the described snap
+     */
+    private BackupFileInfo s(long low, long high) {
+        return new BackupFileInfo(
+                new File(TestBackupProvider.backupName(Util.SNAP_PREFIX, low, high)),
+                System.currentTimeMillis(),
+                100);
+    }
+
+    /**
+     * Helper method for creating a description of a txlog in the test cases
+     * @param low the starting zxid for the log
+     * @param high the ending zxid for the log
+     * @return the backup file info for the described log
+     */
+    private BackupFileInfo l(long low, long high) {
+        return new BackupFileInfo(
+                new File(TestBackupProvider.backupName(Util.TXLOG_PREFIX, low, high)),
+                System.currentTimeMillis(),
+                100);
+    }
+
+    /**
+     * Helper method for creating a description of a lost log range in the test cases
+     * @param low the first zxid of the range that has been lost
+     * @param high the last zxid of the range that has been lost
+     * @return the backup file info for the described lost log range
+     */
+    private BackupFileInfo ll(long low, long high) {
+        return new BackupFileInfo(
+                new File(TestBackupProvider.backupName(BackupUtil.LOST_LOG_PREFIX, low, high)),
+                System.currentTimeMillis(),
+                100);
+    }
+
+
+
+    /**
+     * Run a test case
+     *  - creates the backup storage in the state specified
+     *  - runs the restore tool requesting a restore to the latest possible zxid
+     *  - validates the results of the tool (run result plus names of copied files)
+     * @param expectedRunResult the expected result of the restore tool
+     * @param backupStateDescriptions the descriptions for the files that exist in the
+     *                                backup storage provider for this test case
+     * @param expectedBackupsCopiedDescriptions the descriptions for the files that are expected
+     *                                          to be copied by the restore tool as part of the
+     *                                          test run
+     * @throws IOException
+     */
+    private static void run(
+            boolean expectedRunResult,
+            BackupInfoLists backupStateDescriptions,
+            BackupInfoLists expectedBackupsCopiedDescriptions) throws IOException {
+
+        run(Long.MAX_VALUE,
+            expectedRunResult,
+            backupStateDescriptions,
+            expectedBackupsCopiedDescriptions);
+    }
+
+    /**
+     * Run a test case
+     *  - creates the backup storage in the state specified
+     *  - runs the restore tool requesting a restore to the requested zxid
+     *  - validates the results of the tool (run result plus names of copied files)
+     * @param expectedRunResult the expected result of the restore tool
+     * @param backupStateDescriptions the descriptions for the files that exist in the
+     *                                backup storage provider for this test case
+     * @param expectedBackupsCopiedDescriptions the descriptions for the files that are expected
+     *                                          to be copied by the restore tool as part of the
+     *                                          test run
+     * @throws IOException
+     */
+    private static void run(
+            long zxid,
+            boolean expectedRunResult,
+            BackupInfoLists backupStateDescriptions,
+            BackupInfoLists expectedBackupsCopiedDescriptions) throws IOException {
+
+        TestBackupProvider storage = new TestBackupProvider();
+        TestFileTxnSnapLog snapLog = new TestFileTxnSnapLog(tmpDir, tmpDir);
+        RestoreFromBackupTool tool = new RestoreFromBackupTool(storage, snapLog, zxid, false);
+
+        Assert.assertTrue("Cannot expect to have copied LostLogs",
+                expectedBackupsCopiedDescriptions.lostLogs.isEmpty());
+
+        storage.setAvailableBackups(backupStateDescriptions);
+
+        Assert.assertEquals("Restore result", expectedRunResult, tool.run());
+        Assert.assertArrayEquals("Snaps",
+                TestBackupProvider.getBackupNames(expectedBackupsCopiedDescriptions.snaps),
+                TestBackupProvider.getBackupNames(storage.getCopiedSnaps()));
+        Assert.assertArrayEquals("Logs",
+                TestBackupProvider.getBackupNames(expectedBackupsCopiedDescriptions.logs),
+                TestBackupProvider.getBackupNames(storage.getCopiedLogs()));
+
+        if (zxid == Long.MAX_VALUE) {
+            Assert.assertEquals("Truncation should NOT have been called.",
+                    -1,
+                    snapLog.getTruncationZxid());
+
+        } else if (expectedRunResult) {
+            Assert.assertEquals("Truncation should have been called with the proper zxid",
+                    zxid,
+                    snapLog.getTruncationZxid());
+        }
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ZxidRangeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ZxidRangeTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.server.persistence.ZxidRange;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Test ZxidRange functionality
+ */
+public class ZxidRangeTest extends ZKTestCase {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void positiveTests() {
+        ZxidRange zr = new ZxidRange(44, 66);
+        Range<Long> r = zr.toRange();
+        Assert.assertEquals(44, zr.getLow());
+        Assert.assertEquals(66, zr.getHigh());
+        Assert.assertTrue(zr.isHighPresent());
+        Assert.assertEquals(44, (long)r.lowerEndpoint());
+        Assert.assertEquals(66, (long)r.upperEndpoint());
+        Assert.assertEquals(BoundType.CLOSED, r.lowerBoundType());
+        Assert.assertEquals(BoundType.CLOSED, r.upperBoundType());
+
+        zr = new ZxidRange(99);
+        r = zr.toRange();
+        Assert.assertEquals(99, zr.getLow());
+        Assert.assertFalse(zr.isHighPresent());
+        Assert.assertEquals(99, (long)r.lowerEndpoint());
+        Assert.assertEquals(Long.MAX_VALUE, (long)r.upperEndpoint());
+        Assert.assertEquals(BoundType.CLOSED, r.lowerBoundType());
+        Assert.assertEquals(BoundType.CLOSED, r.upperBoundType());
+
+        zr = new ZxidRange(Range.closed(33L, 101L));
+        Assert.assertEquals(33, zr.getLow());
+        Assert.assertEquals(101, zr.getHigh());
+        Assert.assertTrue(zr.isHighPresent());
+
+        zr = ZxidRange.parse("1-1");
+        Assert.assertEquals(1, zr.getLow());
+        Assert.assertEquals(1, zr.getHigh());
+        Assert.assertTrue(zr.isHighPresent());
+
+        zr = ZxidRange.parse("9f0285dc59-9f02871e94");
+        Assert.assertEquals(0x9f0285dc59L, zr.getLow());
+        Assert.assertEquals(0x9f02871e94L, zr.getHigh());
+        Assert.assertTrue(zr.isHighPresent());
+
+        zr = ZxidRange.parse("9f028d5781");
+        Assert.assertEquals(0x9f028d5781L, zr.getLow());
+        Assert.assertFalse(zr.isHighPresent());
+
+        zr = ZxidRange.parse(":12-34");
+        Assert.assertEquals(ZxidRange.INVALID, zr);
+
+        zr = ZxidRange.parse("45234-");
+        Assert.assertEquals(ZxidRange.INVALID, zr);
+
+        zr = ZxidRange.parse("barf");
+        Assert.assertEquals(ZxidRange.INVALID, zr);
+
+        zr = ZxidRange.parse("-55");
+        Assert.assertEquals(ZxidRange.INVALID, zr);
+    }
+
+    @Test
+    public void reverseRangeTest() {
+        boolean failed = false;
+        try {
+            ZxidRange zr = new ZxidRange(20, 10);
+            failed = true;
+        }
+        catch (IllegalArgumentException ex) {
+        }
+
+        if (failed) {
+            Assert.fail("Expected IllegalArgumentException not thrown.");
+        }
+    }
+}


### PR DESCRIPTION
WIP / Don't merge please. This branch currently is not buildable. Submit for LinkedIn folks / get early community feedback.

Implement in-process backup and restore for ZooKeeper. Support point in time backup and recovery. The idea is simple: each ZK server optionally can enable a backup process where it periodically sending the transaction log and snapshot required for recovery to a storage provider. Currently HDFS storage provider is implemented. This can also be used to support multiple version of ZooKeeper data tree for forensic / debug purposes.