### PR TITLE
Backport ZOOKEEPER-3423 to Branch 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,6 @@ zookeeper-client/zookeeper-client-c/depcomp
 zookeeper-client/zookeeper-client-c/install-sh
 zookeeper-client/zookeeper-client-c/ltmain.sh
 zookeeper-client/zookeeper-client-c/missing
-zookeeper-server/src/main/java/org/apache/zookeeper/version/Info.java
 zookeeper-server/src/test/resources/
 
 # Python

--- a/build.xml
+++ b/build.xml
@@ -110,6 +110,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <property name="build.dir" value="${basedir}/build" />
     <property name="distribution" value="${basedir}/distribution" />
     <property name="src_generated.dir" value="${basedir}/zookeeper-jute/target/main/java" />
+    <property name="src_version_generated.dir" value="${basedir}/zookeeper-server/target/generated-sources/java" />
     <property name="c.src.dir" value="${basedir}/zookeeper-client/zookeeper-client-c" />
     <property name="csrc_generated.dir" value="${c.src.dir}/generated" />
 
@@ -392,6 +393,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
             <arg value="${version}" />
             <arg value="${lastRevision}" />
             <arg value="${build.time}" />
+            <arg value="${src_version_generated.dir}" />
             <classpath>
                 <pathelement path="${build.classes}" />
             </classpath>
@@ -500,6 +502,7 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
                target="${javac.target}" source="${javac.source}" debug="on" encoding="${build.encoding}">
             <src path="${java.server.src.dir}"/>
             <src path="${jute.src.dir}"/>
+            <src path="${src_version_generated.dir}"/>
             <classpath refid="java.classpath"/>
             <compilerarg value="-Xlint:all"/>
             <compilerarg value="-Xlint:-path"/>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -180,6 +180,17 @@
               <timeZone>GMT</timeZone>
             </configuration>
           </execution>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/java</source>
+              </sources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -220,6 +231,7 @@
                 <argument>${project.version}</argument>
                 <argument>${git.commit.id}</argument>
                 <argument>${build.time}</argument>
+                <argument>${project.basedir}/target/generated-sources/java</argument>
               </arguments>
             </configuration>
           </execution>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
@@ -30,7 +30,7 @@ public class VerGen {
 
     static void printUsage() {
         System.out.print("Usage:\tjava  -cp <classpath> org.apache.zookeeper."
-                + "version.util.VerGen maj.min.micro[-qualifier] rev buildDate");
+                + "version.util.VerGen maj.min.micro[-qualifier] rev buildDate outputDirectory");
         System.exit(1);
     }
 
@@ -141,7 +141,7 @@ public class VerGen {
      *            </ul>
      */
     public static void main(String[] args) {
-        if (args.length != 3)
+        if (args.length != 4)
             printUsage();
         try {
             Version version = parseVersionString(args[0]);
@@ -156,7 +156,7 @@ public class VerGen {
             } else {
                 rev = rev.trim();
             }
-            generateFile(new File("."), version, rev, args[2]);
+            generateFile(new File(args[3]), version, rev, args[2]);
         } catch (NumberFormatException e) {
             System.err.println(
                     "All version-related parameters must be valid integers!");


### PR DESCRIPTION
- when I `mvn clean package -DskipTests` to build the `branch-3.5`, then I git checkout to `master` branch, and build master branch, I got the following:

```
                  [ERROR] Failed to execute goal
                  > > org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile
                  > > (default-compile) on project zookeeper: Fatal error compiling:
                  > > java.lang.NullPointerException -> [Help 1]
```

- From this [email](https://www.mail-archive.com/user@zookeeper.apache.org/msg09639.html), we have a workaround: `git clean -xdf`. The root cause is the file(`zookeeper-server/src/main/java/org/apache/zookeeper/version/Info.java`) generated in branch-3.5 and affected the compile in the master.
- This issue is poisonous and not easy to debug
- I backport to [ZOOKEEPER-3423](https://github.com/apache/zookeeper/pull/980) to fix this. Now branch-3.6 and branch-3.5 used the same way to generate version files, master and branch-3.7 uses another new approach.