### PR TITLE
ZOOKEEPER-4490 - Publish Clover results to SonarQube

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,6 +445,97 @@
         <maven.compiler.release>8</maven.compiler.release>
       </properties>
     </profile>
+    <profile>
+      <id>clover</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>clover</name>
+        </property>
+      </activation>
+      <properties>
+        <cloverDatabase>${project.build.directory}/clover/zookeeper-coverage.db</cloverDatabase>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.openclover</groupId>
+            <artifactId>clover-maven-plugin</artifactId>
+            <configuration>
+              <includesAllSourceRoots>false</includesAllSourceRoots>
+              <includesTestSourceRoots>true</includesTestSourceRoots>
+              <cloverDatabase>${cloverDatabase}</cloverDatabase>
+              <targetPercentage>50%</targetPercentage>
+              <outputDirectory>${project.build.directory}/clover</outputDirectory>
+              <alwaysReport>true</alwaysReport>
+              <generateHistorical>false</generateHistorical>
+              <cloverDatabase>${project.build.directory}/clover/zookeeper-coverage.db</cloverDatabase>
+              <cloverMergeDatabase>${project.build.directory}/clover/zookeeper-coverage.db</cloverMergeDatabase>
+              <outputDirectory>${project.build.directory}/clover</outputDirectory>
+              <generateHtml>true</generateHtml>
+              <generateXml>true</generateXml>
+              <includesAllSourceRoots>false</includesAllSourceRoots>
+              <includesTestSourceRoots>true</includesTestSourceRoots>
+              <includes>
+                <include>org/apache/zookeeper/**/*</include>
+              </includes>
+              <excludes>
+                <exclude>org/apache/zookeeper/version/**/*</exclude>
+                  <exclude>**/ReadOnlyModeTest.java</exclude>
+                  <exclude>**/KeeperStateTest.java</exclude>
+              </excludes>
+            </configuration>
+            <executions>
+              <execution>
+                <id>clover-setup</id>
+                <phase>process-sources</phase>
+                <goals>
+                  <goal>setup</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>clover</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>clover</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>sonar</id>
+      <properties>
+        <sonar.php.coverage.reportPaths>${project.build.directory}/clover/clover.xml</sonar.php.coverage.reportPaths>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonarsource.scanner.maven</groupId>
+            <artifactId>sonar-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.sonarsource.scanner.maven</groupId>
+              <artifactId>sonar-maven-plugin</artifactId>
+              <version>3.7.0.1746</version>
+              <configuration>
+                <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+                <sonar.core.codeCoveragePlugin>clover</sonar.core.codeCoveragePlugin>
+                <sonar.clover.reportPath>${project.build.directory}/clover/clover.xml</sonar.clover.reportPath>
+                <sonar.surefire.reportsPath>target/surefire-reports</sonar.surefire.reportsPath>
+                <sonar.core.codeCoveragePlugin>clover</sonar.core.codeCoveragePlugin>
+                <sonar.clover.version>${clover-maven-plugin.version}</sonar.clover.version>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
   </profiles>
 
   <properties>
@@ -481,6 +572,7 @@
     <checkstyle.version>8.39</checkstyle.version>
     <enforcer.version>3.0.0-M3</enforcer.version>
     <commons-io.version>2.11.0</commons-io.version>
+    <clover-maven-plugin.version>4.4.1</clover-maven-plugin.version>
 
     <!-- parameters to pass to C client build -->
     <c-client-openssl>yes</c-client-openssl>
@@ -785,7 +877,7 @@
         <plugin>
           <groupId>org.openclover</groupId>
           <artifactId>clover-maven-plugin</artifactId>
