### PR TITLE
ZOOKEEPER-4648 FinalRequestProcessor addAuditLog after the process of request maybe better.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
@@ -208,8 +208,6 @@ public class FinalRequestProcessor implements RequestProcessor {
               throw KeeperException.create(Code.THROTTLEDOP);
             }
 
-            AuditHelper.addAuditLog(request, rc);
-
             switch (request.type) {
             case OpCode.ping: {
                 lastOp = "PING";
@@ -576,6 +574,8 @@ public class FinalRequestProcessor implements RequestProcessor {
             err = Code.MARSHALLINGERROR;
         }
 
+        rc.err = err.intValue();
+        AuditHelper.addAuditLog(request, rc);
         ReplyHeader hdr = new ReplyHeader(request.cxid, lastZxid, err.intValue());
 
         updateStats(request, lastOp, lastZxid);


### PR DESCRIPTION
ZOOKEEPER-4648 FinalRequestProcessor addAuditLog before the process of request and make failedTxn=false. But I think failedTxn should be true if the request can not pass the checkACL and throw KeeperException or other exceptions, **since the err code after request processing is also important for audit.**
```java
@param failedTxn whether audit is being done failed transaction for normal transaction

public void processRequest(Request request) {
        ......
        Code err = Code.OK;
        try {
            ......
            AuditHelper.addAuditLog(request, rc);

            switch (request.type) {
            ......
            case OpCode.getAllChildrenNumber: {
                lastOp = "GETACN";
                ......
                zks.checkACL(
                    request.cnxn,
                    zks.getZKDatabase().aclForNode(n),
                    ZooDefs.Perms.READ,
                    request.authInfo,
                    path,
                    null);
                ......
                break;
            }
            ......
            }
        } catch (SessionMovedException e) {
            ......
        } catch (KeeperException e) {
            err = e.code();
        } catch (Exception e) {
            ......
        }
```
if the failedTxn == true or the rc.err != Code.OK, the log result will be FAILURE: 
```java
    private static Result getResult(ProcessTxnResult rc, boolean failedTxn) {
        if (failedTxn) {
            return Result.FAILURE;
        } else {
            return rc.err == KeeperException.Code.OK.intValue() ? Result.SUCCESS : Result.FAILURE;
        }
    }
```
So we could add audit log after request processing and record the err code like below, the log info maybe more accurate. 
```java
        Code err = Code.OK;
        try { 
             ......
        } catch (SessionMovedException e) {
            ......
        } catch (KeeperException e) {
            err = e.code();
        } catch (Exception e) {
            ......
        }
        rc.err = err.intValue();
        AuditHelper.addAuditLog(request, rc);
```
