### PR TITLE
ZOOKEEPER-4045: CVE-2020-25649 - Upgrade jackson databind to 2.10.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -439,7 +439,7 @@
     <commons-cli.version>1.4</commons-cli.version>
     <netty.version>4.1.50.Final</netty.version>
     <jetty.version>9.4.35.v20201120</jetty.version>
-    <jackson.version>2.10.5</jackson.version>
+    <jackson.version>2.10.5.1</jackson.version>
     <jline.version>2.14.6</jline.version>
     <snappy.version>1.1.7.7</snappy.version>
     <kerby.version>2.0.0</kerby.version>


### PR DESCRIPTION
Jackson reported a vulnerability under CVE-2020-25649. Upgrading to 2.10.5.1 will resolve the problem. See https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.10#micro-patches for more details.