### PR TITLE
Fixed leak of sync processor upon follower server shutdown

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerZooKeeperServer.java
@@ -163,6 +163,19 @@ public abstract class LearnerZooKeeperServer extends QuorumZooKeeperServer {
         } catch (Exception e) {
             LOG.warn("Ignoring unexpected exception during shutdown", e);
         }
+        shutdownSyncProcessor();
+    }
+
+    public void shutdown(boolean fullyShutDown) {
+        try {
+            super.shutdown(fullyShutDown);
+        } catch (Exception e) {
+            LOG.warn("Ignoring unexpected exception during shutdown", e);
+        }
+        shutdownSyncProcessor();
+    }
+
+    private void shutdownSyncProcessor() {
         try {
             if (syncProcessor != null) {
                 syncProcessor.shutdown();


### PR DESCRIPTION
This PR addresses leak of sync processor upon follower shutdown mentioned in [ZOOKEEPER-4502](https://issues.apache.org/jira/projects/ZOOKEEPER/issues/ZOOKEEPER-4502?filter=allopenissues)