### PR TITLE
ZOOKEEPER-4010:ProviderRegistry.initialized is not volatile

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/ProviderRegistry.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/ProviderRegistry.java
@@ -31,7 +31,7 @@ public class ProviderRegistry {
 
     public static final String AUTHPROVIDER_PROPERTY_PREFIX = "zookeeper.authProvider.";
 
-    private static boolean initialized = false;
+    private static volatile boolean initialized = false;
     private static final Map<String, AuthenticationProvider> authenticationProviders = new HashMap<>();
 
     //VisibleForTesting


### PR DESCRIPTION
ProviderRegistry.initialized is not volatile