### PR TITLE
ZOOKEEPER-4246: Resource leaks in org.apache.zookeeper.server.persistence.SnapStream#getInputStream and #getOutputStream

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
@@ -102,28 +102,23 @@ public class SnapStream {
     public static CheckedInputStream getInputStream(File file) throws IOException {
         FileInputStream fis = new FileInputStream(file);
         InputStream is;
-        switch (getStreamMode(file.getName())) {
-        case GZIP:
-            try {
-                is = new GZIPInputStream(fis);
-            } catch (IOException e) {
-                fis.close();
-                throw e;
+        try {
+            switch (getStreamMode(file.getName())) {
+                case GZIP:
+                    is = new GZIPInputStream(fis);
+                    break;
+                case SNAPPY:
+                    is = new SnappyInputStream(fis);
+                    break;
+                case CHECKED:
+                default:
+                    is = new BufferedInputStream(fis);
             }
-            break;
-        case SNAPPY:
-            try {
-                is = new SnappyInputStream(fis);
-            } catch (IOException e) {
-                fis.close();
-                throw e;
-            }
-            break;
-        case CHECKED:
-        default:
-            is = new BufferedInputStream(fis);
+            return new CheckedInputStream(is, new Adler32());
+        } catch (IOException e) {
+            fis.close();
+            throw e;
         }
-        return new CheckedInputStream(is, new Adler32());
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
@@ -104,10 +104,20 @@ public class SnapStream {
         InputStream is;
         switch (getStreamMode(file.getName())) {
         case GZIP:
-            is = new GZIPInputStream(fis);
+	    try {
+		is = new GZIPInputStream(fis);
+	    } catch (IOException e) {
+		fis.close();
+		throw e;
+	    }
             break;
         case SNAPPY:
-            is = new SnappyInputStream(fis);
+	    try {
+		is = new SnappyInputStream(fis);
+	    } catch (IOException e) {
+		fis.close();
+		throw e;
+	    }
             break;
         case CHECKED:
         default:
@@ -129,9 +139,16 @@ public class SnapStream {
         OutputStream os;
         switch (streamMode) {
         case GZIP:
-            os = new GZIPOutputStream(fos);
+	    try {
+		os = new GZIPOutputStream(fos);
+	    } catch (IOException e) {
+	        fos.close();
+		throw e;
+	    }
             break;
         case SNAPPY:
+	    // Unlike SnappyInputStream, the SnappyOutputStream
+	    // constructor cannot throw an IOException.
             os = new SnappyOutputStream(fos);
             break;
         case CHECKED:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
@@ -105,19 +105,19 @@ public class SnapStream {
         switch (getStreamMode(file.getName())) {
         case GZIP:
             try {
-		is = new GZIPInputStream(fis);
-	    } catch (IOException e) {
-		fis.close();
-		throw e;
-	    }
+                is = new GZIPInputStream(fis);
+            } catch (IOException e) {
+                fis.close();
+                throw e;
+            }
             break;
         case SNAPPY:
-	    try {
-		is = new SnappyInputStream(fis);
-	    } catch (IOException e) {
-		fis.close();
-		throw e;
-	    }
+            try {
+                is = new SnappyInputStream(fis);
+            } catch (IOException e) {
+                fis.close();
+                throw e;
+            }
             break;
         case CHECKED:
         default:
@@ -139,16 +139,16 @@ public class SnapStream {
         OutputStream os;
         switch (streamMode) {
         case GZIP:
-	    try {
-		os = new GZIPOutputStream(fos);
-	    } catch (IOException e) {
-	        fos.close();
-		throw e;
-	    }
+            try {
+                os = new GZIPOutputStream(fos);
+            } catch (IOException e) {
+                fos.close();
+                throw e;
+            }
             break;
         case SNAPPY:
-	    // Unlike SnappyInputStream, the SnappyOutputStream
-	    // constructor cannot throw an IOException.
+            // Unlike SnappyInputStream, the SnappyOutputStream
+            // constructor cannot throw an IOException.
             os = new SnappyOutputStream(fos);
             break;
         case CHECKED:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
@@ -104,7 +104,7 @@ public class SnapStream {
         InputStream is;
         switch (getStreamMode(file.getName())) {
         case GZIP:
-	    try {
+            try {
 		is = new GZIPInputStream(fis);
 	    } catch (IOException e) {
 		fis.close();


### PR DESCRIPTION
Bug report is here: https://issues.apache.org/jira/browse/ZOOKEEPER-4246

This fix is simple: it just closes the possibly-leaked streams and re-throws the exception. We can't use a try-with-resources or a `finally` block here because in the happy case the resulting streams need to be returned open. I checked each of the other constructor calls in these methods, and none of the others can throw an exception as far as I can tell.