### PR TITLE
ZOOKEEPER-4331: add headers back in osgi artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -607,6 +607,11 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>4.1.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -263,7 +263,46 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
-	  
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build bundle</id>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <instructions>
+            <Import-Package>
+              javax.management;resolution:=optional,
+              javax.security.auth.callback,
+              javax.security.auth.login,
+              javax.security.sasl,
+              org.slf4j,
+              io.netty.buffer;resolution:=optional,
+              io.netty.channel;resolution:=optional,
+              io.netty.channel.group;resolution:=optional,
+              io.netty.channel.socket.nio;resolution:=optional,
+              org.osgi.framework;resolution:=optional,
+              org.osgi.util.tracker;resolution:=optional,
+              org.ietf.jgss,
+              *;resolution:=optional
+            </Import-Package>
+            <Export-Package>
+              org.apache.zookeeper*
+            </Export-Package>
+            <Bundle-Name>ZooKeeper Bundle</Bundle-Name>
+            <Bundle-DocURL>https://zookeeper.apache.org/doc/current/</Bundle-DocURL>
+          </instructions>
+          <classifier>osgi</classifier>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
As an alternative to https://github.com/apache/zookeeper/pull/1720, this change employs bundle plugin to build another artifact of classifier "osgi".

The advantage would be bundle plugin remains employed to maintain the topology of versioned packages, and the original artifact without classifier is left untouched.

The disadvantage would be we've one more artifact delivered in this project.

```
$ ls zookeeper-server/target/ | grep jar$
zookeeper-3.5.9.jar
zookeeper-3.5.9-javadoc.jar
zookeeper-3.5.9-osgi.jar
zookeeper-3.5.9-sources.jar
zookeeper-3.5.9-tests.jar
```