### PR TITLE
zookeeper 4556 function zoo_version_str

### DIFF
--- a/zookeeper-client/zookeeper-client-c/include/zookeeper.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper.h
@@ -669,6 +669,20 @@ ZOOAPI sasl_callback_t *zoo_sasl_make_basic_callbacks(const char *user,
 
 #endif /* HAVE_CYRUS_SASL_H */
 
+
+/**
+ * \brief return the zookeeper MAJOR.MINOR.PATCH version as a string
+ *
+ * This method allows a calling program to determine at runtime if the
+ * version of the dynamically loaded zookeeper library is the same as
+ * the version of the library when the calling program was compiled.
+ *
+ * See {@link https://issues.apache.org/jira/browse/ZOOKEEPER-4556}
+
+ * \return a string "MAJOR.MINOR.PATCH"
+ */
+ZOOAPI const char* zoo_version_str();
+
 /**
  * \brief update the list of servers this client will connect to.
  *

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -1296,20 +1296,11 @@ static void log_env(zhandle_t *zh) {
 }
 
 /**
- * Macros only used in zoo_version_str
- */
-#define STRINGIFY_WITH_EXPAND(x) STRINGIFY_NO_EXPAND(x)
-#define STRINGIFY_NO_EXPAND(x) #x
-
-/**
  * Return string of "MAJOR.MINOR.PATCH"
  */
 const char *zoo_version_str()
 {
-    return
-      STRINGIFY_WITH_EXPAND(ZOO_MAJOR_VERSION) "."
-      STRINGIFY_WITH_EXPAND(ZOO_MINOR_VERSION) "."
-      STRINGIFY_WITH_EXPAND(ZOO_PATCH_VERSION);
+    return ZOO_VERSION;
 }
 
 /**

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -1296,6 +1296,23 @@ static void log_env(zhandle_t *zh) {
 }
 
 /**
+ * Macros only used in zoo_version_str
+ */
+#define STRINGIFY_WITH_EXPAND(x) STRINGIFY_NO_EXPAND(x)
+#define STRINGIFY_NO_EXPAND(x) #x
+
+/**
+ * Return string of "MAJOR.MINOR.PATCH"
+ */
+const char *zoo_version_str()
+{
+    return
+      STRINGIFY_WITH_EXPAND(ZOO_MAJOR_VERSION) "."
+      STRINGIFY_WITH_EXPAND(ZOO_MINOR_VERSION) "."
+      STRINGIFY_WITH_EXPAND(ZOO_PATCH_VERSION);
+}
+
+/**
  * Create a zookeeper handle associated with the given host and port.
  */
 static zhandle_t *zookeeper_init_internal(const char *host, watcher_fn watcher,

--- a/zookeeper-client/zookeeper-client-c/tests/TestZookeeperInit.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestZookeeperInit.cc
@@ -36,6 +36,7 @@ using namespace std;
 class Zookeeper_init : public CPPUNIT_NS::TestFixture
 {
     CPPUNIT_TEST_SUITE(Zookeeper_init);
+    CPPUNIT_TEST(testVersion);
     CPPUNIT_TEST(testBasic);
     CPPUNIT_TEST(testAddressResolution);
     CPPUNIT_TEST(testMultipleAddressResolution);
@@ -90,6 +91,20 @@ public:
 #endif
     }
 
+    void testVersion()
+    {
+        char EXPECTED_VERSION_STR[256];
+        EXPECTED_VERSION_STR[0] = 0;
+#ifdef ZOO_VERSION
+	snprintf(EXPECTED_VERSION_STR, sizeof(EXPECTED_VERSION_STR), "%s", ZOO_VERSION);
+#endif
+#ifdef ZOO_VERSION_MAJOR
+	// In case this test is back-ported to an earlier release.
+	snprintf(EXPECTED_VERSION_STR, sizeof(EXPECTED_VERSION_STR), "%d.%d.%d", (int)ZOO_VERSION_MAJOR, (int) ZOO_VERSION_MINOR, (int) ZOO_VERSION_PATCH);
+#endif
+	const char *version_str = zoo_version_str();
+	CPPUNIT_ASSERT_EQUAL(string(EXPECTED_VERSION_STR),string(version_str));
+    }
     void testBasic()
     {
         const string EXPECTED_HOST("127.0.0.1:2121");


### PR DESCRIPTION
This implements https://issues.apache.org/jira/browse/ZOOKEEPER-4556

The strongest use case for a function zoo_version_str is when an application is making use of https://sourceware.org/libffi/ or similar solution for their application language and wants to be sure that the preprocessed/cached C declarations it might use are consistent with the version of libzookeeper_mt.so that is available at runtime for dynamic loading with dlopen. The zookeeper_version.h may not be available at runtime depending on the deployment scenario for the application, and would require additional parsing toil if it were.

The unit test is coded to work with any version of zookeeper, but the implementation
would need to be adjusted to use the code shown in the referenced issue if this patch
were to be back-ported to a 3.5 or earlier branch.

