### PR TITLE
ZOOKEEPER-4340 : add tab unit test for StringUtils#split

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/StringUtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/StringUtilTest.java
@@ -38,6 +38,9 @@ public class StringUtilTest extends ZKTestCase {
 
         final String s3 = "1, , 2";
         assertEquals(Arrays.asList("1", "2"), StringUtils.split(s3, ","));
+        
+        final String s4 = "1,\t,2";
+        assertEquals(Arrays.asList("1","2"), StringUtils.split(s4, ","));
     }
 
     @Test

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/StringUtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/StringUtilTest.java
@@ -40,7 +40,7 @@ public class StringUtilTest extends ZKTestCase {
         assertEquals(Arrays.asList("1", "2"), StringUtils.split(s3, ","));
 
         final String s4 = "1, \t , 2";
-        assertEquals(Arrays.asList("1","2"), StringUtils.split(s4, ","));
+        assertEquals(Arrays.asList("1", "2"), StringUtils.split(s4, ","));
     }
 
     @Test

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/StringUtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/StringUtilTest.java
@@ -38,8 +38,8 @@ public class StringUtilTest extends ZKTestCase {
 
         final String s3 = "1, , 2";
         assertEquals(Arrays.asList("1", "2"), StringUtils.split(s3, ","));
-        
-        final String s4 = "1,\t,2";
+
+        final String s4 = "1, \t , 2";
         assertEquals(Arrays.asList("1","2"), StringUtils.split(s4, ","));
     }
 


### PR DESCRIPTION
Adding a test case to StringUtils to ensure spaces expressed as something other than ' ' are covered.