### PR TITLE
ZOOKEEPER-4265: Fix broken links (some files have been archived) & terminology

### DIFF
--- a/src/main/resources/markdown/releases.md
+++ b/src/main/resources/markdown/releases.md
@@ -24,7 +24,7 @@ The Apache ZooKeeper system for distributed coordination is a high-performance s
 <a name="download"></a>
 ## Download
 
-Apache ZooKeeper 3.7.0 is our latest stable release.
+Apache ZooKeeper 3.7.0 is our current release, and 3.6.2 our latest stable release.
 
 ### Apache ZooKeeper 3.7.0
 
@@ -32,28 +32,21 @@ Apache ZooKeeper 3.7.0 is our latest stable release.
 
 [Apache ZooKeeper 3.7.0 Source Release](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.7.0/apache-zookeeper-3.7.0.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.7.0/apache-zookeeper-3.7.0.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.7.0/apache-zookeeper-3.7.0.tar.gz.sha512))
 
----
-
-Older releases are available.
-
 ### Apache ZooKeeper 3.6.2
 
 [Apache ZooKeeper 3.6.2](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.6.2/apache-zookeeper-3.6.2-bin.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.6.2/apache-zookeeper-3.6.2-bin.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.6.2/apache-zookeeper-3.6.2-bin.tar.gz.sha512))
 
 [Apache ZooKeeper 3.6.2 Source Release](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.6.2/apache-zookeeper-3.6.2.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.6.2/apache-zookeeper-3.6.2.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.6.2/apache-zookeeper-3.6.2.tar.gz.sha512))
 
-### Apache ZooKeeper 3.6.1
-
-[Apache ZooKeeper 3.6.1](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.6.1/apache-zookeeper-3.6.1-bin.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.6.1/apache-zookeeper-3.6.1-bin.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.6.1/apache-zookeeper-3.6.1-bin.tar.gz.sha512))
-
-[Apache ZooKeeper 3.6.1 Source Release](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.6.1/apache-zookeeper-3.6.1.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.6.1/apache-zookeeper-3.6.1.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.6.1/apache-zookeeper-3.6.1.tar.gz.sha512))
-
-
 ### Apache ZooKeeper 3.5.9
 
 [Apache ZooKeeper 3.5.9](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.5.9/apache-zookeeper-3.5.9-bin.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.5.9/apache-zookeeper-3.5.9-bin.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.5.9/apache-zookeeper-3.5.9-bin.tar.gz.sha512))
 
 [Apache ZooKeeper 3.5.9 Source Release](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.5.9/apache-zookeeper-3.5.9.tar.gz)([asc](https://downloads.apache.org/zookeeper/zookeeper-3.5.9/apache-zookeeper-3.5.9.tar.gz.asc), [sha512](https://downloads.apache.org/zookeeper/zookeeper-3.5.9/apache-zookeeper-3.5.9.tar.gz.sha512))
+
+---
+
+Older releases are available [in the archive](https://archive.apache.org/dist/zookeeper/).
 
 <a name="verifying"></a>
 ## Verifying Hashes and Signatures


### PR DESCRIPTION
The 3.5.9 release has been restored in SVN, as we currently have three active branches/release lines: 3.5, 3.6 and 3.7.

This commit removes 3.6.1 from the releases page, as it has been archived and 3.6.2 is a straightforward upgrade.

It also clears up some terminology and adds a link to the archive.
