### PR TITLE
ZOOKEEPER-3808: fix the documentation about digest.enabled

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1089,7 +1089,7 @@ property, when available, is noted below.
     due to the potential inconsistency in the /zookeeper/quota stat node,
     we can include that after that issue is fixed.
 
-    By default, this feautre is disabled, set "true" to enable it.
+    By default, this feature is enabled, set "false" to disable it.
 
 * *snapshot.trust.empty* :
     (Java system property: **zookeeper.snapshot.trust.empty**)


### PR DESCRIPTION
The digest.enabled is true by default, not false (as the admin guide suggested before)

The digest feature was added to detect the data inconsistency inside ZooKeeper when
loading database from disk, catching up and following leader.

This fix is needed on master and branch-3.6. (the feature was not available in 3.5)