### PR TITLE
ZOOKEEPER-4465: zooinspector logback pattern config add escape for '(' and ')'

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/resources/logback.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/resources/logback.xml
@@ -22,7 +22,7 @@
 <configuration>
   <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%5p [%t] (%F:%L) - %m%n</pattern>
+      <pattern>%5p [%t] \(%F:%L\) - %m%n</pattern>
     </encoder>
   </appender>
   <root level="INFO">


### PR DESCRIPTION
zooinspect logback config file `logback.xml` currently use a pattern of this 
`<pattern>%5p [%t] (%F:%L) - %m%n</pattern> `
which not escape the '(' and ')', cause logback to ignore parts after ')'. 

according to logback documents, '(' and ')' is used for grouping, need escape by '\' if used as normal char
https://logback.qos.ch/manual/layouts.html#grouping  

this pr update it to (add '\' to escape)
`<pattern>%5p [%t] \(%F:%L\) - %m%n</pattern> `