### PR TITLE
document the need for local sessions within the readonly mode

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1817,8 +1817,10 @@ New features that are currently considered experimental.
     (Java system property: **readonlymode.enabled**)
     **New in 3.4.0:**
     Setting this value to true enables Read Only Mode server
-    support (disabled by default). ROM allows clients
-    sessions which requested ROM support to connect to the
+    support (disabled by default).
+    *localSessionsEnabled* has to be activated to serve clients.
+    A downgrade of an existing connections is currently not supported.
+    ROM allows clients sessions which requested ROM support to connect to the
     server even when the server might be partitioned from
     the quorum. In this mode ROM clients can still read
     values from the ZK service, but will be unable to write


### PR DESCRIPTION
Starting with commit https://github.com/apache/zookeeper/commit/c47ef905e077184bc5b7f555a3e2dfeb6dc046e1 the readonly mode requires local sessions to be activated.
This commit appends the related information to the docu.

In addition the impossibility to a client downgrade is noted