### PR TITLE
ZOOKEEPER-4030: Optionally canonicalize host names in quorum SASL authentication

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1705,6 +1705,14 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     (e.g. the zk/myhost@EXAMPLE.COM client principal will be authenticated in ZooKeeper as zk/myhost)
     Default: false
 
+* *kerberos.canonicalizeHostNames*
+    (Java system property: **zookeeper.kerberos.canonicalizeHostNames**)
+    **New in 3.7.0:**
+    Instructs ZooKeeper to canonicalize server host names extracted from *server.x* lines.
+    This allows using e.g. `CNAME` records to reference servers in configuration files, while still enabling SASL Kerberos authentication between quorum members.
+    It is essentially the quorum equivalent of the *zookeeper.sasl.client.canonicalize.hostname* property for clients.
+    The default value is **false** for backwards compatibility.
+
 * *multiAddress.enabled* :
     (Java system property: **zookeeper.multiAddress.enabled**)
     **New in 3.6.0:**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -265,13 +265,35 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
             }
         }
 
+        public QuorumServer(long sid, String addressStr) throws ConfigException {
+            this.id = sid;
+            initializeWithAddressString(addressStr);
+        }
+
+        public QuorumServer(long id, InetSocketAddress addr, InetSocketAddress electionAddr, LearnerType type) {
+            this(id, addr, electionAddr, null, type);
+        }
+
+        public QuorumServer(long id, InetSocketAddress addr, InetSocketAddress electionAddr, InetSocketAddress clientAddr, LearnerType type) {
+            this.id = id;
+            if (addr != null) {
+                this.addr.addAddress(addr);
+            }
+            if (electionAddr != null) {
+                this.electionAddr.addAddress(electionAddr);
+            }
+            this.type = type;
+            this.clientAddr = clientAddr;
+
+            setMyAddrs();
+        }
+
         private static final String wrongFormat =
             " does not have the form server_config or server_config;client_config"
             + " where server_config is the pipe separated list of host:port:port or host:port:port:type"
             + " and client_config is port or host:port";
 
-        public QuorumServer(long sid, String addressStr) throws ConfigException {
-            this.id = sid;
+        private void initializeWithAddressString(String addressStr) throws ConfigException {
             LearnerType newType = null;
             String[] serverClientParts = addressStr.split(";");
             String[] serverAddresses = serverClientParts[0].split("\\|");
@@ -342,24 +364,6 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
             if (newType != null) {
                 type = newType;
             }
-
-            setMyAddrs();
-        }
-
-        public QuorumServer(long id, InetSocketAddress addr, InetSocketAddress electionAddr, LearnerType type) {
-            this(id, addr, electionAddr, null, type);
-        }
-
-        public QuorumServer(long id, InetSocketAddress addr, InetSocketAddress electionAddr, InetSocketAddress clientAddr, LearnerType type) {
-            this.id = id;
-            if (addr != null) {
-                this.addr.addAddress(addr);
-            }
-            if (electionAddr != null) {
-                this.electionAddr.addAddress(electionAddr);
-            }
-            this.type = type;
-            this.clientAddr = clientAddr;
 
             setMyAddrs();
         }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumCanonicalizeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumCanonicalizeTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.quorum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig.ConfigException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class QuorumCanonicalizeTest extends ZKTestCase {
+
+    private static final InetSocketAddress SA_DONT_CARE = InetSocketAddress.createUnresolved("dont.care.invalid", 80);
+
+    private static final String ZK1_ALIAS = "zookeeper.invalid";
+    private static final String ZK1_FQDN = "zk1.invalid";
+    private static final String ZK1_IP = "169.254.0.42";
+    private static final InetAddress IA_MOCK_ZK1;
+
+    static {
+        InetAddress ia = mock(InetAddress.class);
+
+        when(ia.getCanonicalHostName()).thenReturn(ZK1_FQDN);
+
+        IA_MOCK_ZK1 = ia;
+    }
+
+    private static InetAddress getInetAddress(InetSocketAddress addr) {
+        if (addr.getHostName().equals(ZK1_ALIAS) || addr.getHostName().equals(ZK1_IP)) {
+            return IA_MOCK_ZK1;
+        }
+
+        return addr.getAddress();
+    };
+
+    @AfterEach
+    public void cleanUpEnvironment() {
+        System.clearProperty(QuorumPeer.CONFIG_KEY_KERBEROS_CANONICALIZE_HOST_NAMES);
+    }
+
+    private QuorumPeer.QuorumServer createQuorumServer(String hostName) throws ConfigException {
+        return new QuorumPeer.QuorumServer(0, hostName + ":1234:5678", QuorumCanonicalizeTest::getInetAddress);
+    }
+
+    @Test
+    public void testQuorumDefaultCanonicalization() throws ConfigException {
+        QuorumPeer.QuorumServer qps = createQuorumServer(ZK1_ALIAS);
+
+        assertEquals(ZK1_ALIAS, qps.hostname,
+           "The host name has been \"changed\" (canonicalized?) despite default settings");
+    }
+
+    @Test
+    public void testQuorumNoCanonicalization() throws ConfigException {
+        System.setProperty(QuorumPeer.CONFIG_KEY_KERBEROS_CANONICALIZE_HOST_NAMES, Boolean.FALSE.toString());
+
+        QuorumPeer.QuorumServer qps = createQuorumServer(ZK1_ALIAS);
+
+        assertEquals(ZK1_ALIAS, qps.hostname,
+           "The host name has been \"changed\" (canonicalized?) despite default settings");
+    }
+
+    @Test
+    public void testQuorumCanonicalization() throws ConfigException {
+        System.setProperty(QuorumPeer.CONFIG_KEY_KERBEROS_CANONICALIZE_HOST_NAMES, Boolean.TRUE.toString());
+
+        QuorumPeer.QuorumServer qps = createQuorumServer(ZK1_ALIAS);
+
+        assertEquals(ZK1_FQDN, qps.hostname,
+            "The host name hasn't been correctly canonicalized");
+    }
+
+    @Test
+    public void testQuorumCanonicalizationFromIp() throws ConfigException {
+        System.setProperty(QuorumPeer.CONFIG_KEY_KERBEROS_CANONICALIZE_HOST_NAMES, Boolean.TRUE.toString());
+
+        QuorumPeer.QuorumServer qps = createQuorumServer(ZK1_IP);
+
+        assertEquals(ZK1_FQDN, qps.hostname,
+            "The host name hasn't been correctly canonicalized");
+    }
+}


### PR DESCRIPTION
Without the option provided by this changeset, it is not convenient to use `CNAME`s to reference servers in `server.x` configuration lines while using quorum Kerberos authentication, as "incorrect" principals are generated by default.

Setting `kerberos.canonicalizeHostNames=true` causes the quorum server to substitute the canonical host name for the one specified in the configuration.  This has an effect on principal generation, and on the filtering of authorization IDs from incoming connections.

