### PR TITLE
ZOOKEEPER-4293: Lock Contention in ClientCnxnSocketNetty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -559,7 +559,7 @@
     <mockito.version>4.9.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <commons-cli.version>1.5.0</commons-cli.version>
-    <netty.version>4.1.105.Final</netty.version>
+    <netty.version>4.1.113.Final</netty.version>
     <jetty.version>9.4.53.v20231009</jetty.version>
     <jackson.version>2.15.2</jackson.version>
     <jline.version>2.14.6</jline.version>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
@@ -203,7 +203,7 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
                 connectFuture = null;
             }
             if (channel != null) {
-                channel.close().syncUninterruptibly();
+                channel.close();
                 channel = null;
             }
         } finally {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
@@ -255,7 +255,7 @@ public class UnifiedServerSocket extends ServerSocket {
                 bytesRead = 0;
             }
 
-            if (bytesRead == litmus.length && SslHandler.isEncrypted(Unpooled.wrappedBuffer(litmus))) {
+            if (bytesRead == litmus.length && SslHandler.isEncrypted(Unpooled.wrappedBuffer(litmus), false)) {
                 try {
                     sslSocket = x509Util.createSSLSocket(prependableSocket, litmus);
                 } catch (X509Exception e) {


### PR DESCRIPTION
Check for failed/cancelled ChannelFutures before acquiring connectLock. This prevents lock contention where cleanup is unable to complete.

Replaces #1713 (target `master` rather than `branch-3.5`)