### PR TITLE
ZOOKEEPER-4250: Resolve zookeeper quorum from DNS entry.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/DNSDomainNameResolver.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/DNSDomainNameResolver.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.client;
+
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * DNSDomainNameResolver wraps up the default DNS service for forward/reverse
+ * DNS lookup. It also provides a function to resolve a host name to all of
+ * fully qualified domain names belonging to the IPs from this host name
+ */
+public class DNSDomainNameResolver implements DomainNameResolver {
+  @Override
+  public InetAddress[] getAllByDomainName(String domainName)
+          throws UnknownHostException {
+    return InetAddress.getAllByName(domainName);
+  }
+
+  @Override
+  public String getHostnameByIP(InetAddress address) {
+    String host = address.getCanonicalHostName();
+    if (host != null && host.length() != 0
+            && host.charAt(host.length()-1) == '.') {
+      host = host.substring(0, host.length()-1);
+    }
+    return host;
+  }
+
+  @Override
+  public String[] getAllResolvedHostnameByDomainName(
+          String domainName, boolean useFQDN) throws UnknownHostException {
+    InetAddress[] addresses = getAllByDomainName(domainName);
+    String[] hosts = new String[addresses.length];
+    if (useFQDN) {
+      for (int i = 0; i < addresses.length; i++) {
+        hosts[i] = getHostnameByIP(addresses[i]);
+      }
+    } else {
+      for (int i = 0; i < addresses.length; i++) {
+        hosts[i] = addresses[i].getHostAddress();
+      }
+    }
+
+    return hosts;
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/DomainNameResolver.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/DomainNameResolver.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.client;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * This interface provides methods for the failover proxy to get IP addresses
+ * of the associated servers (NameNodes, RBF routers etc). Implementations will
+ * use their own service discovery mechanism, DNS, Zookeeper etc
+ */
+public interface DomainNameResolver {
+  enum Type { DNSDomainNameResolver };
+  /**
+   * Takes one domain name and returns its IP addresses based on the actual
+   * service discovery methods.
+   *
+   * @param domainName
+   * @return all IP addresses
+   * @throws UnknownHostException
+   */
+  InetAddress[] getAllByDomainName(String domainName)
+          throws UnknownHostException;
+
+  /**
+   * Reverse lookup an IP address and get the fully qualified domain name(fqdn).
+   *
+   * @param address
+   * @return fully qualified domain name
+   */
+  String getHostnameByIP(InetAddress address);
+
+  /**
+   * This function combines getAllByDomainName and getHostnameByIP, for a single
+   * domain name, it will first do a forward lookup to get all of IP addresses,
+   * then for each IP address, it will do a reverse lookup to get the fqdn.
+   * This function is necessary in secure environment since Kerberos uses fqdn
+   * in the service principal instead of IP.
+   *
+   * @param domainName
+   * @return all fully qualified domain names belonging to the IPs resolved from
+   * the input domainName
+   * @throws UnknownHostException
+   */
+  String[] getAllResolvedHostnameByDomainName(
+          String domainName, boolean useFQDN) throws UnknownHostException;
+
+  static DomainNameResolver create(String resolverType) {
+    Type type = Type.valueOf(resolverType);
+    switch (type) {
+      case DNSDomainNameResolver:
+        return new DNSDomainNameResolver();
+      default:
+        throw new IllegalArgumentException("Invalid DomainNameResolver type:" + type);
+    }
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZKClientConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZKClientConfig.java
@@ -52,6 +52,16 @@ public class ZKClientConfig extends ZKConfig {
     public static final String DISABLE_AUTO_WATCH_RESET = "zookeeper.disableAutoWatchReset";
     @SuppressWarnings("deprecation")
     public static final String ZOOKEEPER_CLIENT_CNXN_SOCKET = ZooKeeper.ZOOKEEPER_CLIENT_CNXN_SOCKET;
+
+    /**
+     * Some configurations related to resolve DNS entry to zookeeper hosts.
+     */
+    public static final String RESOLVE_ADDRESS_NEEDED_KEY = "zookeeper.quorum.resolve-needed";
+    public static final boolean RESOLVE_ADDRESS_NEEDED_DEFAULT = true;
+    public static final String RESOLVE_SERVICE_KEY = "zookeeper.quorum.resolver.impl";
+    public static final String  RESOLVE_ADDRESS_TO_FQDN = "zookeeper.quorum.resolver.useFQDN";
+    public static final boolean RESOLVE_ADDRESS_TO_FQDN_DEFAULT = true;
+
     /**
      * Setting this to "true" will enable encrypted client-server communication.
      */

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/TestableZooKeeper.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/TestableZooKeeper.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.jute.Record;
 import org.apache.zookeeper.admin.ZooKeeperAdmin;
+import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.proto.ReplyHeader;
 import org.apache.zookeeper.proto.RequestHeader;
 
@@ -31,6 +32,10 @@ public class TestableZooKeeper extends ZooKeeperAdmin {
 
     public TestableZooKeeper(String host, int sessionTimeout, Watcher watcher) throws IOException {
         super(host, sessionTimeout, watcher);
+    }
+
+    public TestableZooKeeper(String host, int sessionTimeout, Watcher watcher, ZKClientConfig conf) throws IOException {
+        super(host, sessionTimeout, watcher, conf);
     }
 
     public void setXid(int xid) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ZooKeeperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ZooKeeperTest.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,6 +44,7 @@ import org.apache.zookeeper.cli.SyncCommand;
 import org.apache.zookeeper.cli.WhoAmICommand;
 import org.apache.zookeeper.client.ConnectStringParser;
 import org.apache.zookeeper.client.HostProvider;
+import org.apache.zookeeper.client.MockDomainNameResolver;
 import org.apache.zookeeper.client.StaticHostProvider;
 import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.common.StringUtils;
@@ -765,6 +768,26 @@ public class ZooKeeperTest extends ClientBase {
         expectedResults.add("digest: user2");
         actualResult = runCommandExpect(cmd);
         assertClientAuthInfo(expectedResults, actualResult);
+    }
+
+    @Test
+    public void testResolveQuorumFromDNS() throws Exception {
+        ZKClientConfig conf = new ZKClientConfig();
+        final ZooKeeper zk = createClient(conf);
+
+        Field resolveQuorumNeededField = ZooKeeper.class.getDeclaredField("resolveQuorumNeeded");
+        resolveQuorumNeededField.setAccessible(true);
+        resolveQuorumNeededField.setBoolean(zk, true);
+
+        Field resolverField = ZooKeeper.class.getDeclaredField("resolver");
+        resolverField.setAccessible(true);
+        resolverField.set(zk, new MockDomainNameResolver());
+
+        Method resolveQuorumIfNecessaryMethod = ZooKeeper.class.getDeclaredMethod("resolveQuorumIfNecessary", String.class);
+        resolveQuorumIfNecessaryMethod.setAccessible(true);
+        String resolveQuorum = (String)resolveQuorumIfNecessaryMethod.invoke(zk, "test.foo.bar:2181");
+
+        assertEquals("host01.test:2181,host02.test:2181", resolveQuorum);
     }
 
     private void assertClientAuthInfo(List<String> expected, String actual) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/client/MockDomainNameResolver.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/client/MockDomainNameResolver.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.client;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * This mock resolver class returns the predefined resolving/reverse lookup
+ * results. By default it uses a default "test.foo.bar" domain with two
+ * IP addresses.
+ */
+public class MockDomainNameResolver implements DomainNameResolver {
+
+  public static final String DOMAIN1 = "test.foo.bar";
+  public static final byte[] BYTE_ADDR_1 = new byte[]{10, 1, 1, 1};
+  public static final byte[] BYTE_ADDR_2 = new byte[]{10, 1, 1, 2};
+  public static final String FQDN_1 = "host01.test";
+  public static final String FQDN_2 = "host02.test";
+
+  /** Internal mapping of domain names and IP addresses. */
+  private Map<String, InetAddress[]> addrs = new TreeMap<>();
+  /** Internal mapping from IP addresses to fqdns. */
+  private Map<InetAddress, String> ptrMap = new HashMap<>();
+
+  public MockDomainNameResolver() {
+    try {
+      InetAddress nn1Address = InetAddress.getByAddress(BYTE_ADDR_1);
+      InetAddress nn2Address = InetAddress.getByAddress(BYTE_ADDR_2);
+      addrs.put(DOMAIN1, new InetAddress[]{nn1Address, nn2Address});
+      ptrMap.put(nn1Address, FQDN_1);
+      ptrMap.put(nn2Address, FQDN_2);
+    } catch (UnknownHostException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public InetAddress[] getAllByDomainName(String domainName)
+          throws UnknownHostException {
+    if (!addrs.containsKey(domainName)) {
+      throw new UnknownHostException(domainName + " is not resolvable");
+    }
+    return addrs.get(domainName);
+  }
+
+  @Override
+  public String getHostnameByIP(InetAddress address) {
+    return ptrMap.containsKey(address) ? ptrMap.get(address) : null;
+  }
+
+  @Override
+  public String[] getAllResolvedHostnameByDomainName(
+          String domainName, boolean useFQDN) throws UnknownHostException {
+    InetAddress[] addresses = getAllByDomainName(domainName);
+    String[] hosts = new String[addresses.length];
+    if (useFQDN) {
+      for (int i = 0; i < hosts.length; i++) {
+        hosts[i] = this.ptrMap.get(addresses[i]);
+      }
+    } else {
+      for (int i = 0; i < hosts.length; i++) {
+        hosts[i] = addresses[i].getHostAddress();
+      }
+    }
+
+    return hosts;
+  }
+
+  public void setAddressMap(Map<String, InetAddress[]> addresses) {
+    this.addrs = addresses;
+  }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
@@ -179,23 +179,36 @@ public abstract class ClientBase extends ZKTestCase {
 
     protected TestableZooKeeper createClient(String hp) throws IOException, InterruptedException {
         CountdownWatcher watcher = new CountdownWatcher();
-        return createClient(watcher, hp);
+        return createClient(watcher, hp, null);
     }
 
     protected TestableZooKeeper createClient(CountdownWatcher watcher) throws IOException, InterruptedException {
-        return createClient(watcher, hostPort);
+        return createClient(watcher, hostPort, null);
+    }
+
+    protected TestableZooKeeper createClient(ZKClientConfig conf) throws IOException, InterruptedException {
+        CountdownWatcher watcher = new CountdownWatcher();
+        return createClient(watcher, hostPort, conf);
     }
 
     private List<ZooKeeper> allClients;
     private boolean allClientsSetup = false;
 
     protected TestableZooKeeper createClient(CountdownWatcher watcher, String hp) throws IOException, InterruptedException {
-        return createClient(watcher, hp, CONNECTION_TIMEOUT);
+        return createClient(watcher, hp, null);
+    }
+
+    protected TestableZooKeeper createClient(CountdownWatcher watcher, String hp, ZKClientConfig conf) throws IOException, InterruptedException {
+        return createClient(watcher, hp, CONNECTION_TIMEOUT, conf);
     }
 
     protected TestableZooKeeper createClient(CountdownWatcher watcher, String hp, int timeout) throws IOException, InterruptedException {
+        return createClient(watcher, hp, timeout, null);
+    }
+
+    protected TestableZooKeeper createClient(CountdownWatcher watcher, String hp, int timeout, ZKClientConfig conf) throws IOException, InterruptedException {
         watcher.reset();
-        TestableZooKeeper zk = new TestableZooKeeper(hp, timeout, watcher);
+        TestableZooKeeper zk = new TestableZooKeeper(hp, timeout, watcher, conf);
         if (!watcher.clientConnected.await(timeout, TimeUnit.MILLISECONDS)) {
             if (exceptionOnFailedConnect) {
                 throw new ProtocolException("Unable to connect to server");


### PR DESCRIPTION
This is to support resolving configured DNS entry to the list of quorum hosts.  It will resolve the DNS into multiple ip addresses and then reverse lookup the host names from the ip addresses. The host name is needed in secured cluster for Kerberos authentication.

To use this feature, the client needs to:
1. create ZKClientConfig to set 'zookeeper.quorum.resolve-needed' to true
2. create ZooKeeper from the constructor with provided ZKClientConfig

