### PR TITLE
ZOOKEEPER-4301: fix typo

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -199,7 +199,7 @@ ensemble:
 
      You can find the meanings of these and other configuration
   settings in the section [Configuration Parameters](#sc_configuration). A word
-  though about a few here:
+  thought about a few here:
   Every machine that is part of the ZooKeeper ensemble should know
   about every other machine in the ensemble. You accomplish this with
   the series of lines of the form **server.id=host:port:port**.
@@ -256,8 +256,8 @@ ensemble:
 
 ### Single Server and Developer Setup
 
-If you want to setup ZooKeeper for development purposes, you will
-probably want to setup a single server instance of ZooKeeper, and then
+If you want to set up ZooKeeper for development purposes, you will
+probably want to set up a single server instance of ZooKeeper, and then
 install either the Java or C client-side libraries and bindings on your
 development machine.
 
@@ -461,7 +461,7 @@ this.
 
 You will want to have a supervisory process that manages
 each of your ZooKeeper server processes (JVM). The ZK server is
-designed to be "fail fast" meaning that it will shutdown
+designed to be "fail fast" meaning that it will shut down
 (process exit) if an error occurs that it cannot recover
 from. As a ZooKeeper serving cluster is highly reliable, this
 means that while the server may go down the cluster as a whole
@@ -613,8 +613,7 @@ property, when available, is noted below.
     and snapshots.
     ###### Note
     >Having a dedicated log device has a large impact on
-    throughput and stable latencies. It is highly recommended to
-    dedicate a log device and set **dataLogDir** to point to a directory on
+    throughput and stable latencies. It is highly recommended dedicating a log device and set **dataLogDir** to point to a directory on
     that device, and then make sure to point **dataDir** to a directory
     _not_ residing on that device.
 
@@ -818,7 +817,7 @@ property, when available, is noted below.
 * *watcherCleanThreshold* :
   (Java system property only: **zookeeper.watcherCleanThreshold**)
   **New in 3.6.0:** Added in [ZOOKEEPER-1179](https://issues.apache.org/jira/browse/ZOOKEEPER-1179)
-  The new watcher manager WatchManagerOptimized will clean up the dead watchers lazily, the clean up process is relatively
+  The new watcher manager WatchManagerOptimized will clean up the dead watchers lazily, the cleanup process is relatively
   heavy, batch processing will reduce the cost and improve the performance. This setting is used to decide
   the batch size. The default one is 1000, we don't need to change it if there is no memory or clean up
   speed issue.
@@ -826,7 +825,7 @@ property, when available, is noted below.
 * *watcherCleanIntervalInSeconds* :
   (Java system property only:**zookeeper.watcherCleanIntervalInSeconds**)
   **New in 3.6.0:** Added in [ZOOKEEPER-1179](https://issues.apache.org/jira/browse/ZOOKEEPER-1179)
-  The new watcher manager WatchManagerOptimized will clean up the dead watchers lazily, the clean up process is relatively
+  The new watcher manager WatchManagerOptimized will clean up the dead watchers lazily, the cleanup process is relatively
   heavy, batch processing will reduce the cost and improve the performance. Besides watcherCleanThreshold,
   this setting is used to clean up the dead watchers after certain time even the dead watchers are not larger
   than watcherCleanThreshold, so that we won't leave the dead watchers there for too long. The default setting
@@ -1082,12 +1081,12 @@ property, when available, is noted below.
     hash function, but it’s more efficient compared to collisionless hash, and the
     collision possibility is really really rare and can already meet our needs here.
 
-    This feature is backward and forward compatible, so it can safely rolling upgrade,
+    This feature is backward and forward compatible, so it can safely roll upgrade,
     downgrade, enabled and later disabled without any compatible issue. Here are the
     scenarios have been covered and tested:
 
     1. When leader runs with new code while follower runs with old one, the digest will
-       be append to the end of each txn, follower will only read header and txn data,
+       be appended to the end of each txn, follower will only read header and txn data,
        digest value in the txn will be ignored. It won't affect the follower reads and
        processes the next txn.
     2. When leader runs with old code while follower runs with new one, the digest won't
@@ -1097,7 +1096,7 @@ property, when available, is noted below.
        read the non-exist digest value, and the exception will be caught and digest will
        be set to null, which means we won't compare digest when loading this snapshot,
        which is expected to happen during rolling upgrade
-    4. When loading new snapshot with old code, it will finish successfully after deserialzing
+    4. When loading new snapshot with old code, it will finish successfully after deserializing
        the data tree, the digest value at the end of snapshot file will be ignored
     5. The scenarios of rolling restart with flags change are similar to the 1st and 2nd
        scenarios discussed above, if the leader enabled but follower not, digest value will
@@ -1129,7 +1128,7 @@ property, when available, is noted below.
     files. This should only be set during upgrading from old versions of
     ZooKeeper (3.4.x, pre 3.5.3) where ZooKeeper might only have transaction
     log files but without presence of snapshot files. If the value is set
-    during upgrade, we recommend to set the value back to false after upgrading
+    during upgrade, we recommend setting the value back to false after upgrading
     and restart ZooKeeper process so ZooKeeper can continue normal data
     consistency check during recovery process.
     Default value is false.
@@ -1158,7 +1157,7 @@ property, when available, is noted below.
     The size threshold after which a request is considered a large request. If it is -1, then all requests are considered small, effectively turning off large request throttling. The default is -1.
 
 * *outstandingHandshake.limit*
-    (Jave system property only: **zookeeper.netty.server.outstandingHandshake.limit**)
+    (Java system property only: **zookeeper.netty.server.outstandingHandshake.limit**)
     The maximum in-flight TLS handshake connections could have in ZooKeeper,
     the connections exceed this limit will be rejected before starting handshake.
     This setting doesn't limit the max TLS concurrency, but helps avoid herd
@@ -1168,7 +1167,7 @@ property, when available, is noted below.
 * *throttledOpWaitTime*
     (Java system property: **zookeeper.throttled_op_wait_time**)
     The time in the RequestThrottler queue longer than which a request will be marked as throttled.
-    A throttled requests will not be processed other than being fed down the pipeline of the server it belongs to
+    A throttled requests will not be processed other than being fed down the pipeline of the server it belongs 
     to preserve the order of all requests.
     The FinalProcessor will issue an error response (new error code: ZTHROTTLEDOP) for these undigested requests.
     The intent is for the clients not to retry them immediately.
@@ -1178,14 +1177,14 @@ property, when available, is noted below.
   (Java system property: **zookeeper.learner.closeSocketAsync**)
   (Java system property: **learner.closeSocketAsync**)(Added for backward compatibility)
     **New in 3.7.0:**
-    When enabled, a learner will close the quorum socket asynchronously. This is useful for TLS connections where closing a socket might take a long time, block the shutdown process, potentially delay a new leader election, and leave the quorum unavailabe. Closing the socket asynchronously avoids blocking the shutdown process despite the long socket closing time and a new leader election can be started while the socket being closed. 
+    When enabled, a learner will close the quorum socket asynchronously. This is useful for TLS connections where closing a socket might take a long time, block the shutdown process, potentially delay a new leader election, and leave the quorum unavailable. Closing the socket asynchronously avoids blocking the shutdown process despite the long socket closing time and a new leader election can be started while the socket being closed. 
     The default is false.
 
 * *leader.closeSocketAsync*
   (Java system property: **zookeeper.leader.closeSocketAsync**)
   (Java system property: **leader.closeSocketAsync**)(Added for backward compatibility)
    **New in 3.7.0:**
-   When enabled, the leader will close a quorum socket asynchoronously. This is useful for TLS connections where closing a socket might take a long time. If disconnecting a follower is initiated in ping() because of a failed SyncLimitCheck then the long socket closing time will block the sending of pings to other followers. Without receiving pings, the other followers will not send session information to the leader, which causes sessions to expire. Setting this flag to true ensures that pings will be sent regularly.
+   When enabled, the leader will close a quorum socket asynchronously. This is useful for TLS connections where closing a socket might take a long time. If disconnecting a follower is initiated in ping() because of a failed SyncLimitCheck then the long socket closing time will block the sending of pings to other followers. Without receiving pings, the other followers will not send session information to the leader, which causes sessions to expire. Setting this flag to true ensures that pings will be sent regularly.
    The default is false.
 
 * *learner.asyncSending*
@@ -1196,7 +1195,7 @@ property, when available, is noted below.
   The default is false.
 
 * *forward_learner_requests_to_commit_processor_disabled*
-    (Jave system property: **zookeeper.forward_learner_requests_to_commit_processor_disabled**)
+    (Java system property: **zookeeper.forward_learner_requests_to_commit_processor_disabled**)
     When this property is set, the requests from learners won't be enqueued to
     CommitProcessor queue, which will help save the resources and GC time on 
     leader.
@@ -1222,7 +1221,7 @@ of servers -- that is, when deploying clusters of servers.
     ###### Note
     >The implementations of leader election 1, and 2 were
     **deprecated** in 3.4.0. Since 3.6.0 only FastLeaderElection is available,
-    in case of upgrade you have to shutdown all of your servers and
+    in case of upgrade you have to shut down all of your servers and
     restart them with electionAlg=3 (or by removing the line from the configuration file).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        >
 
 * *maxTimeToWaitForEpoch* :
@@ -1230,7 +1229,7 @@ of servers -- that is, when deploying clusters of servers.
   **New in 3.6.0:**
       The maximum time to wait for epoch from voters when activating
       leader. If leader received a LOOKING notification from one of
-      it's voters, and it hasn't received epoch packets from majority
+      its voters, and it hasn't received epoch packets from majority
       within maxTimeToWaitForEpoch, then it will goto LOOKING and
       elect leader again.
       This can be tuned to reduce the quorum or server unavailable
@@ -1274,7 +1273,7 @@ of servers -- that is, when deploying clusters of servers.
     used by the clients must match the list of ZooKeeper servers
     that each ZooKeeper server has.
     There are two port numbers **nnnnn**.
-    The first followers use to connect to the leader, and the second is for
+    The first followers used to connect to the leader, and the second is for
     leader election. If you want to test multiple servers on a single machine, then
     different ports can be used for each server.
 
@@ -1377,7 +1376,7 @@ of servers -- that is, when deploying clusters of servers.
     **"reconfigEnabled=true"**, then the ensemble
     will have reconfig feature enabled. If the leader has a setting of
     **"reconfigEnabled=false"**, then the ensemble
-    will have reconfig feature disabled. It is thus recommended to have a consistent
+    will have reconfig feature disabled. It is thus recommended having a consistent
     value for **"reconfigEnabled"** across servers
     in the ensemble.
 
@@ -1389,7 +1388,7 @@ of servers -- that is, when deploying clusters of servers.
     command must be put in this list else ZooKeeper server will
     not enable the command.
     By default the whitelist only contains "srvr" command
-    which zkServer.sh uses. The rest of four letter word commands are disabled
+    which zkServer.sh uses. The rest of four-letter word commands are disabled
     by default: attempting to use them will gain a response
     ".... is not executed because it is not in the whitelist."
     Here's an example of the configuration that enables stat, ruok, conf, and isro
@@ -1398,9 +1397,9 @@ of servers -- that is, when deploying clusters of servers.
         4lw.commands.whitelist=stat, ruok, conf, isro
 
 
-If you really need enable all four letter word commands by default, you can use
+If you really need enable all four-letter word commands by default, you can use
 the asterisk option so you don't have to include every command one by one in the list.
-As an example, this will enable all four letter word commands:
+As an example, this will enable all four-letter word commands:
 
 
     4lw.commands.whitelist=*
@@ -1414,7 +1413,7 @@ As an example, this will enable all four letter word commands:
     This will allow for connections between quorum members to
     remain up when there is network infrastructure that may
     otherwise break them. Some NATs and firewalls may terminate
-    or lose state for long running or idle connections.
+    or lose state for long-running or idle connections.
     Enabling this option relies on OS level settings to work
     properly, check your operating system's options regarding TCP
     keepalive for more information.  Defaults to
@@ -1590,7 +1589,7 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     in such case, both Java and C client will close the session with server thereafter,
     without further attempts on retrying to reconnect.
 
-    This configuration is short hand for **enforce.auth.enabled=true** and **enforce.auth.scheme=sasl**
+    This configuration is shorthand for **enforce.auth.enabled=true** and **enforce.auth.scheme=sasl**
 
     By default, this feature is disabled. Users who would like to opt-in can enable the feature
     by setting **sessionRequireClientSASLAuth** to **true**.
@@ -1773,7 +1772,7 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     network interfaces can be used parallel in the cluster). ZooKeeper will perform ICMP ECHO requests
     or try to establish a TCP connection on port 7 (Echo) of the destination host in order to find
     the reachable addresses. This happens only if you provide multiple addresses in the configuration.
-    In this property you can set the timeout in millisecs for the reachability check. The check happens
+    In this property you can set the timeout in milliseconds for the reachability check. The check happens
     in parallel for the different addresses, so the timeout you set here is the maximum time will be taken
     by checking the reachability of all addresses.
     The default value is **1000**.
@@ -1872,7 +1871,7 @@ the variable does.
     network interfaces can be used parallel in the cluster). ZooKeeper will perform ICMP ECHO requests
     or try to establish a TCP connection on port 7 (Echo) of the destination host in order to find
     the reachable addresses. This happens only if you provide multiple addresses in the configuration.
-    The reachable check can fail if you hit some ICMP rate-limitation, (e.g. on MacOS) when you try to
+    The reachable check can fail if you hit some ICMP rate-limitation, (e.g. on macOS) when you try to
     start a large (e.g. 11+) ensemble members cluster on a single machine for testing.
 
     Default value is **true**. By setting this parameter to 'false' you can disable the reachability checks.
@@ -1920,7 +1919,7 @@ necessary for the user to first install ZooKeeper, then create
 the data directory (and potentially txnlog directory), and
 then start the server. Otherwise as mentioned in the previous
 paragraph the server will not start. Running **zkServer-initialize.sh** will create the
-required directories, and optionally setup the myid file
+required directories, and optionally set up the myid file
 (optional command line parameter). This script can be used
 even if the autocreate feature itself is not used, and will
 likely be of use to users as this (setup, including creation
@@ -2123,7 +2122,7 @@ options are used to configure the [AdminServer](#sc_adminserver).
     **New in 3.8.0:** Prometheus.io exporter will start a Jetty server and listen this address, default is "0.0.0.0"
   
 * *metricsProvider.httpPort* :
-    Prometheus.io exporter will start a Jetty server and bind to this port, it default to 7000.
+    Prometheus.io exporter will start a Jetty server and bind to this port, it defaults to 7000.
     Prometheus end point will be http://hostname:httPort/metrics.
 
 * *metricsProvider.exportJvmInfo* :
@@ -2253,7 +2252,7 @@ INFO  [main:QuorumPeer@1797] - Port unification enabled
 INFO  [QuorumPeerListener:QuorumCnxManager$Listener@874] - Creating TLS-enabled quorum server socket
 ```
 
-You should also double check after each node restart that the quorum become healthy again.
+You should also double-check after each node restart that the quorum become healthy again.
 
 4. Enable Quorum TLS on each node and do rolling restart:
 
@@ -2465,8 +2464,8 @@ command:
 #### The AdminServer
 
 **New in 3.5.0:** The AdminServer is
-an embedded Jetty server that provides an HTTP interface to the four
-letter word commands.  By default, the server is started on port 8080,
+an embedded Jetty server that provides an HTTP interface to the four-letter
+word commands.  By default, the server is started on port 8080,
 and commands are issued by going to the URL "/commands/\[command name]",
 e.g., http://localhost:8080/commands/stat.  The command response is
 returned as JSON.  Unlike the original protocol, commands are not
@@ -2484,7 +2483,7 @@ The AdminServer is enabled by default, but can be disabled by either:
   useful if you would like to override ZooKeeper's jetty
   dependency.)
 
-Note that the TCP four letter word interface is still available if
+Note that the TCP four-letter word interface is still available if
 the AdminServer is disabled.
 
 Available commands include:
@@ -2768,7 +2767,7 @@ ZooKeeper correctly:
 
 * *Publicly accessible deployment* :
     A ZooKeeper ensemble is expected to operate in a trusted computing environment.
-    It is thus recommended to deploy ZooKeeper behind a firewall.
+    It is thus recommended deploying ZooKeeper behind a firewall.
 
 <a name="sc_bestPractices"></a>
 


### PR DESCRIPTION
- After 'it', use the third-person verb form defaults
- The verb 'set up' is spelled as two words. The noun 'setup' is spelled as one
- The verb 'shut down' instead of the phrasal noun 'shutdown'. 
- The noun cleanup instead of the phrasal verb 'clean up'
- The operating system from Apple is called macOS
- ...