### PR TITLE
ZOOKEEPER-4398: Add configurable Prometheus metric name prefix.

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperMonitor.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperMonitor.md
@@ -46,6 +46,7 @@ All the metrics are included in the `ServerMetrics.java`.
 - Pre-requisites:
   - enable the `Prometheus MetricsProvider` by setting `metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider` in the zoo.cfg.
   - the Port is also configurable by setting `metricsProvider.httpPort`（the default value:7000）
+  - an optional prefix can be given to all Zookeeper metric names by setting `metricsProvider.metricsPrefix` (default is none). For example, a prefix of `zk_` will report the metric `up` as `zk_up`) 
 - Install Prometheus:
   Go to the official website download [page](https://prometheus.io/download/), download the latest release.
   

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderTest.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderTest.java
@@ -311,7 +311,7 @@ public class PrometheusMetricsProviderTest {
                     assertEquals(20, value);
                     break;
                 default:
-                    fail("unespected key " + k);
+                    fail("unexpected key " + k);
                     break;
             }
         }
@@ -366,7 +366,7 @@ public class PrometheusMetricsProviderTest {
                     assertEquals(20, value);
                     break;
                 default:
-                    fail("unespected key " + k);
+                    fail("unexpected key " + k);
                     break;
             }
         }
@@ -423,6 +423,73 @@ public class PrometheusMetricsProviderTest {
     }
 
     @Test
+    public void testSummary_customMetricsPrefix() throws Exception {
+        final Properties config = new Properties();
+        config.setProperty("numWorkerThreads", "0"); // sync behavior for test
+        config.setProperty("httpHost", "127.0.0.1"); // local host for test
+        config.setProperty("httpPort", "0"); // ephemeral port
+        config.setProperty("exportJvmInfo", "false");
+        config.setProperty("metricsPrefix", "zookeeper_");
+
+        PrometheusMetricsProvider metricsProvider = null;
+        try {
+            metricsProvider = new PrometheusMetricsProvider();
+            metricsProvider.configure(config);
+            metricsProvider.start();
+
+            Summary summary = metricsProvider.getRootContext()
+                .getSummary("cc", MetricsContext.DetailLevel.BASIC);
+            summary.add(10);
+            summary.add(10);
+            int[] count = {0};
+            metricsProvider.dump((k, v) -> {
+                    count[0]++;
+                    int value = ((Number) v).intValue();
+
+                    switch (k) {
+                        case "zookeeper_cc{quantile=\"0.5\"}":
+                            assertEquals(10, value);
+                            break;
+                        case "zookeeper_cc_count":
+                            assertEquals(2, value);
+                            break;
+                        case "zookeeper_cc_sum":
+                            assertEquals(20, value);
+                            break;
+                        default:
+                            fail("unexpected key " + k);
+                            break;
+                    }
+                }
+            );
+            assertEquals(3, count[0]);
+            count[0] = 0;
+
+            // we always must get the same object
+            assertSame(summary, metricsProvider.getRootContext()
+                .getSummary("cc", MetricsContext.DetailLevel.BASIC));
+
+            try {
+                metricsProvider.getRootContext()
+                    .getSummary("cc", MetricsContext.DetailLevel.ADVANCED);
+                fail("Can't get the same summary with a different DetailLevel");
+            } catch (IllegalArgumentException err) {
+                assertThat(err.getMessage(), containsString("Already registered"));
+            }
+
+            String res = callServlet();
+            assertThat(res, containsString("# TYPE cc summary"));
+            assertThat(res, CoreMatchers.containsString("cc_sum 20.0"));
+            assertThat(res, CoreMatchers.containsString("cc_count 2.0"));
+            assertThat(res, CoreMatchers.containsString("cc{quantile=\"0.5\",} 10.0"));
+        } finally {
+            if (metricsProvider != null) {
+                metricsProvider.stop();
+            }
+        }
+    }
+
+  @Test
     public void testSummarySet() throws Exception {
         final String name = "ss";
         final String[] keys = {"ns1", "ns2"};


### PR DESCRIPTION
Resolves ZOOKEEPER-4398 by adding an optional metric configuration property for a string prefix for all Zookeeper metric names.

It's common to have Prometheus metrics scoped to a namespace by using the application name as its prefix. For instance, Apache Kafka metrics have the prefix of `kafka_`, making them easier to identify.

This new config could be used to namespace Zookeeper metrics (e.g. `zookeeper_up` instead of simply `up`). The default behavior does not use a prefix.