### PR TITLE
Netty server does not respond to ruok while initializing cluster

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -526,14 +526,9 @@ public class NettyServerCnxn extends ServerCnxn {
                         }
                         ZooKeeperServer zks = this.zkServer;
 
-                        if (zks != null && !zks.isRunning()) {
+                        if (zks != null && zks.isRunning()) {
                             // checkRequestSize will throw IOException if request is rejected
                             zks.checkRequestSizeWhenReceivingMessage(len);
-                        } else {
-                            LOG.debug("Skip configurable check for max receive length");
-                            if (len > 64 * 1024) {
-                                throw new IOException("Received message size too large for uninitialized server");
-                            }
                         }
                         bb = ByteBuffer.allocate(len);
                     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -477,7 +477,7 @@ public class NettyServerCnxn extends ServerCnxn {
                         if (zks == null) {
                             throw new IOException("ZK down");
                         } else if (!zks.isRunning()){
-                            LOG.warn("Zks not running but keep processing");
+                            LOG.debug("Zks not running but keep processing");
                         }
 
                         if (initialized) {
@@ -530,10 +530,10 @@ public class NettyServerCnxn extends ServerCnxn {
                             // checkRequestSize will throw IOException if request is rejected
                             zks.checkRequestSizeWhenReceivingMessage(len);
                         } else {
+                            LOG.debug("Skip configurable check for max receive length");
                             if (len > 64 * 1024) {
                                 throw new IOException("Received message size too large for uninitialized server");
                             }
-                            LOG.warn("Skip configurable check for receive length");
                         }
                         bb = ByteBuffer.allocate(len);
                     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -225,17 +225,6 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
             NettyServerCnxn cnxn = new NettyServerCnxn(channel, zkServer, NettyServerCnxnFactory.this);
             ctx.channel().attr(CONNECTION_ATTRIBUTE).set(cnxn);
 
-            // Check the zkServer assigned to the cnxn is still running,
-            // close it before starting the heavy TLS handshake
-            /*
-            if (!cnxn.isZKServerRunning()) {
-                LOG.warn("Zookeeper server is not running, close the connection before starting the TLS handshake");
-                ServerMetrics.getMetrics().CNXN_CLOSED_WITHOUT_ZK_SERVER_RUNNING.add(1);
-                channel.close();
-                return;
-            }
-             */
-
             if (handshakeThrottlingEnabled) {
                 // Favor to check and throttling even in dual mode which
                 // accepts both secure and insecure connections, since

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -227,12 +227,14 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
 
             // Check the zkServer assigned to the cnxn is still running,
             // close it before starting the heavy TLS handshake
+            /*
             if (!cnxn.isZKServerRunning()) {
                 LOG.warn("Zookeeper server is not running, close the connection before starting the TLS handshake");
                 ServerMetrics.getMetrics().CNXN_CLOSED_WITHOUT_ZK_SERVER_RUNNING.add(1);
                 channel.close();
                 return;
             }
+             */
 
             if (handshakeThrottlingEnabled) {
                 // Favor to check and throttling even in dual mode which
@@ -264,9 +266,18 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
                 if (remoteAddress != null
                         && !((InetSocketAddress) remoteAddress).getAddress().isLoopbackAddress()) {
                     LOG.trace("NettyChannelHandler channelActive: remote={} local={}", remoteAddress, cnxn.getChannel().localAddress());
-                    zkServer.serverStats().incrementNonMTLSRemoteConnCount();
+
+                    if (zkServer == null || zkServer.serverStats() == null) {
+                        LOG.warn("zkServer is not initialized " + (zkServer == null ? "" : "for stats ") + " no remote connection stats update done");
+                    } else {
+                        zkServer.serverStats().incrementNonMTLSRemoteConnCount();
+                    }
                 } else {
-                    zkServer.serverStats().incrementNonMTLSLocalConnCount();
+                    if (zkServer == null || zkServer.serverStats() == null) {
+                        LOG.warn("zkServer is not initialized " + (zkServer == null ? "" : "for stats ") + " no local connection count stats update done" );
+                    } else {
+                        zkServer.serverStats().incrementNonMTLSLocalConnCount();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Apache Pulsar (and others I suspect) use Zookeeper in a Kubernetes statefull set with liveness and ready probes polling the "ruok" Zookeeper command. With the Netty server configured, on later versions of Zookeeper, the first replica would start but never become ready so the statefull set could not scale up from 1 to the desired replica count. This is due to the first replica never replying to "ruok" - it just closes the connection.

Apache Pulsar issue https://github.com/apache/pulsar/issues/11070 reported this failure and this change set was created to get the server to respond to "ruok" while initializing. With these changes the set scales up to the desired 3 replicas.

The issue does not occur with the NIO server context (which is the default) but I've not compared the two to work out exact differences - just modified the Netty one to respond in more cases. There's a tricky issue of disallowing exceedingly large requests as well (in code below) as well as the general question of is it ok to proceed past these checks that were closing the connection. In a multi-threaded server checking a variable isRunning() could be a race in any case so hopefully it's still robust with these changes but they probably need to be taken over by an expert and just used as a starting point for a fix.