### PR TITLE
ZOOKEEPER-4199: Avoid thread leak in QuorumRequestPipelineTest

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumRequestPipelineTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumRequestPipelineTest.java
@@ -36,6 +36,7 @@ import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.quorum.QuorumPeer.ServerState;
 import org.apache.zookeeper.test.QuorumBase;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -57,6 +58,13 @@ public class QuorumRequestPipelineTest extends QuorumBase {
                 Arguments.of(ServerState.LEADING),
                 Arguments.of(ServerState.FOLLOWING),
                 Arguments.of(ServerState.OBSERVING));
+    }
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        //since parameterized test methods need a parameterized setUp method
+        //the inherited method has to be overridden with an empty function body
     }
 
     public void setUp(ServerState serverState) throws Exception {


### PR DESCRIPTION
`QuorumRequestPipelineTest` hosts parameterized tests which explicitly call `QuorumBase.setUp(boolean)`.

This patch overrides the argument-less `QuorumBase.setUp()` with an empty body, as the former is annotated `@BeforeEach`-otherwise causing the runtime to start a fresh 5-ensemble before each test.

Without the override, one such extraneous ensemble is created and immediately leaked for each combination of test method + parameters.

The test consequently requires 4000+ simultaneous threads to complete, and while Linux happily handles that load, macOS Catalina's per-process limit of 2048 threads effectively causes the JVM to "crash" or lock up.

The solution is copied verbatim from another parameterized subclass of `QuorumBase`, `EagerACLFilterTest`.