### PR TITLE
ZOOKEEPER-3983: Avoid mocking unix domain sockets

### DIFF
--- a/zookeeper-client/zookeeper-client-c/tests/LibCMocks.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/LibCMocks.cc
@@ -259,7 +259,12 @@ int setsockopt(int s,int level,int optname,const void *optval,socklen_t optlen){
     return Mock_socket::mock_->callSet(s,level,optname,optval,optlen);      
 }
 int connect(int s,const struct sockaddr *addr,socklen_t len){
+#ifdef AF_UNIX
+    /* don't mock UNIX domain sockets */
+    if (!Mock_socket::mock_ || addr->sa_family == AF_UNIX)
+#else
     if (!Mock_socket::mock_)
+#endif
         return LIBC_SYMBOLS.connect(s,addr,len);
     return Mock_socket::mock_->callConnect(s,addr,len);
 }


### PR DESCRIPTION
This fixes issues with the C client tests, causing them to hang if
certain nameservices are in use (such as SSS), which use UNIX domain
sockets for getting the `getlogin()` and `getpwuid_r()`

This change makes the mocking of sockets less aggressive, since the
tests do not need to mock `AF_UNIX` socket types.