### PR TITLE
ZOOKEEPER-4614: Network event can cause C Client to "forget" to SASL-authenticate

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zk_sasl.c
+++ b/zookeeper-client/zookeeper-client-c/src/zk_sasl.c
@@ -326,9 +326,8 @@ int zoo_sasl_client_start(zhandle_t *zh)
      *
      * so we need to keep track of that.
      */
-    if (strcmp(chosenmech, "GSSAPI") == 0) {
-        sc->is_gssapi = 1;
-    }
+    sc->is_gssapi = strcmp(chosenmech, "GSSAPI") == 0;
+    sc->is_last_packet = 0;
 
     if (sr == SASL_CONTINUE || client_data_len > 0) {
         rc = queue_sasl_request(zh, client_data, client_data_len);


### PR DESCRIPTION
Network hiccups can, if they occur at the "right" point during a SASL authentication sequence, cause the client to lose its connection without putting the itself in ZOO_AUTH_FAILED_STATE.

This is not necessarily a problem; if not in ZOO_AUTH_FAILED_STATE, the client simply tries to reconnect and restart the authentication.

Without this patch, however, a situation such as the one of the first paragraph, but occurring during the very last request/response cycle of a Kerberos/GSSAPI negotiation, causes the internal 'is_last_packet' flag not to be properly reset.

The following connection attempt then cuts its authentication sequence short, effectively "forgetting" to authenticate with the server.  This generally causes subsequent requests to fail due to either global configuration and/or ACLs.

Note that:

 1. The window is very small, so this bug is not expected to happen very often under normal conditions;

 2. This does not give undue privileges to clients, it just *prevents* them from accessing protected members and/or nodes.