### PR TITLE
ZOOKEEPER-4271: Flaky test - ReadOnlyModeTest.testConnectionEvents

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ClientRequestTimeoutTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ClientRequestTimeoutTest.java
@@ -28,7 +28,7 @@ import org.apache.zookeeper.client.HostProvider;
 import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -67,7 +67,7 @@ public class ClientRequestTimeoutTest extends QuorumPeerTestBase {
                 "waiting for server " + i + " being up");
         }
 
-        CountdownWatcher watch1 = new CountdownWatcher();
+        StateWatcher watch1 = new StateWatcher();
         CustomZooKeeper zk = new CustomZooKeeper(getCxnString(clientPorts), ClientBase.CONNECTION_TIMEOUT, watch1);
         watch1.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/RemoveWatchesTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/RemoveWatchesTest.java
@@ -680,7 +680,7 @@ public class RemoveWatchesTest extends ClientBase {
     @ValueSource(booleans = {true, false})
     @Timeout(value = 90)
     public void testNoWatcherServerException(boolean useAsync) throws InterruptedException, IOException, TimeoutException {
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = spy(new ZooKeeper(hostPort, CONNECTION_TIMEOUT, watcher));
         MyWatchManager watchManager = new MyWatchManager(false, watcher);
         doReturn(watchManager).when(zk).getWatchManager();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/SaslAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/SaslAuthTest.java
@@ -97,7 +97,7 @@ public class SaslAuthTest extends ClientBase {
         return createClient(watcher, hp);
     }
 
-    private class MyWatcher extends CountdownWatcher {
+    private class MyWatcher extends StateWatcher {
 
         @Override
         public synchronized void process(WatchedEvent event) {
@@ -167,7 +167,7 @@ public class SaslAuthTest extends ClientBase {
 
     @Test
     public void testZKOperationsAfterClientSaslAuthFailure() throws Exception {
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(hostPort, CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(CONNECTION_TIMEOUT);
         try {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ZooKeeperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ZooKeeperTest.java
@@ -663,7 +663,7 @@ public class ZooKeeperTest extends ClientBase {
             zk = createClient();
             ZKClientConfig clientConfig = new ZKClientConfig();
             clientConfig.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET, "org.apache.zookeeper.ClientCnxnSocketNetty");
-            CountdownWatcher watcher = new CountdownWatcher();
+            StateWatcher watcher = new StateWatcher();
             HostProvider aHostProvider = new StaticHostProvider(new ConnectStringParser(hostPort).getServerAddresses());
             newZKClient = new ZooKeeper(
                 hostPort,

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/audit/Log4jAuditLoggerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/audit/Log4jAuditLoggerTest.java
@@ -47,7 +47,7 @@ import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -230,7 +230,7 @@ public class Log4jAuditLoggerTest extends QuorumPeerTestBase {
     public void testEphemralZNodeAuditLogs()
             throws Exception {
         String ephemralPath = "/ephemral";
-        CountdownWatcher watcher2 = new CountdownWatcher();
+        StateWatcher watcher2 = new StateWatcher();
         ZooKeeper zk2 = new ZooKeeper(
                 "127.0.0.1:" + mt[0].getQuorumPeer().getClientPort(),
                 ClientBase.CONNECTION_TIMEOUT, watcher2);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/audit/ZKAuditLoggerPerformance.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/audit/ZKAuditLoggerPerformance.java
@@ -25,7 +25,7 @@ import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.data.Stat;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,7 +94,7 @@ public class ZKAuditLoggerPerformance {
             System.exit(1);
         }
         String cxnString = args[0];
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zkClient = null;
         try {
             zkClient = new ZooKeeper(cxnString, 60000, watcher);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/BlueThrottleTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/BlueThrottleTest.java
@@ -168,7 +168,7 @@ public class BlueThrottleTest extends ZKTestCase {
     }
 
     private QuorumUtil quorumUtil = new QuorumUtil(1);
-    private ClientBase.CountdownWatcher[] watchers;
+    private ClientBase.StateWatcher[] watchers;
     private ZooKeeper[] zks;
 
     private int connect(int n) throws Exception {
@@ -176,9 +176,9 @@ public class BlueThrottleTest extends ZKTestCase {
         int connected = 0;
 
         zks = new ZooKeeper[n];
-        watchers = new ClientBase.CountdownWatcher[n];
+        watchers = new ClientBase.StateWatcher[n];
         for (int i = 0; i < n; i++){
-            watchers[i] = new ClientBase.CountdownWatcher();
+            watchers[i] = new ClientBase.StateWatcher();
             zks[i] = new ZooKeeper(connStr, 3000, watchers[i]);
             try {
                 watchers[i].waitForConnected(RAPID_TIMEOUT);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ConnectionMetricsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ConnectionMetricsTest.java
@@ -60,7 +60,7 @@ public class ConnectionMetricsTest extends ZKTestCase {
         int follower1 = (int) util.getFollowerQuorumPeers().get(0).getId();
         int follower2 = (int) util.getFollowerQuorumPeers().get(1).getId();
         LOG.info("connecting to server: {}", follower1);
-        ClientBase.CountdownWatcher watcher = new ClientBase.CountdownWatcher();
+        ClientBase.StateWatcher watcher = new ClientBase.StateWatcher();
         // create a connection to follower
         ZooKeeper zk = new ZooKeeper(util.getConnectionStringForServer(follower1), ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/X509AuthFailureTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/X509AuthFailureTest.java
@@ -90,7 +90,7 @@ public class X509AuthFailureTest extends ZKTestCase {
     }
 
     private ZooKeeper createZKClnt(String cxnString) throws Exception {
-        ClientBase.CountdownWatcher watcher = new ClientBase.CountdownWatcher();
+        ClientBase.StateWatcher watcher = new ClientBase.StateWatcher();
         ZooKeeper zk = new ZooKeeper(cxnString, TIMEOUT, watcher);
         watcher.waitForConnected(CONNECTION_TIMEOUT);
         return zk;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerMaxCnxnsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerMaxCnxnsTest.java
@@ -30,7 +30,7 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -117,7 +117,7 @@ public class ZooKeeperServerMaxCnxnsTest extends QuorumPeerTestBase {
 
         // No more client to be allowed to connect now as we have reached the
         // max connections
-        CountdownWatcher cdw = new CountdownWatcher();
+        StateWatcher cdw = new StateWatcher();
         ZooKeeper extraClient = new ZooKeeper(cxnString, ClientBase.CONNECTION_TIMEOUT, cdw);
         try {
             cdw.waitForConnected(ClientBase.CONNECTION_TIMEOUT / 2);
@@ -130,7 +130,7 @@ public class ZooKeeperServerMaxCnxnsTest extends QuorumPeerTestBase {
         clients[0].close();
 
         // Now extra client must automatically get connected
-        cdw = new CountdownWatcher();
+        cdw = new StateWatcher();
         extraClient = new ZooKeeper(cxnString, ClientBase.CONNECTION_TIMEOUT, cdw);
         cdw.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerStartupTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerStartupTest.java
@@ -32,7 +32,7 @@ import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.common.X509Exception.SSLContextException;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -86,7 +86,7 @@ public class ZooKeeperServerStartupTest extends ZKTestCase {
         SimpleZooKeeperServer simplezks = (SimpleZooKeeperServer) zks;
         assertTrue(simplezks.waitForStartupInvocation(10), "Failed to invoke zks#startup() method during server startup");
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zkClient = new ZooKeeper(HOSTPORT, ClientBase.CONNECTION_TIMEOUT, watcher);
 
         assertFalse(simplezks.waitForSessionCreation(5),
@@ -120,7 +120,7 @@ public class ZooKeeperServerStartupTest extends ZKTestCase {
             SimpleZooKeeperServer simplezks = (SimpleZooKeeperServer) zks;
             assertTrue(simplezks.waitForStartupInvocation(10), "Failed to invoke zks#startup() method during server startup");
 
-            CountdownWatcher watcher = new CountdownWatcher();
+            StateWatcher watcher = new StateWatcher();
             ZooKeeper zkClient = new ZooKeeper(HOSTPORT, ClientBase.CONNECTION_TIMEOUT, watcher);
 
             assertFalse(simplezks.waitForSessionCreation(5), "Since server is not fully started, zks#createSession() shouldn't be invoked");

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZxidRolloverTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZxidRolloverTest.java
@@ -29,7 +29,7 @@ import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.apache.zookeeper.test.ClientTest;
 import org.apache.zookeeper.test.QuorumUtil;
 import org.apache.zookeeper.test.QuorumUtil.PeerStruct;
@@ -49,7 +49,7 @@ public class ZxidRolloverTest extends ZKTestCase {
     private QuorumUtil qu;
     private ZooKeeperServer zksLeader;
     private ZooKeeper[] zkClients = new ZooKeeper[3];
-    private CountdownWatcher[] zkClientWatchers = new CountdownWatcher[3];
+    private StateWatcher[] zkClientWatchers = new StateWatcher[3];
     private int idxLeader;
     private int idxFollower;
 
@@ -69,7 +69,7 @@ public class ZxidRolloverTest extends ZKTestCase {
         startAll();
 
         for (int i = 0; i < zkClients.length; i++) {
-            zkClientWatchers[i] = new CountdownWatcher();
+            zkClientWatchers[i] = new StateWatcher();
             PeerStruct peer = qu.getPeer(i + 1);
             zkClients[i] = new ZooKeeper(
                     "127.0.0.1:" + peer.clientPort,

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/DIFFSyncConsistencyTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/DIFFSyncConsistencyTest.java
@@ -38,7 +38,7 @@ import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.quorum.Leader.Proposal;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -80,7 +80,7 @@ public class DIFFSyncConsistencyTest extends QuorumPeerTestBase {
         }
 
         int leader = findLeader(mt);
-        CountdownWatcher watch = new CountdownWatcher();
+        StateWatcher watch = new StateWatcher();
         ZooKeeper zk = new ZooKeeper("127.0.0.1:" + clientPorts[leader], ClientBase.CONNECTION_TIMEOUT, watch);
         watch.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EagerACLFilterTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EagerACLFilterTest.java
@@ -70,8 +70,8 @@ public class EagerACLFilterTest extends QuorumBase {
 
     public void setUp(ServerState serverState, boolean checkEnabled) throws Exception {
         ensureCheck(checkEnabled);
-        CountdownWatcher clientWatch = new CountdownWatcher();
-        CountdownWatcher clientWatchB = new CountdownWatcher();
+        StateWatcher clientWatch = new StateWatcher();
+        StateWatcher clientWatchB = new StateWatcher();
         super.setUp(true, true);
 
         String hostPort = getPeersMatching(serverState).split(",")[0];
@@ -252,7 +252,7 @@ public class EagerACLFilterTest extends QuorumBase {
     @MethodSource("data")
     public void testBadACL(ServerState serverState, boolean checkEnabled) throws Exception {
         setUp(serverState, checkEnabled);
-        CountdownWatcher cw = new CountdownWatcher();
+        StateWatcher cw = new StateWatcher();
         TestableZooKeeper zk = createClient(cw, getPeersMatching(serverState));
         long lastxid;
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeDeletionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeDeletionTest.java
@@ -37,7 +37,7 @@ import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.quorum.QuorumPeer.ServerState;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -84,7 +84,7 @@ public class EphemeralNodeDeletionTest extends QuorumPeerTestBase {
                     "waiting for server " + i + " being up");
         }
 
-        CountdownWatcher watch = new CountdownWatcher();
+        StateWatcher watch = new StateWatcher();
         ZooKeeper zk = new ZooKeeper("127.0.0.1:" + clientPorts[1], ClientBase.CONNECTION_TIMEOUT, watch);
         watch.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
 
@@ -118,14 +118,14 @@ public class EphemeralNodeDeletionTest extends QuorumPeerTestBase {
         assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + leader.getClientPort(), CONNECTION_TIMEOUT),
                 "Leader must be running");
 
-        watch = new CountdownWatcher();
+        watch = new StateWatcher();
         zk = new ZooKeeper("127.0.0.1:" + leader.getClientPort(), ClientBase.CONNECTION_TIMEOUT, watch);
         watch.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
 
         Stat exists = zk.exists(nodePath, false);
         assertNull(exists, "Node must have been deleted from leader");
 
-        CountdownWatcher followerWatch = new CountdownWatcher();
+        StateWatcher followerWatch = new StateWatcher();
         ZooKeeper followerZK = new ZooKeeper(
                 "127.0.0.1:" + follower.getClientPort(),
                 ClientBase.CONNECTION_TIMEOUT,

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EpochWriteFailureTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EpochWriteFailureTest.java
@@ -29,7 +29,7 @@ import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -72,7 +72,7 @@ public class EpochWriteFailureTest extends QuorumPeerTestBase {
                     "waiting for server " + i + " being up");
         }
 
-        CountdownWatcher watch1 = new CountdownWatcher();
+        StateWatcher watch1 = new StateWatcher();
         zk = new ZooKeeper("127.0.0.1:" + clientPorts[0], ClientBase.CONNECTION_TIMEOUT,
                 watch1);
         watch1.waitForConnected(ClientBase.CONNECTION_TIMEOUT);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumRequestPipelineTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumRequestPipelineTest.java
@@ -68,7 +68,7 @@ public class QuorumRequestPipelineTest extends QuorumBase {
     }
 
     public void setUp(ServerState serverState) throws Exception {
-        CountdownWatcher clientWatch = new CountdownWatcher();
+        StateWatcher clientWatch = new StateWatcher();
         super.setUp(true, true);
         zkClient = createClient(clientWatch, getPeersMatching(serverState));
         zkClient.addAuthInfo(AUTH_PROVIDER, AUTH);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ReconfigDuringLeaderSyncTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/ReconfigDuringLeaderSyncTest.java
@@ -36,7 +36,7 @@ import org.apache.zookeeper.server.admin.AdminServer.AdminServerException;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.quorum.flexible.QuorumMaj;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -108,7 +108,7 @@ public class ReconfigDuringLeaderSyncTest extends QuorumPeerTestBase {
             assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPorts[i], CONNECTION_TIMEOUT),
                     "waiting for server " + i + " being up");
         }
-        CountdownWatcher watch = new CountdownWatcher();
+        StateWatcher watch = new StateWatcher();
         ZooKeeperAdmin preReconfigClient = new ZooKeeperAdmin(
             "127.0.0.1:" + clientPorts[0],
             ClientBase.CONNECTION_TIMEOUT,
@@ -172,7 +172,7 @@ public class ReconfigDuringLeaderSyncTest extends QuorumPeerTestBase {
                 Thread.sleep(10);
             }
         }
-        watch = new CountdownWatcher();
+        watch = new StateWatcher();
         ZooKeeper postReconfigClient = new ZooKeeper(
                 "127.0.0.1:" + clientPorts[joinerId],
                 ClientBase.CONNECTION_TIMEOUT,

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumAuthUpgradeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumAuthUpgradeTest.java
@@ -30,7 +30,7 @@ import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.server.quorum.QuorumPeerTestBase.MainThread;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.apache.zookeeper.test.ClientTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -91,7 +91,7 @@ public class QuorumAuthUpgradeTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_SASL_AUTH_ENABLED, "false");
 
         String connectStr = startQuorum(2, authConfigs, 0);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         zk.create("/foo", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
@@ -110,7 +110,7 @@ public class QuorumAuthUpgradeTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_SASL_AUTH_ENABLED, "true");
 
         String connectStr = startQuorum(2, authConfigs, 1);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         zk.create("/foo", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
@@ -129,7 +129,7 @@ public class QuorumAuthUpgradeTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_SASL_AUTH_ENABLED, "true");
 
         String connectStr = startQuorum(2, authConfigs, 2);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         zk.create("/foo", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
@@ -150,7 +150,7 @@ public class QuorumAuthUpgradeTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
 
         String connectStr = startQuorum(2, authConfigs, 2);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         zk.create("/foo", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
@@ -182,7 +182,7 @@ public class QuorumAuthUpgradeTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_SASL_AUTH_ENABLED, "false");
 
         String connectStr = startQuorum(3, authConfigs, 0);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         zk.create("/foo", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_SEQUENTIAL);
@@ -228,7 +228,7 @@ public class QuorumAuthUpgradeTest extends QuorumAuthTestBase {
         Map<String, String> authConfigs,
         int index,
         ZooKeeper zk,
-        CountdownWatcher watcher) throws IOException, KeeperException, InterruptedException, TimeoutException {
+        StateWatcher watcher) throws IOException, KeeperException, InterruptedException, TimeoutException {
             LOG.info("Restarting server myid={}", index);
             MainThread m = shutdown(index);
             startServer(m, authConfigs);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumDigestAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumDigestAuthTest.java
@@ -33,7 +33,7 @@ import org.apache.zookeeper.server.quorum.QuorumPeerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
 import org.apache.zookeeper.server.quorum.QuorumPeerTestBase.MainThread;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -87,7 +87,7 @@ public class QuorumDigestAuthTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
 
         String connectStr = startQuorum(3, authConfigs, 3);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         for (int i = 0; i < 10; i++) {
@@ -109,7 +109,7 @@ public class QuorumDigestAuthTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
 
         String connectStr = startMultiAddressQuorum(3, authConfigs, 3);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         for (int i = 0; i < 10; i++) {
@@ -131,7 +131,7 @@ public class QuorumDigestAuthTest extends QuorumAuthTestBase {
         authConfigs.put(QuorumAuth.QUORUM_SASL_AUTH_ENABLED, "false");
         authConfigs.put(QuorumAuth.QUORUM_SERVER_SASL_AUTH_REQUIRED, "false");
         String connectStr = startQuorum(3, authConfigs, 3);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         for (int i = 0; i < 10; i++) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumKerberosAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumKerberosAuthTest.java
@@ -28,7 +28,7 @@ import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.server.quorum.QuorumPeerTestBase.MainThread;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -120,7 +120,7 @@ public class QuorumKerberosAuthTest extends KerberosSecurityTestcase {
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_KERBEROS_SERVICE_PRINCIPAL, serverPrincipal);
         String connectStr = startQuorum(3, authConfigs, 3);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         for (int i = 0; i < 10; i++) {
@@ -144,7 +144,7 @@ public class QuorumKerberosAuthTest extends KerberosSecurityTestcase {
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_KERBEROS_SERVICE_PRINCIPAL, serverPrincipal);
         String connectStr = startMultiAddressQuorum(3, authConfigs, 3);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         for (int i = 0; i < 10; i++) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumKerberosHostBasedAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumKerberosHostBasedAuthTest.java
@@ -31,7 +31,7 @@ import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.server.quorum.QuorumPeerTestBase.MainThread;
 import org.apache.zookeeper.test.ClientBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -144,7 +144,7 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_KERBEROS_SERVICE_PRINCIPAL, serverPrincipal);
         String connectStr = startQuorum(3, authConfigs, 3);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         for (int i = 0; i < 10; i++) {
@@ -167,7 +167,7 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_KERBEROS_SERVICE_PRINCIPAL, serverPrincipal);
         String connectStr = startMultiAddressQuorum(3, authConfigs, 3);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         for (int i = 0; i < 10; i++) {
@@ -189,7 +189,7 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
         authConfigs.put(QuorumAuth.QUORUM_KERBEROS_SERVICE_PRINCIPAL, serverPrincipal);
         String connectStr = startQuorum(3, authConfigs, 3);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
         for (int i = 0; i < 10; i++) {
@@ -209,7 +209,7 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
         authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_LOGIN_CONTEXT, "QuorumLearnerMyHost");
         MainThread badServer = new MainThread(myid, clientPort, quorumCfgSection, authConfigs);
         badServer.start();
-        watcher = new CountdownWatcher();
+        watcher = new StateWatcher();
         connectStr = "127.0.0.1:" + clientPort;
         zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
         try {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/AsyncHammerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/AsyncHammerTest.java
@@ -33,7 +33,7 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.data.Stat;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,7 +82,7 @@ public class AsyncHammerTest extends ZKTestCase implements StringCallback, VoidC
 
         public void run() {
             try {
-                CountdownWatcher watcher = new CountdownWatcher();
+                StateWatcher watcher = new StateWatcher();
                 zk = new TestableZooKeeper(qb.hostPort, CONNECTION_TIMEOUT, watcher);
                 watcher.waitForConnected(CONNECTION_TIMEOUT);
                 while (bang) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/AuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/AuthTest.java
@@ -65,7 +65,7 @@ public class AuthTest extends ClientBase {
         return createClient(watcher, hp);
     }
 
-    private class MyWatcher extends CountdownWatcher {
+    private class MyWatcher extends StateWatcher {
 
         @Override
         public synchronized void process(WatchedEvent event) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
@@ -124,6 +124,11 @@ public abstract class ClientBase extends ZKTestCase {
         public synchronized boolean isConnected() {
             return connected;
         }
+
+        public boolean awaitConnected(long timeout) throws InterruptedException {
+            return clientConnected.await(timeout, TimeUnit.MILLISECONDS);
+        }
+
         public synchronized void waitForConnected(long timeout) throws InterruptedException, TimeoutException {
             long expire = Time.currentElapsedTime() + timeout;
             long left = timeout;
@@ -196,7 +201,7 @@ public abstract class ClientBase extends ZKTestCase {
     protected TestableZooKeeper createClient(CountdownWatcher watcher, String hp, int timeout) throws IOException, InterruptedException {
         watcher.reset();
         TestableZooKeeper zk = new TestableZooKeeper(hp, timeout, watcher);
-        if (!watcher.clientConnected.await(timeout, TimeUnit.MILLISECONDS)) {
+        if (!watcher.awaitConnected(timeout)) {
             if (exceptionOnFailedConnect) {
                 throw new ProtocolException("Unable to connect to server");
             }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientBase.java
@@ -79,7 +79,7 @@ public abstract class ClientBase extends ZKTestCase {
         super();
     }
 
-    public static class CountdownWatcher implements Watcher {
+    public static class StateWatcher implements Watcher {
 
         // Set to true when connected to a quorum server
         volatile boolean syncConnected;
@@ -153,22 +153,22 @@ public abstract class ClientBase extends ZKTestCase {
     }
 
     protected TestableZooKeeper createClient(String hp) throws IOException, InterruptedException {
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         return createClient(watcher, hp);
     }
 
-    protected TestableZooKeeper createClient(CountdownWatcher watcher) throws IOException, InterruptedException {
+    protected TestableZooKeeper createClient(StateWatcher watcher) throws IOException, InterruptedException {
         return createClient(watcher, hostPort);
     }
 
     private List<ZooKeeper> allClients;
     private boolean allClientsSetup = false;
 
-    protected TestableZooKeeper createClient(CountdownWatcher watcher, String hp) throws IOException, InterruptedException {
+    protected TestableZooKeeper createClient(StateWatcher watcher, String hp) throws IOException, InterruptedException {
         return createClient(watcher, hp, CONNECTION_TIMEOUT);
     }
 
-    protected TestableZooKeeper createClient(CountdownWatcher watcher, String hp, int timeout) throws IOException, InterruptedException {
+    protected TestableZooKeeper createClient(StateWatcher watcher, String hp, int timeout) throws IOException, InterruptedException {
         watcher.reset();
         TestableZooKeeper zk = new TestableZooKeeper(hp, timeout, watcher);
         if (!watcher.awaitConnected(timeout)) {
@@ -696,7 +696,7 @@ public abstract class ClientBase extends ZKTestCase {
 
     public static ZooKeeper createZKClient(String cxnString, int sessionTimeout,
         long connectionTimeout, ZKClientConfig config) throws IOException {
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(cxnString, sessionTimeout, watcher, config);
         try {
             watcher.waitForConnected(connectionTimeout);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientRetryTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientRetryTest.java
@@ -48,8 +48,8 @@ public class ClientRetryTest extends ClientBase {
      */
     @Test
     public void testClientRetry() throws IOException, InterruptedException, TimeoutException {
-        CountdownWatcher cdw1 = new CountdownWatcher();
-        CountdownWatcher cdw2 = new CountdownWatcher();
+        StateWatcher cdw1 = new StateWatcher();
+        StateWatcher cdw2 = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(hostPort, 10000, cdw1);
         try {
             cdw1.waitForConnected(CONNECTION_TIMEOUT);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientTest.java
@@ -68,7 +68,7 @@ public class ClientTest extends ClientBase {
         ZooKeeper zkIdle = null;
         ZooKeeper zkWatchCreator = null;
         try {
-            CountdownWatcher watcher = new CountdownWatcher();
+            StateWatcher watcher = new StateWatcher();
             zkIdle = createClient(watcher, hostPort, 10000);
 
             zkWatchCreator = createClient();
@@ -240,7 +240,7 @@ public class ClientTest extends ClientBase {
         }
     }
 
-    private class MyWatcher extends CountdownWatcher {
+    private class MyWatcher extends StateWatcher {
 
         LinkedBlockingQueue<WatchedEvent> events = new LinkedBlockingQueue<WatchedEvent>();
 
@@ -263,7 +263,7 @@ public class ClientTest extends ClientBase {
      */
     @Test
     public void testMutipleWatcherObjs() throws IOException, InterruptedException, KeeperException {
-        ZooKeeper zk = createClient(new CountdownWatcher(), hostPort);
+        ZooKeeper zk = createClient(new StateWatcher(), hostPort);
         try {
             MyWatcher[] watchers = new MyWatcher[100];
             MyWatcher[] watchers2 = new MyWatcher[watchers.length];

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/DigestAuthDisabledTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/DigestAuthDisabledTest.java
@@ -51,7 +51,7 @@ public class DigestAuthDisabledTest extends ClientBase {
         return createClient(watcher, hp);
     }
 
-    private class MyWatcher extends CountdownWatcher {
+    private class MyWatcher extends StateWatcher {
 
         @Override
         public synchronized void process(WatchedEvent event) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/DisconnectedWatcherTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/DisconnectedWatcherTest.java
@@ -41,7 +41,7 @@ public class DisconnectedWatcherTest extends ClientBase {
     protected static final Logger LOG = LoggerFactory.getLogger(DisconnectedWatcherTest.class);
     final int TIMEOUT = 5000;
 
-    private class MyWatcher extends CountdownWatcher {
+    private class MyWatcher extends StateWatcher {
 
         LinkedBlockingQueue<WatchedEvent> events = new LinkedBlockingQueue<WatchedEvent>();
 
@@ -58,7 +58,7 @@ public class DisconnectedWatcherTest extends ClientBase {
 
     }
 
-    private CountdownWatcher watcher1;
+    private StateWatcher watcher1;
     private ZooKeeper zk1;
     private MyWatcher watcher2;
     private ZooKeeper zk2;
@@ -66,7 +66,7 @@ public class DisconnectedWatcherTest extends ClientBase {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        watcher1 = new CountdownWatcher();
+        watcher1 = new StateWatcher();
         zk1 = createClient(watcher1);
         watcher2 = new MyWatcher();
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/DuplicateLocalSessionUpgradeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/DuplicateLocalSessionUpgradeTest.java
@@ -26,7 +26,7 @@ import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,7 +80,7 @@ public class DuplicateLocalSessionUpgradeTest extends ZKTestCase {
         int testPeerIdx = testLeader ? leaderIdx : followerIdx;
         String[] hostPorts = qb.hostPort.split(",");
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = qb.createClient(watcher, hostPorts[testPeerIdx], CONNECTION_TIMEOUT);
         watcher.waitForConnected(CONNECTION_TIMEOUT);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/FollowerResyncConcurrencyTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/FollowerResyncConcurrencyTest.java
@@ -43,7 +43,7 @@ import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.quorum.Leader;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,9 +88,9 @@ public class FollowerResyncConcurrencyTest extends ZKTestCase {
      */
     @Test
     public void testLaggingFollowerResyncsUnderNewEpoch() throws Exception {
-        CountdownWatcher watcher1 = new CountdownWatcher();
-        CountdownWatcher watcher2 = new CountdownWatcher();
-        CountdownWatcher watcher3 = new CountdownWatcher();
+        StateWatcher watcher1 = new StateWatcher();
+        StateWatcher watcher2 = new StateWatcher();
+        StateWatcher watcher3 = new StateWatcher();
 
         QuorumUtil qu = new QuorumUtil(1);
         qu.shutdownAll();
@@ -185,9 +185,9 @@ public class FollowerResyncConcurrencyTest extends ZKTestCase {
 
         QuorumUtil qu = new QuorumUtil(1);
         qu.startAll();
-        CountdownWatcher watcher1 = new CountdownWatcher();
-        CountdownWatcher watcher2 = new CountdownWatcher();
-        CountdownWatcher watcher3 = new CountdownWatcher();
+        StateWatcher watcher1 = new StateWatcher();
+        StateWatcher watcher2 = new StateWatcher();
+        StateWatcher watcher3 = new StateWatcher();
 
         int index = 1;
         while (qu.getPeer(index).peer.leader == null) {
@@ -362,9 +362,9 @@ public class FollowerResyncConcurrencyTest extends ZKTestCase {
 
         QuorumUtil qu = new QuorumUtil(1);
         qu.startAll();
-        CountdownWatcher watcher1 = new CountdownWatcher();
-        CountdownWatcher watcher2 = new CountdownWatcher();
-        CountdownWatcher watcher3 = new CountdownWatcher();
+        StateWatcher watcher1 = new StateWatcher();
+        StateWatcher watcher2 = new StateWatcher();
+        StateWatcher watcher3 = new StateWatcher();
 
         int index = 1;
         while (qu.getPeer(index).peer.leader == null) {
@@ -491,7 +491,7 @@ public class FollowerResyncConcurrencyTest extends ZKTestCase {
         qu.shutdownAll();
     }
 
-    private static DisconnectableZooKeeper createClient(int port, CountdownWatcher watcher) throws IOException, TimeoutException, InterruptedException {
+    private static DisconnectableZooKeeper createClient(int port, StateWatcher watcher) throws IOException, TimeoutException, InterruptedException {
         DisconnectableZooKeeper zk = new DisconnectableZooKeeper(
                 "127.0.0.1:" + port,
                 ClientBase.CONNECTION_TIMEOUT,
@@ -547,12 +547,12 @@ public class FollowerResyncConcurrencyTest extends ZKTestCase {
     }
 
     private static TestableZooKeeper createTestableClient(String hp) throws IOException, TimeoutException, InterruptedException {
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         return createTestableClient(watcher, hp);
     }
 
     private static TestableZooKeeper createTestableClient(
-            CountdownWatcher watcher, String hp) throws IOException, TimeoutException, InterruptedException {
+            StateWatcher watcher, String hp) throws IOException, TimeoutException, InterruptedException {
         TestableZooKeeper zk = new TestableZooKeeper(hp, ClientBase.CONNECTION_TIMEOUT, watcher);
 
         watcher.waitForConnected(CONNECTION_TIMEOUT);
@@ -633,7 +633,7 @@ public class FollowerResyncConcurrencyTest extends ZKTestCase {
         qu.shutdownAll();
     }
 
-    private class MyWatcher extends CountdownWatcher {
+    private class MyWatcher extends StateWatcher {
 
         LinkedBlockingQueue<WatchedEvent> events = new LinkedBlockingQueue<WatchedEvent>();
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/FollowerResyncConcurrencyTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/FollowerResyncConcurrencyTest.java
@@ -675,7 +675,7 @@ public class FollowerResyncConcurrencyTest extends ZKTestCase {
 
         watcher.reset();
         zk2.testableConnloss();
-        if (!watcher.clientConnected.await(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)) {
+        if (!watcher.awaitConnected(CONNECTION_TIMEOUT)) {
             fail("Unable to connect to server");
         }
         assertArrayEquals("foo".getBytes(), zk2.getData("/foo", false, null));

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/HierarchicalQuorumTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/HierarchicalQuorumTest.java
@@ -291,7 +291,7 @@ public class HierarchicalQuorumTest extends ClientBase {
     }
 
     protected TestableZooKeeper createClient(String hp) throws IOException, InterruptedException {
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         return createClient(watcher, hp);
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/LocalSessionRequestTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/LocalSessionRequestTest.java
@@ -25,7 +25,7 @@ import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.quorum.Leader.Proposal;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -102,7 +102,7 @@ public class LocalSessionRequestTest extends ZKTestCase {
 
         String[] hostPorts = qb.hostPort.split(",");
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         DisconnectableZooKeeper client = new DisconnectableZooKeeper(hostPorts[testPeerIdx], CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(CONNECTION_TIMEOUT);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/LocalSessionsOnlyTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/LocalSessionsOnlyTest.java
@@ -30,7 +30,7 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -83,7 +83,7 @@ public class LocalSessionsOnlyTest extends ZKTestCase {
         int testPeerIdx = testLeader ? leaderIdx : followerIdx;
         String[] hostPorts = qb.hostPort.split(",");
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = qb.createClient(watcher, hostPorts[testPeerIdx], CONNECTION_TIMEOUT);
         watcher.waitForConnected(CONNECTION_TIMEOUT);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/NonRecoverableErrorTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/NonRecoverableErrorTest.java
@@ -35,7 +35,7 @@ import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.server.quorum.QuorumPeer.ServerState;
 import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -80,7 +80,7 @@ public class NonRecoverableErrorTest extends QuorumPeerTestBase {
                     "waiting for server " + i + " being up");
         }
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper("127.0.0.1:" + clientPorts[0], ClientBase.CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/PersistentRecursiveWatcherTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/PersistentRecursiveWatcherTest.java
@@ -56,7 +56,7 @@ public class PersistentRecursiveWatcherTest extends ClientBase {
     @Test
     public void testBasic()
             throws IOException, InterruptedException, KeeperException {
-        try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk = createClient(new StateWatcher(), hostPort)) {
             zk.addWatch("/a/b", persistentWatcher, PERSISTENT_RECURSIVE);
             internalTestBasic(zk);
         }
@@ -65,7 +65,7 @@ public class PersistentRecursiveWatcherTest extends ClientBase {
     @Test
     public void testBasicAsync()
             throws IOException, InterruptedException, KeeperException {
-        try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk = createClient(new StateWatcher(), hostPort)) {
             final CountDownLatch latch = new CountDownLatch(1);
             AsyncCallback.VoidCallback cb = (rc, path, ctx) -> {
                 if (rc == KeeperException.Code.OK.intValue()) {
@@ -100,7 +100,7 @@ public class PersistentRecursiveWatcherTest extends ClientBase {
     @Test
     public void testRemoval()
             throws IOException, InterruptedException, KeeperException {
-        try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk = createClient(new StateWatcher(), hostPort)) {
             zk.addWatch("/a/b", persistentWatcher, PERSISTENT_RECURSIVE);
             zk.create("/a", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             zk.create("/a/b", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
@@ -116,7 +116,7 @@ public class PersistentRecursiveWatcherTest extends ClientBase {
 
     @Test
     public void testDisconnect() throws Exception {
-        try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk = createClient(new StateWatcher(), hostPort)) {
             zk.addWatch("/a/b", persistentWatcher, PERSISTENT_RECURSIVE);
             stopServer();
             assertEvent(events, Watcher.Event.EventType.None, null);
@@ -129,7 +129,7 @@ public class PersistentRecursiveWatcherTest extends ClientBase {
     @Test
     public void testMultiClient()
             throws IOException, InterruptedException, KeeperException {
-        try (ZooKeeper zk1 = createClient(new CountdownWatcher(), hostPort); ZooKeeper zk2 = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk1 = createClient(new StateWatcher(), hostPort); ZooKeeper zk2 = createClient(new StateWatcher(), hostPort)) {
 
             zk1.create("/a", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             zk1.create("/a/b", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
@@ -153,7 +153,7 @@ public class PersistentRecursiveWatcherTest extends ClientBase {
     @Test
     public void testRootWatcher()
             throws IOException, InterruptedException, KeeperException {
-        try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk = createClient(new StateWatcher(), hostPort)) {
             zk.addWatch("/", persistentWatcher, PERSISTENT_RECURSIVE);
             zk.create("/a", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             zk.create("/a/b", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/PersistentWatcherTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/PersistentWatcherTest.java
@@ -57,7 +57,7 @@ public class PersistentWatcherTest extends ClientBase {
     @Test
     public void testBasic()
             throws IOException, InterruptedException, KeeperException {
-        try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk = createClient(new StateWatcher(), hostPort)) {
             zk.addWatch("/a/b", persistentWatcher, PERSISTENT);
             internalTestBasic(zk);
         }
@@ -66,7 +66,7 @@ public class PersistentWatcherTest extends ClientBase {
     @Test
     public void testNullWatch()
             throws IOException, InterruptedException, KeeperException {
-        try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk = createClient(new StateWatcher(), hostPort)) {
             assertThrows(IllegalArgumentException.class, () -> {
                 zk.addWatch("/a/b", null, PERSISTENT);
             });
@@ -80,7 +80,7 @@ public class PersistentWatcherTest extends ClientBase {
     @Test
     public void testDefaultWatcher()
             throws IOException, InterruptedException, KeeperException {
-        CountdownWatcher watcher = new CountdownWatcher() {
+        StateWatcher watcher = new StateWatcher() {
             @Override
             public synchronized void process(WatchedEvent event) {
                 super.process(event);
@@ -97,7 +97,7 @@ public class PersistentWatcherTest extends ClientBase {
     @Test
     public void testBasicAsync()
             throws IOException, InterruptedException, KeeperException {
-        CountdownWatcher watcher = new CountdownWatcher() {
+        StateWatcher watcher = new StateWatcher() {
             @Override
             public synchronized void process(WatchedEvent event) {
                 super.process(event);
@@ -121,7 +121,7 @@ public class PersistentWatcherTest extends ClientBase {
     @Test
     public void testAsyncDefaultWatcher()
             throws IOException, InterruptedException, KeeperException {
-        try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk = createClient(new StateWatcher(), hostPort)) {
             final CountDownLatch latch = new CountDownLatch(1);
             AsyncCallback.VoidCallback cb = (rc, path, ctx) -> {
                 if (rc == KeeperException.Code.OK.intValue()) {
@@ -154,7 +154,7 @@ public class PersistentWatcherTest extends ClientBase {
     @Test
     public void testRemoval()
             throws IOException, InterruptedException, KeeperException {
-        try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk = createClient(new StateWatcher(), hostPort)) {
             zk.addWatch("/a/b", persistentWatcher, PERSISTENT);
             zk.create("/a", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             zk.create("/a/b", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
@@ -171,7 +171,7 @@ public class PersistentWatcherTest extends ClientBase {
 
     @Test
     public void testDisconnect() throws Exception {
-        try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk = createClient(new StateWatcher(), hostPort)) {
             zk.addWatch("/a/b", persistentWatcher, PERSISTENT);
             stopServer();
             assertEvent(events, Watcher.Event.EventType.None, null);
@@ -184,8 +184,8 @@ public class PersistentWatcherTest extends ClientBase {
     @Test
     public void testMultiClient()
             throws IOException, InterruptedException, KeeperException {
-        try (ZooKeeper zk1 = createClient(new CountdownWatcher(), hostPort);
-             ZooKeeper zk2 = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk1 = createClient(new StateWatcher(), hostPort);
+             ZooKeeper zk2 = createClient(new StateWatcher(), hostPort)) {
 
             zk1.create("/a", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             zk1.create("/a/b", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
@@ -208,7 +208,7 @@ public class PersistentWatcherTest extends ClientBase {
     @Test
     public void testRootWatcher()
             throws IOException, InterruptedException, KeeperException {
-        try (ZooKeeper zk = createClient(new CountdownWatcher(), hostPort)) {
+        try (ZooKeeper zk = createClient(new StateWatcher(), hostPort)) {
             zk.addWatch("/", persistentWatcher, PERSISTENT);
             zk.create("/a", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             zk.setData("/a", new byte[0], -1);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumBase.java
@@ -507,11 +507,11 @@ public class QuorumBase extends ClientBase {
     }
 
     protected TestableZooKeeper createClient(String hp) throws IOException, InterruptedException {
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         return createClient(watcher, hp);
     }
 
-    protected TestableZooKeeper createClient(CountdownWatcher watcher, ServerState state) throws IOException, InterruptedException {
+    protected TestableZooKeeper createClient(StateWatcher watcher, ServerState state) throws IOException, InterruptedException {
         return createClient(watcher, getPeersMatching(state));
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumBaseOracle_2Nodes.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumBaseOracle_2Nodes.java
@@ -339,11 +339,11 @@ public class QuorumBaseOracle_2Nodes extends ClientBase{
     }
 
     protected TestableZooKeeper createClient(String hp) throws IOException, InterruptedException {
-        ClientBase.CountdownWatcher watcher = new ClientBase.CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         return createClient(watcher, hp);
     }
 
-    protected TestableZooKeeper createClient(ClientBase.CountdownWatcher watcher, QuorumPeer.ServerState state) throws IOException, InterruptedException {
+    protected TestableZooKeeper createClient(StateWatcher watcher, QuorumPeer.ServerState state) throws IOException, InterruptedException {
         return createClient(watcher, getPeersMatching(state));
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/QuorumTest.java
@@ -40,7 +40,7 @@ import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.server.quorum.Leader;
 import org.apache.zookeeper.server.quorum.LearnerHandler;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -335,7 +335,7 @@ public class QuorumTest extends ZKTestCase {
     @Test
     public void testFollowersStartAfterLeader() throws Exception {
         qu = new QuorumUtil(1);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         qu.startQuorum();
 
         int index = 1;
@@ -379,7 +379,7 @@ public class QuorumTest extends ZKTestCase {
     @Test
     public void testMultiToFollower() throws Exception {
         qu = new QuorumUtil(1);
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         qu.startQuorum();
 
         int index = 1;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReadOnlyModeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReadOnlyModeTest.java
@@ -42,7 +42,7 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.ZooKeeper.States;
 import org.apache.zookeeper.common.Time;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,7 +75,7 @@ public class ReadOnlyModeTest extends ZKTestCase {
         qu.enableLocalSession(true);
         qu.startQuorum();
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(qu.getConnString(), CONNECTION_TIMEOUT, watcher, true);
         watcher.waitForConnected(CONNECTION_TIMEOUT); // ensure zk got connected
 
@@ -119,7 +119,7 @@ public class ReadOnlyModeTest extends ZKTestCase {
         qu.enableLocalSession(true);
         qu.startQuorum();
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(qu.getConnString(), CONNECTION_TIMEOUT, watcher, true);
         watcher.waitForConnected(CONNECTION_TIMEOUT); // ensure zk got connected
 
@@ -173,7 +173,7 @@ public class ReadOnlyModeTest extends ZKTestCase {
         qu.enableLocalSession(true);
         qu.startQuorum();
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(qu.getConnString(), CONNECTION_TIMEOUT, watcher, true);
         boolean success = false;
         for (int i = 0; i < 30; i++) {
@@ -219,7 +219,7 @@ public class ReadOnlyModeTest extends ZKTestCase {
 
         qu.shutdown(2);
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(qu.getConnString(), CONNECTION_TIMEOUT, watcher, true);
         watcher.waitForConnected(CONNECTION_TIMEOUT);
         assertSame(States.CONNECTEDREADONLY, zk.getState(), "should be in r/o mode");
@@ -250,7 +250,7 @@ public class ReadOnlyModeTest extends ZKTestCase {
     public void testGlobalSessionInRO() throws Exception {
         qu.startQuorum();
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(qu.getConnString(), CONNECTION_TIMEOUT, watcher, true);
         watcher.waitForConnected(CONNECTION_TIMEOUT);
         LOG.info("global session created 0x{}", Long.toHexString(zk.getSessionId()));
@@ -305,7 +305,7 @@ public class ReadOnlyModeTest extends ZKTestCase {
 
         try {
             qu.shutdown(2);
-            CountdownWatcher watcher = new CountdownWatcher();
+            StateWatcher watcher = new StateWatcher();
             ZooKeeper zk = new ZooKeeper(qu.getConnString(), CONNECTION_TIMEOUT, watcher, true);
             watcher.waitForConnected(CONNECTION_TIMEOUT);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReadOnlyModeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReadOnlyModeTest.java
@@ -86,8 +86,10 @@ public class ReadOnlyModeTest extends ZKTestCase {
         zk.close();
         watcher.waitForDisconnected(CONNECTION_TIMEOUT);
 
-        watcher.reset();
         qu.shutdown(2);
+        zk.close();
+        watcher.reset();
+
         zk = new ZooKeeper(qu.getConnString(), CONNECTION_TIMEOUT, watcher, true);
         watcher.waitForConnected(CONNECTION_TIMEOUT);
         assertEquals(States.CONNECTEDREADONLY, zk.getState(), "Should be in r-o mode");
@@ -107,6 +109,7 @@ public class ReadOnlyModeTest extends ZKTestCase {
         }
 
         assertNull(zk.exists(node2, false), "Should have created the znode:" + node2);
+        zk.close();
     }
 
     /**
@@ -127,9 +130,9 @@ public class ReadOnlyModeTest extends ZKTestCase {
         final String node = "/tnode";
         zk.create(node, data.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 
-        watcher.reset();
         qu.shutdown(2);
         zk.close();
+        watcher.reset();
 
         // Re-connect the client (in case we were connected to the shut down
         // server and the local session was not persisted).
@@ -191,6 +194,8 @@ public class ReadOnlyModeTest extends ZKTestCase {
         // kill peer and wait no more than 5 seconds for read-only server
         // to be started (which should take one tickTime (2 seconds))
         qu.shutdown(2);
+        zk.close();
+        watcher.reset();
 
         // Re-connect the client (in case we were connected to the shut down
         // server and the local session was not persisted).
@@ -255,8 +260,8 @@ public class ReadOnlyModeTest extends ZKTestCase {
         watcher.waitForConnected(CONNECTION_TIMEOUT);
         LOG.info("global session created 0x{}", Long.toHexString(zk.getSessionId()));
 
-        watcher.reset();
         qu.shutdown(2);
+        watcher.reset();
         try {
             watcher.waitForConnected(CONNECTION_TIMEOUT);
             fail("Should not be able to renew a global session");
@@ -323,6 +328,7 @@ public class ReadOnlyModeTest extends ZKTestCase {
 
             // resume poor fellow
             qu.getPeer(1).peer.resume();
+            zk.close();
         } finally {
             zlogger.removeAppender(appender);
         }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigExceptionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigExceptionTest.java
@@ -188,7 +188,7 @@ public class ReconfigExceptionTest extends ZKTestCase {
     // quorum servers.
     private void resetZKAdmin() throws InterruptedException {
         String cnxString;
-        ClientBase.CountdownWatcher watcher = new ClientBase.CountdownWatcher();
+        ClientBase.StateWatcher watcher = new ClientBase.StateWatcher();
         try {
             cnxString = "127.0.0.1:" + qu.getPeer(1).peer.getClientPort();
             if (zkAdmin != null) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigMisconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigMisconfigTest.java
@@ -98,7 +98,7 @@ public class ReconfigMisconfigTest extends ZKTestCase {
 
     private void instantiateZKAdmin() throws InterruptedException {
         String cnxString;
-        ClientBase.CountdownWatcher watcher = new ClientBase.CountdownWatcher();
+        ClientBase.StateWatcher watcher = new ClientBase.StateWatcher();
         try {
             cnxString = "127.0.0.1:" + qu.getPeer(1).peer.getClientPort();
             zkAdmin = new ZooKeeperAdmin(cnxString, ClientBase.CONNECTION_TIMEOUT, watcher);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SSLAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SSLAuthTest.java
@@ -96,7 +96,7 @@ public class SSLAuthTest extends ClientBase {
 
         // Handshake will take place, and then X509AuthenticationProvider should reject the untrusted cert
         new TestableZooKeeper(hostPort, CONNECTION_TIMEOUT, watcher);
-        assertFalse(watcher.clientConnected.await(1000, TimeUnit.MILLISECONDS), "Untrusted certificate should not result in successful connection");
+        assertFalse(watcher.awaitConnected(1000), "Untrusted certificate should not result in successful connection");
     }
 
     @Test
@@ -109,7 +109,7 @@ public class SSLAuthTest extends ClientBase {
 
         CountdownWatcher watcher = new CountdownWatcher();
         new TestableZooKeeper(hostPort, CONNECTION_TIMEOUT, watcher);
-        assertFalse(watcher.clientConnected.await(1000, TimeUnit.MILLISECONDS), "Missing SSL configuration should not result in successful connection");
+        assertFalse(watcher.awaitConnected(1000), "Missing SSL configuration should not result in successful connection");
     }
 
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SSLAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SSLAuthTest.java
@@ -20,7 +20,6 @@ package org.apache.zookeeper.test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.net.InetSocketAddress;
-import java.util.concurrent.TimeUnit;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.TestableZooKeeper;
 import org.apache.zookeeper.client.ZKClientConfig;
@@ -92,7 +91,7 @@ public class SSLAuthTest extends ClientBase {
                                                                                     + "/ssl/testUntrustedKeyStore.jks");
         System.setProperty(clientX509Util.getSslKeystorePasswdProperty(), "testpass");
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
 
         // Handshake will take place, and then X509AuthenticationProvider should reject the untrusted cert
         new TestableZooKeeper(hostPort, CONNECTION_TIMEOUT, watcher);
@@ -107,7 +106,7 @@ public class SSLAuthTest extends ClientBase {
         System.clearProperty(clientX509Util.getSslTruststoreLocationProperty());
         System.clearProperty(clientX509Util.getSslTruststorePasswdProperty());
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         new TestableZooKeeper(hostPort, CONNECTION_TIMEOUT, watcher);
         assertFalse(watcher.awaitConnected(1000), "Missing SSL configuration should not result in successful connection");
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthDesignatedServerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthDesignatedServerTest.java
@@ -58,7 +58,7 @@ public class SaslAuthDesignatedServerTest extends ClientBase {
 
     private AtomicInteger authFailed = new AtomicInteger(0);
 
-    private class MyWatcher extends CountdownWatcher {
+    private class MyWatcher extends StateWatcher {
 
         volatile CountDownLatch authCompleted;
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthFailDesignatedClientTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthFailDesignatedClientTest.java
@@ -72,7 +72,7 @@ public class SaslAuthFailDesignatedClientTest extends ClientBase {
         // JMXEnv.ensureAll is called which will fail the test case
         CountdownWatcher watcher = new CountdownWatcher();
         TestableZooKeeper zk = new TestableZooKeeper(hostPort, CONNECTION_TIMEOUT, watcher);
-        if (!watcher.clientConnected.await(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)) {
+        if (!watcher.awaitConnected(CONNECTION_TIMEOUT)) {
             fail("Unable to connect to server");
         }
         try {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthFailDesignatedClientTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthFailDesignatedClientTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.TestableZooKeeper;
@@ -70,7 +69,7 @@ public class SaslAuthFailDesignatedClientTest extends ClientBase {
     public void testAuth() throws Exception {
         // Cannot use createClient here because server may close session before
         // JMXEnv.ensureAll is called which will fail the test case
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         TestableZooKeeper zk = new TestableZooKeeper(hostPort, CONNECTION_TIMEOUT, watcher);
         if (!watcher.awaitConnected(CONNECTION_TIMEOUT)) {
             fail("Unable to connect to server");

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthFailTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthFailTest.java
@@ -62,7 +62,7 @@ public class SaslAuthFailTest extends ClientBase {
 
     private CountDownLatch authFailed = new CountDownLatch(1);
 
-    private class MyWatcher extends CountdownWatcher {
+    private class MyWatcher extends StateWatcher {
 
         @Override
         public synchronized void process(WatchedEvent event) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthRequiredFailNoSASLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthRequiredFailNoSASLTest.java
@@ -45,7 +45,7 @@ public class SaslAuthRequiredFailNoSASLTest extends ClientBase {
     @Test
     public void testClientOpWithoutSASLConfigured() throws Exception {
         ZooKeeper zk = null;
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         try {
             zk = createClient(watcher);
             zk.create("/foo", null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthRequiredFailWrongSASLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthRequiredFailWrongSASLTest.java
@@ -47,7 +47,7 @@ public class SaslAuthRequiredFailWrongSASLTest extends ClientBase {
     @Test
     public void testClientOpWithFailedSASLAuth() throws Exception {
         ZooKeeper zk = null;
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         try {
             zk = createClient(watcher);
             zk.create("/bar", null, Ids.CREATOR_ALL_ACL, CreateMode.PERSISTENT);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthRequiredTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslAuthRequiredTest.java
@@ -46,7 +46,7 @@ public class SaslAuthRequiredTest extends ClientBase {
     @Test
     public void testClientOpWithValidSASLAuth() throws Exception {
         ZooKeeper zk = null;
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         try {
             zk = createClient(watcher);
             zk.create("/foobar", null, Ids.CREATOR_ALL_ACL, CreateMode.PERSISTENT);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslSuperUserTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslSuperUserTest.java
@@ -104,7 +104,7 @@ public class SaslSuperUserTest extends ClientBase {
         return createClient(watcher, hp);
     }
 
-    private class MyWatcher extends CountdownWatcher {
+    private class MyWatcher extends StateWatcher {
 
         @Override
         public synchronized void process(WatchedEvent event) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/SessionUpgradeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/SessionUpgradeTest.java
@@ -26,7 +26,7 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,7 +81,7 @@ public class SessionUpgradeTest extends ZKTestCase {
         int otherFollowerIdx = (leaderIdx + 2) % 5;
         int testPeerIdx = testLeader ? leaderIdx : followerIdx;
         String[] hostPorts = qb.hostPort.split(",");
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         DisconnectableZooKeeper zk = new DisconnectableZooKeeper(hostPorts[testPeerIdx], CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(CONNECTION_TIMEOUT);
 
@@ -162,7 +162,7 @@ public class SessionUpgradeTest extends ZKTestCase {
         int testPeerIdx = testLeader ? leaderIdx : followerIdx;
         String[] hostPorts = qb.hostPort.split(",");
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         DisconnectableZooKeeper zk = new DisconnectableZooKeeper(hostPorts[testPeerIdx], CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(CONNECTION_TIMEOUT);
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/StandaloneTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/StandaloneTest.java
@@ -35,7 +35,7 @@ import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -132,7 +132,7 @@ public class StandaloneTest extends QuorumPeerTestBase implements Watcher {
         f.startup(zks);
         assertTrue(ClientBase.waitForServerUp(HOSTPORT, CONNECTION_TIMEOUT), "waiting for server being up ");
 
-        CountdownWatcher watcher = new CountdownWatcher();
+        StateWatcher watcher = new StateWatcher();
         ZooKeeper zk = new ZooKeeper(HOSTPORT, CONNECTION_TIMEOUT, watcher);
         ZooKeeperAdmin zkAdmin = new ZooKeeperAdmin(HOSTPORT, CONNECTION_TIMEOUT, watcher);
         watcher.waitForConnected(CONNECTION_TIMEOUT);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/WatchEventWhenAutoResetTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/WatchEventWhenAutoResetTest.java
@@ -32,7 +32,7 @@ import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
-import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
+import org.apache.zookeeper.test.ClientBase.StateWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,7 +49,7 @@ public class WatchEventWhenAutoResetTest extends ZKTestCase {
     private EventsWatcher watcher;
     private ZooKeeper zk1, zk2;
 
-    public static class EventsWatcher extends CountdownWatcher {
+    public static class EventsWatcher extends StateWatcher {
 
         private LinkedBlockingQueue<WatchedEvent> dataEvents = new LinkedBlockingQueue<WatchedEvent>();
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/WatcherTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/WatcherTest.java
@@ -61,7 +61,7 @@ public class WatcherTest extends ClientBase {
 
     }
 
-    private class MyWatcher extends CountdownWatcher {
+    private class MyWatcher extends StateWatcher {
 
         LinkedBlockingQueue<WatchedEvent> events = new LinkedBlockingQueue<WatchedEvent>();
 


### PR DESCRIPTION
Some refactoring and cleanup, followed by the fix - client wasn't properly shut down between tests so occasionally they contaminated each other with unwanted events.