### PR TITLE
ZOOKEEPER-4604: Fix missing break in switch branch COMPLETION_STRING_STAT

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -3628,6 +3628,7 @@ static completion_list_t* do_create_completion_entry(zhandle_t *zh, int xid,
         break;
     case COMPLETION_STRING_STAT:
         c->c.string_stat_result = (string_stat_completion_t)dc;
+        break;
     case COMPLETION_ACLLIST:
         c->c.acl_result = (acl_completion_t)dc;
         break;


### PR DESCRIPTION
c->c is a union so setting c.acl_result would override c.string_stat_result.

However, since they're all function pointers pointing to the same function, this won't cause any issue as c.string_stat_result is still correct. This might cause issue if we change the type of these completions in the future.

This also makes the code consistent.