### PR TITLE
ZOOKEEPER-4636: Fix zkServer.sh for AIX

### DIFF
--- a/bin/zkServer.sh
+++ b/bin/zkServer.sh
@@ -171,6 +171,9 @@ start)
       *solaris*)
         /bin/echo "${!}\\c" > "$ZOOPIDFILE"
         ;;
+      aix*)
+        /bin/echo "$!\c" > "$ZOOPIDFILE"
+        ;;
       *)
         /bin/echo -n $! > "$ZOOPIDFILE"
         ;;


### PR DESCRIPTION
AIX "echo" does not support "-n" argument.
