### PR TITLE
ZOOKEEPER-4074: Network issue while Learner is executing writePacket can cause the follower to hang

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1152,7 +1152,7 @@ property, when available, is noted below.
 * *learner.asyncSending*
     (Jave system property only: **learner.closeSocketAsync**)
     **New in 3.7.0:**
-    When enabled, sending packets in Learner is moved to a seperate thread. Otherwise the packet sending and receiving in Learner are synchronous and may result in a bug. The default is true.
+    The sending and receiving packets in Learner were done synchronously in a critical section. An untimely network issue could cause the followers to hang (see ZOOKEEPER-3575 and ZOOKEEPER-4074). The new design moves sending packets in Learner to a separate thread and sends the packets asynchronously. The new design is enabled with this parameter (learner.asyncSending). The default setting is true.
 
 * *leader.closeSocketAsync*
    (Java system property only: **leader.closeSocketAsync**)

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1149,6 +1149,11 @@ property, when available, is noted below.
     **New in 3.6.2:**
     When enabled, a learner will close the quorum socket asynchronously. This is useful for TLS connections where closing a socket might take a long time, block the shutdown process, potentially delay a new leader election, and leave the quorum unavailabe. Closing the socket asynchronously avoids blocking the shutdown process despite the long socket closing time and a new leader election can be started while the socket being closed. The default is false.
 
+* *learner.asyncSending*
+    (Jave system property only: **learner.closeSocketAsync**)
+    **New in 3.7.0:**
+    When enabled, sending packets in Learner is moved to a seperate thread. Otherwise the packet sending and receiving in Learner are synchronous and may result in a bug. The default is true.
+
 * *leader.closeSocketAsync*
    (Java system property only: **leader.closeSocketAsync**)
    **New in 3.6.2:**

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1152,7 +1152,7 @@ property, when available, is noted below.
 * *learner.asyncSending*
     (Jave system property only: **learner.closeSocketAsync**)
     **New in 3.7.0:**
-    The sending and receiving packets in Learner were done synchronously in a critical section. An untimely network issue could cause the followers to hang (see ZOOKEEPER-3575 and ZOOKEEPER-4074). The new design moves sending packets in Learner to a separate thread and sends the packets asynchronously. The new design is enabled with this parameter (learner.asyncSending). The default setting is true.
+    The sending and receiving packets in Learner were done synchronously in a critical section. An untimely network issue could cause the followers to hang (see [ZOOKEEPER-3575](https://issues.apache.org/jira/browse/ZOOKEEPER-3575) and [ZOOKEEPER-4074](https://issues.apache.org/jira/browse/ZOOKEEPER-4074)). The new design moves sending packets in Learner to a separate thread and sends the packets asynchronously. The new design is enabled with this parameter (learner.asyncSending). The default setting is true.
 
 * *leader.closeSocketAsync*
    (Java system property only: **leader.closeSocketAsync**)

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -119,7 +119,7 @@ public class Learner {
     private static final boolean nodelay = System.getProperty("follower.nodelay", "true").equals("true");
 
     public static final String LEARNER_ASYNC_SENDING = "learner.asyncSending";
-    private static boolean asyncSending = Boolean.getBoolean(LEARNER_ASYNC_SENDING);
+    private static boolean asyncSending = System.getProperty(LEARNER_ASYNC_SENDING, "true").equals("true");
     public static final String LEARNER_CLOSE_SOCKET_ASYNC = "learner.closeSocketAsync";
     public static final boolean closeSocketAsync = Boolean.getBoolean(LEARNER_CLOSE_SOCKET_ASYNC);
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -208,7 +208,7 @@ public class Learner {
     /**
      * Start thread that will forward any packet in the queue to the leader
      */
-    protected void startSendingThread() {
+    public void startSendingThread() {
         sender = new LearnerSender(this);
         sender.start();
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerTest.java
@@ -94,11 +94,11 @@ public class LearnerTest extends ZKTestCase {
         private Socket socketToBeCreated = null;
         private Set<InetSocketAddress> unreachableAddresses = emptySet();
 
-        private void setTimeMultiplier(long multiplier) {
+        protected void setTimeMultiplier(long multiplier) {
             timeMultiplier = multiplier;
         }
 
-        private void setPassConnectAttempt(int num) {
+        protected void setPassConnectAttempt(int num) {
             passSocketConnectOnAttempt = num;
         }
 
@@ -106,15 +106,15 @@ public class LearnerTest extends ZKTestCase {
             return socketConnectAttempt * timeMultiplier;
         }
 
-        private int getSockConnectAttempt() {
+        protected int getSockConnectAttempt() {
             return socketConnectAttempt;
         }
 
-        private void setSocketToBeCreated(Socket socketToBeCreated) {
+        protected void setSocketToBeCreated(Socket socketToBeCreated) {
             this.socketToBeCreated = socketToBeCreated;
         }
 
-        private void setUnreachableAddresses(Set<InetSocketAddress> unreachableAddresses) {
+        protected void setUnreachableAddresses(Set<InetSocketAddress> unreachableAddresses) {
             this.unreachableAddresses = unreachableAddresses;
         }
 
@@ -133,6 +133,18 @@ public class LearnerTest extends ZKTestCase {
                 return socketToBeCreated;
             }
             return super.createSocket();
+        }
+    }
+
+    static class TestLearnerWithZk extends TestLearner {
+        TestLearnerWithZk() throws IOException {
+            super();
+            File tmpFile = File.createTempFile("test", ".dir", testData);
+            tmpFile.delete();
+            FileTxnSnapLog ftsl = new FileTxnSnapLog(tmpFile, tmpFile);
+            self = new QuorumPeer();
+            zk = new SimpleLearnerZooKeeperServer(ftsl, self);
+            ((SimpleLearnerZooKeeperServer) zk).learner = this;
         }
     }
 
@@ -216,7 +228,7 @@ public class LearnerTest extends ZKTestCase {
     @Test
     public void multipleAddressesSomeAreFailing() throws Exception {
         System.setProperty(QuorumPeer.CONFIG_KEY_MULTI_ADDRESS_ENABLED, "true");
-        TestLearner learner = new TestLearner();
+        TestLearner learner = new TestLearnerWithZk();
         learner.self = new QuorumPeer();
         learner.self.setTickTime(2000);
         learner.self.setInitLimit(5);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/WatchLeakTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/WatchLeakTest.java
@@ -112,6 +112,7 @@ public class WatchLeakTest {
             fzks.startup();
             fzks.setServerCnxnFactory(serverCnxnFactory);
             quorumPeer.follower = new MyFollower(quorumPeer, fzks);
+            quorumPeer.follower.startSendingThread();
             LOG.info("Follower created");
             // Simulate a socket channel between a client and a follower
             final SocketChannel socketChannel = createClientSocketChannel();


### PR DESCRIPTION
I provide a fix for the issue [ZOOKEEPER-4074](https://issues.apache.org/jira/browse/ZOOKEEPER-4074) that I proposed.
I basically by default enable learner.asyncSending introduced by [ZOOKEEPER-3575](https://issues.apache.org/jira/browse/ZOOKEEPER-3575), which is already tested. I also update the document for the learner.asyncSending configuration.
I modify a test case in LearnerTest a little bit because enabling learner.asyncSending may require more initialization in Learner for testing.
ZOOKEEPER-3575 will not take effect until 3.7.0, so I am also wondering if we need to backport this patch to 3.6.x?