### PR TITLE
ZOOKEEPER-4510:dependency-check:check failing - reload4j-1.2.19.jar: CVE-2020-9493, CVE-2022-23307

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -891,7 +891,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>6.5.3</version>
+          <version>7.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Upgraded dependency-check-maven plugin from 6.5.3 to 7.1.0