### PR TITLE
ZOOKEEPER-4241: Change log level without restarting zookeeper

### DIFF
--- a/bin/zkEnv.sh
+++ b/bin/zkEnv.sh
@@ -70,11 +70,6 @@ then
     ZOO_LOG_DIR="$ZOOKEEPER_PREFIX/logs"
 fi
 
-if [ "x${ZOO_LOG4J_PROP}" = "x" ]
-then
-    ZOO_LOG4J_PROP="INFO,CONSOLE"
-fi
-
 if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
     JAVA="$JAVA_HOME/bin/java"
 elif type -p java; then

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1168,6 +1168,27 @@ property, when available, is noted below.
 
     The default value is false.
 
+* *log4j.configuration.watch* :
+  (Java system property: **zookeeper.log4j.configuration.watch**)
+  **New in 3.8.0:**
+  By default log4j configuration watcher is disabled. Set "true" to enable it.
+  If enabled ZooKeeper server log levels can be changed without restarting the servers
+  by just modifying the log4j configuration properties.
+
+* *log4j.configuration.watch.interval* :
+  (Java system property: **zookeeper.log4j.configuration.watch.interval**)
+  **New in 3.8.0:**
+  Time interval in milliseconds when log4j configuration file is checked for any change in it.
+  Default value is 60000
+
+* *log4j.configuration* :
+  (Java system property: **zookeeper.log4j.configuration**)
+  **New in 3.8.0:**
+  Specifies the log4j configuration URL. If only file name is specified then file must be available in class path.
+  Default value is log4j.properties
+  Config examples:
+  log4j.configuration=custom-log4j.properties
+  log4j.configuration=file:/some/path/custom-log4j.properties
 
 <a name="sc_clusterOptions"></a>
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/log/Log4jConfigWatcher.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/log/Log4jConfigWatcher.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.log;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Enumeration;
+import org.apache.log4j.PropertyConfigurator;
+import org.apache.log4j.xml.DOMConfigurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Watches log4j configuration file for a change.
+ * Reloads the configuration into memory whenever there is a change log4j configuration file.
+ */
+public class Log4jConfigWatcher {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Log4jConfigWatcher.class);
+    private static final String DEFAULT_LOG4J_CONFIG = "log4j.properties";
+
+    // If log4j configuration is already watched then skip starting watch again
+    private static boolean isWatching = false;
+    static final String LOG4J_CONFIGURATION_WATCH = "zookeeper.log4j.configuration.watch";
+    static final String LOG4J_CONFIGURATION_WATCH_INTERVAL =
+        "zookeeper.log4j.configuration.watch.interval";
+    // Default 60 seconds
+    private static final int LOG4J_CONFIGURATION_WATCH_DEFAULT = 60000;
+    static final String LOG4J_CONFIGURATION = "zookeeper.log4j.configuration";
+
+    /**
+     * Watches log4j configuration file for a change if Log4jConfigWatcher feature is enabled.
+     * Reloads the configuration into memory whenever there is a change in configuration file.
+     * This method should be called only once per JVM. One thread
+     * will be created to watch log4j configuration changes.
+     */
+    public static synchronized void watchLog4jConfiguration() {
+        if (isWatching) {
+            // Already watching, no need to initialize watcher again
+            return;
+        }
+
+        // This feature is disabled by default
+        boolean log4jConfigWatchEnable = Boolean.getBoolean(LOG4J_CONFIGURATION_WATCH);
+        if (log4jConfigWatchEnable) {
+            LOGGER.info("log4j config watcher is enabled.");
+        } else {
+            LOGGER.info("log4j config watcher is disabled.");
+            return;
+        }
+
+        URL log4jUrl = getLog4jConfigUrl();
+        if (log4jUrl == null) {
+            LOGGER.warn("No log4j configuration file found to watch.");
+            return;
+        }
+
+        String log4jConfigPath = log4jUrl.getPath();
+        if (!new File(log4jConfigPath).exists()) {
+            LOGGER.warn("Not watching for log4j config changes as file {} does not exist.",
+                log4jConfigPath);
+            return;
+        }
+        int log4jConfigWatchInterval = getLog4jConfigWatchInterval();
+        if (log4jConfigPath.endsWith(".xml")) {
+            DOMConfigurator.configureAndWatch(log4jUrl.getPath(), log4jConfigWatchInterval);
+        } else {
+            PropertyConfigurator.configureAndWatch(log4jUrl.getPath(), log4jConfigWatchInterval);
+        }
+        isWatching = true;
+        LOGGER.info("Watching {} for changes with interval {} ms ", log4jConfigPath,
+            log4jConfigWatchInterval);
+    }
+
+    private static int getLog4jConfigWatchInterval() {
+        String intervalProp = getConfig(LOG4J_CONFIGURATION_WATCH_INTERVAL);
+        if (intervalProp != null) {
+            try {
+                return Integer.parseInt(intervalProp);
+            } catch (NumberFormatException e) {
+                LOGGER.warn("Error while parsing interval property {} to integer."
+                        + " Default interval {} will be used", intervalProp,
+                    LOG4J_CONFIGURATION_WATCH_DEFAULT);
+            }
+        }
+        return LOG4J_CONFIGURATION_WATCH_DEFAULT;
+    }
+
+    private static String getConfig(String configName) {
+        String property = System.getProperty(configName);
+        return property == null ? null : property.trim();
+    }
+
+    private static URL getLog4jConfigUrl() {
+        String log4jConfiguration = getConfig(LOG4J_CONFIGURATION);
+        URL log4jUrl = null;
+        if (null != log4jConfiguration && !log4jConfiguration.isEmpty()) {
+            // Load the configuration if its configured.
+            try {
+                return new URL(log4jConfiguration);
+            } catch (final MalformedURLException e) {
+                // Ignore it, this happens when only file name is specified
+                // which should be searched in classpath
+            }
+            log4jUrl = getUrl(log4jConfiguration);
+        } else {
+            log4jUrl = getUrl(DEFAULT_LOG4J_CONFIG);
+        }
+        return log4jUrl;
+    }
+
+    private static URL getUrl(String log4jConfiguration) {
+        try {
+            Enumeration<URL> resources =
+                Log4jConfigWatcher.class.getClassLoader().getResources(log4jConfiguration);
+            while (resources.hasMoreElements()) {
+                URL url = resources.nextElement();
+                if (url.getPath().contains(".jar")) {
+                    // log4j configuration file in jar file can not be watched for modification
+                    LOGGER.debug("Skipping log4j configuration {}", url.getPath());
+                    continue;
+                }
+                return url;
+            }
+        } catch (IOException e) {
+            LOGGER.warn("Error while searching resource {}, error={}", log4jConfiguration, e);
+        }
+        return null;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
@@ -24,6 +24,7 @@ import javax.security.sasl.SaslException;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.audit.ZKAuditProvider;
 import org.apache.zookeeper.jmx.ManagedUtil;
+import org.apache.zookeeper.log.Log4jConfigWatcher;
 import org.apache.zookeeper.metrics.MetricsProvider;
 import org.apache.zookeeper.metrics.MetricsProviderLifeCycleException;
 import org.apache.zookeeper.metrics.impl.MetricsProviderBootstrap;
@@ -124,6 +125,9 @@ public class QuorumPeerMain {
         if (args.length == 1) {
             config.parse(args[0]);
         }
+
+        // Watch log4j configuration for change if feature is enabled
+        Log4jConfigWatcher.watchLog4jConfiguration();
 
         // Start and schedule the the purge task
         DatadirCleanupManager purgeMgr = new DatadirCleanupManager(

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/log/Log4jConfigWatcherTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/log/Log4jConfigWatcherTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.log;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Log4jConfigWatcherTest {
+    private static String testLogFilePath;
+    private static final String zookeeperLogLevel = "zookeeper.root.logger=";
+    private static final String LOG_4_J_WATCHER_LOG_DIR = "log4j.watcher.log.dir";
+
+    @Before
+    public void setUp() throws Exception {
+        File tempDir = ClientBase.createEmptyTestDir();
+        testLogFilePath = tempDir.getPath() + "/zookeeper.log";
+        System.setProperty(LOG_4_J_WATCHER_LOG_DIR, tempDir.getPath());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty(Log4jConfigWatcher.LOG4J_CONFIGURATION_WATCH);
+        System.clearProperty(Log4jConfigWatcher.LOG4J_CONFIGURATION);
+        System.clearProperty(Log4jConfigWatcher.LOG4J_CONFIGURATION_WATCH_INTERVAL);
+        System.clearProperty(LOG_4_J_WATCHER_LOG_DIR);
+        File dir = new File(testLogFilePath);
+        dir.delete();
+    }
+
+    @Test
+    public void testLogLevelChangeWithoutRestartingJVM() throws Exception {
+        System.setProperty(Log4jConfigWatcher.LOG4J_CONFIGURATION_WATCH, "true");
+        System
+            .setProperty(Log4jConfigWatcher.LOG4J_CONFIGURATION, "log4j-watcher-log4j.properties");
+        System.setProperty(Log4jConfigWatcher.LOG4J_CONFIGURATION_WATCH_INTERVAL, "2000");
+        Log4jConfigWatcher.watchLog4jConfiguration();
+
+        // Changed the log level to WARN
+        alterLogConfigFile("/" + System.getProperty(Log4jConfigWatcher.LOG4J_CONFIGURATION),
+            zookeeperLogLevel, zookeeperLogLevel + "WARN, ROLLINGFILE");
+        // Waiting for some time so configuration event is triggered and changes reloaded into memory
+        Thread.sleep(5000);
+        Logger LOG = LoggerFactory.getLogger(Log4jConfigWatcherTest.class);
+        LOG.warn("Warn level log is present in initial Configuration");
+        LOG.info("Info level log is present in initial Configuration");
+        Assert.assertTrue(checkTargetInLogFile(testLogFilePath,
+            "Warn level log is present in initial Configuration"));
+        Assert.assertFalse(checkTargetInLogFile(testLogFilePath,
+            "Info level log is present in initial Configuration"));
+
+        // Changed the log level to INFO
+        alterLogConfigFile("/" + System.getProperty(Log4jConfigWatcher.LOG4J_CONFIGURATION),
+            zookeeperLogLevel, zookeeperLogLevel + "INFO, ROLLINGFILE");
+        // Waiting for some time so configuration event is triggered and changes reloaded into memory
+        Thread.sleep(5000);
+        LOG.info("Info level log is present after altering the Configuration");
+        Assert.assertTrue(checkTargetInLogFile(testLogFilePath,
+            "Info level log is present after altering the Configuration"));
+    }
+
+    private void alterLogConfigFile(String log4jConfigurationFile, String key, String value)
+        throws IOException {
+        InputStream inputStream = null;
+        BufferedWriter bw = null;
+        try {
+            // log4j configuration file is modified from classpath, not from the resource folder
+            inputStream = getClass().getResourceAsStream(log4jConfigurationFile);
+            List<String> lines = IOUtils.readLines(inputStream, "UTF-8");
+            FileWriter fileWriter =
+                new FileWriter(getClass().getResource(log4jConfigurationFile).getPath());
+            bw = new BufferedWriter(fileWriter);
+            for (String line : lines) {
+                if (line.contains(key)) {
+                    line = value;
+                }
+                bw.write(line);
+                bw.newLine();
+            }
+            bw.flush();
+        } finally {
+            org.apache.zookeeper.common.IOUtils.closeStream(inputStream);
+            org.apache.zookeeper.common.IOUtils.closeStream(bw);
+        }
+    }
+
+    private Boolean checkTargetInLogFile(String fileName, String targetString) throws IOException {
+        FileInputStream input = new FileInputStream(fileName);
+        List<String> lines = IOUtils.readLines(input, "UTF-8");
+        for (String line : lines) {
+            if (line.contains(targetString)) {
+                return true;
+            }
+        }
+        org.apache.zookeeper.common.IOUtils.closeStream(input);
+        return false;
+    }
+}

--- a/zookeeper-server/src/test/resources/log4j-watcher-log4j.properties
+++ b/zookeeper-server/src/test/resources/log4j-watcher-log4j.properties
@@ -1,0 +1,39 @@
+# Copyright 2012 The Apache Software Foundation
+# 
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define some default values that can be overridden by system properties
+zookeeper.root.logger=INFO, ROLLINGFILE
+        
+zookeeper.log.dir=${log4j.watcher.log.dir}
+zookeeper.log.file=zookeeper.log
+zookeeper.log.threshold=ALL
+zookeeper.log.maxfilesize=256MB
+zookeeper.log.maxbackupindex=20
+
+log4j.rootLogger=${zookeeper.root.logger}
+
+#
+# Add ROLLINGFILE to rootLogger to get log file output
+#
+log4j.appender.ROLLINGFILE=org.apache.log4j.RollingFileAppender
+log4j.appender.ROLLINGFILE.Threshold=${zookeeper.log.threshold}
+log4j.appender.ROLLINGFILE.File=${zookeeper.log.dir}/${zookeeper.log.file}
+log4j.appender.ROLLINGFILE.MaxFileSize=${zookeeper.log.maxfilesize}
+log4j.appender.ROLLINGFILE.MaxBackupIndex=${zookeeper.log.maxbackupindex}
+log4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n


### PR DESCRIPTION
Added 3 new configurations 
log4j.configuration.watch
log4j.configuration.watch.interval
log4j.configuration

By default feature is disabled, configure log4j.configuration.watch=true in zoo.cfg to enable the feature.

When this feature is enabled, ZooKeeper server log levels can be changed without restarting the servers  by just modifying the log4j configuration properties.