### PR TITLE
ZOOKEEPER-4508: Fix endless-loop in ClientCnxn.SendThread.run when all zk servers down

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
@@ -804,7 +804,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
                 Thread.sleep(1000);
                 zkArr[serverIndex].setData("/test", "teststr".getBytes(), -1);
                 fail("New client connected to new client port!");
-            } catch (KeeperException.ConnectionLossException e) {
+            } catch (KeeperException.ConnectionLossException | KeeperException.SessionExpiredException e) {
                 // Exception is expected
             }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/WatcherTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/WatcherTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -186,6 +187,19 @@ public class WatcherTest extends ClientBase {
             }
         }
 
+    }
+
+    @Test
+    public void testWatcherExpiredAfterAllServerDown() throws Exception {
+        ZooKeeper zk = createClient();
+        CompletableFuture<Void> expired = new CompletableFuture<>();
+        zk.register(event -> {
+            if (event.getState() == Watcher.Event.KeeperState.Expired) {
+                expired.complete(null);
+            }
+        });
+        stopServer();
+        expired.join();
     }
 
     @Test


### PR DESCRIPTION

The observable behavior is that client will not get expired event from watcher.
The cause is twofold:
1. `updateLastSendAndHeard` is called in reconnection so the session
   will not timeout.
2. No `break` after session timeout in `ClientCnxn.SendThread.run`.