### PR TITLE
ZOOKEEPER-4342: Fix: Robustify C client against errors during SASL negotiation

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -2927,8 +2927,10 @@ static int process_sasl_response(zhandle_t *zh, char *buffer, int len)
     struct SetSASLResponse res;
     int rc;
 
+    memset(&res, 0, sizeof(res));
     rc = ia ? ZOK : ZSYSTEMERROR;
     rc = rc < 0 ? rc : deserialize_ReplyHeader(ia, "hdr", &hdr);
+    rc = rc < 0 ? rc : hdr.err;
     rc = rc < 0 ? rc : deserialize_SetSASLResponse(ia, "reply", &res);
     rc = rc < 0 ? rc : zoo_sasl_client_step(zh, res.token.buff, res.token.len);
     deallocate_SetSASLResponse(&res);
@@ -3018,6 +3020,7 @@ static int check_events(zhandle_t *zh, int events)
                 } else {
                     rc = process_sasl_response(zh, zh->input_buffer->buffer, zh->input_buffer->curr_offset);
                     free_buffer(zh->input_buffer);
+                    zh->input_buffer = 0;
                     if (rc < 0) {
                         zoo_sasl_mark_failed(zh);
                         return rc;


### PR DESCRIPTION
Before this, the client was ignoring the error field of the response header, and only considering SASL-level errors.

This commit makes it consider `hdr.err`.  It also zeroes the `res` data structure, to avoid a crash in `deallocate` if `deserialize` is skipped, and sets `input_buffer` to `NULL` to avoid a double-free.

(I looked into adding a non-regression test, but doing so requires adding quite a bit of infrastructure to the mocks so that the SASL library can be correctly initialized.  Punting for now.)