### PR TITLE
ZOOKEEPER-4382: Update Maven Bundle Plugin to 5.1.1 - build on JDK18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -829,7 +829,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>4.1.0</version>
+          <version>5.1.1</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
More context here
https://issues.apache.org/jira/browse/ZOOKEEPER-4382