### PR TITLE
Jonmv/zookeeper 4541

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -883,7 +883,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                 //  * If we fetch a new snapshot from leader, the zkDb will be
                 //    cleared anyway before loading the snapshot
                 try {
-                    //This will fast forward the database to the latest recorded transactions
+                    // This will fast-forward the database to the latest recorded transactions
                     zkDb.fastForwardDataBase();
                 } catch (IOException e) {
                     LOG.error("Error updating DB", e);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderZooKeeperServer.java
@@ -155,11 +155,11 @@ public class LeaderZooKeeperServer extends QuorumZooKeeperServer {
     }
 
     @Override
-    public synchronized void shutdown() {
+    public synchronized void shutdown(boolean fullyShutDown) {
         if (containerManager != null) {
             containerManager.stop();
         }
-        super.shutdown();
+        super.shutdown(fullyShutDown);
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverZooKeeperServer.java
@@ -73,7 +73,7 @@ public class ObserverZooKeeperServer extends LearnerZooKeeperServer {
      * @param request
      */
     public void commitRequest(Request request) {
-        if (syncRequestProcessorEnabled) {
+        if (syncProcessor != null) {
             // Write to txnlog and take periodic snapshot
             syncProcessor.processRequest(request);
         }
@@ -107,6 +107,9 @@ public class ObserverZooKeeperServer extends LearnerZooKeeperServer {
             syncProcessor = new SyncRequestProcessor(this, null);
             syncProcessor.start();
         }
+        else {
+            syncProcessor = null;
+        }
     }
 
     /*
@@ -125,18 +128,6 @@ public class ObserverZooKeeperServer extends LearnerZooKeeperServer {
     @Override
     public String getState() {
         return "observer";
-    }
-
-    @Override
-    public synchronized void shutdown() {
-        if (!canShutdown()) {
-            LOG.debug("ZooKeeper server is not running, so not proceeding to shutdown!");
-            return;
-        }
-        super.shutdown();
-        if (syncRequestProcessorEnabled && syncProcessor != null) {
-            syncProcessor.shutdown();
-        }
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyZooKeeperServer.java
@@ -190,23 +190,24 @@ public class ReadOnlyZooKeeperServer extends ZooKeeperServer {
     }
 
     @Override
-    public synchronized void shutdown() {
+    public synchronized void shutdown(boolean fullyShutDown) {
         if (!canShutdown()) {
+            super.shutdown(fullyShutDown);
             LOG.debug("ZooKeeper server is not running, so not proceeding to shutdown!");
-            return;
         }
-        shutdown = true;
-        unregisterJMX(this);
+        else {
+            shutdown = true;
+            unregisterJMX(this);
 
-        // set peer's server to null
-        self.setZooKeeperServer(null);
-        // clear all the connections
-        self.closeAllConnections();
+            // set peer's server to null
+            self.setZooKeeperServer(null);
+            // clear all the connections
+            self.closeAllConnections();
 
-        self.adminServer.setZooKeeperServer(null);
-
+            self.adminServer.setZooKeeperServer(null);
+        }
         // shutdown the server itself
-        super.shutdown();
+        super.shutdown(fullyShutDown);
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/SendAckRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/SendAckRequestProcessor.java
@@ -20,6 +20,8 @@ package org.apache.zookeeper.server.quorum;
 
 import java.io.Flushable;
 import java.io.IOException;
+import java.net.Socket;
+
 import org.apache.zookeeper.ZooDefs.OpCode;
 import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.RequestProcessor;
@@ -64,7 +66,8 @@ public class SendAckRequestProcessor implements RequestProcessor, Flushable {
         } catch (IOException e) {
             LOG.warn("Closing connection to leader, exception during packet send", e);
             try {
-                if (!learner.sock.isClosed()) {
+                Socket socket = learner.sock;
+                if ( socket != null && ! learner.sock.isClosed()) {
                     learner.sock.close();
                 }
             } catch (IOException e1) {


### PR DESCRIPTION
This fixes two bugs in shutdown logic, in the zookeeper server.

1. The `SendAckRequestProcessor` may die when attempting to close its `Learner` owner's socket, to signal that something went wrong, _if the learner already closed the socket because something (the same thing) went wrong (namely, the leader disconnecting). This is fixed by simply checking for nullity. 
2. `ZooKeeperServer.shutdown(boolean)` is not present in child classes, so many uses here fail to properly shut down child resources, such as the `SyncRequestProcessor`. This is fixed by refactoring shutdown for the child classes.

A unit test is also added, that fails when either of the two fixes are not present. 
To be precise, it fails only because the `SyncRequestProcessor` is never shut down (thread leak), once the first fix is applied; I didn't spend more time looking for other weird failures that may arise from what is obviously a bug anyway. 

See [ZOOKEEPER-4541](https://issues.apache.org/jira/browse/ZOOKEEPER-4541) for full details.