### PR TITLE
ZOOKEEPER-4656: Allow ZooKeeperAdmin creation with custom HostProvider

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/admin/ZooKeeperAdmin.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/admin/ZooKeeperAdmin.java
@@ -26,6 +26,7 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.client.HostProvider;
 import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.common.StringUtils;
 import org.apache.zookeeper.data.Stat;
@@ -122,6 +123,53 @@ public class ZooKeeperAdmin extends ZooKeeper {
         Watcher watcher,
         ZKClientConfig conf) throws IOException {
         super(connectString, sessionTimeout, watcher, conf);
+    }
+
+    /**
+     * Create a ZooKeeperAdmin object which is used to perform dynamic reconfiguration
+     * operations.
+     *
+     * @param connectString
+     *            comma separated host:port pairs, each corresponding to a zk
+     *            server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002" If
+     *            the optional chroot suffix is used the example would look
+     *            like: "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002/app/a"
+     *            where the client would be rooted at "/app/a" and all paths
+     *            would be relative to this root - ie getting/setting/etc...
+     *            "/foo/bar" would result in operations being run on
+     *            "/app/a/foo/bar" (from the server perspective).
+     * @param sessionTimeout
+     *            session timeout in milliseconds
+     * @param watcher
+     *            a watcher object which will be notified of state changes, may
+     *            also be notified for node events
+     * @param canBeReadOnly
+     *            whether the created client is allowed to go to
+     *            read-only mode in case of partitioning. Read-only mode
+     *            basically means that if the client can't find any majority
+     *            servers but there's partitioned server it could reach, it
+     *            connects to one in read-only mode, i.e. read requests are
+     *            allowed while write requests are not. It continues seeking for
+     *            majority in the background.
+     * @param hostProvider
+     *            use this as HostProvider to enable custom behaviour.
+     *
+     * @throws IOException
+     *             in cases of network failure
+     * @throws IllegalArgumentException
+     *             if an invalid chroot path is specified
+     *
+     * @see ZooKeeper#ZooKeeper(String, int, Watcher, boolean, HostProvider)
+     *
+     * @since 3.8.1
+     */
+    public ZooKeeperAdmin(
+        String connectString,
+        int sessionTimeout,
+        Watcher watcher,
+        boolean canBeReadOnly,
+        HostProvider hostProvider) throws IOException {
+        super(connectString, sessionTimeout, watcher, canBeReadOnly, hostProvider);
     }
 
     /**


### PR DESCRIPTION
It's currently not possible to create a ZooKeeperAdmin instance with a custom HostProvider because the ZooKeeperAdmin doesn't expose the necessary ZooKeeper base class constructor. To make this possible, this PR adds ZooKeeperAdmin constructor that passes a given HostProvider parameter to the ZooKeeper base class constructor.