### PR TITLE
ZOOKEEPER-4628: Upgrade jackson-databind dependency for CVE-2022-4200…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -560,7 +560,7 @@
     <commons-cli.version>1.4</commons-cli.version>
     <netty.version>4.1.76.Final</netty.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
-    <jackson.version>2.13.2.1</jackson.version>
+    <jackson.version>2.13.4.1</jackson.version>
     <jline.version>2.14.6</jline.version>
     <snappy.version>1.1.7.7</snappy.version>
     <kerby.version>2.0.0</kerby.version>


### PR DESCRIPTION
…3, CVE-2022-42004

Need to update jackson-databind dependency for the following CVEs
https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004