### PR TITLE
ZOOKEEPER-4218:zooKeeperSaslClient will product a null state event and then caused NPE while used switch(state) to deal with event

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java
@@ -355,6 +355,7 @@ public class ZooKeeperSaslClient {
         try {
             cnxn.sendPacket(request, response, cb, ZooDefs.OpCode.sasl);
         } catch (IOException e) {
+            saslState = SaslState.FAILED;
             throw new SaslException("Failed to send SASL packet to server.", e);
         }
     }
@@ -369,6 +370,7 @@ public class ZooKeeperSaslClient {
         try {
             cnxn.sendPacket(request, response, cb, ZooDefs.OpCode.sasl);
         } catch (IOException e) {
+            saslState = SaslState.FAILED;
             throw new SaslException("Failed to send SASL packet to server due " + "to IOException:", e);
         }
     }


### PR DESCRIPTION
while excute zooKeeperSaslClient.initialize(ClientCnxn.this) occurred some exception, at time saslState is SaslState.INITIAL, and then sendAuthEvent will be set true,  but  KeeperState authState = zooKeeperSaslClient.getKeeperState() will return null authState, so client will create a null state event.