### PR TITLE
ZOOKEEPER-4058: Update checkstyle to the latest version 8.39

### DIFF
--- a/checkstyle-simple.xml
+++ b/checkstyle-simple.xml
@@ -16,8 +16,8 @@
     limitations under the License.
 -->
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!-- This is a checkstyle configuration file. For descriptions of
 what the following rules do, please see the checkstyle configuration

--- a/checkstyle-strict.xml
+++ b/checkstyle-strict.xml
@@ -16,12 +16,12 @@
     limitations under the License.
 -->
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!-- This is a checkstyle configuration file. For descriptions of
 what the following rules do, please see the checkstyle configuration
-page at http://checkstyle.sourceforge.net/config.html -->
+page at https://checkstyle.sourceforge.io/config.html -->
 
 <module name="Checker">
 
@@ -140,7 +140,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
         -->
 
         <!-- Checks for Javadoc comments.                     -->
-        <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+        <!-- See https://checkstyle.sourceforge.io/config_javadoc.html -->
         <module name="JavadocMethod">
             <property name="scope" value="protected"/>
             <property name="severity" value="error"/>

--- a/checkstyle-strict.xml
+++ b/checkstyle-strict.xml
@@ -144,12 +144,8 @@ page at http://checkstyle.sourceforge.net/config.html -->
         <module name="JavadocMethod">
             <property name="scope" value="protected"/>
             <property name="severity" value="error"/>
-            <property name="allowMissingJavadoc" value="true"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
-            <property name="allowUndeclaredRTE" value="true"/>
         </module>
 
         <!-- Check that paragraph tags are used correctly in Javadoc. -->
@@ -269,27 +265,6 @@ page at http://checkstyle.sourceforge.net/config.html -->
         <module name="InterfaceTypeParameterName">
             <property name="format" value="^(((T|K|V|W|X|R)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>
             <property name="severity" value="error"/>
-        </module>
-
-        <!--
-
-        LENGTH and CODING CHECKS
-
-        -->
-
-        <module name="LineLength">
-            <!-- Checks if a line is too long. -->
-            <property name="max" value="120"/>
-            <property name="severity" value="error"/>
-
-            <!--
-              The default ignore pattern exempts the following elements:
-                - import statements
-                - long URLs inside comments
-            -->
-
-            <property name="ignorePattern"
-                      value="^(package .*;\s*)|(import .*;\s*)|( *\* .*https?://.*)$"/>
         </module>
 
         <module name="LeftCurly">
@@ -432,5 +407,26 @@ page at http://checkstyle.sourceforge.net/config.html -->
             <property name="severity" value="error"/>
         </module>
 
+    </module>
+
+    <!--
+
+    LENGTH and CODING CHECKS
+
+    -->
+
+    <module name="LineLength">
+        <!-- Checks if a line is too long. -->
+        <property name="max" value="120"/>
+        <property name="severity" value="error"/>
+
+        <!--
+          The default ignore pattern exempts the following elements:
+            - import statements
+            - long URLs inside comments
+        -->
+
+        <property name="ignorePattern"
+                  value="^(package .*;\s*)|(import .*;\s*)|( *\* .*https?://.*)$"/>
     </module>
 </module>

--- a/checkstyleSuppressions.xml
+++ b/checkstyleSuppressions.xml
@@ -13,9 +13,8 @@
   limitations under the License. See accompanying LICENSE file.
 -->
 <!DOCTYPE suppressions PUBLIC
-        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
-        "https://checkstyle.org/dtds/configuration_1_3.dtd">
-
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.0//EN"
+        "https://checkstyle.org/dtds/suppressions_1_0.dtd">
 <suppressions>
     <!-- suppress all checks in the generated directories -->
     <suppress checks=".*" files=".+[\\/]classes[\\/].+\.java" />

--- a/checkstyleSuppressions.xml
+++ b/checkstyleSuppressions.xml
@@ -13,8 +13,8 @@
   limitations under the License. See accompanying LICENSE file.
 -->
 <!DOCTYPE suppressions PUBLIC
-        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <suppressions>
     <!-- suppress all checks in the generated directories -->

--- a/pom.xml
+++ b/pom.xml
@@ -447,7 +447,7 @@
     <commons-collections.version>4.4</commons-collections.version>
     <dropwizard.version>4.1.12.1</dropwizard.version>
     <spotbugsannotations.version>4.0.2</spotbugsannotations.version>
