### PR TITLE
ZOOKEEPER-3973: Add GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,88 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This workflow will build a Java project with Maven
+# See also:
+#   https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: CI
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  mvn:
+    strategy:
+      matrix:
+        profile:
+          - name: 'full-build-jdk8'
+            jdk: 8
+            args: '-Pfull-build apache-rat:check verify -DskipTests spotbugs:check checkstyle:check'
+          - name: 'full-build-jdk11'
+            jdk: 11
+            args: '-Pfull-build apache-rat:check verify -DskipTests spotbugs:check checkstyle:check'
+          - name: 'full-build-java-tests'
+            jdk: 11
+            args: '-Pfull-build verify -Dsurefire-forkcount=1C -DskipCppUnit -Dsurefire.rerunFailingTestsCount=5'
+          - name: 'full-build-cppunit-tests'
+            jdk: 11
+            args: '-Pfull-build verify -Dtest=_ -DfailIfNoTests=false'
+      fail-fast: false
+    timeout-minutes: 360
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.profile.jdk }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.profile.jdk }}
+    - name: Cache local maven repository
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.m2/repository/
+          !~/.m2/repository/org/apache/zookeeper
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Show the first log message
+      run: git log -n1
+    - name: Install C Dependencies
+      run: sudo apt-get install libcppunit-dev libsasl2-dev
+    - name: Build with Maven (${{ matrix.profile.name }})
+      run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ matrix.profile.args }}
+      env:
+        MAVEN_OPTS: -Djansi.force=true
+    - name: Upload unit test results
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: surefire-reports-${{ matrix.profile.name }}
+        path: ./**/target/surefire-reports/
+        if-no-files-found: ignore
+    - name: Upload integration test results
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: failsafe-reports-${{ matrix.profile.name }}
+        path: ./**/target/failsafe-reports/
+        if-no-files-found: ignore
+

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -1,0 +1,85 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This workflow will build a Java project with Maven
+# See also:
+#   https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+#   https://docs.github.com/en/actions/reference/events-that-trigger-workflows#manual-events
+
+name: Manual Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      buildRef:
+        description: Ref to build (commit, branch, or refs/pull/1234/head or refs/pull/1234/merge)
+        required: true
+        default: refs/pull/1234/merge
+      mvnOpts:
+        description: Maven options
+        required: true
+        default: --fail-at-end
+      goals:
+        description: Maven goals
+        required: true
+        default: -Pfull-build apache-rat:check verify -DskipTests spotbugs:check checkstyle:check javadoc:jar
+jobs:
+  mvn:
+    name: mvn (triggered by ${{ github.event.sender.login }})
+    timeout-minutes: 360
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.inputs.buildRef }}
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Cache local maven repository
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.m2/repository/
+          !~/.m2/repository/org/apache/zookeeper
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Show the first log message
+      run: git log -n1
+    - name: Install C Dependencies
+      run: sudo apt-get install libcppunit-dev libsasl2-dev
+    - name: Build with Maven
+      run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ github.event.inputs.mvnOpts }} ${{ github.event.inputs.goals }}
+      env:
+        MAVEN_OPTS: -Djansi.force=true
+    - name: Upload unit test results
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: surefire-reports
+        path: ./**/target/surefire-reports/
+        if-no-files-found: ignore
+    - name: Upload integration test results
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: failsafe-reports
+        path: ./**/target/failsafe-reports/
+        if-no-files-found: ignore
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: java
 matrix:
   include:
     - os: linux
-      jdk: openjdk8
-    - os: linux
-      jdk: openjdk11
-    - os: linux
       arch: arm64
       jdk: openjdk11
     - os: linux
@@ -38,5 +34,6 @@ script: mvn clean apache-rat:check verify -DskipTests spotbugs:check checkstyle:
 branches:
   only:
   - master
+  - branch-3.7
+  - branch-3.6
   - branch-3.5
