### PR TITLE
ZOOKEEPER-4333 QuorumSSLTest - testOCSP fails on JDK17

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
@@ -229,19 +229,19 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
             byte[] responseBytes;
             try {
                 String uri = httpExchange.getRequestURI().toString();
-                LOG.info("OCSP request: {} {} {}", httpExchange.getRequestMethod(), uri, httpExchange.getRequestHeaders().entrySet());
+                LOG.info("OCSP request: {} {}", httpExchange.getRequestMethod(), uri);
                 httpExchange.getRequestHeaders().entrySet().forEach((e) -> {
                     LOG.info("OCSP request header: {} {}", e.getKey(), e.getValue());
                 });
                 InputStream request = httpExchange.getRequestBody();
                 byte[] requestBytes = new byte[10000];
                 int len = request.read(requestBytes);
-                LOG.info("OCSP request size {}: {}", len, new String(requestBytes, StandardCharsets.UTF_8));
+                LOG.info("OCSP request size {}", len);
 
                 if (len < 0) {
-                    String removedUriEncodiing = URLDecoder.decode(uri.substring(1), "utf-8");
-                    LOG.info("OCSP request from URI no encoding {}", removedUriEncodiing);
-                    requestBytes = Base64.getDecoder().decode(removedUriEncodiing);
+                    String removedUriEncoding = URLDecoder.decode(uri.substring(1), "utf-8");
+                    LOG.info("OCSP request from URI no encoding {}", removedUriEncoding);
+                    requestBytes = Base64.getDecoder().decode(removedUriEncoding);
                 }
                 OCSPReq ocspRequest = new OCSPReq(requestBytes);
                 Req[] requestList = ocspRequest.getRequestList();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
@@ -35,7 +35,6 @@ import java.io.OutputStream;
 import java.math.BigInteger;
 import java.net.InetSocketAddress;
 import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
@@ -27,8 +27,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-
-import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -99,7 +97,6 @@ import org.bouncycastle.cert.ocsp.CertificateID;
 import org.bouncycastle.cert.ocsp.CertificateStatus;
 import org.bouncycastle.cert.ocsp.OCSPException;
 import org.bouncycastle.cert.ocsp.OCSPReq;
-import org.bouncycastle.cert.ocsp.OCSPReqBuilder;
 import org.bouncycastle.cert.ocsp.OCSPResp;
 import org.bouncycastle.cert.ocsp.OCSPRespBuilder;
 import org.bouncycastle.cert.ocsp.Req;
@@ -233,7 +230,7 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
             try {
                 String uri = httpExchange.getRequestURI().toString();
                 LOG.info("OCSP request: {} {} {}", httpExchange.getRequestMethod(), uri, httpExchange.getRequestHeaders().entrySet());
-                httpExchange.getRequestHeaders().entrySet().forEach( (e) -> {
+                httpExchange.getRequestHeaders().entrySet().forEach((e) -> {
                     LOG.info("OCSP request header: {} {}", e.getKey(), e.getValue());
                 });
                 InputStream request = httpExchange.getRequestBody();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
@@ -27,6 +27,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+
+import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -34,6 +36,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigInteger;
 import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
@@ -45,6 +49,8 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -93,6 +99,7 @@ import org.bouncycastle.cert.ocsp.CertificateID;
 import org.bouncycastle.cert.ocsp.CertificateStatus;
 import org.bouncycastle.cert.ocsp.OCSPException;
 import org.bouncycastle.cert.ocsp.OCSPReq;
+import org.bouncycastle.cert.ocsp.OCSPReqBuilder;
 import org.bouncycastle.cert.ocsp.OCSPResp;
 import org.bouncycastle.cert.ocsp.OCSPRespBuilder;
 import org.bouncycastle.cert.ocsp.Req;
@@ -224,12 +231,24 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
         public void handle(com.sun.net.httpserver.HttpExchange httpExchange) throws IOException {
             byte[] responseBytes;
             try {
+                String uri = httpExchange.getRequestURI().toString();
+                LOG.info("OCSP request: {} {} {}", httpExchange.getRequestMethod(), uri, httpExchange.getRequestHeaders().entrySet());
+                httpExchange.getRequestHeaders().entrySet().forEach( (e) -> {
+                    LOG.info("OCSP request header: {} {}", e.getKey(), e.getValue());
+                });
                 InputStream request = httpExchange.getRequestBody();
                 byte[] requestBytes = new byte[10000];
-                request.read(requestBytes);
+                int len = request.read(requestBytes);
+                LOG.info("OCSP request size {}: {}", len, new String(requestBytes, StandardCharsets.UTF_8));
 
+                if (len < 0) {
+                    String removedUriEncodiing = URLDecoder.decode(uri.substring(1), "utf-8");
+                    LOG.info("OCSP request from URI no encoding {}", removedUriEncodiing);
+                    requestBytes = Base64.getDecoder().decode(removedUriEncodiing);
+                }
                 OCSPReq ocspRequest = new OCSPReq(requestBytes);
                 Req[] requestList = ocspRequest.getRequestList();
+                LOG.info("requestList {}", Arrays.toString(requestList));
 
                 DigestCalculator digestCalculator = new JcaDigestCalculatorProviderBuilder().build().get(CertificateID.HASH_SHA1);
 
@@ -243,16 +262,21 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
                     } else {
                         certificateStatus = CertificateStatus.GOOD;
                     }
-
+                    LOG.info("addResponse {} {}", certId, certificateStatus);
                     responseBuilder.addResponse(certId, certificateStatus, null);
                 }
 
                 X509CertificateHolder[] chain = new X509CertificateHolder[]{new JcaX509CertificateHolder(rootCertificate)};
                 ContentSigner signer = new JcaContentSignerBuilder("SHA1withRSA").setProvider("BC").build(rootKeyPair.getPrivate());
                 BasicOCSPResp ocspResponse = responseBuilder.build(signer, chain, Calendar.getInstance().getTime());
-
+                LOG.info("response {}", ocspResponse);
                 responseBytes = new OCSPRespBuilder().build(OCSPRespBuilder.SUCCESSFUL, ocspResponse).getEncoded();
+                LOG.error("OCSP server response OK");
             } catch (OperatorException | CertificateEncodingException | OCSPException exception) {
+                LOG.error("Internal OCSP server error", exception);
+                responseBytes = new OCSPResp(new OCSPResponse(new OCSPResponseStatus(OCSPRespBuilder.INTERNAL_ERROR), null)).getEncoded();
+            } catch (Throwable exception) {
+                LOG.error("Internal OCSP server error", exception);
                 responseBytes = new OCSPResp(new OCSPResponse(new OCSPResponseStatus(OCSPRespBuilder.INTERNAL_ERROR), null)).getEncoded();
             }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZOOKEEPER-4333

in JDK17 the OCSP request is sent in the URI and not inside the POST BODY