### PR TITLE
ZOOKEEPER-4387 Close ZkDb when ZooKeeper Server shutdown

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -833,6 +833,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
             if (fullyShutDown && zkDb != null) {
                 zkDb.clear();
             }
+            tryCloseZkDb();
             LOG.debug("ZooKeeper server is not running, so not proceeding to shutdown!");
             return;
         }
@@ -879,10 +880,19 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                     zkDb.clear();
                 }
             }
+            tryCloseZkDb();
         }
 
         requestPathMetricsCollector.shutdown();
         unregisterJMX();
+    }
+
+    private void tryCloseZkDb() {
+        try {
+            zkDb.close();
+        } catch (Exception e) {
+            LOG.warn("try to close zkDb failed ", e);
+        }
     }
 
     protected void unregisterJMX() {


### PR DESCRIPTION
Close ZkDb when ZooKeeper Server shutdown. This can be useful when people delete zookeeper directory when zookeeper server shutdown. Typically useful on windows unit test