### PR TITLE
ZOOKEEPER-4203: Leader swallows the ZooKeeperServer.State.ERROR from Leader.LearnerCnxAcceptor in some concurrency condition

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumZooKeeperServer.java
@@ -189,9 +189,18 @@ public abstract class QuorumZooKeeperServer extends ZooKeeperServer {
         pwriter.print(self.getQuorumVerifier().toString());
     }
 
+    private final Object stateChangeMutex = new Object();
+
     @Override
     protected void setState(State state) {
-        this.state = state;
+        synchronized (stateChangeMutex) {
+            if (this.state == State.ERROR) {
+                if (state == State.RUNNING || state == State.INITIAL) {
+                    return;
+                }
+            }
+            this.state = state;
+        }
     }
 
     @Override


### PR DESCRIPTION
The fix of [ZOOKEEPER-4203](https://issues.apache.org/jira/browse/ZOOKEEPER-4203) is implemented. In my local machine, it is able to pass all test cases.