### PR TITLE
ZOOKEEPER-4331: add headers back in osgi artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -820,6 +820,11 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>4.1.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/zookeeper-jute/pom.xml
+++ b/zookeeper-jute/pom.xml
@@ -174,7 +174,7 @@
               !org.apache.zookeeper*,
               org.apache.jute*
             </Export-Package>
-            <Bundle-Name>ZooKeeper Bundle</Bundle-Name>
+            <Bundle-Name>ZooKeeper Jute Bundle</Bundle-Name>
             <Bundle-DocURL>https://zookeeper.apache.org/doc/current/</Bundle-DocURL>
             <Implementation-Build>${mvngit.commit.id}</Implementation-Build>
             <Merge-Headers>!Implementation-Build,*</Merge-Headers>

--- a/zookeeper-jute/pom.xml
+++ b/zookeeper-jute/pom.xml
@@ -150,6 +150,38 @@
             <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build bundle</id>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <instructions>
+            <Import-Package>
+              *;resolution:=optional
+            </Import-Package>
+            <Export-Package>
+              org.apache.zookeeper.data,
+              org.apache.zookeeper.proto,
+              org.apache.zookeeper.txn,
+              !org.apache.zookeeper*,
+              org.apache.jute*
+            </Export-Package>
+            <Bundle-Name>ZooKeeper Bundle</Bundle-Name>
+            <Bundle-DocURL>https://zookeeper.apache.org/doc/current/</Bundle-DocURL>
+            <Implementation-Build>${mvngit.commit.id}</Implementation-Build>
+            <Merge-Headers>!Implementation-Build,*</Merge-Headers>
+          </instructions>
+          <classifier>osgi</classifier>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -277,7 +277,51 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
-	  
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build bundle</id>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <instructions>
+            <Import-Package>
+              io.netty.buffer;resolution:=optional,
+              io.netty.channel;resolution:=optional,
+              io.netty.channel.group;resolution:=optional,
+              io.netty.channel.socket.nio;resolution:=optional,
+              javax.management;resolution:=optional,
+              javax.security.auth.callback,
+              javax.security.auth.login,
+              javax.security.sasl,
+              org.ietf.jgss,
+              org.osgi.framework;resolution:=optional,
+              org.osgi.util.tracker;resolution:=optional,
+              org.slf4j,
+              *;resolution:=optional
+            </Import-Package>
+            <Export-Package>
+              !org.apache.zookeeper.data,
+              !org.apache.zookeeper.proto,
+              !org.apache.zookeeper.txn,
+              org.apache.zookeeper*
+            </Export-Package>
+            <Bundle-Name>ZooKeeper Bundle</Bundle-Name>
+            <Bundle-DocURL>https://zookeeper.apache.org/doc/current/</Bundle-DocURL>
+            <Implementation-Build>${mvngit.commit.id}</Implementation-Build>
+            <Merge-Headers>!Implementation-Build,*</Merge-Headers>
+          </instructions>
+          <classifier>osgi</classifier>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
Following up https://github.com/apache/zookeeper/pull/1722, I'm applying the change on master instead of 3.5.x as advised.

As an alternative to https://github.com/apache/zookeeper/pull/1726, this change employs bundle plugin to build another artifact of classifier "osgi".

The advantage would be bundle plugin remains employed to maintain the topology of versioned packages, and the original artifact without classifier is left untouched.

The disadvantage would be we've one more artifact delivered in this project.

```
$ ls zookeeper-server/target/ | grep jar$
zookeeper-3.5.9.jar
zookeeper-3.5.9-javadoc.jar
zookeeper-3.5.9-osgi.jar
zookeeper-3.5.9-sources.jar
zookeeper-3.5.9-tests.jar
```