### PR TITLE
[ZOOKEEPER-4671] Java classpath should contain libs about metrics providers

### DIFF
--- a/bin/zkEnv.sh
+++ b/bin/zkEnv.sh
@@ -111,7 +111,14 @@ do
    CLASSPATH="$d:$CLASSPATH"
 done
 
+#make it work for developers
 for d in "$ZOOBINDIR"/../zookeeper-server/target/lib/*.jar
+do
+   CLASSPATH="$d:$CLASSPATH"
+done
+
+#make it work for developers
+for d in "$ZOOBINDIR"/../zookeeper-metrics-providers/zookeeper-prometheus-metrics/target/lib/*.jar
 do
    CLASSPATH="$d:$CLASSPATH"
 done
@@ -121,6 +128,9 @@ CLASSPATH="$ZOOBINDIR/../build/classes:$CLASSPATH"
 
 #make it work for developers
 CLASSPATH="$ZOOBINDIR/../zookeeper-server/target/classes:$CLASSPATH"
+
+#make it work for developers
+CLASSPATH="$ZOOBINDIR/../zookeeper-metrics-providers/zookeeper-prometheus-metrics/target/classes:$CLASSPATH"
 
 case "`uname`" in
     CYGWIN*|MINGW*) cygwin=true ;;


### PR DESCRIPTION
Hi all,

When developing zookeeper, we often start or debug it by using the current source code instead of the built package. So it is good to add the classes about metrics providers to the classpath to avoid ClassNotFound exception. This ClassNotFound exception happens when we use the config `metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider` to start zookeeper.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong