### PR TITLE
ZOOKEEPER-3991: Refresh InetSocketAddress before binding quorum server socket

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -1132,12 +1132,7 @@ public class QuorumCnxManager {
                 }
 
                 socket.setReuseAddress(true);
-
-                if (address.isUnresolved()) {
-                    // Retry DNS resolution
-                    address = new InetSocketAddress(address.getHostName(), address.getPort());
-                }
-
+                address = new InetSocketAddress(address.getHostString(), address.getPort());
                 socket.bind(address);
 
                 return socket;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -1132,6 +1132,12 @@ public class QuorumCnxManager {
                 }
 
                 socket.setReuseAddress(true);
+
+                if (address.isUnresolved()) {
+                    // Retry DNS resolution
+                    address = new InetSocketAddress(address.getHostName(), address.getPort());
+                }
+
                 socket.bind(address);
 
                 return socket;


### PR DESCRIPTION
Setting `electionPortBindRetry` to 0 (as recommended by the documentation for the setup we are using) results in this code being called in a loop. 

The desired behaviour is that in case of a bad DNS reply the server socket creation will fail and keep retrying until the hostname resolves. The current behaviour is that it keeps throwing unresolved address errors even though the DNS entry became correct.

For more details and reproduction steps see the Jira issue at https://issues.apache.org/jira/browse/ZOOKEEPER-3991

Please note that the contents of this PR are different from the patch I initially attached to the issue.