### PR TITLE
ZOOKEEPER-4289: Reduce the performance impact of Prometheus metrics

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -2129,7 +2129,23 @@ options are used to configure the [AdminServer](#sc_adminserver).
 * *metricsProvider.exportJvmInfo* :
     If this property is set to **true** Prometheus.io will export useful metrics about the JVM.
     The default is true.
-
+    
+* *metricsProvider.numWorkerThreads* :
+   **New in 3.7.1:**
+   Number of worker threads for reporting Prometheus summary metrics. 
+   Default value is 1. 
+   If the number is less than 1, the main thread will be used.
+    
+* *metricsProvider.maxQueueSize* :
+   **New in 3.7.1:**
+   The max queue size for Prometheus summary metrics reporting task.
+   Default value is 1000000.
+   
+* *metricsProvider.workerShutdownTimeoutMs* :
+   **New in 3.7.1:**
+   The timeout in ms for Prometheus worker threads shutdown.
+   Default value is 1000ms.
+   
 <a name="Communication+using+the+Netty+framework"></a>
 
 ### Communication using the Netty framework


### PR DESCRIPTION
Enabling Prometheus provider has significant impact on the performance of both read and write operations. This is to reduce the impact by making the Prometheus summary reporting as an async operation.

Load test results showed that the avg read latency and throughput after the fix is on par with the performance when Prometheus is disabled. For writes, the avg latency was reduced 25% and the avg throughput was increased 20% after the fix.