### PR TITLE
ZOOKEEPER-4331: add headers back

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -607,6 +607,11 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>4.1.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>zookeeper</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <name>Apache ZooKeeper - Server</name>
   <description>ZooKeeper server</description>
 
@@ -263,7 +263,37 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
-	  
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>
+              javax.management;resolution:=optional,
+              javax.security.auth.callback,
+              javax.security.auth.login,
+              javax.security.sasl,
+              org.slf4j,
+              io.netty.buffer;resolution:=optional,
+              io.netty.channel;resolution:=optional,
+              io.netty.channel.group;resolution:=optional,
+              io.netty.channel.socket.nio;resolution:=optional,
+              org.osgi.framework;resolution:=optional,
+              org.osgi.util.tracker;resolution:=optional,
+              org.ietf.jgss,
+              *;resolution:=optional
+            </Import-Package>
+            <Export-Package>
+              org.apache.zookeeper*
+            </Export-Package>
+            <Bundle-Name>ZooKeeper Bundle</Bundle-Name>
+            <Bundle-DocURL>https://zookeeper.apache.org/doc/current/</Bundle-DocURL>
+          </instructions>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
This change primarily copies the planted headers from build.xml to pom.xml. In this way, it shouldn't touch anything but the manifest, and I'm appending a diff from my dev box in the end. I'm looking for a fix to 3.5, 3.6 and 3.7, so please let me know if any further PR is required for this to happen.

As things have changed a lot since 3.4 when the header values in build.xml take effect, please feel free to let me know if any correction is required. Thanks!

