### PR TITLE
ZOOKEEPER-4510: dependency-check:check failing - reload4j-1.2.19.jar: CVE-2020-9493, CVE-2022-23307

### DIFF
--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -71,4 +71,11 @@
       <cve>CVE-2021-34429</cve>
    </suppress>
 
+   <suppress>
+      <!-- https://github.com/jeremylong/DependencyCheck/issues/4316
+              False positive on reload4j-1.2.19.jar-->
+      <cve>CVE-2020-9493</cve>
+      <cve>CVE-2022-23307</cve>
+   </suppress>
+
 </suppressions>


### PR DESCRIPTION
As the CVEs are false positive, suppressed these CVEs.