### PR TITLE
ZOOKEEPER-3766 zkServer and other scripts should export CLASSPATH rather than use -cp

### DIFF
--- a/bin/zkCleanup.sh
+++ b/bin/zkCleanup.sh
@@ -41,13 +41,11 @@ ZOODATALOGDIR="$(grep "^[[:space:]]*dataLogDir=" "$ZOOCFG" | sed -e 's/.*=//')"
 
 ZOO_LOG_FILE=zookeeper-$USER-cleanup-$HOSTNAME.log
 
-if [ "x$ZOODATALOGDIR" = "x" ]
-then
-"$JAVA" "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" "-Dzookeeper.log.file=${ZOO_LOG_FILE}" \
-     -cp "$CLASSPATH" $JVMFLAGS \
-     org.apache.zookeeper.server.PurgeTxnLog "$ZOODATADIR" $*
+export CLASSPATH=$CLASSPATH
+if [ "x$ZOODATALOGDIR" = "x" ]; then
+  "$JAVA" "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" "-Dzookeeper.log.file=${ZOO_LOG_FILE}" $JVMFLAGS \
+      org.apache.zookeeper.server.PurgeTxnLog "$ZOODATADIR" $*
 else
-"$JAVA" "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" "-Dzookeeper.log.file=${ZOO_LOG_FILE}" \
-     -cp "$CLASSPATH" $JVMFLAGS \
-     org.apache.zookeeper.server.PurgeTxnLog "$ZOODATALOGDIR" "$ZOODATADIR" $*
+  "$JAVA" "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" "-Dzookeeper.log.file=${ZOO_LOG_FILE}" $JVMFLAGS \
+      org.apache.zookeeper.server.PurgeTxnLog "$ZOODATALOGDIR" "$ZOODATADIR" $*
 fi

--- a/bin/zkCli.sh
+++ b/bin/zkCli.sh
@@ -37,7 +37,7 @@ else
 fi
 
 ZOO_LOG_FILE=zookeeper-$USER-cli-$HOSTNAME.log
-
+export CLASSPATH=$CLASSPATH
 "$JAVA" "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" "-Dzookeeper.log.file=${ZOO_LOG_FILE}" \
-     -cp "$CLASSPATH" $CLIENT_JVMFLAGS $JVMFLAGS \
+     $CLIENT_JVMFLAGS $JVMFLAGS \
      org.apache.zookeeper.ZooKeeperMain "$@"

--- a/bin/zkEnv.sh
+++ b/bin/zkEnv.sh
@@ -137,8 +137,6 @@ then
     CLASSPATH=`cygpath -wp "$CLASSPATH"`
 fi
 
-#echo "CLASSPATH=$CLASSPATH"
-
 # default heap for zookeeper server
 ZK_SERVER_HEAP="${ZK_SERVER_HEAP:-1000}"
 export SERVER_JVMFLAGS="-Xmx${ZK_SERVER_HEAP}m $SERVER_JVMFLAGS"

--- a/bin/zkServer.sh
+++ b/bin/zkServer.sh
@@ -152,6 +152,7 @@ fi
 ZOO_LOG_FILE=zookeeper-$USER-server-$HOSTNAME.log
 _ZOO_DAEMON_OUT="$ZOO_LOG_DIR/zookeeper-$USER-server-$HOSTNAME.out"
 
+export CLASSPATH=$CLASSPATH
 case $1 in
 start)
     echo  -n "Starting zookeeper ... "
@@ -164,7 +165,7 @@ start)
     nohup "$JAVA" $ZOO_DATADIR_AUTOCREATE "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" \
     "-Dzookeeper.log.file=${ZOO_LOG_FILE}" "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" \
     -XX:+HeapDumpOnOutOfMemoryError -XX:OnOutOfMemoryError='kill -9 %p' \
-    -cp "$CLASSPATH" $JVMFLAGS $ZOOMAIN "$ZOOCFG" > "$_ZOO_DAEMON_OUT" 2>&1 < /dev/null &
+    $JVMFLAGS $ZOOMAIN "$ZOOCFG" > "$_ZOO_DAEMON_OUT" 2>&1 < /dev/null &
     if [ $? -eq 0 ]
     then
       case "$OSTYPE" in
@@ -202,13 +203,13 @@ start-foreground)
     "${ZOO_CMD[@]}" $ZOO_DATADIR_AUTOCREATE "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" \
     "-Dzookeeper.log.file=${ZOO_LOG_FILE}" "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" \
     -XX:+HeapDumpOnOutOfMemoryError -XX:OnOutOfMemoryError='kill -9 %p' \
