### PR TITLE
ZOOKEEPER-4446 branch-3.6 txnLogCountTest use wrong version of Junit Assert import

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/TxnLogCountTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/TxnLogCountTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.zookeeper.server;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;


### PR DESCRIPTION
This PR mean to fix the invalid import static for junit Assert that only available in Junit 5.