### PR TITLE
ZOOKEEPER-3992: addWatch api should check the null watch

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
@@ -3180,6 +3180,7 @@ public class ZooKeeper implements AutoCloseable {
     public void addWatch(String basePath, Watcher watcher, AddWatchMode mode)
             throws KeeperException, InterruptedException {
         PathUtils.validatePath(basePath);
+        validateWatcher(watcher);
         String serverPath = prependChroot(basePath);
 
         RequestHeader h = new RequestHeader();
@@ -3225,6 +3226,7 @@ public class ZooKeeper implements AutoCloseable {
     public void addWatch(String basePath, Watcher watcher, AddWatchMode mode,
                          VoidCallback cb, Object ctx) {
         PathUtils.validatePath(basePath);
+        validateWatcher(watcher);
         String serverPath = prependChroot(basePath);
 
         RequestHeader h = new RequestHeader();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/PersistentWatcherTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/PersistentWatcherTest.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.test;
 
 import static org.apache.zookeeper.AddWatchMode.PERSISTENT;
+import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -57,6 +58,27 @@ public class PersistentWatcherTest extends ClientBase {
         try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
             zk.addWatch("/a/b", persistentWatcher, PERSISTENT);
             internalTestBasic(zk);
+        }
+    }
+
+    @Test
+    public void testNullWatch()
+            throws IOException, InterruptedException, KeeperException {
+        try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
+            try {
+                zk.addWatch("/a/b", null, PERSISTENT);
+                fail("IllegalArgumentException was not thrown.");
+            } catch (IllegalArgumentException e) {
+                // Ignore expected exception
+            }
+
+            try {
+                AsyncCallback.VoidCallback cb = (rc, path, ctx) -> {};
+                zk.addWatch("/a/b", null, PERSISTENT, cb, null);
+                fail("IllegalArgumentException was not thrown.");
+            } catch (IllegalArgumentException e) {
+                // Ignore expected exception
+            }
         }
     }
 


### PR DESCRIPTION
This is the backport pull request for https://github.com/apache/zookeeper/pull/1529

Main issue [ZOOKEEPER-3992](https://issues.apache.org/jira/projects/ZOOKEEPER/issues/ZOOKEEPER-3992?filter=allissues)