### PR TITLE
ZOOKEEPER-4296: Add null checks to ClientCnxnSocketNetty onClosing

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
@@ -244,7 +244,9 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
 
     @Override
     void onClosing() {
-        firstConnect.countDown();
+        if (firstConnect != null) {
+            firstConnect.countDown();
+        }
         wakeupCnxn();
         LOG.info("channel is told closing");
     }
@@ -253,7 +255,9 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
         if (needSasl.get()) {
             waitSasl.release();
         }
-        outgoingQueue.add(WakeupPacket.getInstance());
+        if (outgoingQueue != null) {
+          outgoingQueue.add(WakeupPacket.getInstance());
+        }
     }
 
     @Override

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ClientCnxnSocketTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ClientCnxnSocketTest.java
@@ -97,7 +97,7 @@ public class ClientCnxnSocketTest {
         final ClientCnxnSocketNetty clientCnxnSocket = new ClientCnxnSocketNetty(clientConfig);
         // Should not throw
         clientCnxnSocket.close();
-        // Call onClosing explicitly since it otherwise won't be invoked without more setup. 
+        // Call onClosing explicitly since it otherwise won't be invoked without more setup.
         clientCnxnSocket.onClosing();
     }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ClientCnxnSocketTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ClientCnxnSocketTest.java
@@ -96,7 +96,8 @@ public class ClientCnxnSocketTest {
         ZKClientConfig clientConfig = new ZKClientConfig();
         final ClientCnxnSocketNetty clientCnxnSocket = new ClientCnxnSocketNetty(clientConfig);
         // Should not throw
-        clientCnxnSocket.onClosing();
         clientCnxnSocket.close();
+        // Call onClosing explicitly since it otherwise won't be invoked without more setup. 
+        clientCnxnSocket.onClosing();
     }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ClientCnxnSocketTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ClientCnxnSocketTest.java
@@ -90,4 +90,13 @@ public class ClientCnxnSocketTest {
             assertEquals("Packet len " + length + " is out of range!", e.getMessage());
         }
     }
+
+    @Test
+    public void testClientCanBeClosedWhenNotInitialized() throws IOException {
+        ZKClientConfig clientConfig = new ZKClientConfig();
+        final ClientCnxnSocketNetty clientCnxnSocket = new ClientCnxnSocketNetty(clientConfig);
+        // Should not throw
+        clientCnxnSocket.onClosing();
+        clientCnxnSocket.close();
+    }
 }


### PR DESCRIPTION
See [ZOOKEEPER-4296](https://issues.apache.org/jira/browse/ZOOKEEPER-4296) for more context.
What I've done here fixes (the symptoms of?) a problem that I have hit in the real world when using Solr's SolrZkClient. But I don't have enough knowledge of ZooKeeper's code to say whether there's a bigger issue in terms of how `ClientCnxnSocketNetty` is being used. What I do know is that `ClientCnxnSocketNIO` handled the same scenario without any apparent issue.

In any case getting NullPointerExceptions when closing something isn't helpful.