### PR TITLE
ZOOKEEPER-4544: sync ant and maven dependencies on branch-3.5

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -26,18 +26,18 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
     <!-- ====================================================== -->
     <!-- Dependency versions                                    -->
     <!-- ====================================================== -->
-    <property name="slf4j.version" value="1.7.25"/>
+    <property name="slf4j.version" value="1.7.36"/>
     <property name="commons-cli.version" value="1.2"/>
     <property name="spotbugsannotations.version" value="3.1.9"/>
 
     <property name="wagon-http.version" value="2.4"/>
     <property name="maven-ant-tasks.version" value="2.1.3"/>
-    <property name="log4j.version" value="1.2.17"/>
-    <property name="jline.version" value="2.11"/>
+    <property name="reload4j.version" value="1.2.20"/>
+    <property name="jline.version" value="2.14.6"/>
 
     <property name="audience-annotations.version" value="0.5.0" />
 
-    <property name="netty.version" value="4.1.73.Final"/>
+    <property name="netty.version" value="4.1.77.Final"/>
 
     <property name="junit.version" value="4.12"/>
     <property name="mockito.version" value="2.27.0"/>
@@ -54,8 +54,8 @@ xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant">
 
     <property name="javacc.version" value="5.0"/>
 
-    <property name="jetty.version" value="9.4.43.v20210629"/>
-    <property name="jackson.version" value="2.13.1"/>
+    <property name="jetty.version" value="9.4.46.v20220331"/>
+    <property name="jackson.version" value="2.13.3"/>
     <property name="dependency-check-ant.version" value="5.2.4"/>
 
     <property name="commons-io.version" value="2.6"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -53,7 +53,7 @@
     <dependency org="org.apache.maven" name="maven-ant-tasks" rev="${maven-ant-tasks.version}"
                 conf="mvn-ant-task->master"/>
     <!-- transitive false turns off dependency checking, log4j deps seem borked -->
-    <dependency org="log4j" name="log4j" rev="${log4j.version}" transitive="false"/>
+    <dependency org="ch.qos.reload4j" name="reload4j" rev="${reload4j.version}" transitive="false"/>
     <dependency org="jline" name="jline" rev="${jline.version}" transitive="false"
                 conf="optional->default"/>
 


### PR DESCRIPTION
Our default build system is maven on branch-3.5. However, ant is still
supported (and in some cases, like zkpython, one can not even build on
branch-3.5 unless we built zookeeper-server with ant before).

Currently if one builds ZooKeeper with ant, she/he will end up having
different dependency versions compared to maven (including log4j instead
of reload4j).

After this patch, if one executs the following commands:

```
git clean -xdf
ant clean compile compile-native
cd zookeeper-contrib/zookeeper-contrib-zkpython/
ant compile
ant test
```

then:

- zkpython built / tested successfully
- the zookeeper server related 3pp libs in build/libs folder
  are up-to-date and should not contain CVEs
- reload4j jar file is present in build/libs/ instead of log4j