### PR TITLE
[TEST - DO NOT MERGE] Try CI tests using JDK8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,10 +41,10 @@ jobs:
             jdk: 11
             args: '-Pfull-build apache-rat:check verify -DskipTests spotbugs:check checkstyle:check'
           - name: 'full-build-java-tests'
-            jdk: 11
+            jdk: 8
             args: '-Pfull-build verify -Dsurefire-forkcount=1C -DskipCppUnit -Dsurefire.rerunFailingTestsCount=5'
           - name: 'full-build-cppunit-tests'
-            jdk: 11
+            jdk: 8
             args: '-Pfull-build verify -Dtest=_ -DfailIfNoTests=false'
       fail-fast: false
     timeout-minutes: 360


### PR DESCRIPTION
Update GitHub Actions CI configuration to do the full tests with JDK8
instead of JDK11, as a test.