### PR TITLE
ZOOKEEPER-4425: `snap` 4lw command enabling on demand snapshots

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerCnxnFactory.java
@@ -144,15 +144,24 @@ public abstract class ServerCnxnFactory {
     public abstract void start();
 
     protected ZooKeeperServer zkServer;
+
+    protected ZooKeeperServer lastConnectedServer;
+
     public final void setZooKeeperServer(ZooKeeperServer zks) {
         this.zkServer = zks;
         if (zks != null) {
+            lastConnectedServer = zks;
+
             if (secure) {
                 zks.setSecureServerCnxnFactory(this);
             } else {
                 zks.setServerCnxnFactory(this);
             }
         }
+    }
+
+    public final ZooKeeperServer getLastConnectedZooKeeperServer() {
+        return lastConnectedServer;
     }
 
     public abstract void closeAll(ServerCnxn.DisconnectReason reason);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/CommandExecutor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/CommandExecutor.java
@@ -81,6 +81,8 @@ public class CommandExecutor {
             command = new IsroCommand(pwriter, serverCnxn);
         } else if (commandCode == FourLetterCommands.hashCmd) {
             command = new DigestCommand(pwriter, serverCnxn);
+        } else if (commandCode == FourLetterCommands.snapCmd) {
+            command = new TakeSnapshotCommand(pwriter, serverCnxn);
         }
 
         return command;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/FourLetterCommands.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/FourLetterCommands.java
@@ -252,5 +252,6 @@ public class FourLetterCommands {
         cmd2String.put(isroCmd, "isro");
         cmd2String.put(telnetCloseCmd, "telnet close");
         cmd2String.put(hashCmd, "hash");
+        cmd2String.put(snapCmd, "snap");
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/FourLetterCommands.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/FourLetterCommands.java
@@ -140,6 +140,12 @@ public class FourLetterCommands {
     protected static final int hashCmd = ByteBuffer.wrap("hash".getBytes()).getInt();
 
     /*
+     * See <a href="{@docRoot}/../../../docs/zookeeperAdmin.html#sc_zkCommands">
+     * Zk Admin</a>. this link is for all the commands.
+     */
+    protected static final int snapCmd = ByteBuffer.wrap("snap".getBytes()).getInt();
+
+    /*
      * The control sequence sent by the telnet program when it closes a
      * connection. Include simply to keep the logs cleaner (the server would
      * close the connection anyway because it would parse this as a negative

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/TakeSnapshotCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/TakeSnapshotCommand.java
@@ -19,6 +19,8 @@
 package org.apache.zookeeper.server.command;
 
 import org.apache.zookeeper.server.ServerCnxn;
+import org.apache.zookeeper.server.ZooKeeperServer;
+
 import java.io.PrintWriter;
 
 public class TakeSnapshotCommand extends AbstractFourLetterCommand {
@@ -29,7 +31,17 @@ public class TakeSnapshotCommand extends AbstractFourLetterCommand {
 
     @Override
     public void commandRun() {
-        zkServer.takeSnapshot(true);
-        pw.println("Snapshot taken");
+        ZooKeeperServer server = zkServer;
+
+        if (server == null) {
+            server = factory.getLastConnectedZooKeeperServer();
+        }
+
+        if (server != null) {
+            server.takeSnapshot(true);
+            pw.println("Snapshot taken");
+        } else {
+            pw.println("Couldn't access the most recent DB");
+        }
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/TakeSnapshotCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/TakeSnapshotCommand.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.command;
+
+import org.apache.zookeeper.server.ServerCnxn;
+import java.io.PrintWriter;
+
+public class TakeSnapshotCommand extends AbstractFourLetterCommand {
+
+    public TakeSnapshotCommand(PrintWriter pw, ServerCnxn serverCnxn) {
+        super(pw, serverCnxn);
+    }
+
+    @Override
+    public void commandRun() {
+        zkServer.takeSnapshot(true);
+        pw.println("Snapshot taken");
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/TakeSnapshotCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/TakeSnapshotCommand.java
@@ -18,10 +18,9 @@
 
 package org.apache.zookeeper.server.command;
 
+import java.io.PrintWriter;
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ZooKeeperServer;
-
-import java.io.PrintWriter;
 
 public class TakeSnapshotCommand extends AbstractFourLetterCommand {
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/command/TakeSnapshotCommandTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/command/TakeSnapshotCommandTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.command;
+
+import org.apache.zookeeper.server.ServerCnxn;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.apache.zookeeper.server.command.AbstractFourLetterCommand.ZK_NOT_SERVING;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TakeSnapshotCommandTest {
+    private TakeSnapshotCommand takeSnapshotCommand;
+    private StringWriter outputWriter;
+    private ZooKeeperServer zks;
+
+    @BeforeEach
+    public void setUp() {
+        outputWriter = new StringWriter();
+        ServerCnxn serverCnxnMock = mock(ServerCnxn.class);
+
+        zks = mock(ZooKeeperServer.class);
+        when(zks.isRunning()).thenReturn(true);
+
+        takeSnapshotCommand = new TakeSnapshotCommand(new PrintWriter(outputWriter), serverCnxnMock);
+        takeSnapshotCommand.setZkServer(zks);
+    }
+
+    @Test
+    public void testTakeSnapshot() {
+        // Arrange
+        doNothing().when(zks).takeSnapshot();
+
+        // Act
+        takeSnapshotCommand.commandRun();
+
+        // Assert
+        String output = outputWriter.toString();
+        assertEquals("Snapshot taken", output.trim());
+    }
+
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/command/TakeSnapshotCommandTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/command/TakeSnapshotCommandTest.java
@@ -18,17 +18,16 @@
 
 package org.apache.zookeeper.server.command;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.io.PrintWriter;
-import java.io.StringWriter;
-
-import static org.apache.zookeeper.server.command.AbstractFourLetterCommand.ZK_NOT_SERVING;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 class TakeSnapshotCommandTest {
     private TakeSnapshotCommand takeSnapshotCommand;


### PR DESCRIPTION
This PR contains the patch corresponding to the JIRA issue https://issues.apache.org/jira/browse/ZOOKEEPER-4425

It aims to:

- Make the last in-memory copy of a node database to be accessible to 4lw commands, even after a disconnection event happens and the references to the connected Zookeeper server become `null`.
- Use this internal feature to provide a `snap` _for letter words_ command that makes the receiving ZooKeeper instance to save its local copy of the database to disk as any regular snapshot.

Example of usage:

```bash
echo "snap" | nc localhost 2184
``` 