### PR TITLE
ZOOKEEPER-4619: Enable the certificate password to support commas (,).

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -1457,7 +1457,7 @@ zhandle_t *zookeeper_init_ssl(const char *host, const char *cert, watcher_fn wat
     zcert.ca = strtok(strdup(cert), ",");
     zcert.cert = strtok(NULL, ",");
     zcert.key = strtok(NULL, ",");
-    zcert.passwd = strtok(NULL, ",");       
+    zcert.passwd = strtok(NULL, "");
     return zookeeper_init_internal(host, watcher, recv_timeout, clientid, context, flags, NULL, &zcert, NULL);
 }
 #endif


### PR DESCRIPTION
Enable the certificate password to support commas (,)