### PR TITLE
ZOOKEEPER-4232: InvalidSnapshotTest corrupts its own test data

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/InvalidSnapshotTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/InvalidSnapshotTest.java
@@ -20,7 +20,9 @@ package org.apache.zookeeper.test;
 
 import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import java.io.File;
+import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZKTestCase;
@@ -72,6 +74,24 @@ public class InvalidSnapshotTest extends ZKTestCase {
         File snapfile = new File(new File(snapDir, "version-2"), "snapshot.273");
         String[] args = {snapfile.getCanonicalFile().toString()};
         SnapshotFormatter.main(args);
+    }
+
+    /**
+     * Verify the SnapshotFormatter fails as expected on corrupted snapshot.
+     */
+    @Test
+    public void testSnapshotFormatterWithInvalidSnap() throws Exception {
+        File snapDir = new File(testData, "invalidsnap");
+        // Broken snapshot introduced by ZOOKEEPER-367, and used to
+        // demonstrate recovery in testSnapshot below.
+        File snapfile = new File(new File(snapDir, "version-2"), "snapshot.83f");
+        String[] args = {snapfile.getCanonicalFile().toString()};
+        try {
+            SnapshotFormatter.main(args);
+            fail("Snapshot '" + snapfile + "' unexpectedly parsed without error.");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("Unreasonable length = 977468229"));
+        }
     }
 
     /**

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/InvalidSnapshotTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/InvalidSnapshotTest.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.test;
 import static org.apache.zookeeper.test.ClientBase.CONNECTION_TIMEOUT;
 import static org.junit.Assert.assertTrue;
 import java.io.File;
+import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooKeeper;
@@ -79,7 +80,12 @@ public class InvalidSnapshotTest extends ZKTestCase {
      */
     @Test
     public void testSnapshot() throws Exception {
-        File snapDir = new File(testData, "invalidsnap");
+        File origSnapDir = new File(testData, "invalidsnap");
+
+        // This test otherwise updates the resources directory.
+        File snapDir = ClientBase.createTmpDir();
+        FileUtils.copyDirectory(origSnapDir, snapDir);
+
         ZooKeeperServer zks = new ZooKeeperServer(snapDir, snapDir, 3000);
         SyncRequestProcessor.setSnapCount(1000);
         final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);


### PR DESCRIPTION
`InvalidSnapshotTest.testSnapshot` starts an instance of
`ZooKeeperServer` on the version-controlled `resources/data/invalidsnap`
directory, which, as a side-effect, \"fixes\" the following
snapshot—which was broken on purpose (see ZOOKEEPER-367):

`zookeeper-server/src/test/resources/data/invalidsnap/version-2/snapshot.83f`

This status quo creates a number of problems:

1.  It makes the test ineffective after the first run;
2.  The file shows as modified in version control tools, which can be
    annoying;
3.  The \"fixed\" snapshot can end up being committed by mistake,
    invalidating the test.

(\#3 is not theoretical; that \"fixed\" snapshot frequently shows up in
pull requests, and was recently merged into `master`.)
