### PR TITLE
ZOOKEEPER-1871: Add an option to zkCli to wait for connection before executing commands

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -150,9 +150,9 @@ public class ZooKeeperMain {
                 ZooKeeperMain.printMessage("WATCHER::");
                 ZooKeeperMain.printMessage(event.toString());
             }
-            if(connectLatch != null){
+            if (connectLatch != null){
                 // connection success
-                if ( event.getType() == Event.EventType.None
+                if (event.getType() == Event.EventType.None
                 && event.getState() == Event.KeeperState.SyncConnected) {
                     connectLatch.countDown();
                 }
@@ -306,7 +306,7 @@ public class ZooKeeperMain {
             connectLatch = new CountDownLatch(1);
         }
         int timeout = Integer.parseInt(cl.getOption("timeout"));
-        zk = new ZooKeeperAdmin(host, timeout, new MyWatcher(),readOnly);
+        zk = new ZooKeeperAdmin(host, timeout, new MyWatcher(), readOnly);
         if (connectLatch != null) {
             if (!connectLatch.await(timeout, TimeUnit.MILLISECONDS)) {
                 zk.close();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -33,6 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -89,6 +92,7 @@ public class ZooKeeperMain {
 
     protected ZooKeeper zk;
     protected String host = "";
+    private CountDownLatch connectLatch = null;
 
     public boolean getPrintWatches() {
         return printWatches;
@@ -145,6 +149,13 @@ public class ZooKeeperMain {
             if (getPrintWatches()) {
                 ZooKeeperMain.printMessage("WATCHER::");
                 ZooKeeperMain.printMessage(event.toString());
+            }
+            if(connectLatch != null){
+                // connection success
+                if ( event.getType() == Event.EventType.None
+                && event.getState() == Event.KeeperState.SyncConnected) {
+                    connectLatch.countDown();
+                }
             }
         }
 
@@ -208,6 +219,8 @@ public class ZooKeeperMain {
                         options.put("readonly", "true");
                     } else if (opt.equals("-client-configuration")) {
                         options.put("client-configuration", it.next());
+                    } else if (opt.equals("-waitforconnection")) {
+                        options.put("waitforconnection", "true");
                     }
                 } catch (NoSuchElementException e) {
                     System.err.println("Error: no argument found for option " + opt);
@@ -288,6 +301,17 @@ public class ZooKeeperMain {
         if (cl.getOption("secure") != null) {
             System.setProperty(ZKClientConfig.SECURE_CLIENT, "true");
             System.out.println("Secure connection is enabled");
+        }
+        if (cl.getOption("waitforconnection") != null) {
+            connectLatch = new CountDownLatch(1);
+        }
+        int timeout = Integer.parseInt(cl.getOption("timeout"));
+        zk = new ZooKeeperAdmin(host, timeout, new MyWatcher(),readOnly);
+        if (connectLatch != null) {
+            if (!connectLatch.await(timeout, TimeUnit.MILLISECONDS)) {
+                zk.close();
+                throw new IOException(KeeperException.create(KeeperException.Code.CONNECTIONLOSS));
+            }
         }
 
         ZKClientConfig clientConfig = null;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ZooKeeperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ZooKeeperTest.java
@@ -48,7 +48,6 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.PortAssignment;
 import org.junit.Test;
 
 /**
@@ -689,21 +688,21 @@ public class ZooKeeperTest extends ClientBase {
     @Test
     public void testWaitForConnection() throws Exception {
         // get a wrong port number
-        int invalid_port = PortAssignment.unique();
+        int invalidPort = PortAssignment.unique();
         long timeout = 3000L; // millisecond
-        String[] args1 = {"-server", "localhost:" + invalid_port, "-timeout",
+        String[] args1 = {"-server", "localhost:" + invalidPort, "-timeout",
             Long.toString(timeout), "-waitforconnection", "ls", "/"};
-        long start_time = System.currentTimeMillis();
+        long startTime = System.currentTimeMillis();
         // try to connect to a non-existing server so as to wait until wait_timeout
-        try{
+        try {
             ZooKeeperMain zkMain = new ZooKeeperMain(args1);
             fail("IOException was expected");
-        }catch (IOException e) {
+        } catch (IOException e) {
             // do nothing
         }
-        long end_time = System.currentTimeMillis();
+        long endTime = System.currentTimeMillis();
         assertTrue("ZooKeeeperMain does not wait until the specified timeout",
-                end_time - start_time >= timeout);
+                endTime - startTime >= timeout);
 
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ZooKeeperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ZooKeeperTest.java
@@ -48,6 +48,7 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.test.ClientBase;
+import org.apache.zookeeper.PortAssignment;
 import org.junit.Test;
 
 /**
@@ -683,6 +684,27 @@ public class ZooKeeperTest extends ClientBase {
         expected.add("Sync is OK");
 
         runCommandExpect(cmd, expected);
+    }
+
+    @Test
+    public void testWaitForConnection() throws Exception {
+        // get a wrong port number
+        int invalid_port = PortAssignment.unique();
+        long timeout = 3000L; // millisecond
+        String[] args1 = {"-server", "localhost:" + invalid_port, "-timeout",
+            Long.toString(timeout), "-waitforconnection", "ls", "/"};
+        long start_time = System.currentTimeMillis();
+        // try to connect to a non-existing server so as to wait until wait_timeout
+        try{
+            ZooKeeperMain zkMain = new ZooKeeperMain(args1);
+            fail("IOException was expected");
+        }catch (IOException e) {
+            // do nothing
+        }
+        long end_time = System.currentTimeMillis();
+        assertTrue("ZooKeeeperMain does not wait until the specified timeout",
+                end_time - start_time >= timeout);
+
     }
 
 }


### PR DESCRIPTION
-waitforconnection option will make zk client wait for -timeout time to connect to zk server.  timeout time is 30ms by default but can be specified explicitly using -timeout option.