### PR TITLE
ZOOKEEPER-4400 Zookeeper not getting Graceful Termination

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerConfig.java
@@ -50,6 +50,7 @@ public class ServerConfig {
     protected int minSessionTimeout = -1;
     /** defaults to -1 if not set explicitly */
     protected int maxSessionTimeout = -1;
+    protected boolean registerShutdownHook;
     protected String metricsProviderClassName = DefaultMetricsProvider.class.getName();
     protected Properties metricsProviderConfiguration = new Properties();
     /** defaults to -1 if not set explicitly */
@@ -113,6 +114,7 @@ public class ServerConfig {
         maxClientCnxns = config.getMaxClientCnxns();
         minSessionTimeout = config.getMinSessionTimeout();
         maxSessionTimeout = config.getMaxSessionTimeout();
+        registerShutdownHook = config.registerShutdownHook();
         jvmPauseMonitorToRun = config.isJvmPauseMonitorToRun();
         jvmPauseInfoThresholdMs = config.getJvmPauseInfoThresholdMs();
         jvmPauseWarnThresholdMs = config.getJvmPauseWarnThresholdMs();
@@ -148,6 +150,10 @@ public class ServerConfig {
     /** maximum session timeout in milliseconds, -1 if unset */
     public int getMaxSessionTimeout() {
         return maxSessionTimeout;
+    }
+
+    public boolean registerShutdownHook() {
+        return registerShutdownHook;
     }
 
     public long getJvmPauseInfoThresholdMs() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
@@ -180,6 +180,10 @@ public class ZooKeeperServerMain {
 
             serverStarted();
 
+            if (config.registerShutdownHook()) {
+                Runtime.getRuntime().addShutdownHook(new Thread(this::shutdown));
+            }
+
             // Watch status of ZooKeeper server. It will do a graceful shutdown
             // if the server is not running or hits an internal error.
             shutdownLatch.await();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -86,6 +86,7 @@ public class QuorumPeerConfig {
     protected int minSessionTimeout = -1;
     /** defaults to -1 if not set explicitly */
     protected int maxSessionTimeout = -1;
+    protected boolean registerShutdownHook;
     protected String metricsProviderClassName = DefaultMetricsProvider.class.getName();
     protected Properties metricsProviderConfiguration = new Properties();
     protected boolean localSessionsEnabled = false;
@@ -308,6 +309,8 @@ public class QuorumPeerConfig {
                 minSessionTimeout = Integer.parseInt(value);
             } else if (key.equals("maxSessionTimeout")) {
                 maxSessionTimeout = Integer.parseInt(value);
+            } else if (key.equals("registerShutdownHook")) {
+                registerShutdownHook = Boolean.parseBoolean(value);
             } else if (key.equals("initLimit")) {
                 initLimit = Integer.parseInt(value);
             } else if (key.equals("syncLimit")) {
@@ -825,6 +828,9 @@ public class QuorumPeerConfig {
     }
     public int getMaxSessionTimeout() {
         return maxSessionTimeout;
+    }
+    public boolean registerShutdownHook() {
+        return registerShutdownHook;
     }
     public String getMetricsProviderClassName() {
         return metricsProviderClassName;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
@@ -226,6 +226,10 @@ public class QuorumPeerMain {
                 quorumPeer.setJvmPauseMonitor(new JvmPauseMonitor(config));
             }
 
+            if (config.registerShutdownHook()) {
+                Runtime.getRuntime().addShutdownHook(new Thread(quorumPeer::shutdown));
+            }
+
             quorumPeer.start();
             ZKAuditProvider.addZKStartStopAuditLog();
             quorumPeer.join();


### PR DESCRIPTION
Register shutdown hook in order for zookeeper server to respond to SIGTERM signals and shut down gracefully. Introduce `registerShutdownHook` config flag (defaults to `false`) for backward compatibility.