### PR TITLE
ZOOKEEPER-4194: ZooInspector throws NullPointerExceptions to console when node data is null

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/java/org/apache/zookeeper/inspector/encryption/BasicDataEncryptionManager.java
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/java/org/apache/zookeeper/inspector/encryption/BasicDataEncryptionManager.java
@@ -30,6 +30,9 @@ public class BasicDataEncryptionManager implements DataEncryptionManager {
      * (byte[])
      */
     public String decryptData(byte[] encrypted) throws Exception {
+        if(encrypted == null) {
+            return "";
+        }
         return new String(encrypted);
     }
 


### PR DESCRIPTION
ISSUE
---
See https://issues.apache.org/jira/browse/ZOOKEEPER-4194 for details on the issue.

This is a very minor fix to a NullPointerException present in the ZooInspector utility which prevents a NullPointerException getting thrown when ZooInspector inspects an empty node.  The error is:

```
ERROR [SwingWorker-pool-1-thread-3] (ZooInspectorManagerImpl.java:255) - 
Error occurred getting data for node: /BrentTest/EXTERNALVIEWERROR [SwingWorker-pool-1-thread-3] (ZooInspectorManagerImpl.java:255) - 
Error occurred getting data for node: /BrentTest/EXTERNALVIEW
java.lang.NullPointerException at java.lang.String.<init>(String.java:566) at org.apache.zookeeper.inspector.encryption.BasicDataEncryptionManager.decryptData(BasicDataEncryptionManager.java:33) at 
org.apache.zookeeper.inspector.manager.ZooInspectorManagerImpl.getData(ZooInspectorManagerImpl.java:251) at
 org.apache.zookeeper.inspector.gui.nodeviewer.NodeViewerData$2.doInBackground(NodeViewerData.java:105) at
 org.apache.zookeeper.inspector.gui.nodeviewer.NodeViewerData$2.doInBackground(NodeViewerData.java:100) at 
javax.swing.SwingWorker$1.call(SwingWorker.java:295) at java.util.concurrent.FutureTask.run(FutureTask.java:266) at 
javax.swing.SwingWorker.run(SwingWorker.java:334) at 
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) at 
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) at
 java.lang.Thread.run(Thread.java:748)
```

TESTING
---
I've tested cloning, building and running ZooInspector on Mac OS Catalina (10.15.7) on Java 8 with these fixes and running zooInspector.sh to investigate empty nodes (that were previously problematic).  

I ran `mvn verify spotbugs:check checkstyle:check -Pfull-build -Dsurefire-forkcount=4` in the `zookeeper-contrib/zookeeper-contrib-zooinspector` directory (per https://cwiki.apache.org/confluence/display/ZOOKEEPER/HowToContribute#HowToContribute-FinalChecksonPullRequest) and got these results:

```
[INFO] Starting audit...
Audit done.
[INFO] You have 0 Checkstyle violations.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  24.753 s
[INFO] Finished at: 2021-02-10T00:49:42Z
[INFO] ------------------------------------------------------------------------
```

As per previous PRs, since all of my proposed changes are in the `zookeeper-contrib` subtree (and specifically only in `zookeeper-contrib-zooinspector`, I did not run the wider unit tests for the Zookeeper project as a whole.