### PR TITLE
ZOOKEEPER-4012: zookeeper-client-c: add an `install` target to CMakeLists

### DIFF
--- a/zookeeper-client/zookeeper-client-c/CMakeLists.txt
+++ b/zookeeper-client/zookeeper-client-c/CMakeLists.txt
@@ -290,3 +290,20 @@ if(WANT_CPPUNIT)
     "ZKROOT=${CMAKE_CURRENT_SOURCE_DIR}/../.."
     "CLASSPATH=$CLASSPATH:$CLOVER_HOME/lib/clover*.jar")
 endif()
+
+# set up `make install`.
+# headers end up in /usr/local/include/zookeeper/*.h
+# (with /usr/local being overrideable by using --prefix etc)
+INSTALL(FILES
+    include/zookeeper.h
+    include/proto.h
+    include/config.h
+    include/zookeeper_version.h
+    include/winconfig.h
+    include/zookeeper_log.h
+    include/recordio.h
+  DESTINATION include/zookeeper/)
+# libzookeeper.a ends up in /usr/local/lib/libzookeeper.a
+INSTALL(TARGETS zookeeper
+  ARCHIVE DESTINATION lib)
+


### PR DESCRIPTION
Previously, did this:

    ; cmake .
    ; make
    ; make install

ended up doing nothing, because CMakeLists.txt didn't include
INSTALL() directives.  With this commit applied, the last
command outputs:

    ; make install
    [ 18%] Built target hashtable
    [ 75%] Built target zookeeper
    [ 87%] Built target load_gen
    [100%] Built target cli
    Install the project...
    -- Install configuration: ""
    -- Installing: /usr/local/include/zookeeper/zookeeper.h
    -- Installing: /usr/local/include/zookeeper/proto.h
    -- Installing: /usr/local/include/zookeeper/config.h
    -- Installing: /usr/local/include/zookeeper/zookeeper_version.h
    -- Installing: /usr/local/include/zookeeper/winconfig.h
    -- Installing: /usr/local/include/zookeeper/zookeeper_log.h
    -- Installing: /usr/local/include/zookeeper/recordio.h
    -- Installing: /usr/local/lib/libzookeeper.a