-    <checkstyle.version>8.17</checkstyle.version>
+    <checkstyle.version>8.39</checkstyle.version>
     <enforcer.version>3.0.0-M3</enforcer.version>
 
     <!-- parameters to pass to C client build -->
@@ -760,7 +760,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.1</version>
           <dependencies>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>

--- a/zookeeper-compatibility-tests/zookeeper-compatibility-tests-curator/src/test/java/org/apache/zookeeper/compatibility/TestApacheCuratorCompatibility.java
+++ b/zookeeper-compatibility-tests/zookeeper-compatibility-tests-curator/src/test/java/org/apache/zookeeper/compatibility/TestApacheCuratorCompatibility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -465,8 +465,8 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
                 }
                 InetAddress inetaddr = addr.getAddress();
 
-                if (inetaddr == null || inetaddr.isAnyLocalAddress() || // wildCard addresses (0.0.0.0 or [::])
-                    inetaddr.isLoopbackAddress()) { // loopback address(localhost/127.0.0.1)
+                if (inetaddr == null || inetaddr.isAnyLocalAddress() // wildCard addresses (0.0.0.0 or [::])
+                    || inetaddr.isLoopbackAddress()) { // loopback address(localhost/127.0.0.1)
                     continue;
                 }
                 included.add(addr);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/util/PemReader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/util/PemReader.java
@@ -67,21 +67,21 @@ import javax.security.auth.x500.X500Principal;
 public final class PemReader {
 
     private static final Pattern CERT_PATTERN = Pattern.compile(
-        "-+BEGIN\\s+.*CERTIFICATE[^-]*-+(?:\\s|\\r|\\n)+" + // Header
-        "([a-z0-9+/=\\r\\n]+)" +                    // Base64 text
-        "-+END\\s+.*CERTIFICATE[^-]*-+",            // Footer
+        "-+BEGIN\\s+.*CERTIFICATE[^-]*-+(?:\\s|\\r|\\n)+" // Header
+        + "([a-z0-9+/=\\r\\n]+)"                     // Base64 text
+        + "-+END\\s+.*CERTIFICATE[^-]*-+",           // Footer
         CASE_INSENSITIVE);
 
     private static final Pattern PRIVATE_KEY_PATTERN = Pattern.compile(
-        "-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" + // Header
-        "([a-z0-9+/=\\r\\n]+)" +                       // Base64 text
-        "-+END\\s+.*PRIVATE\\s+KEY[^-]*-+",            // Footer
+        "-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" // Header
+        + "([a-z0-9+/=\\r\\n]+)"                       // Base64 text
+        + "-+END\\s+.*PRIVATE\\s+KEY[^-]*-+",            // Footer
         CASE_INSENSITIVE);
 
     private static final Pattern PUBLIC_KEY_PATTERN = Pattern.compile(
-        "-+BEGIN\\s+.*PUBLIC\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" + // Header
-        "([a-z0-9+/=\\r\\n]+)" +                      // Base64 text
-        "-+END\\s+.*PUBLIC\\s+KEY[^-]*-+",            // Footer
+        "-+BEGIN\\s+.*PUBLIC\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" // Header
+        + "([a-z0-9+/=\\r\\n]+)"                      // Base64 text
+        + "-+END\\s+.*PUBLIC\\s+KEY[^-]*-+",            // Footer
         CASE_INSENSITIVE);
 
     private PemReader() {


### PR DESCRIPTION
1.update checkstyle to latest version 8.39
See [https://checkstyle.sourceforge.io/config_javadoc.html](https://checkstyle.sourceforge.io/config_javadoc.html)


- JavadocMethod: remove properties `allowMissingJavadoc,allowMissingThrowsTags,allowThrowsTagsForSubclasses,allowUndeclaredRTE`

- LineLength: change it's parent to Checker

2.update XML dtd: `checkstyle-strict.xml, checkstyle-simple.xml, checkstyleSuppressions.xml`

3.fix code style:
- `QuorumPeer.java, PemReader.java`.  Operators like + and ? appear at newlines rather than at the end of the previous line.
- license of `TestApacheCuratorCompatibility.java`. Checkstyle JavadocParagraph:`<p>` tag should be placed immediately before the first word.