### PR TITLE
Bump actions/checkout to v3 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 360
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK ${{ matrix.profile.jdk }}
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 360
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 360
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.buildRef }}
     - name: Set up JDK 11


### PR DESCRIPTION
Proposing bumping the version of `actions/checkout` used in these GitHub Actions workflows to v3 - https://github.com/actions/checkout#checkout-v3