### PR TITLE
ZOOKEEPER-3950: [ADDENDUM] fix checksyle error on branch-3.6

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/BCFKSFileLoaderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/BCFKSFileLoaderTest.java
@@ -21,7 +21,6 @@ package org.apache.zookeeper.common;
 import java.io.IOException;
 import java.security.KeyStore;
 import java.util.Collection;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
when I cherry-picked ZOOKEEPER-3950 to branch-3.6, I had to change the unit test (from junit 5 to junit 4). I left a checkstyle error in the test code, so checkstyle fails now on branch-3.6. This trivial commit fixes that.