### PR TITLE
ZOOKEEPER-3982: export ZooKeeper version as prometheus metric

### DIFF
--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/main/java/org/apache/zookeeper/metrics/prometheus/CustomizedExports.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/main/java/org/apache/zookeeper/metrics/prometheus/CustomizedExports.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.metrics.prometheus;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+
+/**
+ * The Customized Exports is different from the Summary, Counter, Gauge which is usually a number.
+ * <p>
+ * The Customized Exports can be text information. For example: {@link VersionInfoExports}
+ * </p>
+ * @since 3.8.0
+ */
+
+public class CustomizedExports {
+    private final Collector versionInfoExports;
+
+    private CustomizedExports() {
+        this.versionInfoExports = new VersionInfoExports();
+    }
+
+    private static class SingletonHolder {
+        private static final CustomizedExports SINGLETON = new CustomizedExports();
+    }
+
+    public static CustomizedExports instance() {
+        return SingletonHolder.SINGLETON;
+    }
+
+    public void initialize() {
+        versionInfoExports.register(CollectorRegistry.defaultRegistry);
+    }
+
+    // VisibleForTesting
+    public void terminate() {
+        CollectorRegistry.defaultRegistry.unregister(versionInfoExports);
+    }
+}

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/main/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProvider.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/main/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProvider.java
@@ -70,6 +70,7 @@ public class PrometheusMetricsProvider implements MetricsProvider {
     private Server server;
     private final MetricsServletImpl servlet = new MetricsServletImpl();
     private final Context rootContext = new Context();
+    public final CustomizedExports customizedExports = CustomizedExports.instance();
 
     @Override
     public void configure(Properties configuration) throws MetricsProviderLifeCycleException {
@@ -87,6 +88,8 @@ public class PrometheusMetricsProvider implements MetricsProvider {
             if (exportJvmInfo) {
                 DefaultExports.initialize();
             }
+            customizedExports.initialize();
+
             server = new Server(new InetSocketAddress(host, port));
             ServletContextHandler context = new ServletContextHandler();
             context.setContextPath("/");

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/main/java/org/apache/zookeeper/metrics/prometheus/VersionInfoExports.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/main/java/org/apache/zookeeper/metrics/prometheus/VersionInfoExports.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.metrics.prometheus;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.zookeeper.Version;
+
+/**
+ * Exports ZooKeeper version info.
+ * Example usage:
+ * <pre>
+ * {@code
+ *   new VersionInfoExports().register();
+ * }
+ * </pre>
+ * Metrics being exported:
+ * <pre>
+ *   zk_version_info{version="3.8.0-SNAPSHOT",revision_hash="e897abb8b60321c693050add06ba1f9706c220ce",
+ *   built_on="2021-06-27 10:46 UTC",} 1.0
+ * </pre>
+ *
+ * @since 3.8.0
+ */
+
+public class VersionInfoExports extends Collector {
+
+    public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples> mfs = new ArrayList<>();
+
+        GaugeMetricFamily zkVersionInfo = new GaugeMetricFamily(
+                "zk_version_info",
+                "ZooKeeper version info",
+                Arrays.asList("version", "revision_hash", "built_on"));
+        zkVersionInfo.addMetric(
+                Arrays.asList(
+                        Version.getVersion(),
+                        Version.getRevisionHash(),
+                        Version.getBuildDate()),
+                    1L);
+        mfs.add(zkVersionInfo);
+
+        return mfs;
+    }
+}


### PR DESCRIPTION
- Apply this patch, we can export ZooKeeper version as prometheus metric. For example:
```
leader_unavailable_time_sum 0.0
# HELP zk_version_info ZooKeeper version info
# TYPE zk_version_info gauge
zk_version_info{version="3.7.0-SNAPSHOT",revision_hash="b761b77a3bf8cd02edaad88a33bafbc8b6c65be4",built_on="2020-11-07 08:03 UTC",} 1.0
# HELP ensemble_auth_success ensemble_auth_success
```

- more details in the [ZOOKEEPER-3982](https://issues.apache.org/jira/browse/ZOOKEEPER-3982)