### PR TITLE
ZOOKEEPER-4406: fix the znode type for Barrier implementation in the zookeeperTutorial.md

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperTutorial.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperTutorial.md
@@ -156,7 +156,7 @@ a boolean flag that enables the process to set a watch. In the code the flag is 
 
     boolean enter() throws KeeperException, InterruptedException{
         zk.create(root + "/" + name, new byte[0], Ids.OPEN_ACL_UNSAFE,
-                CreateMode.EPHEMERAL_SEQUENTIAL);
+                CreateMode.EPHEMERAL);
         while (true) {
             synchronized (mutex) {
                 List<String> list = zk.getChildren(root, true);
@@ -463,7 +463,7 @@ Start a barrier with 2 participants (start as many times as many participants yo
 
             boolean enter() throws KeeperException, InterruptedException{
                 zk.create(root + "/" + name, new byte[0], Ids.OPEN_ACL_UNSAFE,
-                        CreateMode.EPHEMERAL_SEQUENTIAL);
+                        CreateMode.EPHEMERAL);
                 while (true) {
                     synchronized (mutex) {
                         List<String> list = zk.getChildren(root, true);


### PR DESCRIPTION
With EPHEMERAL_SEQUENTIAL,the generated node name will be added with the sequence number, and the delete() will report error that it cannot be found
EPHEMERAL_SEQUENTIAL产生的节点名会加上顺序编号，删除会报找不到