### PR TITLE
ZOOKEEPER-4504: ZKUtil#deleteRecursive causing deadlock in HDFS HA functionality

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZKUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZKUtil.java
@@ -61,7 +61,15 @@ public class ZKUtil {
         List<String> tree = listSubTreeBFS(zk, pathRoot);
         LOG.debug("Deleting tree: {}", tree);
 
-        return deleteInBatch(zk, tree, batchSize);
+        if (batchSize > 0) {
+            return deleteInBatch(zk, tree, batchSize);
+        } else {
+            for (int i = tree.size() - 1; i >= 0; --i) {
+                //Delete the leaves first and eventually get rid of the root
+                zk.delete(tree.get(i), -1); //Delete all versions of the node with -1.
+            }
+            return true;
+        }
     }
 
     /**
@@ -73,7 +81,7 @@ public class ZKUtil {
     public static void deleteRecursive(
         ZooKeeper zk,
         final String pathRoot) throws InterruptedException, KeeperException {
-        deleteRecursive(zk, pathRoot, 1000);
+        deleteRecursive(zk, pathRoot, 0);
     }
 
     private static class BatchedDeleteCbContext {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZKUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZKUtil.java
@@ -49,7 +49,14 @@ public class ZKUtil {
      * If there is an error with deleting one of the sub-nodes in the tree,
      * this operation would abort and would be the responsibility of the app to handle the same.
      *
-     *
+     * @param zk Zookeeper client
+     * @param pathRoot path to be deleted
+     * @param batchSize number of delete operations to be submitted in one call.
+     *                  batchSize is also used to decide sync and async delete API invocation.
+     *                  If batchSize>0 then async otherwise sync delete API is invoked. batchSize>0
+     *                  gives better performance. batchSize<=0 scenario is handled to preserve
+     *                  backward compatibility.
+     * @return true if given node and all its sub nodes are deleted successfully otherwise false
      * @throws IllegalArgumentException if an invalid path is specified
      */
     public static boolean deleteRecursive(
@@ -81,6 +88,7 @@ public class ZKUtil {
     public static void deleteRecursive(
         ZooKeeper zk,
         final String pathRoot) throws InterruptedException, KeeperException {
+        // batchSize=0 is passed to preserve the backward compatibility with older clients.
         deleteRecursive(zk, pathRoot, 0);
     }
 


### PR DESCRIPTION
Make ZKUtil#deleteRecursive API fully compatible with older versions