### PR TITLE
fix address parsing error on java 14/15

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/StaticHostProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/StaticHostProvider.java
@@ -132,10 +132,8 @@ public final class StaticHostProvider implements HostProvider {
                 hostString = addr.getHostName();
             }
         } else {
-            // According to the Java 6 documentation, if the hostname is
-            // unresolved, then the string before the colon is the hostname.
-            String addrString = addr.toString();
-            hostString = addrString.substring(0, addrString.lastIndexOf(':'));
+            // if the addr is unresolved, then get address by hostname.
+            hostString = addr.getHostName();
         }
 
         return hostString;


### PR DESCRIPTION
`InetSocketAddress.toString()` is changed from java 14,  unresovled address is format as `127.0.0.1/<unresolved>:2181`, the `org.apache.zookeeper.client.StaticHostProvider#getHostString`  parsing failed:

```java
     String addrString = addr.toString();
     hostString = addrString.substring(0, addrString.lastIndexOf(':'));
```

```
[19/10/20 03:18:53:053 CST] main-SendThread(127.0.0.1:2181)  INFO zookeeper.ClientCnxn: Opening socket connection to server 127.0.0.1/<unresolved>:2181. Will not attempt to authenticate using SASL (unknown error)
[19/10/20 03:18:53:053 CST] main-SendThread(127.0.0.1:2181)  WARN zookeeper.ClientCnxn: Session 0x0 for server 127.0.0.1/<unresolved>:2181, unexpected error, closing socket connection and attempting reconnect
java.nio.channels.UnresolvedAddressException
	at java.base/sun.nio.ch.Net.checkAddress(Net.java:149)
	at java.base/sun.nio.ch.Net.checkAddress(Net.java:157)
	at java.base/sun.nio.ch.SocketChannelImpl.checkRemote(SocketChannelImpl.java:753)
	at java.base/sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:774)
	at org.apache.zookeeper.ClientCnxnSocketNIO.registerAndConnect(ClientCnxnSocketNIO.java:277)
	at org.apache.zookeeper.ClientCnxnSocketNIO.connect(ClientCnxnSocketNIO.java:287)
	at org.apache.zookeeper.ClientCnxn$SendThread.startConnect(ClientCnxn.java:1021)
	at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1064)
```

When the address is unresovled, it should be resolved from the hostname.
