### PR TITLE
ZOOKEEPER-3959: Add support for multiple SASL-authenticated super users

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1474,6 +1474,9 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     Similar to **zookeeper.X509AuthenticationProvider.superUser**
     but is generic for SASL based logins. It stores the name of
     a user that can access the znode hierarchy as a "super" user.
+    You can specify multiple SASL super users using the
+    **zookeeper.superUser.[suffix]** notation, e.g.:
+    `zookeeper.superUser.1=...`.
 
 * *ssl.authProvider* :
     (Java system property: **zookeeper.ssl.authProvider**)

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -1670,6 +1670,10 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                     if (System.getProperty("zookeeper.superUser") != null
                         && authorizationID.equals(System.getProperty("zookeeper.superUser"))) {
                         cnxn.addAuthInfo(new Id("super", ""));
+                        LOG.info(
+                            "Session 0x{}: Authenticated Id '{}' as super user",
+                            Long.toHexString(cnxn.getSessionId()),
+                            authorizationID);
                     }
                 }
             } catch (SaslException e) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -106,6 +106,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
     static final boolean skipACL;
 
+    public static final String SASL_SUPER_USER = "zookeeper.superUser";
     public static final String ALLOW_SASL_FAILED_CLIENTS = "zookeeper.allowSaslFailedClients";
     public static final String ZOOKEEPER_DIGEST_ENABLED = "zookeeper.digest.enabled";
     private static boolean digestEnabled;
@@ -1644,6 +1645,12 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         }
     }
 
+    private static boolean isSaslSuperUser(String id) {
+        String superUser = System.getProperty(SASL_SUPER_USER);
+
+        return superUser != null && superUser.equals(id);
+    }
+
     private static boolean shouldAllowSaslFailedClientsConnect() {
         return Boolean.getBoolean(ALLOW_SASL_FAILED_CLIENTS);
     }
@@ -1667,8 +1674,8 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                     LOG.info("Session 0x{}: adding SASL authorization for authorizationID: {}",
                             Long.toHexString(cnxn.getSessionId()), authorizationID);
                     cnxn.addAuthInfo(new Id("sasl", authorizationID));
