### PR TITLE
ZOOKEEPER-3561: Generalize target authentication scheme for ZooKeeper authentication enforcement.

### DIFF
--- a/zookeeper-client/zookeeper-client-c/include/zookeeper.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper.h
@@ -140,7 +140,7 @@ enum ZOO_ERRORS {
   ZEPHEMERALONLOCALSESSION = -120, /*!< Attempt to create ephemeral node on a local session */
   ZNOWATCHER = -121, /*!< The watcher couldn't be found */
   ZRECONFIGDISABLED = -123, /*!< Attempts to perform a reconfiguration operation when reconfiguration feature is disabled */
-  ZSESSIONCLOSEDREQUIRESASLAUTH = -124, /*!< The session has been closed by server because server requires client to do SASL authentication, but client is not configured with SASL authentication or configuted with SASL but failed (i.e. wrong credential used.). */
+  ZSESSIONCLOSEDREQUIRESASLAUTH = -124, /*!< The session has been closed by server because server requires client to do authentication via configured authentication scheme at server, but client is not configured with required authentication scheme or configured but failed (i.e. wrong credential used.). */
   ZTHROTTLEDOP = -127 /*!< Operation was throttled and not executed at all. please, retry! */
 
   /* when adding/changing values here also update zerror(int) to return correct error message */

--- a/zookeeper-client/zookeeper-client-c/tests/zkServer.sh
+++ b/zookeeper-client/zookeeper-client-c/tests/zkServer.sh
@@ -128,9 +128,9 @@ PROPERTIES="$EXTRA_JVM_ARGS -Dzookeeper.extendedTypesEnabled=true -Dznode.contai
 if [ "x$1" == "xstartRequireSASLAuth" ]
 then
     PROPERTIES="-Dzookeeper.sessionRequireClientSASLAuth=true $PROPERTIES"
+    PROPERTIES="$PROPERTIES -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
     if [ "x$2" != "x" ]
     then
-        PROPERTIES="$PROPERTIES -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
         PROPERTIES="$PROPERTIES -Djava.security.auth.login.config=$2"
     fi
     if [ "x$3" != "x" ]

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1498,8 +1498,8 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     If the credential is not in the list, the connection request will be refused.
     This prevents a client accidentally connecting to a wrong ensemble.
 
-* *zookeeper.sessionRequireClientSASLAuth* :
-    (Java system property only: **zookeeper.sessionRequireClientSASLAuth**)
+* *sessionRequireClientSASLAuth* :
+    (Java system property: **zookeeper.sessionRequireClientSASLAuth**)
     **New in 3.6.0:**
     When set to **true**, ZooKeeper server will only accept connections and requests from clients
     that have authenticated with server via SASL. Clients that are not configured with SASL
@@ -1508,12 +1508,39 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     in such case, both Java and C client will close the session with server thereafter,
     without further attempts on retrying to reconnect.
 
+    This configuration is short hand for **enforce.auth.enabled=true** and **enforce.auth.scheme=sasl**
+
     By default, this feature is disabled. Users who would like to opt-in can enable the feature
-    by setting **zookeeper.sessionRequireClientSASLAuth** to **true**.
+    by setting **sessionRequireClientSASLAuth** to **true**.
 
     This feature overrules the <emphasis role="bold">zookeeper.allowSaslFailedClients</emphasis> option, so even if server is
     configured to allow clients that fail SASL authentication to login, client will not be able to
     establish a session with server if this feature is enabled.
+
+* *enforce.auth.enabled* :
+    (Java system property : **zookeeper.enforce.auth.enabled**)
+    **New in 3.7.0:**
+    When set to **true**, ZooKeeper server will only accept connections and requests from clients
+    that have authenticated with server via configured auth scheme. Authentication scheme
+    can be configured using property enforce.auth.scheme. Clients that are not
+    configured with the auth scheme configured at server or configured but failed authentication (i.e. with invalid credential)
+    will not be able to establish a session with server. A typed error code (-124) will be delivered
+    in such case, both Java and C client will close the session with server thereafter,
+    without further attempts on retrying to reconnect.
+
+    By default, this feature is disabled. Users who would like to opt-in can enable the feature
+    by setting **enforce.auth.enabled** to **true**.
+
+    When **enforce.auth.enabled=true** and **enforce.auth.scheme=sasl** then <emphasis role="bold">zookeeper.allowSaslFailedClients</emphasis> configuration is overruled. So even if server is
+    configured to allow clients that fail SASL authentication to login, client will not be able to
+    establish a session with server if this feature is enabled.
+
+* *enforce.auth.scheme* :
+    (Java system property : **zookeeper.enforce.auth.enabled**)
+    **New in 3.7.0:**
+    Specifies the authentication scheme with which all clients must get authenticated before doing
+    any zookeeper operations. This property is used only when **enforce.auth.enabled** is to
+    **true**.
 
 * *sslQuorum* :
     (Java system property: **zookeeper.sslQuorum**)

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1521,9 +1521,9 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     (Java system property : **zookeeper.enforce.auth.enabled**)
     **New in 3.7.0:**
     When set to **true**, ZooKeeper server will only accept connections and requests from clients
-    that have authenticated with server via configured auth scheme. Authentication scheme
-    can be configured using property enforce.auth.scheme. Clients that are not
-    configured with the auth scheme configured at server or configured but failed authentication (i.e. with invalid credential)
+    that have authenticated with server via configured auth scheme. Authentication schemes
+    can be configured using property enforce.auth.schemes. Clients that are not
+    configured with the any of the auth scheme configured at server or configured but failed authentication (i.e. with invalid credential)
     will not be able to establish a session with server. A typed error code (-124) will be delivered
     in such case, both Java and C client will close the session with server thereafter,
     without further attempts on retrying to reconnect.
@@ -1531,16 +1531,17 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     By default, this feature is disabled. Users who would like to opt-in can enable the feature
     by setting **enforce.auth.enabled** to **true**.
 
-    When **enforce.auth.enabled=true** and **enforce.auth.scheme=sasl** then <emphasis role="bold">zookeeper.allowSaslFailedClients</emphasis> configuration is overruled. So even if server is
+    When **enforce.auth.enabled=true** and **enforce.auth.schemes=sasl** then 
+    <emphasis role="bold">zookeeper.allowSaslFailedClients</emphasis> configuration is overruled. So even if server is
     configured to allow clients that fail SASL authentication to login, client will not be able to
-    establish a session with server if this feature is enabled.
+    establish a session with server if this feature is enabled with sasl as authentication scheme.
 
-* *enforce.auth.scheme* :
-    (Java system property : **zookeeper.enforce.auth.scheme**)
+* *enforce.auth.schemes* :
+    (Java system property : **zookeeper.enforce.auth.schemes**)
     **New in 3.7.0:**
-    Specifies the authentication scheme with which all clients must get authenticated before doing
-    any zookeeper operations. This property is used only when **enforce.auth.enabled** is to
-    **true**.
+    Comma separated list of authentication schemes. Clients must be authenticated with at least one
+    authentication scheme before doing any zookeeper operations. 
+    This property is used only when **enforce.auth.enabled** is to **true**.
 
 * *sslQuorum* :
     (Java system property: **zookeeper.sslQuorum**)

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1536,7 +1536,7 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     establish a session with server if this feature is enabled.
 
 * *enforce.auth.scheme* :
-    (Java system property : **zookeeper.enforce.auth.enabled**)
+    (Java system property : **zookeeper.enforce.auth.scheme**)
     **New in 3.7.0:**
     Specifies the authentication scheme with which all clients must get authenticated before doing
     any zookeeper operations. This property is used only when **enforce.auth.enabled** is to

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/KeeperException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/KeeperException.java
@@ -403,8 +403,9 @@ public abstract class KeeperException extends Exception {
         REQUESTTIMEOUT(-122),
         /** Attempts to perform a reconfiguration operation when reconfiguration feature is disabled. */
         RECONFIGDISABLED(-123),
-        /** The session has been closed by server because server requires client to do SASL authentication,
-         *  but client is not configured with SASL authentication or configuted with SASL but failed
+        /** The session has been closed by server because server requires client to do authentication
+         *  with configured authentication scheme at the server, but client is not configured with
+         *  required  authentication scheme or configured but authentication failed
          *  (i.e. wrong credential used.). */
         SESSIONCLOSEDREQUIRESASLAUTH(-124),
         /** Operation was throttled and not executed at all. This error code indicates that zookeeper server

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/AuthenticationHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/AuthenticationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,16 +17,15 @@
  */
 package org.apache.zookeeper.server;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.proto.ReplyHeader;
 import org.apache.zookeeper.server.auth.ProviderRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Contains helper methods to enforce authentication
@@ -36,7 +35,8 @@ public class AuthenticationHelper {
 
     public static final String ENFORCE_AUTH_ENABLED = "zookeeper.enforce.auth.enabled";
     public static final String ENFORCE_AUTH_SCHEME = "zookeeper.enforce.auth.scheme";
-    public static final String SESSION_REQUIRE_CLIENT_SASL_AUTH = "zookeeper.sessionRequireClientSASLAuth";
+    public static final String SESSION_REQUIRE_CLIENT_SASL_AUTH =
+        "zookeeper.sessionRequireClientSASLAuth";
     public static final String SASL_AUTH_SCHEME = "sasl";
 
     private boolean enforceAuthEnabled;
@@ -66,7 +66,7 @@ public class AuthenticationHelper {
         if (enforceAuthEnabled) {
             if (enforceAuthScheme == null) {
                 String msg = ENFORCE_AUTH_ENABLED + " is true " + ENFORCE_AUTH_SCHEME + " must be  "
-                        + "configured.";
+                    + "configured.";
                 LOG.error(msg);
                 throw new IllegalArgumentException(msg);
             }
@@ -104,8 +104,7 @@ public class AuthenticationHelper {
      * @param xid        current operation xid
      * @return true when authentication enforcement is success otherwise false
      */
-    public boolean enforceAuthentication(ServerCnxn connection, int xid)
-        throws IOException {
+    public boolean enforceAuthentication(ServerCnxn connection, int xid) throws IOException {
         if (isEnforceAuthEnabled() && !isCnxnAuthenticated(connection)) {
             //Un authenticated connection, lets inform user with response and then close the session
             LOG.error(

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/AuthenticationHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/AuthenticationHelper.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Id;
+import org.apache.zookeeper.proto.ReplyHeader;
+import org.apache.zookeeper.server.auth.ProviderRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Contains helper methods to enforce authentication
+ */
+public class AuthenticationHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(AuthenticationHelper.class);
+
+    public static final String ENFORCE_AUTH_ENABLED = "zookeeper.enforce.auth.enabled";
+    public static final String ENFORCE_AUTH_SCHEME = "zookeeper.enforce.auth.scheme";
+    public static final String SESSION_REQUIRE_CLIENT_SASL_AUTH = "zookeeper.sessionRequireClientSASLAuth";
+    public static final String SASL_AUTH_SCHEME = "sasl";
+
+    private boolean enforceAuthEnabled;
+    private String enforceAuthScheme;
+    private boolean saslAuthRequired;
+
+    public AuthenticationHelper() {
+        initConfigurations();
+    }
+
+    private void initConfigurations() {
+        if (Boolean.parseBoolean(System.getProperty(SESSION_REQUIRE_CLIENT_SASL_AUTH, "false"))) {
+            enforceAuthEnabled = true;
+            enforceAuthScheme = SASL_AUTH_SCHEME;
+        } else {
+            enforceAuthEnabled =
+                Boolean.parseBoolean(System.getProperty(ENFORCE_AUTH_ENABLED, "false"));
+            enforceAuthScheme = System.getProperty(ENFORCE_AUTH_SCHEME);
+        }
+        LOG.info("{} = {}", ENFORCE_AUTH_ENABLED, enforceAuthEnabled);
+        LOG.info("{} = {}", ENFORCE_AUTH_SCHEME, enforceAuthScheme);
+        validateConfiguredProperties();
+        saslAuthRequired = enforceAuthEnabled && SASL_AUTH_SCHEME.equals(enforceAuthScheme);
+    }
+
+    private void validateConfiguredProperties() {
+        if (enforceAuthEnabled) {
+            if (enforceAuthScheme == null) {
+                String msg = ENFORCE_AUTH_ENABLED + " is true " + ENFORCE_AUTH_SCHEME + " must be  "
+                        + "configured.";
+                LOG.error(msg);
+                throw new IllegalArgumentException(msg);
+            }
+            if (ProviderRegistry.getProvider(enforceAuthScheme) == null) {
+                String msg = "Authentication scheme " + enforceAuthScheme + " is not available.";
+                LOG.error(msg);
+                throw new IllegalArgumentException(msg);
+            }
+        }
+    }
+
+    /**
+     * Checks if connection is authenticated or not.
+     *
+     * @param cnxn server connection
+     * @return boolean
+     */
+    private boolean isCnxnAuthenticated(ServerCnxn cnxn) {
+        for (Id id : cnxn.getAuthInfo()) {
+            if (id.getScheme().equals(enforceAuthScheme)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isEnforceAuthEnabled() {
+        return enforceAuthEnabled;
+    }
+
+    /**
+     * Returns true when authentication enforcement was success otherwise returns false also closes the connection
+     *
+     * @param connection server connection
+     * @param xid        current operation xid
+     * @return true when authentication enforcement is success otherwise false
+     */
+    public boolean enforceAuthentication(ServerCnxn connection, int xid)
+        throws IOException {
+        if (isEnforceAuthEnabled() && !isCnxnAuthenticated(connection)) {
+            //Un authenticated connection, lets inform user with response and then close the session
+            LOG.error(
+                "Client authentication scheme(s) {} does not match with expected  authentication scheme {}, "
+                    + "closing session.", getAuthSchemes(connection), enforceAuthScheme);
+            ReplyHeader replyHeader = new ReplyHeader(xid, 0,
+                KeeperException.Code.SESSIONCLOSEDREQUIRESASLAUTH.intValue());
+            connection.sendResponse(replyHeader, null, "response");
+            connection.sendCloseSession();
+            connection.disableRecv();
+            return false;
+        }
+        return true;
+    }
+
+    private List<String> getAuthSchemes(ServerCnxn connection) {
+        return connection.getAuthInfo().stream().map(Id::getScheme).collect(Collectors.toList());
+    }
+
+    public boolean isSaslAuthRequired() {
+        return saslAuthRequired;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -1626,7 +1626,8 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
             processSasl(incomingBuffer, cnxn, h);
         } else {
             if (!authHelper.enforceAuthentication(cnxn, h.getXid())) {
-                // Authentication enforcement is not successful, close is already closed. lets return.
+                // Authentication enforcement is failed
+                // Already sent response to user about failure and closed the session, lets return
                 return;
             } else {
                 Request si = new Request(cnxn, cnxn.getSessionId(), h.getXid(), h.getType(), incomingBuffer, cnxn.getAuthInfo());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -107,9 +107,6 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
     static final boolean skipACL;
 
     public static final String ALLOW_SASL_FAILED_CLIENTS = "zookeeper.allowSaslFailedClients";
-    public static final String SESSION_REQUIRE_CLIENT_SASL_AUTH = "zookeeper.sessionRequireClientSASLAuth";
-    public static final String SASL_AUTH_SCHEME = "sasl";
-
     public static final String ZOOKEEPER_DIGEST_ENABLED = "zookeeper.digest.enabled";
     private static boolean digestEnabled;
 
@@ -284,6 +281,8 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
     private final AtomicInteger currentLargeRequestBytes = new AtomicInteger(0);
 
+    private AuthenticationHelper authHelper;
+
     void removeCnxn(ServerCnxn cnxn) {
         zkDb.removeCnxn(cnxn);
     }
@@ -298,6 +297,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         listener = new ZooKeeperServerListenerImpl(this);
         serverStats = new ServerStats(this);
         this.requestPathMetricsCollector = new RequestPathMetricsCollector();
+        this.authHelper = new AuthenticationHelper();
     }
 
     /**
@@ -338,6 +338,8 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         this.requestPathMetricsCollector = new RequestPathMetricsCollector();
 
         this.initLargeRequestThrottlingSettings();
+
+        this.authHelper = new AuthenticationHelper();
 
         LOG.info(
             "Created server with"
@@ -1623,11 +1625,9 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         } else if (h.getType() == OpCode.sasl) {
             processSasl(incomingBuffer, cnxn, h);
         } else {
-            if (shouldRequireClientSaslAuth() && !hasCnxSASLAuthenticated(cnxn)) {
-                ReplyHeader replyHeader = new ReplyHeader(h.getXid(), 0, Code.SESSIONCLOSEDREQUIRESASLAUTH.intValue());
-                cnxn.sendResponse(replyHeader, null, "response");
-                cnxn.sendCloseSession();
-                cnxn.disableRecv();
+            if (!authHelper.enforceAuthentication(cnxn, h.getXid())) {
+                // Authentication enforcement is not successful, close is already closed. lets return.
+                return;
             } else {
                 Request si = new Request(cnxn, cnxn.getSessionId(), h.getXid(), h.getType(), incomingBuffer, cnxn.getAuthInfo());
                 int length = incomingBuffer.limit();
@@ -1644,14 +1644,6 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
     private static boolean shouldAllowSaslFailedClientsConnect() {
         return Boolean.getBoolean(ALLOW_SASL_FAILED_CLIENTS);
-    }
-
-    private static boolean shouldRequireClientSaslAuth() {
-        return Boolean.getBoolean(SESSION_REQUIRE_CLIENT_SASL_AUTH);
-    }
-
-    private boolean hasCnxSASLAuthenticated(ServerCnxn cnxn) {
-        return cnxn.getAuthInfo().stream().anyMatch(id -> id.getScheme().equals(SASL_AUTH_SCHEME));
     }
 
     private void processSasl(ByteBuffer incomingBuffer, ServerCnxn cnxn, RequestHeader requestHeader) throws IOException {
@@ -1679,11 +1671,11 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                 }
             } catch (SaslException e) {
                 LOG.warn("Client {} failed to SASL authenticate: {}", cnxn.getRemoteSocketAddress(), e);
-                if (shouldAllowSaslFailedClientsConnect() && !shouldRequireClientSaslAuth()) {
+                if (shouldAllowSaslFailedClientsConnect() && !authHelper.isSaslAuthRequired()) {
                     LOG.warn("Maintaining client connection despite SASL authentication failure.");
                 } else {
                     int error;
-                    if (shouldRequireClientSaslAuth()) {
+                    if (authHelper.isSaslAuthRequired()) {
                         LOG.warn(
                             "Closing client connection due to server requires client SASL authenticaiton,"
                                 + "but client SASL authentication has failed, or client is not configured with SASL "

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/EnforceAuthenticationTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/EnforceAuthenticationTest.java
@@ -68,7 +68,7 @@ public class EnforceAuthenticationTest extends QuorumPeerTestBase {
   }
 
   @Test
-  public void testEnforceAuthenticationOldBehaviourWithNett() throws Exception {
+  public void testEnforceAuthenticationOldBehaviourWithNetty() throws Exception {
     Map<String, String> prop = new HashMap<>();
     //setting property false should give the same behaviour as when property is not set
     prop.put(removeZooKeeper(AuthenticationHelper.ENFORCE_AUTH_ENABLED), "false");

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/EnforceAuthenticationTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/EnforceAuthenticationTest.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper;
+
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.client.ZKClientConfig;
+import org.apache.zookeeper.server.AuthenticationHelper;
+import org.apache.zookeeper.server.ServerConfig;
+import org.apache.zookeeper.server.ZooKeeperServerMain;
+import org.apache.zookeeper.server.admin.AdminServer;
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class EnforceAuthenticationTest extends QuorumPeerTestBase {
+  protected static final Logger LOG = LoggerFactory.getLogger(EnforceAuthenticationTest.class);
+  private MainThread mt;
+  private int clientPort;
+
+  @Before
+  public void setUp() {
+    System.setProperty("zookeeper.admin.enableServer", "false");
+    System.setProperty("zookeeper.4lw.commands.whitelist", "*");
+    System.clearProperty(AuthenticationHelper.ENFORCE_AUTH_ENABLED);
+    System.clearProperty(AuthenticationHelper.ENFORCE_AUTH_SCHEME);
+  }
+
+  /**
+   * When ZooKeeperServer.ENFORCE_AUTH_ENABLED is not set or set to false, behaviour should be same
+   * as the old ie. clients without authentication are allowed to operations
+   */
+  @Test
+  public void testEnforceAuthenticationOldBehaviour() throws Exception {
+    Map<String, String> prop = new HashMap<>();
+    startServer(prop);
+    testEnforceAuthOldBehaviour(false);
+  }
+
+  @Test
+  public void testEnforceAuthenticationOldBehaviourWithNett() throws Exception {
+    Map<String, String> prop = new HashMap<>();
+    //setting property false should give the same behaviour as when property is not set
+    prop.put(removeZooKeeper(AuthenticationHelper.ENFORCE_AUTH_ENABLED), "false");
+    prop.put("serverCnxnFactory", "org.apache.zookeeper.server.NettyServerCnxnFactory");
+    startServer(prop);
+    testEnforceAuthOldBehaviour(true);
+  }
+
+  private void testEnforceAuthOldBehaviour(boolean netty)
+      throws Exception {
+    ZKClientConfig config = new ZKClientConfig();
+    if (netty) {
+      config.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET,
+          "org.apache.zookeeper.ClientCnxnSocketNetty");
+    }
+    ZooKeeper client = ClientBase
+        .createZKClient("127.0.0.1:" + clientPort, CONNECTION_TIMEOUT, CONNECTION_TIMEOUT, config);
+    String path = "/defaultAuth" + System.currentTimeMillis();
+    String data = "someData";
+    client.create(path, data.getBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    byte[] data1 = client.getData(path, false, null);
+    assertEquals(data, new String(data1));
+    client.close();
+  }
+
+  /**
+   * Server start should fail when ZooKeeperServer.ENFORCE_AUTH_ENABLED is set to true  but
+   * ZooKeeperServer .ENFORCE_AUTH_SCHEME is not configured
+   */
+  @Test
+  public void testServerStartShouldFailWhenEnforceAuthSchemeIsNotConfigured()
+      throws Exception {
+    Map<String, String> prop = new HashMap<>();
+    prop.put(removeZooKeeper(AuthenticationHelper.ENFORCE_AUTH_ENABLED), "true");
+    testServerStart(prop);
+  }
+
+  /**
+   * Server start should fail when ZooKeeperServer.ENFORCE_AUTH_ENABLED is set to true,
+   * ZooKeeperServer .ENFORCE_AUTH_SCHEME is configured but authentication provider is not
+   * configured.
+   */
+  @Test
+  public void testServerStartShouldFailWhenAuthProviderIsNotConfigured() throws Exception {
+    Map<String, String> prop = new HashMap<>();
+    prop.put(removeZooKeeper(AuthenticationHelper.ENFORCE_AUTH_ENABLED), "true");
+    prop.put(removeZooKeeper(AuthenticationHelper.ENFORCE_AUTH_SCHEME), "sasl");
+    testServerStart(prop);
+  }
+
+  private void testServerStart(Map<String, String> prop)
+      throws IOException, QuorumPeerConfig.ConfigException, AdminServer.AdminServerException {
+    File confFile = getConfFile(prop);
+    ServerConfig config = new ServerConfig();
+    config.parse(confFile.toString());
+    ZooKeeperServerMain serverMain = new ZooKeeperServerMain();
+    try {
+      serverMain.runFromConfig(config);
+      fail("IllegalArgumentException is expected.");
+    } catch (IllegalArgumentException e) {
+      //do nothing
+    }
+  }
+
+  /**
+   * When ProviderRegistry.DISABLE_DEFAULT_AUTH_PROVIDERS is set to true
+   * DigestAuthenticationProvider is configured in server
+   */
+  @Test
+  public void testEnforceAuthenticationNewBehaviour() throws Exception {
+    Map<String, String> prop = new HashMap<>();
+    prop.put(removeZooKeeper(AuthenticationHelper.ENFORCE_AUTH_ENABLED), "true");
+    prop.put(removeZooKeeper(AuthenticationHelper.ENFORCE_AUTH_SCHEME), "digest");
+    //digest auth provider is started by default, so no need to
+    //prop.put("authProvider.1", DigestAuthenticationProvider.class.getName());
+    startServer(prop);
+    testEnforceAuthNewBehaviour(false);
+  }
+
+  @Test
+  public void testEnforceAuthenticationNewBehaviourWithNetty() throws Exception {
+    Map<String, String> prop = new HashMap<>();
+    prop.put(removeZooKeeper(AuthenticationHelper.ENFORCE_AUTH_ENABLED), "true");
+    prop.put(removeZooKeeper(AuthenticationHelper.ENFORCE_AUTH_SCHEME), "digest");
+    prop.put("serverCnxnFactory", "org.apache.zookeeper.server.NettyServerCnxnFactory");
+    startServer(prop);
+    testEnforceAuthNewBehaviour(true);
+  }
+
+  /**
+   * Client operations are allowed only after the authentication is done
+   */
+  private void testEnforceAuthNewBehaviour(boolean netty)
+      throws Exception {
+    ZKClientConfig config = new ZKClientConfig();
+    if (netty) {
+      config.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET,
+          "org.apache.zookeeper.ClientCnxnSocketNetty");
+    }
+    CountDownLatch countDownLatch = new CountDownLatch(1);
+    ZooKeeper client =
+        new ZooKeeper("127.0.0.1:" + clientPort, CONNECTION_TIMEOUT, getWatcher(countDownLatch),
+            config);
+    countDownLatch.await();
+    String path = "/newAuth" + System.currentTimeMillis();
+    String data = "someData";
+
+    //try without authentication
+    try {
+      client.create(path, data.getBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+      fail("SessionClosedRequireAuthException is expected.");
+    } catch (KeeperException.SessionClosedRequireAuthException e) {
+      //do nothing
+    }
+    client.close();
+    countDownLatch = new CountDownLatch(1);
+    client =
+        new ZooKeeper("127.0.0.1:" + clientPort, CONNECTION_TIMEOUT, getWatcher(countDownLatch),
+            config);
+    countDownLatch.await();
+
+    // try operations after authentication
+    String idPassword = "user1:pass1";
+    client.addAuthInfo("digest", idPassword.getBytes());
+    client.create(path, data.getBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    byte[] data1 = client.getData(path, false, null);
+    assertEquals(data, new String(data1));
+    client.close();
+  }
+
+  private String removeZooKeeper(String prop) {
+    return prop.replace("zookeeper.", "");
+  }
+
+  private File getConfFile(Map<String, String> additionalProp) throws IOException {
+    clientPort = PortAssignment.unique();
+    StringBuilder sb = new StringBuilder();
+    sb.append("standaloneEnabled=true" + "\n");
+    if (null != additionalProp) {
+      for (Map.Entry<String, String> entry : additionalProp.entrySet()) {
+        sb.append(entry.getKey());
+        sb.append("=");
+        sb.append(entry.getValue());
+        sb.append("\n");
+      }
+    }
+    String currentQuorumCfgSection = sb.toString();
+    return new MainThread(1, clientPort, currentQuorumCfgSection, false).getConfFile();
+  }
+
+  private void startServer(Map<String, String> additionalProp) throws IOException {
+    clientPort = PortAssignment.unique();
+    StringBuilder sb = new StringBuilder();
+    sb.append("standaloneEnabled=true");
+    sb.append("\n");
+    if (null != additionalProp) {
+      for (Map.Entry<String, String> entry : additionalProp.entrySet()) {
+        sb.append(entry.getKey());
+        sb.append("=");
+        sb.append(entry.getValue());
+        sb.append("\n");
+      }
+    }
+    String currentQuorumCfgSection = sb.toString();
+    mt = new MainThread(1, clientPort, currentQuorumCfgSection, false);
+    mt.start();
+    Assert.assertTrue("waiting for server 1 being up",
+        ClientBase.waitForServerUp("127.0.0.1:" + clientPort, ClientBase.CONNECTION_TIMEOUT));
+  }
+
+  @After
+  public void tearDown() {
+    if (null != mt) {
+      try {
+        mt.shutdown();
+      } catch (InterruptedException e) {
+        LOG.warn("Failed to shutdown server", e);
+      }
+    }
+    mt = null;
+    System.clearProperty(AuthenticationHelper.ENFORCE_AUTH_ENABLED);
+    System.clearProperty(AuthenticationHelper.ENFORCE_AUTH_SCHEME);
+  }
+
+  private Watcher getWatcher(CountDownLatch countDownLatch) {
+    return event -> {
+      Event.EventType type = event.getType();
+      if (type == Event.EventType.None) {
+        Event.KeeperState state = event.getState();
+        if (state == Event.KeeperState.SyncConnected) {
+          LOG.info("Event.KeeperState.SyncConnected");
+          countDownLatch.countDown();
+        } else if (state == Event.KeeperState.Expired) {
+          LOG.info("Event.KeeperState.Expired");
+        } else if (state == Event.KeeperState.Disconnected) {
+          LOG.info("Event.KeeperState.Disconnected");
+        } else if (state == Event.KeeperState.AuthFailed) {
+          LOG.info("Event.KeeperState.AuthFailed");
+        }
+      }
+    };
+  }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerTestBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerTestBase.java
@@ -406,7 +406,7 @@ public class QuorumPeerTestBase extends ZKTestCase implements Watcher {
 
         MainThread[] mt;
         ZooKeeper[] zk;
-        int[] clientPorts;
+        public int[] clientPorts;
 
         public void shutDownAllServers() throws InterruptedException {
             for (MainThread t : mt) {
@@ -470,23 +470,35 @@ public class QuorumPeerTestBase extends ZKTestCase implements Watcher {
     }
 
     protected Servers LaunchServers(int numServers) throws IOException, InterruptedException {
-        return LaunchServers(numServers, null);
+        return LaunchServers(numServers, (Integer) null);
+    }
+
+    protected Servers LaunchServers(int numServers, Map<String, String> otherConfigs)
+        throws IOException, InterruptedException {
+        return LaunchServers(numServers, 0, null, otherConfigs);
     }
 
     protected Servers LaunchServers(int numServers, Integer tickTime) throws IOException, InterruptedException {
         return LaunchServers(numServers, 0, tickTime);
     }
 
+    protected Servers LaunchServers(int numServers, int numObservers, Integer tickTime)
+        throws IOException, InterruptedException {
+        return LaunchServers(numServers, numObservers, tickTime, new HashMap<>());
+    }
+
     /** * This is a helper function for launching a set of servers
      *
      * @param numServers the number of participant servers
-     * @param numObserver the number of observer servers
+     * @param numObservers the number of observer servers
      * @param tickTime A ticktime to pass to MainThread
+     * @param otherConfigs any zoo.cfg configuration
      * @return
      * @throws IOException
      * @throws InterruptedException
      */
-    protected Servers LaunchServers(int numServers, int numObservers, Integer tickTime) throws IOException, InterruptedException {
+    protected Servers LaunchServers(int numServers, int numObservers, Integer tickTime,
+        Map<String, String> otherConfigs) throws IOException, InterruptedException {
         int SERVER_COUNT = numServers + numObservers;
         QuorumPeerMainTest.Servers svrs = new QuorumPeerMainTest.Servers();
         svrs.clientPorts = new int[SERVER_COUNT];
@@ -504,9 +516,9 @@ public class QuorumPeerTestBase extends ZKTestCase implements Watcher {
         svrs.zk = new ZooKeeper[SERVER_COUNT];
         for (int i = 0; i < SERVER_COUNT; i++) {
             if (tickTime != null) {
-                svrs.mt[i] = new MainThread(i, svrs.clientPorts[i], quorumCfgSection, new HashMap<String, String>(), tickTime);
+                svrs.mt[i] = new MainThread(i, svrs.clientPorts[i], quorumCfgSection, otherConfigs, tickTime);
             } else {
-                svrs.mt[i] = new MainThread(i, svrs.clientPorts[i], quorumCfgSection);
+                svrs.mt[i] = new MainThread(i, svrs.clientPorts[i], quorumCfgSection, otherConfigs);
             }
             svrs.mt[i].start();
             svrs.restartClient(i, this);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
@@ -51,6 +51,7 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.common.IOUtils;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.common.X509Exception.SSLContextException;
@@ -351,6 +352,9 @@ public abstract class ClientBase extends ZKTestCase {
     }
 
     static File createTmpDir(File parentDir, boolean createInitFile) throws IOException {
+        if (!parentDir.exists()) {
+            parentDir.mkdir();
+        }
         File tmpFile = File.createTempFile("test", ".junit", parentDir);
         // don't delete tmpFile - this ensures we don't attempt to create
         // a tmpDir with a duplicate name
@@ -738,9 +742,15 @@ public abstract class ClientBase extends ZKTestCase {
         return createZKClient(cxnString, sessionTimeout, CONNECTION_TIMEOUT);
     }
 
-    public static ZooKeeper createZKClient(String cxnString, int sessionTimeout, long connectionTimeout) throws IOException {
+    public static ZooKeeper createZKClient(String cxnString, int sessionTimeout,
+        long connectionTimeout) throws IOException {
+        return createZKClient(cxnString, sessionTimeout, connectionTimeout, new ZKClientConfig());
+    }
+
+    public static ZooKeeper createZKClient(String cxnString, int sessionTimeout,
+        long connectionTimeout, ZKClientConfig config) throws IOException {
         CountdownWatcher watcher = new CountdownWatcher();
-        ZooKeeper zk = new ZooKeeper(cxnString, sessionTimeout, watcher);
+        ZooKeeper zk = new ZooKeeper(cxnString, sessionTimeout, watcher, config);
         try {
             watcher.waitForConnected(connectionTimeout);
         } catch (InterruptedException | TimeoutException e) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthRequiredFailNoSASLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthRequiredFailNoSASLTest.java
@@ -18,26 +18,29 @@
 
 package org.apache.zookeeper.test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SaslAuthRequiredFailNoSASLTest extends ClientBase {
 
-    @BeforeEach
-    public void setup() {
+    @BeforeAll
+    public static void setup() {
         System.setProperty(SaslTestUtil.requireSASLAuthProperty, "true");
+        System.setProperty(SaslTestUtil.authProviderProperty, SaslTestUtil.authProvider);
     }
 
-    @AfterEach
-    public void tearDown() throws Exception {
+    @AfterAll
+    public static void clearSetup() {
         System.clearProperty(SaslTestUtil.requireSASLAuthProperty);
+        System.clearProperty(SaslTestUtil.authProviderProperty);
     }
 
     @Test
@@ -46,7 +49,7 @@ public class SaslAuthRequiredFailNoSASLTest extends ClientBase {
         CountdownWatcher watcher = new CountdownWatcher();
         try {
             zk = createClient(watcher);
-            zk.create("/foo", null, Ids.CREATOR_ALL_ACL, CreateMode.PERSISTENT);
+            zk.create("/foo", null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             fail("Client is not configured with SASL authentication, so zk.create operation should fail.");
         } catch (KeeperException e) {
             assertTrue(e.code() == KeeperException.Code.SESSIONCLOSEDREQUIRESASLAUTH);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthRequiredFailNoSASLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthRequiredFailNoSASLTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.zookeeper.test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs.Ids;
@@ -25,9 +27,6 @@ import org.apache.zookeeper.ZooKeeper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class SaslAuthRequiredFailNoSASLTest extends ClientBase {
 


### PR DESCRIPTION
Added enforce.auth.enabled and enforce.auth.scheme to enforce any authentication scheme.