### PR TITLE
Add command to force a zookeeper server to take a snapshot

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/SyncRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/SyncRequestProcessor.java
@@ -144,7 +144,8 @@ public class SyncRequestProcessor extends ZooKeeperCriticalThread implements Req
         int logCount = zks.getZKDatabase().getTxnCount();
         long logSize = zks.getZKDatabase().getTxnSize();
         return (logCount > (snapCount / 2 + randRoll))
-               || (snapSizeInBytes > 0 && logSize > (snapSizeInBytes / 2 + randSize));
+                || (snapSizeInBytes > 0 && logSize > (snapSizeInBytes / 2 + randSize))
+                || zks.isForceSnapshot();
     }
 
     private void resetSnapshotStats() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -296,6 +296,11 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
      */
     private volatile int largeRequestThreshold = -1;
 
+    /**
+     * The server should do a snapshot if this field is set to true.
+     */
+    private volatile boolean forceSnapshot = false;
+
     private final AtomicInteger currentLargeRequestBytes = new AtomicInteger(0);
 
     private AuthenticationHelper authHelper;
@@ -525,11 +530,20 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         takeSnapshot();
     }
 
+    public boolean isForceSnapshot() {
+        return forceSnapshot;
+    }
+
+    public void setForceSnapshot(boolean forceSnapshot) {
+        this.forceSnapshot = forceSnapshot;
+    }
+
     public void takeSnapshot() {
         takeSnapshot(false);
     }
 
     public void takeSnapshot(boolean syncSnap) {
+        this.forceSnapshot = false;
         long start = Time.currentElapsedTime();
         try {
             txnLogFactory.save(zkDb.getDataTree(), zkDb.getSessionWithTimeOuts(), syncSnap);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Commands.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Commands.java
@@ -135,6 +135,7 @@ public class Commands {
         registerCommand(new DirsCommand());
         registerCommand(new DumpCommand());
         registerCommand(new EnvCommand());
+        registerCommand(new ForceSnapshotCommand());
         registerCommand(new GetTraceMaskCommand());
         registerCommand(new InitialConfigurationCommand());
         registerCommand(new IsroCommand());
@@ -287,6 +288,19 @@ public class Commands {
             return response;
         }
 
+    }
+
+    public static class ForceSnapshotCommand extends CommandBase {
+
+        protected ForceSnapshotCommand() {
+            super(Arrays.asList("force_snapshot", "fsnp"));
+        }
+
+        @Override
+        public CommandResponse run(ZooKeeperServer zkServer, Map<String, String> kwargs) {
+            zkServer.setForceSnapshot(true);
+            return initializeResponse();
+        }
     }
 
     /**

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ForceSnapshotTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ForceSnapshotTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ForceSnapshotTest extends ClientBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ForceSnapshotTest.class);
+
+    private static final int TEST_OP_COUNT = 10;
+
+    private ZooKeeper zk;
+    private ZooKeeperServer server;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        server = serverFactory.getZooKeeperServer();
+        zk = createClient();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        // server will be closed in super.tearDown
+        super.tearDown();
+
+        if (zk != null) {
+            zk.close();
+        }
+    }
+
+    @Test
+    public void noForceSnapshot() throws Exception {
+        assertFalse(this.server.isForceSnapshot());
+
+        String pathPrefix = "/testForceSnapshot";
+        for (int i = 0; i < TEST_OP_COUNT; i++) {
+            String path = pathPrefix + i;
+            zk.create(path, path.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        }
+
+        FileTxnSnapLog fileTxnSnapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        List<File> snaps = fileTxnSnapLog.findNValidSnapshots(TEST_OP_COUNT * 2);
+        assertEquals(1, snaps.size());
+    }
+
+    @Test
+    public void forceSnapshotOnEveryOp() throws Exception {
+        assertFalse(this.server.isForceSnapshot());
+
+        String pathPrefix = "/testForceSnapshot";
+        for (int i = 0; i < TEST_OP_COUNT; i++) {
+            String path = pathPrefix + i;
+            server.setForceSnapshot(true);
+            zk.create(path, path.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            assertFalse(server.isForceSnapshot());
+        }
+
+        FileTxnSnapLog fileTxnSnapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        List<File> snaps = fileTxnSnapLog.findNValidSnapshots(TEST_OP_COUNT * 2);
+        assertEquals(TEST_OP_COUNT + 1, snaps.size());
+    }
+
+    @Test
+    public void forceSnapshotOnce() throws Exception {
+        assertFalse(this.server.isForceSnapshot());
+
+        String pathPrefix = "/testForceSnapshot";
+        int triggerId = ThreadLocalRandom.current().nextInt(TEST_OP_COUNT);
+        for (int i = 0; i < TEST_OP_COUNT; i++) {
+            String path = pathPrefix + i;
+            if (triggerId == i) {
+                server.setForceSnapshot(true);
+            }
+            zk.create(path, path.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            assertFalse(server.isForceSnapshot());
+        }
+
+        FileTxnSnapLog fileTxnSnapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        List<File> snaps = fileTxnSnapLog.findNValidSnapshots(TEST_OP_COUNT * 2);
+        assertEquals(2, snaps.size());
+    }
+}


### PR DESCRIPTION
Currently a ZooKeeper server takes a snapshot if the number of operations or the size of transactions exceeds configured values. However, it's a common use case to allow system admins to trigger snapshots manually, e.g.:
- trigger a snapshot during the maintenance window to reduce the performance impact
- trigger a snapshot before the backup procedure to reduce the number of data to backup

This PR adds an http command (force_snapshot/fsnp) to allow users to trigger a snapshot manually.