### PR TITLE
ZOOKEEPER-4331: add headers back

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -820,6 +820,11 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>4.1.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/zookeeper-jute/pom.xml
+++ b/zookeeper-jute/pom.xml
@@ -166,7 +166,7 @@
               !org.apache.zookeeper*,
               org.apache.jute*
             </Export-Package>
-            <Bundle-Name>ZooKeeper Bundle</Bundle-Name>
+            <Bundle-Name>ZooKeeper Jute Bundle</Bundle-Name>
             <Bundle-DocURL>https://zookeeper.apache.org/doc/current/</Bundle-DocURL>
             <Implementation-Build>${mvngit.commit.id}</Implementation-Build>
             <Merge-Headers>!Implementation-Build,*</Merge-Headers>

--- a/zookeeper-jute/pom.xml
+++ b/zookeeper-jute/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>zookeeper-jute</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <name>Apache ZooKeeper - Jute</name>
   <description>ZooKeeper jute</description>
 
@@ -148,6 +148,29 @@
         <artifactId>spotbugs-maven-plugin</artifactId>
         <configuration>
             <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>
+              *;resolution:=optional
+            </Import-Package>
+            <Export-Package>
+              org.apache.zookeeper.data,
+              org.apache.zookeeper.proto,
+              org.apache.zookeeper.txn,
+              !org.apache.zookeeper*,
+              org.apache.jute*
+            </Export-Package>
+            <Bundle-Name>ZooKeeper Bundle</Bundle-Name>
+            <Bundle-DocURL>https://zookeeper.apache.org/doc/current/</Bundle-DocURL>
+            <Implementation-Build>${mvngit.commit.id}</Implementation-Build>
+            <Merge-Headers>!Implementation-Build,*</Merge-Headers>
+          </instructions>
         </configuration>
       </plugin>
     </plugins>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>zookeeper</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <name>Apache ZooKeeper - Server</name>
   <description>ZooKeeper server</description>
 
@@ -277,7 +277,42 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
-	  
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>
+              io.netty.buffer;resolution:=optional,
+              io.netty.channel;resolution:=optional,
+              io.netty.channel.group;resolution:=optional,
+              io.netty.channel.socket.nio;resolution:=optional,
+              javax.management;resolution:=optional,
+              javax.security.auth.callback,
+              javax.security.auth.login,
+              javax.security.sasl,
+              org.ietf.jgss,
+              org.osgi.framework;resolution:=optional,
+              org.osgi.util.tracker;resolution:=optional,
+              org.slf4j,
+              *;resolution:=optional
+            </Import-Package>
+            <Export-Package>
+              !org.apache.zookeeper.data,
+              !org.apache.zookeeper.proto,
+              !org.apache.zookeeper.txn,
+              org.apache.zookeeper*
+            </Export-Package>
+            <Bundle-Name>ZooKeeper Bundle</Bundle-Name>
+            <Bundle-DocURL>https://zookeeper.apache.org/doc/current/</Bundle-DocURL>
+            <Implementation-Build>${mvngit.commit.id}</Implementation-Build>
+            <Merge-Headers>!Implementation-Build,*</Merge-Headers>
+          </instructions>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
Following up https://github.com/apache/zookeeper/pull/1720, I'm applying the change on master instead of 3.5.x as advised.

In addition to the original change, pom of zookeeper-jute is also updated because it provides some packages required by zookeeper-server. In this way, it must serve as a bundle directly before zookeeper-server can serve as a bundle.

This remans my preferred approach while I'm preparing the alternatives on master. I'm looking for a fix to 3.6, 3.7 and 3.8, so please let me know if any further PR is required for this to happen.