### PR TITLE
ZOOKEEPER-3295: bin/zkEnv.sh no need to check "$ZOOBINDIR"/../zookeeper-server/src/main/resources/lib/*.jar

### DIFF
--- a/bin/zkEnv.sh
+++ b/bin/zkEnv.sh
@@ -82,11 +82,6 @@ fi
 #add the zoocfg dir to classpath
 CLASSPATH="$ZOOCFGDIR:$CLASSPATH"
 
-for i in "$ZOOBINDIR"/../zookeeper-server/src/main/resources/lib/*.jar
-do
-    CLASSPATH="$i:$CLASSPATH"
-done
-
 #make it work in the binary package
 #(use array for LIBPATH to account for spaces within wildcard expansion)
 if ls "${ZOOKEEPER_PREFIX}"/share/zookeeper/zookeeper-*.jar > /dev/null 2>&1; then 


### PR DESCRIPTION
Hi all,

The directory `zookeeper-server/src/main/resources/lib` doesn't have libs. So it is good to remove it from the shell script.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong