### PR TITLE
ZOOKEEPER-4356 Code blocks do not render correctly in ZK docs site

### DIFF
--- a/zookeeper-docs/pom.xml
+++ b/zookeeper-docs/pom.xml
@@ -49,6 +49,7 @@
           <headerHtmlFile>${project.basedir}/src/main/resources/markdown/html/header.html</headerHtmlFile>
           <footerHtmlFile>${project.basedir}/src/main/resources/markdown/html/footer.html</footerHtmlFile>
           <copyDirectories>images,skin</copyDirectories>
+          <pegdownExtensions>TABLES,FENCED_CODE_BLOCKS</pegdownExtensions>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
* Configure to use FENCED_CODE_BLOCKS. 
* Note: TABLES is the default setting. See https://github.com/walokra/markdown-page-generator-plugin for details on default `pegdownExtensions` setting