### PR TITLE
ZOOKEEPER-4281: Allow packet of max packet length to be deserialized

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocket.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocket.java
@@ -117,7 +117,7 @@ abstract class ClientCnxnSocket {
 
     void readLength() throws IOException {
         int len = incomingBuffer.getInt();
-        if (len < 0 || len >= packetLen) {
+        if (len < 0 || len > packetLen) {
             throw new IOException("Packet len " + len + " is out of range!");
         }
         incomingBuffer = ByteBuffer.allocate(len);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ClientCnxnSocketTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ClientCnxnSocketTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
@@ -63,4 +64,30 @@ public class ClientCnxnSocketTest {
 
     }
 
+    /*
+     * Tests readLength():
+     * 1. successfully read packet if length == jute.maxbuffer;
+     * 2. IOException is thrown if packet length is greater than jute.maxbuffer.
+     */
+    @Test
+    public void testIOExceptionIsThrownWhenPacketLenExceedsJuteMaxBuffer() throws IOException {
+        ClientCnxnSocket clientCnxnSocket = new ClientCnxnSocketNIO(new ZKClientConfig());
+
+        // Should successfully read packet length == jute.maxbuffer
+        int length = ZKClientConfig.CLIENT_MAX_PACKET_LENGTH_DEFAULT;
+        clientCnxnSocket.incomingBuffer.putInt(length);
+        clientCnxnSocket.incomingBuffer.rewind();
+        clientCnxnSocket.readLength();
+
+        // Failed to read packet length > jute.maxbuffer
+        length = ZKClientConfig.CLIENT_MAX_PACKET_LENGTH_DEFAULT + 1;
+        clientCnxnSocket.incomingBuffer.putInt(length);
+        clientCnxnSocket.incomingBuffer.rewind();
+        try {
+            clientCnxnSocket.readLength();
+            fail("IOException is expected.");
+        } catch (IOException e) {
+            assertEquals("Packet len " + length + " is out of range!", e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
### Problem
Resolves https://issues.apache.org/jira/browse/ZOOKEEPER-4281

There are sanity checks for packet size when deserializing a packet. One place has the inclusion: len >= packetLen.  It rejects to deserialize the bytes that are exactly sized jute.maxbuffer. It's confusing. This check should use ">" so the maxbuffer length packet can still be deserialized, like the other checks.
```
if (len < 0 || len >= packetLen) {
    throw new IOException("Packet len " + len + " is out of range!");
}
```

### Solution
Change: `len >= packetLen`   ->  `len > packetLen`
```
if (len < 0 || len > packetLen) {
```