### PR TITLE
ZOOKEEPER-4469: Suppress OWASP false positives related to Netty TCNative

### DIFF
--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -34,6 +34,18 @@
       <!-- https://github.com/jeremylong/DependencyCheck/issues/1653
            False positive on Netty 4.x-->
       <cve>CVE-2018-12056</cve>
+      <!-- other false positives related to Netty TCNative 4.x -->
+      <cve>CVE-2021-43797</cve>
+      <cve>CVE-2019-16869</cve>
+      <cve>CVE-2015-2156</cve>
+      <cve>CVE-2021-37136</cve>
+      <cve>CVE-2014-3488</cve>
+      <cve>CVE-2021-37137</cve>
+      <cve>CVE-2019-20445</cve>
+      <cve>CVE-2019-20444</cve>
+      <cve>CVE-2021-21295</cve>
+      <cve>CVE-2021-21409</cve>
+      <cve>CVE-2021-21290</cve>
    </suppress>
    <suppress>
       <!-- Seems like false positive - we are not using Prometheus

--- a/pom.xml
+++ b/pom.xml
@@ -798,7 +798,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>5.3.0</version>
+          <version>6.5.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
More context here:
https://issues.apache.org/jira/browse/ZOOKEEPER-4469

I am also updating the OWASP dependency check