### PR TITLE
ZOOKEEPER-4419: The potential exception in Learner$LeaderConnector.connectToLeader may cause unnecessary re-election or service delay

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -396,7 +396,7 @@ public class Learner {
         }
 
         private Socket connectToLeader() throws IOException, X509Exception, InterruptedException {
-            Socket sock = createSocket();
+            Socket sock = null;
 
             // leader connection timeout defaults to tickTime * initLimit
             int connectTimeout = self.tickTime * self.initLimit;
@@ -410,8 +410,12 @@ public class Learner {
             int remainingTimeout;
             long startNanoTime = nanoTime();
 
-            for (int tries = 0; tries < 5 && socket.get() == null; tries++) {
+            for (int tries = 0; tries < 5; tries++) {
                 try {
+                    sock = createSocket();
+                    if (socket.get() == null) {
+                        continue;
+                    }
                     // recalculate the init limit time because retries sleep for 1000 milliseconds
                     remainingTimeout = connectTimeout - (int) ((nanoTime() - startNanoTime) / 1_000_000);
                     if (remainingTimeout <= 0) {
@@ -451,7 +455,6 @@ public class Learner {
                           remainingTimeout,
                           address,
                           e);
-                        sock = createSocket();
                     }
                 }
                 Thread.sleep(leaderConnectDelayDuringRetryMs);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -413,9 +413,7 @@ public class Learner {
             for (int tries = 0; tries < 5; tries++) {
                 try {
                     sock = createSocket();
-                    if (socket.get() == null) {
-                        continue;
-                    }
+
                     // recalculate the init limit time because retries sleep for 1000 milliseconds
                     remainingTimeout = connectTimeout - (int) ((nanoTime() - startNanoTime) / 1_000_000);
                     if (remainingTimeout <= 0) {
@@ -427,34 +425,29 @@ public class Learner {
                     if (self.isSslQuorum()) {
                         ((SSLSocket) sock).startHandshake();
                     }
-                    sock.setTcpNoDelay(nodelay);
-                    break;
                 } catch (IOException e) {
+                    // close failed socket before retrying
+                    if (sock != null) {
+                        try {
+                            sock.close();
+                        } catch (IOException closeException) {
+                            LOG.debug("Failed to close socket after connection failure", closeException);
+                        }
+                        sock = null;
+                    }
                     remainingTimeout = connectTimeout - (int) ((nanoTime() - startNanoTime) / 1_000_000);
 
                     if (remainingTimeout <= leaderConnectDelayDuringRetryMs) {
-                        LOG.error(
-                          "Unexpected exception, connectToLeader exceeded. tries={}, remaining init limit={}, connecting to {}",
-                          tries,
-                          remainingTimeout,
-                          address,
-                          e);
+                        LOG.error("Unexpected exception, connectToLeader exceeded. tries={}, remaining init limit={}, connecting to {}",
+                                tries, remainingTimeout, address, e);
                         throw e;
                     } else if (tries >= 4) {
-                        LOG.error(
-                          "Unexpected exception, retries exceeded. tries={}, remaining init limit={}, connecting to {}",
-                          tries,
-                          remainingTimeout,
-                          address,
-                          e);
+                        LOG.error("Unexpected exception, retries exceeded. tries={}, remaining init limit={}, connecting to {}",
+                                tries, remainingTimeout, address, e);
                         throw e;
                     } else {
-                        LOG.warn(
-                          "Unexpected exception, tries={}, remaining init limit={}, connecting to {}",
-                          tries,
-                          remainingTimeout,
-                          address,
-                          e);
+                        LOG.warn("Unexpected exception, tries={}, remaining init limit={}, connecting to {}",
+                                tries, remainingTimeout, address, e);
                     }
                 }
                 Thread.sleep(leaderConnectDelayDuringRetryMs);


### PR DESCRIPTION
The patch for [ZOOKEEPER-4419](https://issues.apache.org/jira/browse/ZOOKEEPER-4419)