### PR TITLE
ZOOKEEPER-4515: ZK Cli quit command always logs error

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -1284,10 +1284,11 @@ public class ClientCnxn {
                 } catch (Throwable e) {
                     if (closing) {
                         // closing so this is expected
-                        LOG.warn(
-                            "An exception was thrown while closing send thread for session 0x{}.",
-                            Long.toHexString(getSessionId()),
-                            e);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug(
+                                "An exception was thrown while closing send thread for session 0x{}.",
+                                Long.toHexString(getSessionId()), e);
+                        }
                         break;
                     } else {
                         LOG.warn(

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/util/ServiceUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/util/ServiceUtils.java
@@ -54,8 +54,12 @@ public abstract class ServiceUtils {
      * No-op strategy, useful for tests.
      */
     public static final Consumer<Integer> LOG_ONLY = (code) -> {
-        LOG.error("Fatal error, JVM should exit with code {}. "
+        if (code != 0) {
+            LOG.error("Fatal error, JVM should exit with code {}. "
                 + "Actually System.exit is disabled", code);
+        } else {
+            LOG.info("JVM should exit with code {}. Actually System.exit is disabled", code);
+        }
     };
 
     private static volatile Consumer<Integer> systemExitProcedure = SYSTEM_EXIT;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/util/ServiceUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/util/ServiceUtils.java
@@ -39,7 +39,14 @@ public abstract class ServiceUtils {
      */
     @SuppressFBWarnings("DM_EXIT")
     public static final Consumer<Integer> SYSTEM_EXIT = (code) -> {
-        LOG.error("Exiting JVM with code {}", code);
+        String msg = "Exiting JVM with code {}";
+        if (code == 0) {
+            // JVM exits normally
+            LOG.info(msg, code);
+        } else {
+            // JVM exits with error
+            LOG.error(msg, code);
+        }
         System.exit(code);
     };
 


### PR DESCRIPTION
1. For connection closing state scenario, changed the log level to debug
2. When JVM exiting with code 0, then logging info instead of error