-  - branch-3.4

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-# Apache ZooKeeper [![Build Status](https://travis-ci.org/apache/zookeeper.svg?branch=master)](https://travis-ci.org/apache/zookeeper) [![Maven Central](https://img.shields.io/maven-central/v/org.apache.zookeeper/zookeeper)](https://zookeeper.apache.org/releases.html) [![License](https://img.shields.io/github/license/apache/zookeeper)](https://github.com/apache/zookeeper/blob/master/LICENSE.txt)
+# Apache ZooKeeper [![GitHub Actions CI][ciBadge]][ciLink] [![Travis CI][trBadge]][trLink] [![Maven Central][mcBadge]][mcLink] [![License][liBadge]][liLink]
 ![alt text](https://zookeeper.apache.org/images/zookeeper_small.gif "ZooKeeper")
 
 For the latest information about Apache ZooKeeper, please visit our website at:
 
-   http://zookeeper.apache.org/
+   https://zookeeper.apache.org
 
 and our wiki, at:
 
    https://cwiki.apache.org/confluence/display/ZOOKEEPER
 
----------------------------
-Packaging/release artifacts
+## Packaging/release artifacts
 
 Either downloaded from https://zookeeper.apache.org/releases.html or
 found in zookeeper-assembly/target directory after building the project with maven.
@@ -33,7 +32,7 @@ As of version 3.5.5, the parent, zookeeper and zookeeper-jute artifacts
 are deployed to the central repository after the release
 is voted on and approved by the Apache ZooKeeper PMC:
 
-  https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/
+  https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper
 
 ## Java 8
 
@@ -44,3 +43,11 @@ recent release at u211 or above.
 We always welcome new contributors to the project! See [How to Contribute](https://cwiki.apache.org/confluence/display/ZOOKEEPER/HowToContribute) for details on how to submit patch through pull request and our contribution workflow.
 
 
+[ciBadge]: https://github.com/apache/zookeeper/workflows/CI/badge.svg
+[ciLink]: https://github.com/apache/zookeeper/actions
+[liBadge]: https://img.shields.io/github/license/apache/zookeeper?color=282661
+[liLink]: https://github.com/apache/zookeeper/blob/master/LICENSE.txt
+[mcBadge]: https://img.shields.io/maven-central/v/org.apache.zookeeper/zookeeper
+[mcLink]: https://zookeeper.apache.org/releases
+[trBadge]: https://travis-ci.org/apache/zookeeper.svg?branch=master
+[trLink]: https://travis-ci.org/apache/zookeeper

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <groupId>org.apache.zookeeper</groupId>
   <artifactId>parent</artifactId>
   <packaging>pom</packaging>
-  <!-- to change version: mvn -\-batch-mode release:update-versions -DdevelopmentVersion=3.6.0-SNAPSHOT -->
+  <!-- to change version: mvn -B release:update-versions -DdevelopmentVersion=3.6.0-SNAPSHOT -->
   <version>3.7.0-SNAPSHOT</version>
   <name>Apache ZooKeeper</name>
   <description>
@@ -778,15 +778,6 @@
             <includeTestResources>false</includeTestResources>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
           </configuration>
-          <executions>
-            <execution>
-              <id>checkstyle</id>
-              <phase>validate</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
         <!-- we don't need this plugin-->
         <plugin>
@@ -843,6 +834,7 @@
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
+            <id>set-hostname-property</id>
             <phase>validate</phase>
             <goals>
               <goal>run</goal>

--- a/zookeeper-client/zookeeper-client-c/pom.xml
+++ b/zookeeper-client/zookeeper-client-c/pom.xml
@@ -35,15 +35,6 @@
     <c-test-coverage-arg> </c-test-coverage-arg>
   </properties>
 
-  <profiles>
-    <profile>
-      <id>c-test-coverage</id>
-      <properties>
-        <c-test-coverage-arg>--enable-gcov</c-test-coverage-arg>
-      </properties>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
         <plugin>
@@ -126,27 +117,6 @@
             </goals>
           </execution>
           <execution>
-            <id>test-cppunit</id>
-            <phase>test</phase>
-            <configuration>
-              <!-- do not run cpp tests if tests are globally skipped -->
-              <skip>${skipTests}</skip>
-              <target>
-                <exec dir="${basedir}/target/c" executable="make" failonerror="true">
-                  <env key="LD_LIBRARY_PATH" value="${env.LD_LIBRARY_PATH};/usr/lib" />
-                  <env key="PATH" path="${env.PATH};${basedir};" />
-                  <env key="CALLER" value="ANT" />
-                  <env key="CLOVER_HOME" value="${basedir}/../../zookeeper-server/target" />
-                  <env key="base_dir" value="${basedir}/../.." />
-                  <arg line="check" />
-                </exec>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-          <execution>
             <id>replace-cclient-files-during-release</id>
             <phase>none</phase>
             <goals>
@@ -173,5 +143,54 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>c-test-coverage</id>
+      <properties>
+        <c-test-coverage-arg>--enable-gcov</c-test-coverage-arg>
+      </properties>
+    </profile>
+    <profile>
+      <!-- can be skipped by deactivating the profile with -P!cppunit (may need to escape or quote exclamation on command-line) -->
+      <id>cppunit</id>
+      <activation>
+        <property>
+          <!-- can also be skipped by -DskipCppUnit or with -DskipTests (see below) -->
+          <name>!skipCppUnit</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>test-cppunit</id>
+                <phase>test</phase>
+                <configuration>
+                  <!-- do not run cpp tests if tests are globally skipped -->
+                  <skip>${skipTests}</skip>
+                  <target>
+                    <exec dir="${basedir}/target/c" executable="make" failonerror="true">
+                      <env key="LD_LIBRARY_PATH" value="${env.LD_LIBRARY_PATH};/usr/lib" />
+                      <env key="PATH" path="${env.PATH};${basedir};" />
+                      <env key="CALLER" value="ANT" />
+                      <env key="CLOVER_HOME" value="${basedir}/../../zookeeper-server/target" />
+                      <env key="base_dir" value="${basedir}/../.." />
+                      <arg line="check" />
+                    </exec>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/zookeeper-contrib/pom.xml
+++ b/zookeeper-contrib/pom.xml
@@ -73,33 +73,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.1.0</version>
-          <dependencies>
-            <dependency>
-              <groupId>com.puppycrawl.tools</groupId>
-              <artifactId>checkstyle</artifactId>
-              <version>${checkstyle.version}</version>
-            </dependency>
-          </dependencies>
           <configuration>
             <configLocation>checkstyle-simple.xml</configLocation>
-            <suppressionsLocation>checkstyleSuppressions.xml</suppressionsLocation>
-            <encoding>UTF-8</encoding>
-            <consoleOutput>true</consoleOutput>
-            <failOnViolation>true</failOnViolation>
-            <includeResources>false</includeResources>
-            <includeTestSourceDirectory>true</includeTestSourceDirectory>
-            <includeTestResources>false</includeTestResources>
           </configuration>
-          <executions>
-            <execution>
-              <id>checkstyle</id>
-              <phase>validate</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
* Add GitHub Actions workflows
  * Add a CI workflow for PRs and branches
  * Add a manual workflow for custom builds
* Remove redundant builds from Travis config (leave only s390x)
* Update build status badges on README
  * Move inline links to bottom of the Markdown page for readability
  * Other: normalize URLs by using https and removing trailing slashes
    and unnecessary trailing .html, and fix syntax for section header
* Remove extraneous unactivated configuration from pom.xml files
  (and update an XML comment to remove an extra confusing backslash)
* Add ability to disable cppunit tests independently of surefire tests
* Build only selected tests in CI workflow for now