-          <version>4.3.1</version>
+          <version>${clover-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>com.github.spotbugs</groupId>
@@ -851,29 +943,6 @@
               <goal>commit</goal>
             </goals>
             <phase>validate</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.openclover</groupId>
-        <artifactId>clover-maven-plugin</artifactId>
-        <configuration>
-          <generateHtml>true</generateHtml>
-          <generateXml>true</generateXml>
-          <includes>
-            <include>org/apache/zookeeper/**/*</include>
-          </includes>
-          <excludes>
-            <exclude>org/apache/zookeeper/version/**/*</exclude>
-          </excludes>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>pre-site</phase>
-            <goals>
-              <goal>instrument</goal>
-              <goal>aggregate</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -522,7 +522,7 @@
             <plugin>
               <groupId>org.sonarsource.scanner.maven</groupId>
               <artifactId>sonar-maven-plugin</artifactId>
-              <version>3.7.0.1746</version>
+              <version>${sonar-maven-plugin.version}</version>
               <configuration>
                 <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
                 <sonar.core.codeCoveragePlugin>clover</sonar.core.codeCoveragePlugin>
@@ -573,6 +573,7 @@
     <enforcer.version>3.0.0-M3</enforcer.version>
     <commons-io.version>2.11.0</commons-io.version>
     <clover-maven-plugin.version>4.4.1</clover-maven-plugin.version>
+    <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
 
     <!-- parameters to pass to C client build -->
     <c-client-openssl>yes</c-client-openssl>

--- a/tools/sonar/code-coverage.sh
+++ b/tools/sonar/code-coverage.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+usage() {
+  echo
+  echo "options:"
+  echo "-h     Display help"
+  echo "-u     SonarQube Host URL"
+  echo "-l     SonarQube Login Credentials"
+  echo "-k     SonarQube Project Key"
+  echo "-n     SonarQube Project Name"
+  echo
+  echo "Important:"
+  echo "    The required parameters for publishing the coverage results to SonarQube:"
+  echo "      - Host URL"
+  echo "      - Login Credentials"
+  echo "      - Project Key"
+  echo
+}
+
+execute() {
+  SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+  MAIN_POM="${SCRIPT_DIR}/../../pom.xml"
+
+  mvn -B -e -Pclover -f "$MAIN_POM" clean install -DskipTests -DskipShade
+
+  mvn -B -e -Pclover -f "$MAIN_POM" test -Dparallel-tests -DtestsThreadCount=8 -Dscale
+
+  mvn -B -e -Pclover -f "$MAIN_POM" clover:aggregate clover:clover
+
+  # If the required parameters are given, the code coverage results are uploaded to the SonarQube Server
+  if [ -n "$SONAR_LOGIN" ] && [ -n "$SONAR_PROJECT_KEY" ] && [ -n "$SONAR_URL" ]; then
+    mvn -B -e -Pclover -f "$MAIN_POM" sonar:sonar -Dsonar.clover.reportPath=./target/clover/clover.xml \
+      -Dsonar.host.url="$SONAR_URL" -Dsonar.login="$SONAR_LOGIN" -Dsonar.projectKey="$SONAR_PROJECT_KEY" -Dsonar.projectName="$SONAR_PROJECT_NAME"
+  fi
+}
+
+while getopts ":u:l:k:n:h" option; do
+  case $option in
+  u) SONAR_URL=${OPTARG:-} ;;
+  l) SONAR_LOGIN=${OPTARG:-} ;;
+  k) SONAR_PROJECT_KEY=${OPTARG:-} ;;
+  n) SONAR_PROJECT_NAME=${OPTARG:-} ;;
+  h) # Display usage
+    usage
+    exit
+    ;;
+  \?) # Invalid option
+    echo "Error: Invalid option"
+    exit
+    ;;
+  esac
+done
+
+# Start code analysis
+execute


### PR DESCRIPTION
The newly added script runs maven with the clover profile which generates the test coverage data and then uploads it to SonarQube if the necessary parameters were given.

The required parameters for publishing to SonarQube are:
- Host URL
- Login Credentials
- Project Key

Example commands:
- Run clover code analysis (without publishing to SonarQube)
`sh tools/sonar/code-coverage.sh`

- Run clover code analysis and publish the results to SonarQube
`sh tools/sonar/code-coverage.sh -l ProjectCredentials -u https://exampleserver.com  -k Project_Key`
