### PR TITLE
ZOOKEEPER-4209: Update Netty to 4.1.53.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
     <hamcrest.version>1.3</hamcrest.version>
     <commons-cli.version>1.2</commons-cli.version>
     <jetty.version>9.4.35.v20201120</jetty.version>
-    <netty.version>4.1.50.Final</netty.version>
+    <netty.version>4.1.53.Final</netty.version>
     <jackson.version>2.10.5.1</jackson.version>
     <json.version>1.1.1</json.version>
     <jline.version>2.14.6</jline.version>


### PR DESCRIPTION
Update Netty to 4.1.53.Final on 3.5 branch to address the vulnerability described at https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439