### PR TITLE
ZOOKEEPER-4000 use the computeIfAbsent to simplify the Leader#processSync method

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -1266,9 +1266,7 @@ public class Leader extends LearnerMaster {
         if (outstandingProposals.isEmpty()) {
             sendSync(r);
         } else {
-            pendingSyncs.computeIfAbsent(lastProposed, k -> {
-                return new ArrayList<>();
-            }).add(r);
+            pendingSyncs.computeIfAbsent(lastProposed, k -> new ArrayList<>()).add(r);
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -1266,12 +1266,9 @@ public class Leader extends LearnerMaster {
         if (outstandingProposals.isEmpty()) {
             sendSync(r);
         } else {
-            List<LearnerSyncRequest> l = pendingSyncs.get(lastProposed);
-            if (l == null) {
-                l = new ArrayList<LearnerSyncRequest>();
-            }
-            l.add(r);
-            pendingSyncs.put(lastProposed, l);
+            pendingSyncs.computeIfAbsent(lastProposed, k -> {
+                return new ArrayList<>();
+            }).add(r);
         }
     }
 


### PR DESCRIPTION
```
public synchronized void processSync(LearnerSyncRequest r) {
    if (outstandingProposals.isEmpty()) {
        sendSync(r);
    } else {
        List<LearnerSyncRequest> l = pendingSyncs.get(lastProposed);
        if (l == null) {
            l = new ArrayList<LearnerSyncRequest>();
        }
        l.add(r);
        pendingSyncs.put(lastProposed, l);
    }
}
```
we can use the computeIfAbsent to make the code more clean and elegant