### PR TITLE
ZOOKEEPER-3987: Reduce fork count for tests to 1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
             args: '-Pfull-build apache-rat:check verify -DskipTests spotbugs:check checkstyle:check'
           - name: 'full-build-java-tests'
             jdk: 11
-            args: '-Pfull-build verify -Dsurefire-forkcount=1C -DskipCppUnit -Dsurefire.rerunFailingTestsCount=5'
+            args: '-Pfull-build verify -Dsurefire-forkcount=1 -DskipCppUnit -Dsurefire.rerunFailingTestsCount=5'
           - name: 'full-build-cppunit-tests'
             jdk: 11
             args: '-Pfull-build verify -Dtest=_ -DfailIfNoTests=false'


### PR DESCRIPTION
Increase test stability by avoiding test failures due to port
collisions by preventing tests from running concurrently in
the GitHub Actions CI builds.