### PR TITLE
ZOOKEEPER-4235 Java Client SendThread does not clean up created objects during constructor of SaslClient and Login

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -1148,8 +1148,9 @@ public class ClientCnxn {
                     if (zooKeeperSaslClient != null) {
                         zooKeeperSaslClient.shutdown();
                     }
-                    zooKeeperSaslClient = new ZooKeeperSaslClient(clientConfig);
-                    zooKeeperSaslClient.createSaslClient(SaslServerPrincipal.getServerPrincipal(addr, clientConfig));
+                    zooKeeperSaslClient = new ZooKeeperSaslClient(SaslServerPrincipal.getServerPrincipal(addr,
+                        clientConfig), clientConfig);
+                    zooKeeperSaslClient.createSaslClient();
                 } catch (LoginException e) {
                     // An authentication error occurred when the SASL client tried to initialize:
                     // for Kerberos this means that the client failed to authenticate with the KDC.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -1148,7 +1148,8 @@ public class ClientCnxn {
                     if (zooKeeperSaslClient != null) {
                         zooKeeperSaslClient.shutdown();
                     }
-                    zooKeeperSaslClient = new ZooKeeperSaslClient(SaslServerPrincipal.getServerPrincipal(addr, clientConfig), clientConfig);
+                    zooKeeperSaslClient = new ZooKeeperSaslClient(clientConfig);
+                    zooKeeperSaslClient.createSaslClient(SaslServerPrincipal.getServerPrincipal(addr, clientConfig));
                 } catch (LoginException e) {
                     // An authentication error occurred when the SASL client tried to initialize:
                     // for Kerberos this means that the client failed to authenticate with the KDC.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Login.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Login.java
@@ -67,6 +67,7 @@ public class Login {
 
     private Subject subject = null;
     private Thread t = null;
+    private final Object loginThreadLock = new Object();
     private Boolean loginThreadCancelled = false;
     private boolean isKrbTicket = false;
     private boolean isUsingTicketCache = false;
@@ -282,7 +283,7 @@ public class Login {
     }
 
     public void startThreadIfNeeded() {
-        synchronized (loginThreadCancelled) {
+        synchronized (loginThreadLock) {
             if (loginThreadCancelled) {
                 return;
             }
@@ -294,7 +295,7 @@ public class Login {
     }
 
     public void shutdown() {
-        synchronized (loginThreadCancelled) {
+        synchronized (loginThreadLock) {
             if ((t != null) && (t.isAlive())) {
                 t.interrupt();
                 try {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Login.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Login.java
@@ -282,9 +282,6 @@ public class Login {
     }
 
     public void startThreadIfNeeded() {
-        if (loginThreadCancelled) {
-            return;
-        }
         synchronized (loginThreadCancelled) {
             if (loginThreadCancelled) {
                 return;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Login.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Login.java
@@ -272,25 +272,22 @@ public class Login {
             // if no TGT, do not bother with ticket management.
             return;
         }
-
-        // Refresh the Ticket Granting Ticket (TGT) periodically. How often to refresh is determined by the
-        // TGT's existing expiry date and the configured MIN_TIME_BEFORE_RELOGIN. For testing and development,
-        // you can decrease the interval of expiration of tickets (for example, to 3 minutes) by running :
-        //  "modprinc -maxlife 3mins <principal>" in kadmin.
-        t = new Thread(new LoginRunnable());
-        t.setDaemon(true);
-        t.start();
+        startLoginThread();
     }
 
-    public void startThreadIfNeeded() {
+    private void startLoginThread() {
+        // Start the thread only if not canceled before reaching here.
         synchronized (loginThreadLock) {
             if (loginThreadCancelled) {
                 return;
             }
-            // thread object 't' will be null if a refresh thread is not needed.
-            if (t != null) {
-                t.start();
-            }
+            // Refresh the Ticket Granting Ticket (TGT) periodically. How often to refresh is determined by the
+            // TGT's existing expiry date and the configured MIN_TIME_BEFORE_RELOGIN. For testing and development,
+            // you can decrease the interval of expiration of tickets (for example, to 3 minutes) by running :
+            //  "modprinc -maxlife 3mins <principal>" in kadmin.
+            t = new Thread(new LoginRunnable());
+            t.setDaemon(true);
+            t.start();
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java
@@ -85,6 +85,7 @@ public class ZooKeeperSaslClient {
     private SaslClient saslClient;
     private boolean isSASLConfigured = true;
     private final ZKClientConfig clientConfig;
+    private final String serverPrincipal;
 
     private byte[] saslToken = new byte[0];
 
@@ -112,11 +113,12 @@ public class ZooKeeperSaslClient {
         return null;
     }
 
-    public ZooKeeperSaslClient(ZKClientConfig clientConfig) throws LoginException {
+    public ZooKeeperSaslClient(final String serverPrincipal, ZKClientConfig clientConfig) throws LoginException {
+        this.serverPrincipal = serverPrincipal;
         this.clientConfig = clientConfig;
     }
 
-    public void createSaslClient(final String serverPrincipal) throws LoginException {
+    public void createSaslClient() throws LoginException {
         /**
          * ZOOKEEPER-1373: allow system property to specify the JAAS
          * configuration section that the zookeeper client should use.
@@ -235,7 +237,8 @@ public class ZooKeeperSaslClient {
 
     }
 
-    private SaslClient createSaslClient(
+    private SaslClient createSaslClient
+        (
         final String servicePrincipal,
         final String loginContext) throws LoginException {
         try {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java
@@ -99,7 +99,7 @@ public class ZooKeeperSaslClient {
 
     private boolean gotLastPacket = false;
     /** informational message indicating the current configuration status */
-    private final String configStatus;
+    private String configStatus;
 
     public SaslState getSaslState() {
         return saslState;
@@ -112,14 +112,17 @@ public class ZooKeeperSaslClient {
         return null;
     }
 
-    public ZooKeeperSaslClient(final String serverPrincipal, ZKClientConfig clientConfig) throws LoginException {
+    public ZooKeeperSaslClient(ZKClientConfig clientConfig) throws LoginException {
+        this.clientConfig = clientConfig;
+    }
+
+    public void createSaslClient(final String serverPrincipal) throws LoginException {
         /**
          * ZOOKEEPER-1373: allow system property to specify the JAAS
          * configuration section that the zookeeper client should use.
          * Default to "Client".
          */
         String clientSection = clientConfig.getProperty(ZKClientConfig.LOGIN_CONTEXT_NAME_KEY, ZKClientConfig.LOGIN_CONTEXT_NAME_KEY_DEFAULT);
-        this.clientConfig = clientConfig;
         // Note that 'Configuration' here refers to javax.security.auth.login.Configuration.
         AppConfigurationEntry[] entries = null;
         RuntimeException runtimeException = null;
@@ -243,7 +246,7 @@ public class ZooKeeperSaslClient {
                         // note that the login object is static: it's shared amongst all zookeeper-related connections.
                         // in order to ensure the login is initialized only once, it must be synchronized the code snippet.
                         login = new Login(loginContext, new SaslClientCallbackHandler(null, "Client"), clientConfig);
-                        login.startThreadIfNeeded();
+                        login.loginAndStartThreadIfRequired();
                         initializedLogin = true;
                     }
                 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerCnxnFactory.java
@@ -271,8 +271,8 @@ public abstract class ServerCnxnFactory {
         try {
             saslServerCallbackHandler = new SaslServerCallbackHandler(Configuration.getConfiguration());
             login = new Login(serverSection, saslServerCallbackHandler, new ZKConfig());
+            login.loginAndStartThreadIfRequired();
             setLoginUser(login.getUserName());
-            login.startThreadIfNeeded();
         } catch (LoginException e) {
             throw new IOException("Could not configure server because SASL configuration did not allow the "
                                   + " ZooKeeper server to authenticate itself properly: "

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/auth/SaslQuorumAuthLearner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/auth/SaslQuorumAuthLearner.java
@@ -66,7 +66,7 @@ public class SaslQuorumAuthLearner implements QuorumAuthLearner {
                 loginContext,
                 new SaslClientCallbackHandler(null, "QuorumLearner"),
                 new ZKConfig());
-            this.learnerLogin.startThreadIfNeeded();
+            this.learnerLogin.loginAndStartThreadIfRequired();
         } catch (LoginException e) {
             throw new SaslException("Failed to initialize authentication mechanism using SASL", e);
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/auth/SaslQuorumAuthServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/auth/SaslQuorumAuthServer.java
@@ -58,7 +58,7 @@ public class SaslQuorumAuthServer implements QuorumAuthServer {
             SaslQuorumServerCallbackHandler saslServerCallbackHandler = new SaslQuorumServerCallbackHandler(
                 Configuration.getConfiguration(), loginContext, authzHosts);
             serverLogin = new Login(loginContext, saslServerCallbackHandler, new ZKConfig());
-            serverLogin.startThreadIfNeeded();
+            serverLogin.loginAndStartThreadIfRequired();
         } catch (Throwable e) {
             throw new SaslException("Failed to initialize authentication mechanism using SASL", e);
         }


### PR DESCRIPTION
Change Description - Move initialization of ZookeeperSaslClient & Login to instance methods.

- Moved ZookeeperSaslClient's initialization from constructor to  instance method createSaslClient()
- Moved Login's initialization from constructor to an instance method loginAndStartThreadIfRequired()
- Moved the anonymous Runnable implementation of login thread to LoginRunnable inner class.