### PR TITLE
ZOOKEEPER-3941: Upgrade commons-cli to 1.4

### DIFF
--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -59,4 +59,10 @@
       <cve>CVE-2021-34429</cve>
    </suppress>
 
+   <suppress>
+      <!-- false positive, reporting CVE in commons-cli, when the actual CVE is
+           about commons-net which we don't use-->
+      <cve>CVE-2021-37533</cve>
+   </suppress>
+
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
     <reload4j.version>1.2.22</reload4j.version>
     <mockito.version>2.27.0</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <commons-cli.version>1.2</commons-cli.version>
+    <commons-cli.version>1.4</commons-cli.version>
     <netty.version>4.1.76.Final</netty.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <jackson.version>2.13.2.1</jackson.version>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/AddAuthCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/AddAuthCommand.java
@@ -19,10 +19,9 @@
 package org.apache.zookeeper.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 
 /**
  * addAuth command for cli
@@ -38,7 +37,7 @@ public class AddAuthCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         CommandLine cl;
         try {
             cl = parser.parse(options, cmdArgs);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/AddWatchCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/AddWatchCommand.java
@@ -20,10 +20,9 @@ package org.apache.zookeeper.cli;
 
 import java.util.Arrays;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.AddWatchMode;
 import org.apache.zookeeper.KeeperException;
 
@@ -50,7 +49,7 @@ public class AddWatchCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CreateCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CreateCommand.java
@@ -20,11 +20,10 @@ package org.apache.zookeeper.cli;
 
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
@@ -54,7 +53,7 @@ public class CreateCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/DelQuotaCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/DelQuotaCommand.java
@@ -21,12 +21,11 @@ package org.apache.zookeeper.cli;
 import java.io.IOException;
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Quotas;
 import org.apache.zookeeper.StatsTrack;
@@ -53,7 +52,7 @@ public class DelQuotaCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/DeleteAllCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/DeleteAllCommand.java
@@ -19,11 +19,10 @@
 package org.apache.zookeeper.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZKUtil;
 
@@ -50,7 +49,7 @@ public class DeleteAllCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/DeleteCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/DeleteCommand.java
@@ -19,10 +19,9 @@
 package org.apache.zookeeper.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 
 /**
@@ -44,7 +43,7 @@ public class DeleteCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {
@@ -64,7 +63,7 @@ public class DeleteCommand extends CliCommand {
         if (args.length > 2) {
             err.println("'delete path [version]' has been deprecated. "
                         + "Please use 'delete [-v version] path' instead.");
-            Parser parser = new PosixParser();
+            DefaultParser parser = new DefaultParser();
             try {
                 cl = parser.parse(options, cmdArgs);
             } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetAclCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetAclCommand.java
@@ -19,10 +19,9 @@ package org.apache.zookeeper.cli;
 
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZKUtil;
 import org.apache.zookeeper.data.ACL;
@@ -47,7 +46,7 @@ public class GetAclCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetAllChildrenNumberCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetAllChildrenNumberCommand.java
@@ -18,10 +18,9 @@
 package org.apache.zookeeper.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 
 /**
@@ -38,7 +37,7 @@ public class GetAllChildrenNumberCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         CommandLine cl;
         try {
             cl = parser.parse(options, cmdArgs);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
@@ -19,10 +19,9 @@
 package org.apache.zookeeper.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 
@@ -47,7 +46,7 @@ public class GetCommand extends CliCommand {
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
 
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {
@@ -69,7 +68,7 @@ public class GetCommand extends CliCommand {
             // rewrite to option
             cmdArgs[2] = "-w";
             err.println("'get path [watch]' has been deprecated. " + "Please use 'get [-s] [-w] path' instead.");
-            Parser parser = new PosixParser();
+            DefaultParser parser = new DefaultParser();
             try {
                 cl = parser.parse(options, cmdArgs);
             } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetConfigCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetConfigCommand.java
@@ -19,10 +19,9 @@
 package org.apache.zookeeper.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.util.ConfigUtils;
@@ -49,7 +48,7 @@ public class GetConfigCommand extends CliCommand {
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
 
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetEphemeralsCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetEphemeralsCommand.java
@@ -19,10 +19,9 @@ package org.apache.zookeeper.cli;
 
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 
 /**
@@ -39,7 +38,7 @@ public class GetEphemeralsCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         CommandLine cl;
         try {
             cl = parser.parse(options, cmdArgs);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ListQuotaCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ListQuotaCommand.java
@@ -19,10 +19,9 @@
 package org.apache.zookeeper.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Quotas;
 import org.apache.zookeeper.StatsTrack;
@@ -42,7 +41,7 @@ public class ListQuotaCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         CommandLine cl;
         try {
             cl = parser.parse(options, cmdArgs);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/LsCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/LsCommand.java
@@ -20,11 +20,10 @@ package org.apache.zookeeper.cli;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.AsyncCallback.StringCallback;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZKUtil;
@@ -57,7 +56,7 @@ public class LsCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {
@@ -80,7 +79,7 @@ public class LsCommand extends CliCommand {
             // rewrite to option
             cmdArgs[2] = "-w";
             err.println("'ls path [watch]' has been deprecated. " + "Please use 'ls [-w] path' instead.");
-            Parser parser = new PosixParser();
+            DefaultParser parser = new DefaultParser();
             try {
                 cl = parser.parse(options, cmdArgs);
             } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ReconfigCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/ReconfigCommand.java
@@ -21,10 +21,9 @@ package org.apache.zookeeper.cli;
 import java.io.FileInputStream;
 import java.util.Properties;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.admin.ZooKeeperAdmin;
 import org.apache.zookeeper.data.Stat;
@@ -83,7 +82,7 @@ public class ReconfigCommand extends CliCommand {
         joining = null;
         leaving = null;
         members = null;
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RemoveWatchesCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RemoveWatchesCommand.java
@@ -19,10 +19,9 @@
 package org.apache.zookeeper.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Watcher.WatcherType;
 
@@ -48,7 +47,7 @@ public class RemoveWatchesCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetAclCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetAclCommand.java
@@ -20,10 +20,9 @@ package org.apache.zookeeper.cli;
 
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.AsyncCallback.StringCallback;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZKUtil;
@@ -54,7 +53,7 @@ public class SetAclCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
@@ -19,10 +19,9 @@
 package org.apache.zookeeper.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 
@@ -46,7 +45,7 @@ public class SetCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetQuotaCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetQuotaCommand.java
@@ -21,12 +21,11 @@ package org.apache.zookeeper.cli;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -61,7 +60,7 @@ public class SetQuotaCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/StatCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/StatCommand.java
@@ -19,10 +19,9 @@
 package org.apache.zookeeper.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 
@@ -45,7 +44,7 @@ public class StatCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         try {
             cl = parser.parse(options, cmdArgs);
         } catch (ParseException ex) {
@@ -67,7 +66,7 @@ public class StatCommand extends CliCommand {
             // rewrite to option
             cmdArgs[2] = "-w";
             err.println("'stat path [watch]' has been deprecated. " + "Please use 'stat [-w] path' instead.");
-            Parser parser = new PosixParser();
+            DefaultParser parser = new DefaultParser();
             try {
                 cl = parser.parse(options, cmdArgs);
             } catch (ParseException ex) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SyncCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SyncCommand.java
@@ -22,10 +22,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.AsyncCallback;
 
 /**
@@ -43,7 +42,7 @@ public class SyncCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         CommandLine cl;
         try {
             cl = parser.parse(options, cmdArgs);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/VersionCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/VersionCommand.java
@@ -18,10 +18,9 @@
 package org.apache.zookeeper.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.Parser;
-import org.apache.commons.cli.PosixParser;
 import org.apache.zookeeper.Version;
 
 /**
@@ -38,7 +37,7 @@ public class VersionCommand extends CliCommand {
 
     @Override
     public CliCommand parse(String[] cmdArgs) throws CliParseException {
-        Parser parser = new PosixParser();
+        DefaultParser parser = new DefaultParser();
         CommandLine cl;
         try {
             cl = parser.parse(options, cmdArgs);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/TxnLogToolkit.java
@@ -39,11 +39,11 @@ import java.util.zip.Adler32;
 import java.util.zip.Checksum;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.Record;
@@ -383,7 +383,7 @@ public class TxnLogToolkit implements Closeable {
     }
 
     private static TxnLogToolkit parseCommandLine(String[] args) throws TxnLogToolkitException, FileNotFoundException {
-        CommandLineParser parser = new PosixParser();
+        CommandLineParser parser = new DefaultParser();
         Options options = new Options();
 
         Option helpOpt = new Option("h", "help", false, "Print help message");


### PR DESCRIPTION
commons-cli 1.2 was released in 2009, time to upgrade it to the newest version (1.4). To avoid deprecation messages we have to upgrade the Java code too.

Author: Tamas Penzes <tamaas@cloudera.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, Mate Szalay-Beko <symat@apache.org>

Closes #1463 from tamaashu/zookeeper-3941

(cherry picked from commit 492fd79b0c7845f1b7f3717632471d79660d1363)