### PR TITLE
ZOOKEEPER-4429: Update jackson-databind to 2.13.1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -55,7 +55,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="javacc.version" value="5.0"/>
 
     <property name="jetty.version" value="9.4.43.v20210629"/>
-    <property name="jackson.version" value="2.10.3"/>
+    <property name="jackson.version" value="2.13.1"/>
     <property name="dependency-check-ant.version" value="5.2.4"/>
 
     <property name="commons-io.version" value="2.6"/>

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
     <commons-cli.version>1.2</commons-cli.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <netty.version>4.1.70.Final</netty.version>
-    <jackson.version>2.10.5.1</jackson.version>
+    <jackson.version>2.13.1</jackson.version>
     <json.version>1.1.1</json.version>
     <jline.version>2.14.6</jline.version>
     <snappy.version>1.1.7</snappy.version>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/JsonOutputter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/JsonOutputter.java
@@ -21,7 +21,7 @@ package org.apache.zookeeper.server.admin;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +40,7 @@ public class JsonOutputter implements CommandOutputter {
         mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
         mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
     }
 
     @Override


### PR DESCRIPTION
This PR updates jackson-databind to 2.13.1 to address a raised vulnerability that could possible DoS attack certain versions of Jackson. Please refer to GH issue #3328 for further info. On top of that, it also fixes now deprecated `PropertyNamingStrategy` class initialization issue #2715.  