### PR TITLE
ZOOKEEPER-3979: Clean up/robustify audit logs

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1117,15 +1117,6 @@ property, when available, is noted below.
     .Log4jAuditLogger is used.
     See the [ZooKeeper audit logs](zookeeperAuditLogs.html) for more information.
 
-* *audit.scheme* :
-    (Java system property: **zookeeper.audit.scheme**)
-    **New in 3.7.0:**
-    Configures the set of authentication schemes to be considered when
-    generating audit log entries.  Multiple values can be added using
-    suffixed properies, e.g.: `zookeeper.audit.scheme.1=sasl`,
-    `zookeeper.audit.scheme.2=x509`.  By default, user IDs from all
-    schemes are included in the log.
-
 * *largeRequestMaxBytes* :
     (Java system property: **zookeeper.largeRequestMaxBytes**)
     **New in 3.6.0:**

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1117,6 +1117,15 @@ property, when available, is noted below.
     .Log4jAuditLogger is used.
     See the [ZooKeeper audit logs](zookeeperAuditLogs.html) for more information.
 
+* *audit.scheme* :
+    (Java system property: **zookeeper.audit.scheme**)
+    **New in 3.7.0:**
+    Configures the set of authentication schemes to be considered when
+    generating audit log entries.  Multiple values can be added using
+    suffixed properies, e.g.: `zookeeper.audit.scheme.1=sasl`,
+    `zookeeper.audit.scheme.2=x509`.  By default, user IDs from all
+    schemes are included in the log.
+
 * *largeRequestMaxBytes* :
     (Java system property: **zookeeper.largeRequestMaxBytes**)
     **New in 3.6.0:**

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1440,6 +1440,16 @@ Beside this page, you can also find useful information about client side configu
 The ZooKeeper Wiki also has useful pages about [ZooKeeper SSL support](https://cwiki.apache.org/confluence/display/ZOOKEEPER/ZooKeeper+SSL+User+Guide),
 and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/display/ZOOKEEPER/ZooKeeper+and+SASL).
 
