### PR TITLE
ZOOKEEPER-4026: Complete support for Stat objects (and create2) in multi requests

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/MultiOperationRecord.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/MultiOperationRecord.java
@@ -126,7 +126,7 @@ public class MultiOperationRecord implements Record, Iterable<Op> {
                 case ZooDefs.OpCode.createContainer:
                     CreateRequest cr = new CreateRequest();
                     cr.deserialize(archive, tag);
-                    add(Op.create(cr.getPath(), cr.getData(), cr.getAcl(), cr.getFlags()));
+                    add(new Op.Create(h.getType(), cr.getPath(), cr.getData(), cr.getAcl(), cr.getFlags()));
                     break;
                 case ZooDefs.OpCode.createTTL:
                     CreateTTLRequest crTtl = new CreateTTLRequest();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Op.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Op.java
@@ -407,7 +407,7 @@ public abstract class Op {
             this(getOpcode(createMode, useCreate2), path, data, acl, createMode.toFlag());
         }
 
-        private Create(int type, String path, byte[] data, List<ACL> acl, int flags) {
+        Create(int type, String path, byte[] data, List<ACL> acl, int flags) {
             super(type, path, OpKind.TRANSACTION);
             this.data = data;
             this.acl = acl;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Op.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Op.java
@@ -311,7 +311,7 @@ public abstract class Op {
          * @param createModeFlag  the create mode encoded as an integer
          * @return the builder, for chaining.
          */
-        public CreateBuilder setCreateModeFlag(Integer createModeFlag) {
+        public CreateBuilder setCreateModeFlag(int createModeFlag) {
             this.createModeFlag = createModeFlag;
             return this;
         }
@@ -353,7 +353,7 @@ public abstract class Op {
          * @param ttl  the TTL for the node
          * @return the builder, for chaining.
          */
-        public CreateBuilder setTTL(Long ttl) {
+        public CreateBuilder setTTL(long ttl) {
             this.ttl = ttl;
             return this;
         }
@@ -365,6 +365,9 @@ public abstract class Op {
          * @return the {@link Create} or {@link CreateTTL} operation.
          */
         public Create build() {
+            Objects.requireNonNull(path, "path cannot be null");
+            Objects.requireNonNull(acl, "acl cannot be null");
+
             final CreateMode resolvedMode;
 
             if (createModeFlag != null) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -979,6 +979,7 @@ public class DataTree {
                     Record record = null;
                     switch (subtxn.getType()) {
                     case OpCode.create:
+                    case OpCode.create2:
                         record = new CreateTxn();
                         break;
                     case OpCode.createTTL:

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/MultiOperationRecordTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/MultiOperationRecordTest.java
@@ -33,7 +33,7 @@ public class MultiOperationRecordTest extends ZKTestCase {
     public void testRoundTrip() throws IOException {
         MultiOperationRecord request = new MultiOperationRecord();
         request.add(Op.check("check", 1));
-        request.add(Op.create("create", "create data".getBytes(), ZooDefs.Ids.CREATOR_ALL_ACL, ZooDefs.Perms.ALL));
+        request.add(Op.create("create", "create data".getBytes(), ZooDefs.Ids.CREATOR_ALL_ACL, 0));
         request.add(Op.delete("delete", 17));
         request.add(Op.setData("setData", "set data".getBytes(), 19));
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/MultiOperationRecordTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/MultiOperationRecordTest.java
@@ -34,6 +34,14 @@ public class MultiOperationRecordTest extends ZKTestCase {
         MultiOperationRecord request = new MultiOperationRecord();
         request.add(Op.check("check", 1));
         request.add(Op.create("create", "create data".getBytes(), ZooDefs.Ids.CREATOR_ALL_ACL, 0));
+        request.add(Op.create("createWithMode", "create data".getBytes(), ZooDefs.Ids.CREATOR_ALL_ACL, CreateMode.EPHEMERAL_SEQUENTIAL));
+        request.add(new Op.CreateBuilder()
+            .setPath("createWithStat")
+            .setData("create data".getBytes())
+            .setACL(ZooDefs.Ids.CREATOR_ALL_ACL)
+            .setCreateMode(CreateMode.PERSISTENT)
+            .setReturnStat(true)
+            .build());
         request.add(Op.delete("delete", 17));
         request.add(Op.setData("setData", "set data".getBytes(), 19));
 


### PR DESCRIPTION
Without this change, non-TTL/container invocations of `Op.create` invariably use `OpCode.create`, whose response does not include a `Stat` object.

Furthermore, there was no other way of requesting one, and that code path was consequently untested.

The patch introduces an additional `createFlags` parameter which can be used to enable that feature.  An invocation with `WANT_STAT` set causes the client to submit an `OpCode.create2`, whose response includes a filled `Stat` object, to the server.

It also completes `OpCode.create2` support for multi transactions, which was problem actually reported by ZOOKEEPER-4026.  Without it, such operations are silently downgraded to `OpCode.create`.