### PR TITLE
ZOOKEEPER-4616: Upgrade docker image to resolve CVEs

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM maven:3.6.3-jdk-8
+FROM maven:3.8.4-jdk-8
 
 RUN apt-get update
 RUN apt-get install -y \


### PR DESCRIPTION
The current docker image `maven:3.6.3-jdk-8` has many critical security issues.

maven@3.6.3-jdk-8 › dpkg@1.19.7 has [CVE-2022-1664](https://www.cve.org/CVERecord?id=CVE-2022-1664)

maven@3.6.3-jdk-8 › openssl@1.1.1d-0+deb10u6 has [CVE-2021-3711](https://www.cve.org/CVERecord?id=CVE-2021-3711)

maven@3.6.3-jdk-8 › gzip@1.9-3 has [CVE-2022-1271](https://www.cve.org/CVERecord?id=CVE-2022-1271)

We need to upgrade the docker base image to version `maven:3.8.4-jdk-8`

See [ZOOKEEPER-4616](https://issues.apache.org/jira/browse/ZOOKEEPER-4616) for full details.