### PR TITLE
ZOOKEEPER-3426: C client: Consider encoded length before completing handshake

### DIFF
--- a/zookeeper-client/zookeeper-client-c/tests/ZKMocks.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/ZKMocks.cc
@@ -346,7 +346,7 @@ string HandshakeResponse::toString() const {
     buf.append(passwd,sizeof(passwd));
     buf.append(&readOnly,sizeof(readOnly));
     // finally set the buffer length
-    tmp=htonl(buf.size()+sizeof(tmp));
+    tmp=htonl(buf.size());
     buf.insert(0,(char*)&tmp, sizeof(tmp));
     return buf;
 }

--- a/zookeeper-client/zookeeper-client-c/tests/ZKMocks.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/ZKMocks.cc
@@ -344,7 +344,9 @@ string HandshakeResponse::toString() const {
     tmp=htonl(passwd_len);
     buf.append((char*)&tmp,sizeof(tmp));
     buf.append(passwd,sizeof(passwd));
-    buf.append(&readOnly,sizeof(readOnly));
+    if (!omitReadOnly) {
+        buf.append(&readOnly,sizeof(readOnly));
+    }
     // finally set the buffer length
     tmp=htonl(buf.size());
     buf.insert(0,(char*)&tmp, sizeof(tmp));

--- a/zookeeper-client/zookeeper-client-c/tests/ZKMocks.h
+++ b/zookeeper-client/zookeeper-client-c/tests/ZKMocks.h
@@ -305,7 +305,7 @@ class HandshakeResponse: public Response
 public:
     HandshakeResponse(int64_t sessId=1):
         protocolVersion(1),timeOut(10000),sessionId(sessId),
-        passwd_len(sizeof(passwd)),readOnly(0)
+        passwd_len(sizeof(passwd)),readOnly(0),omitReadOnly(false)
     {
         memcpy(passwd,"1234567890123456",sizeof(passwd));
     }
@@ -315,6 +315,7 @@ public:
     int32_t passwd_len;
     char passwd[16];
     char readOnly;
+    bool omitReadOnly;
     virtual std::string toString() const ;
 };
 


### PR DESCRIPTION
Suhas Dantkale noticed that the C client, which uses non-blocking sockets, could end up reading only the first 40 bytes of a 41-byte connection response and concluding that its handshake was complete, leaving one byte in the pipe.
    
Similarly (though even less likely), the library could be left hanging waiting for a 41th byte after having received a fragmented 40-byte response from an old server.
    
This patch makes the logic resistant to fragmentation by considering the server-provided length encoded in the response packet.