### PR TITLE
ZOOKEEPER-4467: Format OpCode.addWatch in Request.op2String

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
@@ -364,6 +364,8 @@ public class Request {
                 return "setWatches";
             case OpCode.setWatches2:
                 return "setWatches2";
+            case OpCode.addWatch:
+                return "addWatch";
             case OpCode.sasl:
                 return "sasl";
             case OpCode.getEphemerals:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
@@ -355,7 +355,7 @@ public class Request {
             case OpCode.deleteContainer:
                 return "deleteContainer";
             case OpCode.createTTL:
-                return "createTtl";
+                return "createTTL";
             case OpCode.multiRead:
                 return "multiRead";
             case OpCode.auth:

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ToStringTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ToStringTest.java
@@ -18,8 +18,12 @@
 
 package org.apache.zookeeper.server;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import java.lang.reflect.Field;
 import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.proto.SetDataRequest;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +39,20 @@ public class ToStringTest extends ZKTestCase {
     public void testJuteToString() {
         SetDataRequest req = new SetDataRequest(null, null, 0);
         assertNotSame("ERROR", req.toString());
+    }
+
+    @Test
+    public void testOpCodeToString() throws Exception {
+        Class<?> clazz = ZooDefs.OpCode.class;
+        Field[] fields = clazz.getFields();
+
+        assertNotEquals(0, fields.length);
+
+        for (Field field : fields) {
+            int op_code = field.getInt(null);
+            String op_string = Request.op2String(op_code);
+            assertFalse(op_string.startsWith("unknown "), op_string);
+        }
     }
 
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ToStringTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ToStringTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.zookeeper.server;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import java.lang.reflect.Field;
@@ -49,9 +49,9 @@ public class ToStringTest extends ZKTestCase {
         assertNotEquals(0, fields.length);
 
         for (Field field : fields) {
-            int op_code = field.getInt(null);
-            String op_string = Request.op2String(op_code);
-            assertFalse(op_string.startsWith("unknown "), op_string);
+            int opCode = field.getInt(null);
+            String opString = Request.op2String(opCode);
+            assertEquals(field.getName(), opString);
         }
     }
 


### PR DESCRIPTION
Changes:
* Format `OpCode.addWatch` as "addWatch" in `Request.op2String`.