### PR TITLE
ZOOKEEPER-4247: NPE while processing message from restarted quorum member

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -520,8 +520,12 @@ public class NettyServerCnxn extends ServerCnxn {
                         if (len < 0 || len > BinaryInputArchive.maxBuffer) {
                             throw new IOException("Len error " + len);
                         }
-                        // checkRequestSize will throw IOException if request is rejected
-                        zkServer.checkRequestSizeWhenReceivingMessage(len);
+                        if (zkServer == null || !zkServer.isRunning()) {
+                            throw new IOException("ZK down");
+                        } else {
+                            // checkRequestSize will throw IOException if request is rejected
+                            zkServer.checkRequestSizeWhenReceivingMessage(len);
+                        }
                         bb = ByteBuffer.allocate(len);
                     }
                 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -520,11 +520,12 @@ public class NettyServerCnxn extends ServerCnxn {
                         if (len < 0 || len > BinaryInputArchive.maxBuffer) {
                             throw new IOException("Len error " + len);
                         }
-                        if (zkServer == null || !zkServer.isRunning()) {
+                        ZooKeeperServer zks = this.zkServer;
+                        if (zks == null || !zks.isRunning()) {
                             throw new IOException("ZK down");
                         }
                         // checkRequestSize will throw IOException if request is rejected
-                        zkServer.checkRequestSizeWhenReceivingMessage(len);
+                        zks.checkRequestSizeWhenReceivingMessage(len);
                         bb = ByteBuffer.allocate(len);
                     }
                 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -522,10 +522,9 @@ public class NettyServerCnxn extends ServerCnxn {
                         }
                         if (zkServer == null || !zkServer.isRunning()) {
                             throw new IOException("ZK down");
-                        } else {
-                            // checkRequestSize will throw IOException if request is rejected
-                            zkServer.checkRequestSizeWhenReceivingMessage(len);
                         }
+                        // checkRequestSize will throw IOException if request is rejected
+                        zkServer.checkRequestSizeWhenReceivingMessage(len);
                         bb = ByteBuffer.allocate(len);
                     }
                 }


### PR DESCRIPTION
When a ZooKeeper server realizes that an other quorum peer was shut down (e.g. during a rolling upgrade or
rolling restart), the ServerCnxn.zkServer variable is set to null by QuorumPear.close(). This is why in the code
we usually check the zkServer variable before using it. But this check was missing in one place thus causing 
NPE in NettyServerCnx.receiveMessage:

```
2021-02-08T12:42:08.229+0000 [myid:] - ERROR 
[nioEventLoopGroup-4-1:NettyServerCnxnFactory$CnxnChannelHandler@329]- Unexpected exception in receive
 java.lang.NullPointerException: null ~[zookeeper-3.6.2.jar:3.6.2]
 at org.apache.zookeeper.server.NettyServerCnxn.receiveMessage(NettyServerCnxn.java:518) 
 at org.apache.zookeeper.server.NettyServerCnxn.processMessage(NettyServerCnxn.java:368) 
 at org.apache.zookeeper.server.NettyServerCnxnFactory
        $CnxnChannelHandler.channelRead(NettyServerCnxnFactory.java:326)
...
```

In this commit we add the necessary check and (after throwing an IOException) we will basically ignore the 
processing of the received message when the remote ZooKeeper server is already down.