### PR TITLE
ZOOKEEPER-4505: CVE-2020-36518 - Upgrade jackson databind to 2.13.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,7 +470,7 @@
     <netty.version>4.1.73.Final</netty.version>
     <netty.tcnative.version>2.0.48.Final</netty.tcnative.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
-    <jackson.version>2.13.1</jackson.version>
+    <jackson.version>2.13.2.1</jackson.version>
     <jline.version>2.14.6</jline.version>
     <snappy.version>1.1.7.7</snappy.version>
     <kerby.version>2.0.0</kerby.version>


### PR DESCRIPTION
CVE-2020-36518 vulnerability affects jackson-databind in Zookeeper (see https://github.com/advisories/GHSA-57j2-w4cx-62h2).

Upgrading to jackson-databind version 2.13.2.1 should address this issue.