### PR TITLE
ZOOKEEPER-4617: Upgrade apache-rat-tasks to resolve CVEs

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
@@ -34,7 +34,7 @@
   </description>
 
   <properties>
-    <rat.version>0.6</rat.version>
+    <rat.version>0.12</rat.version>
     <guava.version>18.0</guava.version>
   </properties>
 


### PR DESCRIPTION
The org.apache.rat:apache-rat-tasks@0.6 has two CVEs

[CVE-2015-4852](https://www.cve.org/CVERecord?id=CVE-2015-4852)
[CVE-2015-7501](https://www.cve.org/CVERecord?id=CVE-2015-7501)
The introduction path is: 

org.apache.zookeeper:zookeeper-contrib-zooinspector@3.9.0-SNAPSHOT › org.apache.rat:apache-rat-tasks@0.6 › org.apache.rat:apache-rat-core@0.6 › commons-collections:commons-collections@3.2

Fix: Upgrade to org.apache.rat:apache-rat-tasks@0.12

The [ZOOKEEPER-4617](https://issues.apache.org/jira/browse/ZOOKEEPER-4617) has full details.