### PR TITLE
Add missing .asf.yaml file to publish website

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,8 @@
+
+staging:
+  profile: ~
+  whoami:  asf-staging
+
+publish:
+  whoami:  asf-site
+


### PR DESCRIPTION
This trivial change adds the missing .asf.yaml file that ensures the
asf-site branch gets published to https://zookeeper.apache.org using ASF
publishing mechanisms when things are changed in the git branch.

This resolves the outstanding issue with this site's publishing that was
identified in the INFRA report at
https://infra-reports.apache.org/site-source/