-                    if (System.getProperty("zookeeper.superUser") != null
-                        && authorizationID.equals(System.getProperty("zookeeper.superUser"))) {
+
+                    if (isSaslSuperUser(authorizationID)) {
                         cnxn.addAuthInfo(new Id("super", ""));
                         LOG.info(
                             "Session 0x{}: Authenticated Id '{}' as super user",

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslSuperUserTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslSuperUserTest.java
@@ -111,8 +111,7 @@ public class SaslSuperUserTest extends ClientBase {
 
     }
 
-    @Test
-    public void testSuperIsSuper() throws Exception {
+    private void connectAndPerformSuperOps() throws Exception {
         ZooKeeper zk = createClient();
         try {
             zk.create("/digest_read", null, Arrays.asList(new ACL(Perms.READ, otherDigestUser)), CreateMode.PERSISTENT);
@@ -123,11 +122,15 @@ public class SaslSuperUserTest extends ClientBase {
             zk.delete("/digest_read", -1);
             zk.delete("/sasl_read/sub", -1);
             zk.delete("/sasl_read", -1);
-            //If the test failes it will most likely fail with a NoAuth exception before it ever gets to this assertion
-            assertEquals(authFailed.get(), 0);
         } finally {
             zk.close();
         }
     }
 
+    @Test
+    public void testSuperIsSuper() throws Exception {
+        connectAndPerformSuperOps();
+        //If the test fails it will most likely fail with a NoAuth exception before it ever gets to this assertion
+        assertEquals(authFailed.get(), 0);
+    }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslSuperUserTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslSuperUserTest.java
@@ -30,6 +30,7 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZooDefs.Perms;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.ZooKeeperServer;
@@ -43,12 +44,14 @@ public class SaslSuperUserTest extends ClientBase {
     private static Id otherSaslUser = new Id("sasl", "joe");
     private static Id otherDigestUser;
     private static String oldAuthProvider;
+    private static String oldClientConfigSection;
     private static String oldLoginConfig;
     private static String oldSuperUser;
 
     @BeforeAll
     public static void setupStatic() throws Exception {
         oldAuthProvider = System.setProperty("zookeeper.authProvider.1", "org.apache.zookeeper.server.auth.SASLAuthenticationProvider");
+        oldClientConfigSection = System.getProperty(ZKClientConfig.LOGIN_CONTEXT_NAME_KEY);
 
         File tmpDir = createTmpDir();
         File saslConfFile = new File(tmpDir, "jaas.conf");
@@ -79,6 +82,13 @@ public class SaslSuperUserTest extends ClientBase {
             System.clearProperty("zookeeper.authProvider.1");
         }
         oldAuthProvider = null;
+
+        if (oldClientConfigSection != null) {
+            System.setProperty(ZKClientConfig.LOGIN_CONTEXT_NAME_KEY, oldClientConfigSection);
+        } else {
+            System.clearProperty(ZKClientConfig.LOGIN_CONTEXT_NAME_KEY);
+        }
+        oldClientConfigSection = null;
 
         if (oldLoginConfig != null) {
             System.setProperty("java.security.auth.login.config", oldLoginConfig);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslSuperUserTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslSuperUserTest.java
@@ -76,33 +76,18 @@ public class SaslSuperUserTest extends ClientBase {
 
     @AfterAll
     public static void cleanupStatic() {
-        if (oldAuthProvider != null) {
-            System.setProperty("zookeeper.authProvider.1", oldAuthProvider);
-        } else {
-            System.clearProperty("zookeeper.authProvider.1");
-        }
-        oldAuthProvider = null;
+        restoreProperty("zookeeper.authProvider.1", oldAuthProvider);
+        restoreProperty(ZKClientConfig.LOGIN_CONTEXT_NAME_KEY, oldClientConfigSection);
+        restoreProperty("java.security.auth.login.config", oldLoginConfig);
+        restoreProperty(ZooKeeperServer.SASL_SUPER_USER, oldSuperUser);
+    }
 
-        if (oldClientConfigSection != null) {
-            System.setProperty(ZKClientConfig.LOGIN_CONTEXT_NAME_KEY, oldClientConfigSection);
+    private static void restoreProperty(String property, String oldValue) {
+        if (oldValue != null) {
+            System.setProperty(property, oldValue);
         } else {
-            System.clearProperty(ZKClientConfig.LOGIN_CONTEXT_NAME_KEY);
+            System.clearProperty(property);
         }
-        oldClientConfigSection = null;
-
-        if (oldLoginConfig != null) {
-            System.setProperty("java.security.auth.login.config", oldLoginConfig);
-        } else {
-            System.clearProperty("java.security.auth.login.config");
-        }
-        oldLoginConfig = null;
-
-        if (oldSuperUser != null) {
-            System.setProperty(ZooKeeperServer.SASL_SUPER_USER, oldSuperUser);
-        } else {
-            System.clearProperty(ZooKeeperServer.SASL_SUPER_USER);
-        }
-        oldSuperUser = null;
     }
 
     private AtomicInteger authFailed = new AtomicInteger(0);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslSuperUserTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslSuperUserTest.java
@@ -32,6 +32,7 @@ import org.apache.zookeeper.ZooDefs.Perms;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
+import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.auth.DigestAuthenticationProvider;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -66,7 +67,7 @@ public class SaslSuperUserTest extends ClientBase {
                               + "\n");
         fwriter.close();
         oldLoginConfig = System.setProperty("java.security.auth.login.config", saslConfFile.getAbsolutePath());
-        oldSuperUser = System.setProperty("zookeeper.superUser", "super_duper");
+        oldSuperUser = System.setProperty(ZooKeeperServer.SASL_SUPER_USER, "super_duper");
         otherDigestUser = new Id("digest", DigestAuthenticationProvider.generateDigest("jack:jack"));
     }
 
@@ -87,9 +88,9 @@ public class SaslSuperUserTest extends ClientBase {
         oldLoginConfig = null;
 
         if (oldSuperUser != null) {
-            System.setProperty("zookeeper.superUser", oldSuperUser);
+            System.setProperty(ZooKeeperServer.SASL_SUPER_USER, oldSuperUser);
         } else {
-            System.clearProperty("zookeeper.superUser");
+            System.clearProperty(ZooKeeperServer.SASL_SUPER_USER);
         }
         oldSuperUser = null;
     }


### PR DESCRIPTION
This implements a simple variant of the "multiple SASL-authenticated super users" functionality discussed on ticket ZOOKEEPER-3959.

With this patch, properties matching `zookeeper.superUser.*` are considered, in addition to `zookeeper.superUser`, to determine whether an authenticated ID should be given `super` privileges.

As before, `super` privileges remain a sharp tool and should be avoided where possible--but where necessary, allowing multiple IDs makes audit logs more useful.

(Many thanks to @eolivelli and @symat for their comments and suggestions.)