### PR TITLE
ZOOKEEPER-4214: Update Netty to 4.1.59.Final on Ivy build for 3.5 branch

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -77,7 +77,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     
     <property name="version-major" value="3" />
     <property name="version-minor" value="5" />
-    <property name="version-patch" value="9" />
+    <property name="version-patch" value="10" />
     <property name="version-base" value="${version-major}.${version-minor}.${version-patch}" />
     <property name="version-suffix" value="SNAPSHOT" />
     <property name="version" value="${version-base}-${version-suffix}" />

--- a/build.xml
+++ b/build.xml
@@ -37,7 +37,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
 
     <property name="audience-annotations.version" value="0.5.0" />
 
-    <property name="netty.version" value="4.1.50.Final"/>
+    <property name="netty.version" value="4.1.59.Final"/>
 
     <property name="junit.version" value="4.12"/>
     <property name="mockito.version" value="2.27.0"/>


### PR DESCRIPTION
Update Netty to 4.1.59.Final on to address a vulnerability