### PR TITLE
Add version to file name of C client libraries

### DIFF
--- a/zookeeper-client/zookeeper-client-c/Makefile.am
+++ b/zookeeper-client/zookeeper-client-c/Makefile.am
@@ -22,7 +22,7 @@ endif
 AM_CPPFLAGS = -I${srcdir}/include -I${srcdir}/tests -I${srcdir}/generated $(SOLARIS_CPPFLAGS) $(OPENSSL_CPPFLAGS) $(SASL_CPPFLAGS)
 AM_CFLAGS = -Wall -Werror -Wdeclaration-after-statement
 AM_CXXFLAGS = -Wall $(USEIPV6)
-LIB_LDFLAGS = -no-undefined -version-info 2 $(SOLARIS_LIB_LDFLAGS) $(OPENSSL_LIB_LDFLAGS) $(SASL_LIB_LDFLAGS)
+LIB_LDFLAGS = -no-undefined -release $(PACKAGE_VERSION) -version-info 2 $(SOLARIS_LIB_LDFLAGS) $(OPENSSL_LIB_LDFLAGS) $(SASL_LIB_LDFLAGS)
 
 # Additional flags for coverage testing (if enabled)
 if ENABLEGCOV


### PR DESCRIPTION
```sh
#./configure --prefix=/install/path
make install
```
# AS-IS
```
/install/path/lib
├── libzookeeper_mt.a
├── libzookeeper_mt.la
├── libzookeeper_mt.so -> libzookeeper_mt.so.2.0.0
├── libzookeeper_mt.so.2 -> libzookeeper_mt.so.2.0.0
├── libzookeeper_mt.so.2.0.0
├── libzookeeper_st.a
├── libzookeeper_st.la
├── libzookeeper_st.so -> libzookeeper_st.so.2.0.0
├── libzookeeper_st.so.2 -> libzookeeper_st.so.2.0.0
└── libzookeeper_st.so.2.0.0
```
# TO-BE
```
/install/path/lib
├── libzookeeper_mt-3.8.0.so.2 -> libzookeeper_mt-3.8.0.so.2.0.0
├── libzookeeper_mt-3.8.0.so.2.0.0
├── libzookeeper_mt.a
├── libzookeeper_mt.la
├── libzookeeper_mt.so -> libzookeeper_mt-3.8.0.so.2.0.0
├── libzookeeper_st-3.8.0.so.2 -> libzookeeper_st-3.8.0.so.2.0.0
├── libzookeeper_st-3.8.0.so.2.0.0
├── libzookeeper_st.a
├── libzookeeper_st.la
└── libzookeeper_st.so -> libzookeeper_st-3.8.0.so.2.0.0
```

# JIRA
I have already sent a mail to `dev@zookeeper.apache.org` but have not received a reply.

I also sent an email to `users@infra.apache.org` and got the reply below. So I don't have any jira number.
> You can just make the pull request. The zookeeper community can respond with anything further that they require from there.