-    -cp "$CLASSPATH" $JVMFLAGS $ZOOMAIN "$ZOOCFG"
+    $JVMFLAGS $ZOOMAIN "$ZOOCFG"
     ;;
 print-cmd)
     echo "\"$JAVA\" $ZOO_DATADIR_AUTOCREATE -Dzookeeper.log.dir=\"${ZOO_LOG_DIR}\" \
     -Dzookeeper.log.file=\"${ZOO_LOG_FILE}\" -Dzookeeper.root.logger=\"${ZOO_LOG4J_PROP}\" \
     -XX:+HeapDumpOnOutOfMemoryError -XX:OnOutOfMemoryError='kill -9 %p' \
-    -cp \"$CLASSPATH\" $JVMFLAGS $ZOOMAIN \"$ZOOCFG\" > \"$_ZOO_DAEMON_OUT\" 2>&1 < /dev/null"
+    $JVMFLAGS $ZOOMAIN \"$ZOOCFG\" > \"$_ZOO_DAEMON_OUT\" 2>&1 < /dev/null"
     ;;
 stop)
     echo -n "Stopping zookeeper ... "
@@ -225,7 +226,7 @@ stop)
     ;;
 version)
     ZOOMAIN=org.apache.zookeeper.version.VersionInfoMain
-    $JAVA -cp "$CLASSPATH" $ZOOMAIN 2> /dev/null
+    $JAVA $ZOOMAIN 2> /dev/null
     ;;
 restart)
     shift
@@ -283,7 +284,7 @@ status)
     fi
     echo "Client port found: $clientPort. Client address: $clientPortAddress. Client SSL: $isSSL."
     STAT=`"$JAVA" "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" "-Dzookeeper.log.file=${ZOO_LOG_FILE}" \
-          -cp "$CLASSPATH" $CLIENT_JVMFLAGS $JVMFLAGS org.apache.zookeeper.client.FourLetterWordMain \
+          $CLIENT_JVMFLAGS $JVMFLAGS org.apache.zookeeper.client.FourLetterWordMain \
           $clientPortAddress $clientPort srvr $isSSL 2> /dev/null    \
           | $GREP Mode`
     if [ "x$STAT" = "x" ]

--- a/bin/zkSnapShotToolkit.sh
+++ b/bin/zkSnapShotToolkit.sh
@@ -32,7 +32,7 @@ else
   . "$ZOOBINDIR"/zkEnv.sh
 fi
 
-"$JAVA" -cp "$CLASSPATH" $JVMFLAGS \
-     org.apache.zookeeper.server.SnapshotFormatter "$@"
+export CLASSPATH=$CLASSPATH
+"$JAVA" $JVMFLAGS org.apache.zookeeper.server.SnapshotFormatter "$@"
 
 

--- a/bin/zkSnapshotComparer.sh
+++ b/bin/zkSnapshotComparer.sh
@@ -32,5 +32,5 @@ else
   . "$ZOOBINDIR"/zkEnv.sh
 fi
 
-"$JAVA" -cp "$CLASSPATH" $JVMFLAGS \
-     org.apache.zookeeper.server.SnapshotComparer "$@"
+export CLASSPATH=$CLASSPATH
+"$JAVA" $JVMFLAGS org.apache.zookeeper.server.SnapshotComparer "$@"

--- a/bin/zkTxnLogToolkit.sh
+++ b/bin/zkTxnLogToolkit.sh
@@ -32,7 +32,7 @@ else
   . "$ZOOBINDIR"/zkEnv.sh
 fi
 
-"$JAVA" -cp "$CLASSPATH" $JVMFLAGS \
-     org.apache.zookeeper.server.persistence.TxnLogToolkit "$@"
+export CLASSPATH=$CLASSPATH
+"$JAVA" $JVMFLAGS org.apache.zookeeper.server.persistence.TxnLogToolkit "$@"
 
 


### PR DESCRIPTION
## Motivation

ZooKeeper's launch scripts use `-cp` to pass the class path to Java when launching. This creates insanely large command-lines which are completely unnecessary.

Java respects the CLASSPATH environment variable, and this is how the class path should be passed to Java when the process launches.

So, instead of doing java -cp $CLASSPATH ..., the scripts should be doing export CLASSPATH; java ....

The long command-lines make it difficult to troubleshoot, or view running process lists in tools like top, htop, ps, but also make it impossible to search and manage using tools like pgrep and pkill, which can only search for the first 4096 characters in the command-line. (See https://github.com/apache/fluo-uno/issues/243#issuecomment-601553260 for a specific issue involving this limit caused by ZK's scripts.)

Master issue: [ZOOKEEPER-3766](https://issues.apache.org/jira/projects/ZOOKEEPER/issues/ZOOKEEPER-3766?filter=allopenissues)