### PR TITLE
ZOOKEEPER-4276: Support setupQuorumPeerConfig only with secureClientPort

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -759,14 +759,14 @@ public class QuorumPeerConfig {
             qs.isClientAddrFromStatic = true;
             return;
         }
-        if (clientPortAddress != null &&
-            ((!clientPortAddress.getAddress().isAnyLocalAddress() && clientPortAddress.equals(qs.clientAddr)) ||
-                (clientPortAddress.getAddress().isAnyLocalAddress() && clientPortAddress.getPort() == qs.clientAddr.getPort()))) {
+        if (clientPortAddress != null
+            && ((!clientPortAddress.getAddress().isAnyLocalAddress() && clientPortAddress.equals(qs.clientAddr))
+                || (clientPortAddress.getAddress().isAnyLocalAddress() && clientPortAddress.getPort() == qs.clientAddr.getPort()))) {
             return;
         }
-        if (secureClientPortAddress != null &&
-            ((!secureClientPortAddress.getAddress().isAnyLocalAddress() && secureClientPortAddress.equals(qs.clientAddr)) ||
-                (secureClientPortAddress.getAddress().isAnyLocalAddress() && secureClientPortAddress.getPort() == qs.clientAddr.getPort()))) {
+        if (secureClientPortAddress != null
+            && ((!secureClientPortAddress.getAddress().isAnyLocalAddress() && secureClientPortAddress.equals(qs.clientAddr))
+                || (secureClientPortAddress.getAddress().isAnyLocalAddress() && secureClientPortAddress.getPort() == qs.clientAddr.getPort()))) {
             return;
         }
         throw new ConfigException(

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -747,22 +747,32 @@ public class QuorumPeerConfig {
             return;
         }
         QuorumServer qs = quorumVerifier.getAllMembers().get(serverId);
-        if (clientPortAddress != null && qs != null && qs.clientAddr != null) {
-            if ((!clientPortAddress.getAddress().isAnyLocalAddress() && !clientPortAddress.equals(qs.clientAddr)) || (
-                clientPortAddress.getAddress().isAnyLocalAddress()
-                && clientPortAddress.getPort() != qs.clientAddr.getPort())) {
-                throw new ConfigException("client address for this server (id = " + serverId
-                                          + ") in static config file is " + clientPortAddress
-                                          + " is different from client address found in dynamic file: " + qs.clientAddr);
-            }
+        if (qs == null) {
+            return;
         }
-        if (qs != null && qs.clientAddr != null) {
+        if (clientPortAddress == null && secureClientPortAddress == null && qs.clientAddr != null) {
             clientPortAddress = qs.clientAddr;
+            return;
         }
-        if (qs != null && qs.clientAddr == null) {
+        if (qs.clientAddr == null && clientPortAddress != null) {
             qs.clientAddr = clientPortAddress;
             qs.isClientAddrFromStatic = true;
+            return;
         }
+        if (clientPortAddress != null &&
+            ((!clientPortAddress.getAddress().isAnyLocalAddress() && clientPortAddress.equals(qs.clientAddr)) ||
+                (clientPortAddress.getAddress().isAnyLocalAddress() && clientPortAddress.getPort() == qs.clientAddr.getPort()))) {
+            return;
+        }
+        if (secureClientPortAddress != null &&
+            ((!secureClientPortAddress.getAddress().isAnyLocalAddress() && secureClientPortAddress.equals(qs.clientAddr)) ||
+                (secureClientPortAddress.getAddress().isAnyLocalAddress() && secureClientPortAddress.getPort() == qs.clientAddr.getPort()))) {
+            return;
+        }
+        throw new ConfigException(
+            "client address for this server (id = " + serverId + ") in static config file is "
+                + (clientPortAddress != null ? clientPortAddress : secureClientPortAddress)
+                + " is different from client address found in dynamic file: " + qs.clientAddr);
     }
 
     private void setupPeerType() {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerConfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerConfigTest.java
@@ -99,6 +99,8 @@ public class QuorumPeerConfigTest {
                 fail("ConfigException is expected");
             } catch (ConfigException e) {
                 assertNotNull(e.getMessage());
+            } finally {
+                System.clearProperty(x509Util.getSslAuthProviderProperty());
             }
         }
     }
@@ -195,6 +197,106 @@ public class QuorumPeerConfigTest {
         try {
             quorumPeerConfig.parseProperties(zkProp);
             fail("Must throw exception as 'yes' is not accpetable for parseBoolean!");
+        } catch (ConfigException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Test case for https://issues.apache.rog/jira/browse/ZOOKEEPER-4276
+     */
+    @Test
+    public void testSetupQuorumPeerConfig() throws IOException, ConfigException {
+        long serverId = 1;
+        QuorumPeerConfig quorumPeerConfig = new MockQuorumPeerConfig(serverId);
+        Properties zkProp = getDefaultZKProperties();
+        zkProp.setProperty("clientPort", "2181");
+        quorumPeerConfig.parseProperties(zkProp);
+        Properties dynamicZkProp = new Properties();
+        dynamicZkProp.setProperty("server.1", "localhost:2888:3888;2181");
+        quorumPeerConfig.setupQuorumPeerConfig(dynamicZkProp, false);
+    }
+
+    /**
+     * Test case for https://issues.apache.rog/jira/browse/ZOOKEEPER-4276
+     */
+    @Test
+    public void testSetupQuorumPeerConfigOnlyWithSecureClient() throws IOException, ConfigException {
+        long serverId = 1;
+        QuorumPeerConfig quorumPeerConfig = new MockQuorumPeerConfig(serverId);
+        Properties zkProp = getDefaultZKProperties();
+        zkProp.setProperty("secureClientPort", "12345");
+        quorumPeerConfig.parseProperties(zkProp);
+        Properties dynamicZkProp = new Properties();
+        dynamicZkProp.setProperty("server.1", "localhost:2888:3888;12345");
+        quorumPeerConfig.setupQuorumPeerConfig(dynamicZkProp, false);
+    }
+
+    /**
+     * Test case for https://issues.apache.rog/jira/browse/ZOOKEEPER-4276
+     */
+    @Test
+    public void testSetupQuorumPeerConfigWithBothClients() throws IOException, ConfigException {
+        long serverId = 1;
+        QuorumPeerConfig quorumPeerConfig = new MockQuorumPeerConfig(serverId);
+        Properties zkProp = getDefaultZKProperties();
+        zkProp.setProperty("clientPort", "2181");
+        zkProp.setProperty("secureClientPort", "12345");
+        quorumPeerConfig.parseProperties(zkProp);
+        Properties dynamicZkProp = new Properties();
+        dynamicZkProp.setProperty("server.1", "localhost:2888:3888;2181");
+        quorumPeerConfig.setupQuorumPeerConfig(dynamicZkProp, false);
+    }
+
+    /**
+     * Test case for https://issues.apache.rog/jira/browse/ZOOKEEPER-4276
+     */
+    @Test
+    public void testSetupQuorumPeerConfigWithBothClientsAndSecurePort() throws IOException, ConfigException {
+        long serverId = 1;
+        QuorumPeerConfig quorumPeerConfig = new MockQuorumPeerConfig(serverId);
+        Properties zkProp = getDefaultZKProperties();
+        zkProp.setProperty("clientPort", "2181");
+        zkProp.setProperty("secureClientPort", "12345");
+        quorumPeerConfig.parseProperties(zkProp);
+        Properties dynamicZkProp = new Properties();
+        dynamicZkProp.setProperty("server.1", "localhost:2888:3888;12345");
+        quorumPeerConfig.setupQuorumPeerConfig(dynamicZkProp, false);
+    }
+
+    /**
+     * Test case for https://issues.apache.rog/jira/browse/ZOOKEEPER-4276
+     */
+    @Test
+    public void testSetupQuorumPeerConfigFromStatic() throws IOException,
+        ConfigException {
+        long serverId = 1;
+        QuorumPeerConfig quorumPeerConfig = new MockQuorumPeerConfig(serverId);
+        Properties zkProp = getDefaultZKProperties();
+        zkProp.setProperty("clientPort", "2181");
+        quorumPeerConfig.parseProperties(zkProp);
+        Properties dynamicZkProp = new Properties();
+        dynamicZkProp.setProperty("server.1", "localhost:2888:3888");
+        quorumPeerConfig.setupQuorumPeerConfig(dynamicZkProp, false);
+        assertTrue(quorumPeerConfig.getQuorumVerifier().getAllMembers().get(serverId).isClientAddrFromStatic);
+    }
+
+    /**
+     * Test case for https://issues.apache.rog/jira/browse/ZOOKEEPER-4276
+     */
+    @Test
+    public void testSetupQuorumPeerConfigWithDifferentPorts() throws IOException, ConfigException {
+        long serverId = 1;
+        QuorumPeerConfig quorumPeerConfig = new MockQuorumPeerConfig(serverId);
+        Properties zkProp = getDefaultZKProperties();
+        zkProp.setProperty("clientPort", "2181");
+        zkProp.setProperty("secureClientPort", "12345");
+        quorumPeerConfig.parseProperties(zkProp);
+        Properties dynamicZkProp = new Properties();
+        dynamicZkProp.setProperty("server.1", "localhost:2888:3888;12181");
+        try {
+            quorumPeerConfig.setupQuorumPeerConfig(dynamicZkProp, false);
+            fail("Mus throw exception with different QuorumPeerConfig Ports");
         } catch (ConfigException e) {
             // expected
         }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerConfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerConfigTest.java
@@ -296,7 +296,7 @@ public class QuorumPeerConfigTest {
         dynamicZkProp.setProperty("server.1", "localhost:2888:3888;12181");
         try {
             quorumPeerConfig.setupQuorumPeerConfig(dynamicZkProp, false);
-            fail("Mus throw exception with different QuorumPeerConfig Ports");
+            fail("Must throw exception with different QuorumPeerConfig Ports");
         } catch (ConfigException e) {
             // expected
         }


### PR DESCRIPTION
clientPort in zoo.cfg is forcefully complemented from client address by QuorumPeerConfig#setupClientPort even though secureClientPort is set and matches with client address' port.
Because of this behavior, in case rolling update with replacing clientPort to secureClientPort in the same port number following [Upgrading existing non-TLS cluster with no downtime](https://zookeeper.apache.org/doc/r3.7.0/zookeeperAdmin.html#Upgrading+existing+nonTLS+cluster) conflicts and gets errors below.

```
2021-03-29 23:21:58,638 - INFO  [main:NettyServerCnxnFactory@590] - binding to port /0.0.0.0:2181
2021-03-29 23:21:58,748 - INFO  [main:NettyServerCnxnFactory@595] - bound to port 2181
2021-03-29 23:21:58,749 - INFO  [main:NettyServerCnxnFactory@590] - binding to port 0.0.0.0/0.0.0.0:2181
2021-03-29 23:21:58,753 - ERROR [main:QuorumPeerMain@101] - Unexpected exception, exiting abnormally
java.net.BindException: Address already in use
```

This PR makes clientPort complement by QuorumPeerConfig#setupClientPort only when both clientPort and secureClientPort are empty, and allow serving zookeeper server only with secure client port.