### PR TITLE
ZOOKEEPER-3023: Sync and commit diff log entries before NEWLEADER ack

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/TxnLogEntry.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/TxnLogEntry.java
@@ -47,4 +47,10 @@ public final class TxnLogEntry {
     public TxnDigest getDigest() {
         return digest;
     }
+
+    public Request toRequest() {
+        Request request = new Request(header.getClientId(), header.getCxid(), header.getType(), header, txn, header.getZxid());
+        request.setTxnDigest(digest);
+        return request;
+    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -361,7 +361,7 @@ public class Leader extends LearnerMaster {
 
     /**
      * This message type is sent by the leader to indicate that the follower is
-     * now uptodate andt can start responding to clients.
+     * now uptodate and can start responding to clients.
      */
     static final int UPTODATE = 12;
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
@@ -743,8 +743,8 @@ public class Zab1_0Test extends ZKTestCase {
 
                     readPacketSkippingPing(ia, qp);
                     assertEquals(Leader.ACKEPOCH, qp.getType());
-                    assertEquals(0, qp.getZxid());
-                    assertEquals(ZxidUtils.makeZxid(0, 0), ByteBuffer.wrap(qp.getData()).getInt());
+                    assertEquals(ZxidUtils.makeZxid(0, 0), qp.getZxid());
+                    assertEquals(0, ByteBuffer.wrap(qp.getData()).getInt());
                     assertEquals(1, f.self.getAcceptedEpoch());
                     assertEquals(0, f.self.getCurrentEpoch());
 
@@ -779,24 +779,11 @@ public class Zab1_0Test extends ZKTestCase {
                     assertEquals(1, f.self.getAcceptedEpoch());
                     assertEquals(1, f.self.getCurrentEpoch());
 
-                    //Wait for the transactions to be written out. The thread that writes them out
-                    // does not send anything back when it is done.
-                    long start = System.currentTimeMillis();
-                    while (createSessionZxid != f.fzk.getLastProcessedZxid()
-                                   && (System.currentTimeMillis() - start) < 50) {
-                        Thread.sleep(1);
-                    }
-
                     assertEquals(createSessionZxid, f.fzk.getLastProcessedZxid());
 
                     // Make sure the data was recorded in the filesystem ok
                     ZKDatabase zkDb2 = new ZKDatabase(new FileTxnSnapLog(logDir, snapDir));
-                    start = System.currentTimeMillis();
                     zkDb2.loadDataBase();
-                    while (zkDb2.getSessionWithTimeOuts().isEmpty() && (System.currentTimeMillis() - start) < 50) {
-                        Thread.sleep(1);
-                        zkDb2.loadDataBase();
-                    }
                     LOG.info("zkdb2 sessions:{}", zkDb2.getSessions());
                     LOG.info("zkdb2 with timeouts:{}", zkDb2.getSessionWithTimeOuts());
                     assertNotNull(zkDb2.getSessionWithTimeOuts().get(4L));


### PR DESCRIPTION
ZOOKEEPER-2678 could skip snapshot in diff sync, but diff txns are
logged and committed after NEWLEADER ack. ZOOKEEPER-3911 moves txn
logging before NEWLEADER ack, but the txn logging is asynchronous. So it
is indeterminate whether diff txns have been persisted to disk or not
after NEWLEADER ack.

This commit try to sync and commit txn logs synchronously before ack to
NEWLEADER thus provides strong guarantee that follower is in sync with
leader after NEWLEADER ack received.

This behavior is consistent with pre ZOOKEEPER-2678 and easy to test.