+* *DigestAuthenticationProvider.enabled* :
+    (Java system property: **zookeeper.DigestAuthenticationProvider.enabled**)
+    **New in 3.7:**
+    Determines whether the `digest` authentication provider is
+    enabled.  The default value is **true** for backwards
+    compatibility, but it may be a good idea to disable this provider
+    if not used, as it can result in misleading entries appearing in
+    audit logs
+    (see [ZOOKEEPER-3979](https://issues.apache.org/jira/browse/ZOOKEEPER-3979))
+
 * *DigestAuthenticationProvider.superDigest* :
     (Java system property: **zookeeper.DigestAuthenticationProvider.superDigest**)
     By default this feature is **disabled**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/audit/AuditHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/audit/AuditHelper.java
@@ -179,7 +179,7 @@ public final class AuditHelper {
     }
 
     private static void log(Request request, String path, String op, String acls, String createMode, Result result) {
-        log(request.getUsers(), op, path, acls, createMode,
+        log(request.getUsersForAudit(), op, path, acls, createMode,
                 request.cnxn.getSessionIdHex(), request.cnxn.getHostAddress(), result);
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
@@ -463,10 +463,19 @@ public class Request {
     }
 
     /**
-     * Returns comma separated list of users authenticated in the current
-     * session
+     * Returns a formatted, comma-separated list of the user IDs
+     * associated with this {@code Request}, or {@code null} if no
+     * user IDs were found.
+     *
+     * The return value is used for audit logging.  While it may be
+     * easy on the eyes, it is underspecified: it does not mention the
+     * corresponding {@code scheme}, nor are its components escaped.
+     * This is not a security feature.
+     *
+     * @return a comma-separated list of user IDs, or {@code null} if
+     * no user IDs were found.
      */
-    public String getUsers() {
+    public String getUsersForAudit() {
         return AuthUtil.getUsers(authInfo);
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
@@ -467,26 +467,7 @@ public class Request {
      * session
      */
     public String getUsers() {
-        if (authInfo == null) {
-            return (String) null;
-        }
-        if (authInfo.size() == 1) {
-            return AuthUtil.getUser(authInfo.get(0));
-        }
-        StringBuilder users = new StringBuilder();
-        boolean first = true;
-        for (Id id : authInfo) {
-            String user = AuthUtil.getUser(id);
-            if (user != null) {
-                if (first) {
-                    first = false;
-                } else {
-                    users.append(",");
-                }
-                users.append(user);
-            }
-        }
-        return users.toString();
+        return AuthUtil.getUsers(authInfo);
     }
 
     public TxnDigest getTxnDigest() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
@@ -56,14 +56,9 @@ public class DigestAuthenticationProvider implements AuthenticationProvider {
      */
     private static final String superDigest = System.getProperty("zookeeper.DigestAuthenticationProvider.superDigest");
 
-    private static final boolean enabled;
-
-    static {
-        enabled = Boolean.parseBoolean(System.getProperty(DIGEST_AUTH_ENABLED, "true"));
-        LOG.info("{} = {}", DIGEST_AUTH_ENABLED, enabled);
-    }
-
     public static boolean isEnabled() {
+        boolean enabled = Boolean.parseBoolean(System.getProperty(DIGEST_AUTH_ENABLED, "true"));
+        LOG.info("{} = {}", DIGEST_AUTH_ENABLED, enabled);
         return enabled;
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
@@ -47,12 +47,25 @@ public class DigestAuthenticationProvider implements AuthenticationProvider {
         LOG.info("ACL digest algorithm is: {}", DIGEST_ALGORITHM);
     }
 
+    private static final String DIGEST_AUTH_ENABLED = "zookeeper.DigestAuthenticationProvider.enabled";
+
     /** specify a command line property with key of
      * "zookeeper.DigestAuthenticationProvider.superDigest"
      * and value of "super:&lt;base64encoded(SHA1(password))&gt;" to enable
      * super user access (i.e. acls disabled)
      */
     private static final String superDigest = System.getProperty("zookeeper.DigestAuthenticationProvider.superDigest");
+
+    private static final boolean enabled;
+
+    static {
+        enabled = Boolean.parseBoolean(System.getProperty(DIGEST_AUTH_ENABLED, "true"));
+        LOG.info("{} = {}", DIGEST_AUTH_ENABLED, enabled);
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
 
     public String getScheme() {
         return "digest";

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/ProviderRegistry.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/ProviderRegistry.java
@@ -45,9 +45,13 @@ public class ProviderRegistry {
     public static void initialize() {
         synchronized (ProviderRegistry.class) {
             IPAuthenticationProvider ipp = new IPAuthenticationProvider();
-            DigestAuthenticationProvider digp = new DigestAuthenticationProvider();
             authenticationProviders.put(ipp.getScheme(), ipp);
-            authenticationProviders.put(digp.getScheme(), digp);
+
+            if (DigestAuthenticationProvider.isEnabled()) {
+                DigestAuthenticationProvider digp = new DigestAuthenticationProvider();
+                authenticationProviders.put(digp.getScheme(), digp);
+            }
+
             Enumeration<Object> en = System.getProperties().keys();
             while (en.hasMoreElements()) {
                 String k = (String) en.nextElement();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/AuthUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/AuthUtil.java
@@ -41,6 +41,41 @@ public final class AuthUtil {
     }
 
     /**
+     * Returns an encoded, comma-separated list of the {@code id}s
+     * held in {@code authInfo}.
+     *
+     * Note that while the result may be easy on the eyes, it is
+     * underspecified as it does not mention the corresponding
+     * {@code scheme}.
+     *
+     * @param authInfo A list of {@code Id} objects, or {@code null}.
+     * @return a formatted list of {@code id}s, or {@code null} if no
+     * usable {@code id}s were found.
+     */
+    public static String getUsers(List<Id> authInfo) {
+        if (authInfo == null) {
+            return (String) null;
+        }
+        if (authInfo.size() == 1) {
+            return getUser(authInfo.get(0));
+        }
+        StringBuilder users = new StringBuilder();
+        boolean first = true;
+        for (Id id : authInfo) {
+            String user = getUser(id);
+            if (user != null) {
+                if (first) {
+                    first = false;
+                } else {
+                    users.append(",");
+                }
+                users.append(user);
+            }
+        }
+        return users.toString();
+    }
+
+    /**
      * Gets user from id to prepare ClientInfo.
      *
      * @param authInfo List of id objects. id contains scheme and authentication info
@@ -49,7 +84,7 @@ public final class AuthUtil {
     public static List<ClientInfo> getClientInfos(List<Id> authInfo) {
         List<ClientInfo> clientAuthInfo = new ArrayList<>(authInfo.size());
         authInfo.forEach(id -> {
-            String user = AuthUtil.getUser(id);
+            String user = getUser(id);
             clientAuthInfo.add(new ClientInfo(id.getScheme(), user == null ? "" : user));
         });
         return clientAuthInfo;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/audit/Log4jAuditLoggerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/audit/Log4jAuditLoggerTest.java
@@ -301,7 +301,7 @@ public class Log4jAuditLoggerTest extends QuorumPeerTestBase {
         ServerCnxn next = getServerCnxn();
         Request request = new Request(next, -1, -1, -1, null,
                 next.getAuthInfo());
-        return request.getUsers();
+        return request.getUsersForAudit();
     }
 
     private String getIp() {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/DigestAuthDisabledTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/DigestAuthDisabledTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.TestableZooKeeper;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher.Event.KeeperState;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.jupiter.api.Test;
+
+public class DigestAuthDisabledTest extends ClientBase {
+
+    static {
+        System.setProperty("zookeeper.DigestAuthenticationProvider.enabled", "false");
+    }
+
+    private final CountDownLatch authFailed = new CountDownLatch(1);
+
+    @Override
+    protected TestableZooKeeper createClient(String hp) throws IOException, InterruptedException {
+        MyWatcher watcher = new MyWatcher();
+        return createClient(watcher, hp);
+    }
+
+    private class MyWatcher extends CountdownWatcher {
+
+        @Override
+        public synchronized void process(WatchedEvent event) {
+            if (event.getState() == KeeperState.AuthFailed) {
+                authFailed.countDown();
+            } else {
+                super.process(event);
+            }
+        }
+
+    }
+
+    @Test
+    public void testDigestAuthDisabledTriggersAuthFailed() throws Exception {
+        ZooKeeper zk = createClient();
+        try {
+            zk.addAuthInfo("digest", "roger:muscadet".getBytes());
+            zk.getData("/path1", false, null);
+            fail("Should get auth state error");
+        } catch (KeeperException.AuthFailedException e) {
+            if (!authFailed.await(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)) {
+                fail("Should have called my watcher");
+            }
+        } finally {
+            zk.close();
+        }
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/DigestAuthDisabledTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/DigestAuthDisabledTest.java
@@ -27,12 +27,20 @@ import org.apache.zookeeper.TestableZooKeeper;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZooKeeper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class DigestAuthDisabledTest extends ClientBase {
 
-    static {
+    @BeforeAll
+    public static void setUpEnvironment() {
         System.setProperty("zookeeper.DigestAuthenticationProvider.enabled", "false");
+    }
+
+    @AfterAll
+    public static void cleanUpEnvironment() {
+        System.clearProperty("zookeeper.DigestAuthenticationProvider.enabled");
     }
 
     private final CountDownLatch authFailed = new CountDownLatch(1);


### PR DESCRIPTION
This is a minimally disruptive mitigation for the issue reported in ZOOKEEPER-3979, "Clients can corrupt the audit log."

A new property allows disabling the "legacy" `digest` authentication mechanism, which could be used by "an attacker" to inject unsanitized data into audit logs.

In general, ZooKeeper administrators should disable unused authentication providers, and ensure that the ones which remain enabled to not produce user IDs susceptible to confuse audit log parsers.

The rest of the patch is made of assorted small cleanups which should not have any impact on operation or security.

(Note that the patch *series* attached to https://github.com/apache/zookeeper/pull/1519 contains additional measures, such as filtering audit user IDs by authentication scheme, but those seem to be overkill for typical deployment scenarios.  That code could still be fished out and polished if the circumstances evolved.)