### PR TITLE
Bump netty version to fix CVE-2022-24823

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -558,7 +558,7 @@
     <mockito.version>3.6.28</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <commons-cli.version>1.4</commons-cli.version>
-    <netty.version>4.1.76.Final</netty.version>
+    <netty.version>4.1.77.Final</netty.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <jackson.version>2.13.2.1</jackson.version>
     <jline.version>2.14.6</jline.version>


### PR DESCRIPTION
According to the page https://nvd.nist.gov/vuln/detail/CVE-2022-24823
> The package `io.netty:netty-codec-http` prior to version 4.1.77.Final contains an insufficient fix for CVE-2021-21290.