### PR TITLE
ZOOKEEPER-4331: add headers back manually

### DIFF
--- a/zookeeper-jute/pom.xml
+++ b/zookeeper-jute/pom.xml
@@ -150,6 +150,25 @@
             <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Bundle-Vendor>The Apache Software Foundation</Bundle-Vendor>
+              <Bundle-Name>ZooKeeper Jute Bundle</Bundle-Name>
+              <Bundle-SymbolicName>org.apache.zookeeper.jute</Bundle-SymbolicName>
+              <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+              <Bundle-Version>${project.version}</Bundle-Version>
+              <Bundle-License>http://www.apache.org/licenses/LICENSE-2.0.txt</Bundle-License>
+              <Bundle-DocURL>https://zookeeper.apache.org/doc/current/</Bundle-DocURL>
+              <Import-Package>org.apache.jute;resolution:=optional,org.apache.jute.compiler;resolution:=optional,org.apache.yetus.audience;resolution:=optional,org.apache.zookeeper.data;resolution:=optional</Import-Package>
+              <Export-Package>org.apache.zookeeper.data;uses:="org.apache.jute,org.apache.yetus.audience";version="${project.version}",org.apache.zookeeper.proto;uses:="org.apache.jute,org.apache.yetus.audience,org.apache.zookeeper.data";version="${project.version}",org.apache.zookeeper.txn;uses:="org.apache.jute,org.apache.yetus.audience,org.apache.zookeeper.data";version="${project.version}",org.apache.jute;uses:="org.apache.yetus.audience";version="${project.version}",org.apache.jute.compiler;version="${project.version}",org.apache.jute.compiler.generated;uses:="org.apache.jute.compiler";version="${project.version}"</Export-Package>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -277,10 +277,25 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
-	  
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Bundle-Vendor>The Apache Software Foundation</Bundle-Vendor>
+              <Bundle-Name>ZooKeeper Bundle</Bundle-Name>
+              <Bundle-SymbolicName>org.apache.zookeeper</Bundle-SymbolicName>
+              <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+              <Bundle-Version>${project.version}</Bundle-Version>
+              <Bundle-License>http://www.apache.org/licenses/LICENSE-2.0.txt</Bundle-License>
+              <Bundle-DocURL>https://zookeeper.apache.org/doc/current/</Bundle-DocURL>
+              <Import-Package>javax.management;resolution:=optional,javax.security.auth.callback,javax.security.auth.login,javax.security.sasl,org.slf4j;version="[1.7,2)",io.netty.buffer;resolution:=optional;version="[4.1,5)",io.netty.channel;resolution:=optional;version="[4.1,5)",io.netty.channel.group;resolution:=optional;version="[4.1,5)",io.netty.channel.socket.nio;resolution:=optional;version="[4.1,5)",org.osgi.framework;resolution:=optional,org.osgi.util.tracker;resolution:=optional",org.ietf.jgss</Import-Package>
+              <Export-Package>org.apache.zookeeper;version="${project.version}",org.apache.zookeeper.client;version="${project.version}",org.apache.zookeeper.data;version="${project.version}",org.apache.zookeeper.version;version="${project.version}",org.apache.zookeeper.server;version="${project.version}",org.apache.zookeeper.server.auth;version="${project.version}",org.apache.zookeeper.server.persistence;version="${project.version}",org.apache.zookeeper.server.quorum;version="${project.version}",org.apache.zookeeper.common;version="${project.version}"</Export-Package>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <id>publish-test-jar</id>


### PR DESCRIPTION
Following up https://github.com/apache/zookeeper/pull/1723, I'm applying the change on master instead of 3.5.x as advised.

As an alternative to https://github.com/apache/zookeeper/pull/1726, this change plants manifest entries required by osgi.

The advantage would be the least modification to the code base in all 3 approaches.

The disadvantage would be manual maintenance of these entries, which is too expensive and thus practically impossible.