### PR TITLE
ZOOKEEPER-4182: Enhance message when packet's length over limit.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocket.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocket.java
@@ -118,7 +118,7 @@ abstract class ClientCnxnSocket {
     void readLength() throws IOException {
         int len = incomingBuffer.getInt();
         if (len < 0 || len >= packetLen) {
-            throw new IOException("Packet len " + len + " is out of range!");
+            throw new IOException("Packet len " + len + " is out of range " + packetLen + "!");
         }
         incomingBuffer = ByteBuffer.allocate(len);
     }


### PR DESCRIPTION
Append **packetLen** limit info to the exception message: 
- Tell users the default packet length limit and what value(jute.maxBuffer) they had set
- For better debugging 