### PR TITLE
ZOOKEEPER-4384: Fix 'se[r]ver' typo in ClientCnxn.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -1290,7 +1290,7 @@ public class ClientCnxn {
                         break;
                     } else {
                         LOG.warn(
-                            "Session 0x{} for sever {}, Closing socket connection. "
+                            "Session 0x{} for server {}, Closing socket connection. "
                                 + "Attempting reconnect except it is a SessionExpiredException.",
                             Long.toHexString(getSessionId()),
                             serverAddress,


### PR DESCRIPTION
Hello. Not yet created a JIRA issue for this small logging change, but happy to open one if that is preferred.

Stumbled across this in the ZK logs; also checked via `git grep -in "sever[^a-z]"` that this is the only place with the typo.