### PR TITLE
Build and test on ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
             - maven
             - libcppunit-dev
     - os: linux
-      arch: arm64-graviton2
+      arch: arm64
       jdk: openjdk11
       
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
           packages:
             - maven
             - libcppunit-dev
+    - os: linux
+      arch: arm64-graviton2
+      jdk: openjdk11
+      
 
 cache:
   directories:


### PR DESCRIPTION
More and more software development is being done on ARM64 CPU architecture.
It would be good if Zookeeper is being regularly tested on ARM64.