### PR TITLE
ZOOKEEPER-4372: Added check and unit test for negative sequence numbers in lock recipe

### DIFF
--- a/zookeeper-recipes/zookeeper-recipes-lock/src/main/java/org/apache/zookeeper/recipes/lock/ZNodeName.java
+++ b/zookeeper-recipes/zookeeper-recipes-lock/src/main/java/org/apache/zookeeper/recipes/lock/ZNodeName.java
@@ -51,11 +51,14 @@ class ZNodeName implements Comparable<ZNodeName> {
     public ZNodeName(final String name) {
         this.name = Objects.requireNonNull(name, "ZNode name cannot be null");
 
-        final int idx = name.lastIndexOf('-');
+        int idx = name.lastIndexOf('-');
         if (idx < 0) {
             this.prefix = name;
             this.sequence = Optional.empty();
         } else {
+            if (idx > 0 && name.charAt(idx - 1) == '-') {
+                idx = idx - 1;
+            }
             this.prefix = name.substring(0, idx);
             this.sequence = Optional.ofNullable(parseSequenceString(name.substring(idx + 1)));
         }

--- a/zookeeper-recipes/zookeeper-recipes-lock/src/test/java/org/apache/zookeeper/recipes/lock/ZNodeNameTest.java
+++ b/zookeeper-recipes/zookeeper-recipes-lock/src/test/java/org/apache/zookeeper/recipes/lock/ZNodeNameTest.java
@@ -34,13 +34,18 @@ public class ZNodeNameTest {
 
     @Test
     public void testOrderWithSamePrefix() throws Exception {
-        final String[] names = {"x-3", "x-5", "x-11", "x-1"};
+        final String[] names = {"x-3", "x-5", "x-11", "x-1", "x--20"};
         ZNodeName zname;
 
         final Collection<ZNodeName> nodeNames = Arrays.asList(names).stream()
             .map(name -> new ZNodeName(name)).sorted().collect(Collectors.toList());
 
         final Iterator<ZNodeName> it = nodeNames.iterator();
+
+        zname = it.next();
+        assertEquals("x--20", zname.getName());
+        assertEquals("x", zname.getPrefix());
+        assertEquals(Integer.valueOf(-20), zname.getSequence().get());
 
         zname = it.next();
         assertEquals("x-1", zname.getName());


### PR DESCRIPTION
I took a stab at fixing this and adding a simple case to one of the existing unit tests to check for negative sequence numbers. This is my first time working in the ZK Java implementation so please let me know if I need to make any adjustments. I updated the code to check if there is a prior "-" character in the index before the last "-" and move the index back one if there is.