### PR TITLE
ZOOKEEPER-4651: Fix checkstyle problems on branch-3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
     <commons-collections.version>3.2.2</commons-collections.version>
     <dropwizard.version>3.2.5</dropwizard.version>
     <spotbugsannotations.version>4.0.2</spotbugsannotations.version>
-    <checkstyle.version>8.39</checkstyle.version>
+    <checkstyle.version>8.19</checkstyle.version>
     <enforcer.version>3.0.0-M3</enforcer.version>
 
     <!-- parameter to pass to C client build -->

--- a/zookeeper-compatibility-tests/zookeeper-compatibility-tests-curator/src/test/java/org/apache/zookeeper/compatibility/TestApacheCuratorCompatibility.java
+++ b/zookeeper-compatibility-tests/zookeeper-compatibility-tests-curator/src/test/java/org/apache/zookeeper/compatibility/TestApacheCuratorCompatibility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
Checkstyle was upgraded to 8.39 in ZOOKEEPER-4644 and it doesn't work properly on current branch 3.6. Given that branch 3.6 won't be actively developed in the future, I decided to downgrade checkstyle back to 8.19 instead of fixing the checkstyle config or re-format the code.

But even after downgrading it to 8.19, we still have four checkstyle errors in a license header which I also fix in this commit.