### PR TITLE
ZOOKEEPER-4054: Make prometheus listen host can configure

### DIFF
--- a/conf/zoo_sample.cfg
+++ b/conf/zoo_sample.cfg
@@ -31,6 +31,7 @@ clientPort=2181
 #
 # https://prometheus.io Metrics Exporter
 #metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider
+#metricsProvider.httpHost=0.0.0.0
 #metricsProvider.httpPort=7000
 #metricsProvider.exportJvmInfo=true
 

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -2068,6 +2068,9 @@ options are used to configure the [AdminServer](#sc_adminserver).
     Set to "org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider" to
     enable Prometheus.io exporter.
 
+* *metricsProvider.httpHost* :
+    **New in 3.8.0:** Prometheus.io exporter will start a Jetty server and listen this address, default is "0.0.0.0"
+  
 * *metricsProvider.httpPort* :
     Prometheus.io exporter will start a Jetty server and bind to this port, it default to 7000.
     Prometheus end point will be http://hostname:httPort/metrics.

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderConfigTest.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderConfigTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.metrics.prometheus;
+
+import io.prometheus.client.CollectorRegistry;
+import java.util.Properties;
+import org.apache.zookeeper.metrics.MetricsProviderLifeCycleException;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class PrometheusMetricsProviderConfigTest {
+
+    @Test
+    public void testInvalidPort() {
+        Assert.assertThrows(MetricsProviderLifeCycleException.class, () -> {
+            CollectorRegistry.defaultRegistry.clear();
+            PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
+            Properties configuration = new Properties();
+            configuration.setProperty("httpPort", "65536");
+            configuration.setProperty("exportJvmInfo", "false");
+            provider.configure(configuration);
+            provider.start();
+        });
+    }
+
+    @Test
+    public void testInvalidAddr() {
+        Assert.assertThrows(MetricsProviderLifeCycleException.class, () -> {
+            CollectorRegistry.defaultRegistry.clear();
+            PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
+            Properties configuration = new Properties();
+            configuration.setProperty("httpHost", "master");
+            provider.configure(configuration);
+            provider.start();
+        });
+    }
+
+    @Test
+    public void testValidConfig() throws MetricsProviderLifeCycleException {
+        CollectorRegistry.defaultRegistry.clear();
+        PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
+        Properties configuration = new Properties();
+        configuration.setProperty("httpHost", "0.0.0.0");
+        configuration.setProperty("httpPort", "0");
+        provider.configure(configuration);
+        provider.start();
+    }
+
+}

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderTest.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderTest.java
@@ -56,6 +56,7 @@ public class PrometheusMetricsProviderTest {
         CollectorRegistry.defaultRegistry.clear();
         provider = new PrometheusMetricsProvider();
         Properties configuration = new Properties();
+        configuration.setProperty("httpHost", "127.0.0.1"); // local host for test
         configuration.setProperty("httpPort", "0"); // ephemeral port
         configuration.setProperty("exportJvmInfo", "false");
         provider.configure(configuration);


### PR DESCRIPTION
Make prometheus listen host can configure listen IP, helpful to security. default is 0.0.0.0