### PR TITLE
ZOOKEEPER-3877: JMX Bean RemotePeerBean should enclose IPV6 host in s…

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/RemotePeerBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/RemotePeerBean.java
@@ -18,7 +18,9 @@
 
 package org.apache.zookeeper.server.quorum;
 
+import static org.apache.zookeeper.common.NetUtils.formatInetAddr;
 import java.util.stream.Collectors;
+import org.apache.zookeeper.common.NetUtils;
 import org.apache.zookeeper.jmx.ZKMBeanInfo;
 
 /**
@@ -47,22 +49,20 @@ public class RemotePeerBean implements RemotePeerMXBean, ZKMBeanInfo {
     }
 
     public String getQuorumAddress() {
-        return peer.addr.getAllAddresses().stream()
-                .map(address -> String.format("%s:%d", address.getHostString(), address.getPort()))
-                .collect(Collectors.joining("|"));
+        return peer.addr.getAllAddresses().stream().map(NetUtils::formatInetAddr)
+            .collect(Collectors.joining("|"));
     }
 
     public String getElectionAddress() {
-        return peer.electionAddr.getAllAddresses().stream()
-                .map(address -> String.format("%s:%d", address.getHostString(), address.getPort()))
-                .collect(Collectors.joining("|"));
+        return peer.electionAddr.getAllAddresses().stream().map(NetUtils::formatInetAddr)
+            .collect(Collectors.joining("|"));
     }
 
     public String getClientAddress() {
         if (null == peer.clientAddr) {
             return "";
         }
-        return peer.clientAddr.getHostString() + ":" + peer.clientAddr.getPort();
+        return formatInetAddr(peer.clientAddr);
     }
 
     public String getLearnerType() {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/RemotePeerBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/RemotePeerBeanTest.java
@@ -59,4 +59,20 @@ public class RemotePeerBeanTest {
         assertFalse(remotePeerBean.isLeader());
     }
 
+    @Test
+    public void testHostPortReturnedWhenIPIsIPV6() {
+        QuorumPeer.QuorumServer quorumServerMock = mock(QuorumPeer.QuorumServer.class);
+        InetSocketAddress address = new InetSocketAddress("127::1", 2181);
+        MultipleAddresses multipleAddresses = new MultipleAddresses(address);
+        quorumServerMock.clientAddr = address;
+        quorumServerMock.electionAddr = multipleAddresses;
+        quorumServerMock.addr = multipleAddresses;
+        QuorumPeer peerMock = mock(QuorumPeer.class);
+        RemotePeerBean remotePeerBean = new RemotePeerBean(peerMock, quorumServerMock);
+        String expectedHostPort = "[127:0:0:0:0:0:0:1]:2181";
+        assertEquals(expectedHostPort, remotePeerBean.getClientAddress());
+        assertEquals(expectedHostPort, remotePeerBean.getElectionAddress());
+        assertEquals(expectedHostPort, remotePeerBean.getQuorumAddress());
+    }
+
 }


### PR DESCRIPTION
…quare bracket same as LocalPeerBean