### PR TITLE
ZOOKEEPER-4011: Fix build failure due to jUnit 5 usage in DIFFSyncConsistencyTest

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/DIFFSyncConsistencyTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/DIFFSyncConsistencyTest.java
@@ -19,10 +19,10 @@
 package org.apache.zookeeper.server.quorum;
 
 import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.Map;
@@ -39,17 +39,15 @@ import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.quorum.Leader.Proposal;
 import org.apache.zookeeper.test.ClientBase;
 import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.After;
+import org.junit.Test;
 
 public class DIFFSyncConsistencyTest extends QuorumPeerTestBase {
 
     private static int SERVER_COUNT = 3;
     private MainThread[] mt = new MainThread[SERVER_COUNT];
 
-    @Test
-    @Timeout(value = 120)
+    @Test(timeout = 120 * 1000)
     public void testInconsistentDueToUncommittedLog() throws Exception {
         final int LEADER_TIMEOUT_MS = 10_000;
         final int[] clientPorts = new int[SERVER_COUNT];
@@ -75,8 +73,8 @@ public class DIFFSyncConsistencyTest extends QuorumPeerTestBase {
         }
 
         for (int i = 0; i < SERVER_COUNT; i++) {
-            assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPorts[i], CONNECTION_TIMEOUT),
-                    "waiting for server " + i + " being up");
+            assertTrue("waiting for server " + i + " being up",
+                    ClientBase.waitForServerUp("127.0.0.1:" + clientPorts[i], CONNECTION_TIMEOUT));
         }
 
         int leader = findLeader(mt);
@@ -113,7 +111,7 @@ public class DIFFSyncConsistencyTest extends QuorumPeerTestBase {
         assertTrue(outstanding.size() > 0);
         Proposal p = findProposalOfType(outstanding, OpCode.create);
         LOG.info("Old leader id: {}. All proposals: {}", leader, outstanding);
-        assertNotNull(p, "Old leader doesn't have 'create' proposal");
+        assertNotNull("Old leader doesn't have 'create' proposal", p);
 
         // Make sure leader sync the proposal to disk.
         int sleepTime = 0;
@@ -161,7 +159,7 @@ public class DIFFSyncConsistencyTest extends QuorumPeerTestBase {
             ++c;
             try {
                 Stat stat = zk.exists("/zk" + leader, false);
-                assertNotNull(stat, "server " + leader + " should have /zk");
+                assertNotNull("server " + leader + " should have /zk", stat);
                 break;
             } catch (KeeperException.ConnectionLossException e) {
 
@@ -197,7 +195,7 @@ public class DIFFSyncConsistencyTest extends QuorumPeerTestBase {
         }
 
         int newLeader = findLeader(mt);
-        assertNotEquals(newLeader, leader, "new leader is still the old leader " + leader + " !!");
+        assertNotEquals("new leader is still the old leader " + leader + " !!", newLeader, leader);
 
         // This simulates the case where clients connected to the old leader had a view of the data
         // "/zkX", but clients connect to the new leader does not have the same view of data (missing "/zkX").
@@ -210,14 +208,14 @@ public class DIFFSyncConsistencyTest extends QuorumPeerTestBase {
             zk = new ZooKeeper("127.0.0.1:" + clientPorts[i], ClientBase.CONNECTION_TIMEOUT, watch);
             watch.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
             Stat val = zk.exists("/zk" + leader, false);
-            assertNotNull(val, "Data inconsistency detected! "
-                    + "Server " + i + " should have a view of /zk" + leader + "!");
+            assertNotNull("Data inconsistency detected! Server " + i + " should have a view of /zk" + leader + "!",
+                    val);
         }
 
         zk.close();
     }
 
-    @AfterEach
+    @After
     public void tearDown() {
         for (int i = 0; i < mt.length; i++) {
             try {


### PR DESCRIPTION
### Description
Resolves [ZOOKEEPER-4011](https://issues.apache.org/jira/browse/ZOOKEEPER-4011)

maven build fails on branch-3.6 because a back ported commit from the branch master uses jUnit 5.

### Solution
As discussed in https://github.com/apache/zookeeper/pull/1445, since cherry-picking jUnit 5 upgrades has conflicts, and there won't be too many back ports to 3.6 afterwards, we can just fix the issue by using jUnit 4 in the test.