```
--- MANIFEST.MF.before  2021-06-29 15:22:44.000000000 +0800
+++ MANIFEST.MF.after   2021-06-29 16:02:58.000000000 +0800
@@ -1,13 +1,122 @@
 Manifest-Version: 1.0
-Implementation-Title: Apache ZooKeeper - Server
-Implementation-Version: 3.5.9
-Built-By: bigmarvin
-Specification-Vendor: The Apache Software Foundation
-Specification-Title: Apache ZooKeeper - Server
-Implementation-Vendor-Id: org.apache.zookeeper
-Created-By: Apache Maven 3.3.9
+Bnd-LastModified: 1624953779106
 Build-Jdk: 1.8.0_265
-Specification-Version: 3.5
+Built-By: bigmarvin
+Bundle-Description: ZooKeeper server
+Bundle-DocURL: https://zookeeper.apache.org/doc/current/
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
+Bundle-ManifestVersion: 2
+Bundle-Name: ZooKeeper Bundle
+Bundle-SymbolicName: org.apache.zookeeper
+Bundle-Vendor: The Apache Software Foundation
+Bundle-Version: 3.5.9
+Created-By: Apache Maven Bundle Plugin
+Export-Package: org.apache.zookeeper;uses:="javax.security.auth,javax.
+ security.auth.callback,javax.security.auth.login,org.apache.jute,org.
+ apache.yetus.audience,org.apache.zookeeper.cli,org.apache.zookeeper.c
+ lient,org.apache.zookeeper.common,org.apache.zookeeper.data,org.apach
+ e.zookeeper.proto,org.apache.zookeeper.version,org.slf4j";version="3.
+ 5.9",org.apache.zookeeper.admin;uses:="org.apache.yetus.audience,org.
+ apache.zookeeper,org.apache.zookeeper.client,org.apache.zookeeper.dat
+ a";version="3.5.9",org.apache.zookeeper.cli;uses:="org.apache.commons
+ .cli,org.apache.zookeeper,org.apache.zookeeper.data";version="3.5.9",
+ org.apache.zookeeper.client;uses:="javax.security.auth.login,javax.se
+ curity.sasl,org.apache.yetus.audience,org.apache.zookeeper,org.apache
+ .zookeeper.common,org.apache.zookeeper.data,org.apache.zookeeper.serv
+ er.quorum,org.slf4j";version="3.5.9",org.apache.zookeeper.common;uses
+ :="io.netty.channel,io.netty.channel.socket,io.netty.handler.ssl,java
+ x.net.ssl,org.apache.zookeeper.server.quorum,org.slf4j";version="3.5.
+ 9",org.apache.zookeeper.data;uses:="org.apache.jute,org.apache.yetus.
+ audience";version="3.5.9",org.apache.zookeeper.jmx;uses:="javax.manag
+ ement";version="3.5.9",org.apache.zookeeper.proto;uses:="org.apache.j
+ ute,org.apache.yetus.audience,org.apache.zookeeper.data";version="3.5
+ .9",org.apache.zookeeper.server;uses:="javax.security.sasl,org.apache
+ .jute,org.apache.yetus.audience,org.apache.zookeeper,org.apache.zooke
+ eper.data,org.apache.zookeeper.jmx,org.apache.zookeeper.proto,org.apa
+ che.zookeeper.server.admin,org.apache.zookeeper.server.auth,org.apach
+ e.zookeeper.server.persistence,org.apache.zookeeper.server.quorum,org
+ .apache.zookeeper.server.quorum.flexible,org.apache.zookeeper.txn,org
+ .slf4j";version="3.5.9",org.apache.zookeeper.server.admin;uses:="org.
+ apache.yetus.audience,org.apache.zookeeper.server";version="3.5.9",or
+ g.apache.zookeeper.server.auth;uses:="javax.net.ssl,javax.security.au
+ th,javax.security.auth.callback,javax.security.auth.login,javax.secur
+ ity.auth.spi,org.apache.zookeeper,org.apache.zookeeper.common,org.apa
+ che.zookeeper.server";version="3.5.9",org.apache.zookeeper.server.com
+ mand;uses:="org.apache.zookeeper.server";version="3.5.9",org.apache.z
+ ookeeper.server.persistence;uses:="org.apache.jute,org.apache.yetus.a
+ udience,org.apache.zookeeper,org.apache.zookeeper.server,org.apache.z
+ ookeeper.txn";version="3.5.9",org.apache.zookeeper.server.quorum;uses
+ :="javax.net.ssl,javax.security.sasl,org.apache.jute,org.apache.yetus
+ .audience,org.apache.zookeeper,org.apache.zookeeper.common,org.apache
+ .zookeeper.data,org.apache.zookeeper.jmx,org.apache.zookeeper.server,
+ org.apache.zookeeper.server.admin,org.apache.zookeeper.server.persist
+ ence,org.apache.zookeeper.server.quorum.auth,org.apache.zookeeper.ser
+ ver.quorum.flexible,org.apache.zookeeper.txn,org.slf4j";version="3.5.
+ 9",org.apache.zookeeper.server.quorum.auth;uses:="javax.security.auth
+ .callback,javax.security.auth.login,javax.security.sasl,org.apache.zo
+ okeeper.server.quorum";version="3.5.9",org.apache.zookeeper.server.qu
+ orum.flexible;uses:="org.apache.zookeeper.server.quorum";version="3.5
+ .9",org.apache.zookeeper.server.util;uses:="org.apache.jute,org.apach
+ e.zookeeper.server,org.apache.zookeeper.server.quorum,org.apache.zook
+ eeper.txn,org.slf4j";version="3.5.9",org.apache.zookeeper.txn;uses:="
+ org.apache.jute,org.apache.yetus.audience,org.apache.zookeeper.data";
+ version="3.5.9",org.apache.zookeeper.util;uses:="javax.security.auth,
+ javax.security.auth.callback,javax.security.sasl,org.slf4j";version="
+ 3.5.9",org.apache.zookeeper.version;version="3.5.9",org.apache.zookee
+ per.version.util;version="3.5.9"
+Implementation-Title: Apache ZooKeeper - Server
 Implementation-URL: http://zookeeper.apache.org/zookeeper
 Implementation-Vendor: The Apache Software Foundation
+Implementation-Vendor-Id: org.apache.zookeeper
+Implementation-Version: 3.5.9
+Import-Package: javax.management;resolution:=optional,javax.security.a
+ uth.callback,javax.security.auth.login,javax.security.sasl,org.slf4j;
+ version="[1.7,2)",io.netty.buffer;resolution:=optional;version="[4.1,
+ 5)",io.netty.channel;resolution:=optional;version="[4.1,5)",io.netty.
+ channel.group;resolution:=optional;version="[4.1,5)",io.netty.channel
+ .socket.nio;resolution:=optional;version="[4.1,5)",org.ietf.jgss,com.
+ fasterxml.jackson.core;resolution:=optional;version="[2.10,3)",com.fa
+ sterxml.jackson.databind;resolution:=optional;version="[2.10,3)",io.n
+ etty.bootstrap;resolution:=optional;version="[4.1,5)",io.netty.channe
+ l.epoll;resolution:=optional;version="[4.1,5)",io.netty.channel.nio;r
+ esolution:=optional;version="[4.1,5)",io.netty.channel.socket;resolut
+ ion:=optional;version="[4.1,5)",io.netty.handler.ssl;resolution:=opti
+ onal;version="[4.1,5)",io.netty.util;resolution:=optional;version="[4
+ .1,5)",io.netty.util.concurrent;resolution:=optional;version="[4.1,5)
+ ",javax.crypto;resolution:=optional,javax.crypto.spec;resolution:=opt
+ ional,javax.naming;resolution:=optional,javax.naming.directory;resolu
+ tion:=optional,javax.naming.ldap;resolution:=optional,javax.net.ssl;r
+ esolution:=optional,javax.security.auth;resolution:=optional,javax.se
+ curity.auth.kerberos;resolution:=optional,javax.security.auth.spi;res
+ olution:=optional,javax.security.auth.x500;resolution:=optional,javax
+ .servlet;resolution:=optional;version="[3.1,4)",javax.servlet.http;re
+ solution:=optional;version="[3.1,4)",jline.console.completer;resoluti
+ on:=optional;version="[2.14,3)",org.apache.commons.cli;resolution:=op
+ tional;version="[1.2,2)",org.apache.jute;resolution:=optional,org.apa
+ che.yetus.audience;resolution:=optional,org.apache.zookeeper;resoluti
+ on:=optional,org.apache.zookeeper.admin;resolution:=optional,org.apac
+ he.zookeeper.cli;resolution:=optional,org.apache.zookeeper.client;res
+ olution:=optional,org.apache.zookeeper.common;resolution:=optional,or
+ g.apache.zookeeper.data;resolution:=optional,org.apache.zookeeper.jmx
+ ;resolution:=optional,org.apache.zookeeper.proto;resolution:=optional
+ ,org.apache.zookeeper.server;resolution:=optional,org.apache.zookeepe
+ r.server.admin;resolution:=optional,org.apache.zookeeper.server.auth;
+ resolution:=optional,org.apache.zookeeper.server.command;resolution:=
+ optional,org.apache.zookeeper.server.persistence;resolution:=optional
+ ,org.apache.zookeeper.server.quorum;resolution:=optional,org.apache.z
+ ookeeper.server.quorum.auth;resolution:=optional,org.apache.zookeeper
+ .server.quorum.flexible;resolution:=optional,org.apache.zookeeper.ser
+ ver.util;resolution:=optional,org.apache.zookeeper.txn;resolution:=op
+ tional,org.apache.zookeeper.util;resolution:=optional,org.apache.zook
+ eeper.version;resolution:=optional,org.eclipse.jetty.security;resolut
+ ion:=optional;version="[9.4,10)",org.eclipse.jetty.server;resolution:
+ =optional;version="[9.4,10)",org.eclipse.jetty.servlet;resolution:=op
+ tional;version="[9.4,10)",org.eclipse.jetty.util.security;resolution:
+ =optional;version="[9.4,10)",org.osgi.framework;resolution:=optional,
+ org.osgi.util.tracker;resolution:=optional
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+Specification-Title: Apache ZooKeeper - Server
+Specification-Vendor: The Apache Software Foundation
+Specification-Version: 3.5.9
+Tool: Bnd-4.1.0.201810181252
```