### PR TITLE
ZOOKEEPER-4055: Dockerfile can't build Zookeeper C client library

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -20,4 +20,15 @@
 FROM maven:3.6.3-jdk-8
 
 RUN apt-get update
-RUN apt-get install -y g++ cmake autoconf libcppunit-dev libtool openssl libssl-dev libsasl2-modules-gssapi-mit libsasl2-modules libsasl2-dev
+RUN apt-get install -y \
+  g++ \
+  cmake \
+  autoconf \
+  pkg-config \
+  libcppunit-dev \
+  libtool \
+  openssl \
+  libssl-dev \
+  libsasl2-modules-gssapi-mit \
+  libsasl2-modules \
+  libsasl2-dev


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZOOKEEPER-4055

This PR would fix the build by installing `pkg-config` and enabling `PKG_CHECK_MODULES`.
https://github.com/apache/zookeeper/blob/4e82a8be889d91dde46a11b38c8a20e82f3220f2/zookeeper-client/zookeeper-client-c/acinclude.m4#L314-L327

Another approach is to use a maven image with old Debian but it's less reasonable for me.