### PR TITLE
Backport ZOOKEEPER-3738 to Branch 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ zookeeper-server/version-2/*
 # SVN
 .svn
 .revision
-git.properties
 
 # Eclipse
 .metadata

--- a/pom.xml
+++ b/pom.xml
@@ -470,11 +470,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>properties-maven-plugin</artifactId>
-          <version>1.0.0</version>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
@@ -495,6 +490,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.1.0</version>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Implementation-Build>${mvngit.commit.id}</Implementation-Build>
+              </manifestEntries>
+            </archive>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -544,10 +546,12 @@
           <version>1.6.0</version>
         </plugin>
         <plugin>
-          <groupId>pl.project13.maven</groupId>
-          <artifactId>git-commit-id-plugin</artifactId>
-          <version>2.2.5</version>
-          <inherited>false</inherited>
+          <groupId>com.github.koraktor</groupId>
+          <artifactId>mavanagaiata</artifactId>
+          <version>0.9.4</version>
+          <configuration>
+            <skipNoGit>true</skipNoGit>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -617,33 +621,17 @@
 
     <plugins>
       <plugin>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
+        <groupId>com.github.koraktor</groupId>
+        <artifactId>mavanagaiata</artifactId>
         <executions>
           <execution>
             <id>find-current-git-revision</id>
             <goals>
-              <goal>revision</goal>
+              <goal>commit</goal>
             </goals>
             <phase>validate</phase>
           </execution>
         </executions>
-        <configuration>
-          <skipPoms>false</skipPoms>
-          <runOnlyOnce>true</runOnlyOnce>
-          <failOnNoGitDirectory>false</failOnNoGitDirectory>
-          <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-          <prefix>git</prefix>
-          <verbose>false</verbose>
-          <generateGitPropertiesFile>true</generateGitPropertiesFile>
-          <generateGitPropertiesFilename>${project.basedir}/zookeeper-server/src/main/resources/git.properties</generateGitPropertiesFilename>
-          <format>properties</format>
-          <gitDescribe>
-            <skip>false</skip>
-            <always>false</always>
-            <dirty>-dirty</dirty>
-          </gitDescribe>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.openclover</groupId>
@@ -785,7 +773,6 @@
           <excludes>
             <exclude>**/log4j.properties</exclude>
             <exclude>**/README.md</exclude>
-            <exclude>**/git.properties</exclude>
             <exclude>**/findbugsExcludeFile.xml</exclude>
             <exclude>**/checkstyle-noframes-sorted.xsl</exclude>
             <exclude>**/configure.ac</exclude>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -147,23 +147,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>initialize</phase>
-            <goals>
-              <goal>read-project-properties</goal>
-            </goals>
-            <configuration>
-              <files>
-                <file>${basedir}/src/main/resources/git.properties</file>
-              </files>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin> <!-- ${maven.build.timestamp} does not support timezone :( -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -218,7 +201,7 @@
                 <classpath />
                 <argument>org.apache.zookeeper.version.util.VerGen</argument>
                 <argument>${project.version}</argument>
-                <argument>${git.commit.id}</argument>
+                <argument>${mvngit.commit.id}</argument>
                 <argument>${build.time}</argument>
               </arguments>
             </configuration>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/version/util/VerGen.java
@@ -30,7 +30,7 @@ public class VerGen {
 
     static void printUsage() {
         System.out.print("Usage:\tjava  -cp <classpath> org.apache.zookeeper."
-                + "version.util.VerGen maj.min.micro[-qualifier] rev buildDate");
+                + "version.util.VerGen maj.min.micro[-qualifier] [rev] buildDate outputDirectory");
         System.exit(1);
     }
 
@@ -141,8 +141,12 @@ public class VerGen {
      *            </ul>
      */
     public static void main(String[] args) {
-        if (args.length != 3)
+        if (args.length != 3 && args.length != 4) {
             printUsage();
+        }
+        if (args.length == 3) {
+            args = new String[]{args[0], null, args[1], args[2]};
+        }
         try {
             Version version = parseVersionString(args[0]);
             if (version == null) {


### PR DESCRIPTION
- when I `mvn clean package -DskipTests` to build the branch-3.5, then I git checkout to master branch,
I found an unstash file(`zookeeper-server/src/main/resources/git.properties`) in the master, because 
master now uses `mavanagaiata` for git commit id and doesn't ignore `git.properties` anymore.
- ZOOKEEPER-3738( [PR-1268](https://github.com/apache/zookeeper/pull/1268) and [PR-1321](https://github.com/apache/zookeeper/pull/1321)) had been merged into `master`, `branch-3.7`, `branch-3.6`, I apply it to `branch-3.5` to keep all branches consistency and fix this issue.