### PR TITLE
ZOOKEEPER-3981: Flaky test MultipleAddressTest::testGetValidAddressWithNotValid

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/MultipleAddressesTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/MultipleAddressesTest.java
@@ -110,7 +110,7 @@ public class MultipleAddressesTest {
     @Test
     public void testGetValidAddressWithNotValid() {
         assertThrows(NoRouteToHostException.class, () -> {
-            MultipleAddresses multipleAddresses = new MultipleAddresses(new InetSocketAddress("10.0.0.1", 22));
+            MultipleAddresses multipleAddresses = new MultipleAddresses(new InetSocketAddress("240.0.0.0", 22));
             multipleAddresses.getReachableAddress();
         });
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/MultipleAddressesTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/MultipleAddressesTest.java
@@ -110,7 +110,8 @@ public class MultipleAddressesTest {
     @Test
     public void testGetValidAddressWithNotValid() {
         assertThrows(NoRouteToHostException.class, () -> {
-            MultipleAddresses multipleAddresses = new MultipleAddresses(new InetSocketAddress("240.0.0.0", 22));
+            // IP chosen because it is reserved for documentation/examples and should be unreachable (RFC 5737)
+            MultipleAddresses multipleAddresses = new MultipleAddresses(new InetSocketAddress("203.0.113.1", 22));
             multipleAddresses.getReachableAddress();
         });
     }


### PR DESCRIPTION
Problem:

Test MultipleAddressTest::testGetValidAddressWithNotValid might fail deterministically when the address it's using, 10.0.0.1, is reachable, as per https://tools.ietf.org/html/rfc5735 10.0.0.1 might be allocatable to private network usage. In fact, the router address of my ISP is assigned this IP, leading to this test always failing for me.

Solution:

Replace the address with 240.0.0.0, which is reserved for future use and less likely to be reachable.