### PR TITLE
ZOOKEEPER-4207. Remove extra checkout from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,6 @@ pipeline {
                 stages {
                     stage('BuildAndTest') {
                         steps {
-                            git 'https://github.com/apache/zookeeper'
                             sh "git clean -fxd"
                             sh "mvn verify spotbugs:check checkstyle:check -Pfull-build -Dsurefire-forkcount=4"
                         }


### PR DESCRIPTION
I believe we don't need to add the git checkout to the "Steps" section. I cannot see it neither in owasp nor the PR jenkinsfiles. Also I see that master branch gets also checked out during our normal builds, so I hope this will fix it.

Target branches: master, branch-3.7, branch-3.6, branch-3.5