### PR TITLE
ZOOKEEPER-4639: Provide auth support for admin server APIs

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/html/header.html
+++ b/zookeeper-docs/src/main/resources/markdown/html/header.html
@@ -97,6 +97,9 @@ document.write("Last Published: " + document.lastModified);
                 <a href="zookeeperQuotas.html">Quota Guide</a>
             </div>
             <div class="menuitem">
+                <a href="zookeeperSnapshotAndRestore.html">Snapshot and Restore Guide</a>
+            </div>
+            <div class="menuitem">
                 <a href="zookeeperJMX.html">JMX</a>
             </div>
             <div class="menuitem">

--- a/zookeeper-docs/src/main/resources/markdown/index.md
+++ b/zookeeper-docs/src/main/resources/markdown/index.md
@@ -46,6 +46,7 @@ archives.
     Documents for Administrators and Operations Engineers of ZooKeeper Deployments
     + [Administrator's Guide](zookeeperAdmin.html) - a guide for system administrators and anyone else who might deploy ZooKeeper
     + [Quota Guide](zookeeperQuotas.html) - a guide for system administrators on Quotas in ZooKeeper.
+    + [Snapshot and Restore Guide](zookeeperSnapshotAndRestore.html) - a guide for system administrators on take snapshot and restore ZooKeeper.
     + [JMX](zookeeperJMX.html) - how to enable JMX in ZooKeeper
     + [Hierarchical Quorums](zookeeperHierarchicalQuorums.html) - a guide on how to use hierarchical quorums
     + [Oracle Quorum](zookeeperOracleQuorums.html) - the introduction to Oracle Quorum increases the availability of a cluster of 2 ZooKeeper instances with a failure detector.

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -2122,15 +2122,18 @@ options are used to configure the [AdminServer](#sc_adminserver).
 
 * *admin.snapshot.enabled* :
   (Java system property: **zookeeper.admin.snapshot.enabled**)
-  The flag for enabling the snapshot command. Defaults to false. 
-  It will be enabled by default once the auth support for admin server commands 
-  is available.
+  The flag for enabling the snapshot command. Defaults to true. 
+
   
 * *admin.restore.enabled* :
   (Java system property: **zookeeper.admin.restore.enabled**)
-  The flag for enabling the restore command. Defaults to false.
-  It will be enabled by default once the auth support for admin server commands
-  is available.
+  The flag for enabling the restore command. Defaults to true.
+
+
+* *admin.needClientAuth* :
+  (Java system property: **zookeeper.admin.needClientAuth**)
+  The flag to control whether client auth is needed. Using x509 auth requires true.
+  Defaults to false.
 
 **New in 3.7.1:** The following
 options are used to configure the [AdminServer](#sc_adminserver).

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperSnapshotAndRestore.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperSnapshotAndRestore.md
@@ -1,0 +1,68 @@
+<!--
+Copyright 2002-2004 The Apache Software Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+//-->
+
+# ZooKeeper Snapshot and Restore Guide
+
+Zookeeper is designed to withstand machine failures. A Zookeeper cluster can automatically recover 
+from temporary failures such as machine reboot. It can also tolerate up to (N-1)/2 permanent 
+failures for a cluster of N members due to hardware failures or disk corruption, etc. When a member 
+permanently fails, it loses access to the cluster. If the cluster permanently loses more than 
+(N-1)/2 members, it disastrously fails and loses quorum. Once the quorum is lost, the cluster 
+cannot reach consensus and therefore cannot continue to accept updates.
+
+To recover from such disastrous failures, Zookeeper provides snapshot and restore functionalities to
+restore a cluster from a snapshot.
+
+1. Snapshot and restore operate on the connected server via Admin Server APIs
+1. Snapshot and restore are rate limited to protect the server from being overloaded
+1. Snapshot and restore require authentication and authorization on the root path with ALL permission.
+The supported auth schemas are digest, x509 and IP.
+   
+* [Snapshot](#zookeeper_snapshot)
+* [Restore](#zookeeper_restore)  
+
+<a name="zookeeper_snapshot"></a>
+
+## Snapshot
+Recovering a cluster needs a snapshot from a ZooKeeper cluster. Users can periodically take
+snapshots from a live server which has the highest zxid and stream out data to a local 
+or external storage/file system (e.g., S3).
+
+ ```bash
+ # The snapshot command takes snapshot from the server it connects to and rate limited to once every 5 mins by default
+ curl -H 'Authorization: digest root:root_passwd' http://hostname:adminPort/commands/snapshot?streaming=true --output snapshotFileName
+ ```
+
+<a name="zookeeper_restore"></a>
+## Restore
+
+Restoring a cluster needs a single snapshot as input stream. Restore can be used for recovering a 
+cluster for quorum lost or building a brand-new cluster with seed data. 
+
+All members should restore using the same snapshot. The following are the recommended steps:
+ 
+- Blocking traffic on the client port or client secure port before restore starts
+- Take a snapshot of the latest database state using the snapshot admin server command if applicable
+- For each server
+  - Moving the files in dataDir and dataLogDir to different location to prevent the restored database 
+    from being overwritten when server restarts after restore
+  - Restore the server using restore admin server command
+- Unblocking traffic on the client port or client secure port after restore completes
+
+ ```bash
+ # The restore command takes a snapshot as input stream and restore the db of the server it connects. It is rate limited to once every 5 mins by default
+ curl -H 'Content-Type:application/octet-stream' -H 'Authorization: digest root:root_passwd' -POST http://hostname:adminPort/commands/restore --data-binary "@snapshotFileName" 
+ ```

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -2069,7 +2069,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
     /**
      * Grant or deny authorization to an operation on a node as a function of:
-     * @param cnxn :    the server connection
+     * @param cnxn :    the server connection or null for admin server commands
      * @param acl :     set of ACLs for the node
      * @param perm :    the permission that the client is requesting
      * @param ids :     the credentials supplied by the client

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/AuthRequest.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/AuthRequest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.admin;
+
+import org.apache.zookeeper.ZooDefs;
+
+/**
+ * Class representing auth data for performing ACL check on admin server commands.
+ *
+ * For example, SnapshotCommand requires {@link ZooDefs.Perms.ALL} permission on
+ * the root node.
+ *
+ */
+public class AuthRequest {
+    private final int permission;
+    private final String path;
+
+    /**
+     * @param permission
+     *                      the required permission for auth check
+     * @param path
+     *                      the ZNode path for auth check
+     */
+    public AuthRequest(final int permission, final String path) {
+        this.permission = permission;
+        this.path = path;
+    }
+
+    /**
+     * @return permission
+     */
+    public int getPermission() {
+        return permission;
+    }
+
+    /**
+     * @return ZNode path
+     */
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public String toString() {
+        return "AuthRequest{"
+        + "permission=" + permission
+        + ", path='" + path + '\''
+        + '}';
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Command.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Command.java
@@ -46,16 +46,15 @@ public interface Command {
     String getPrimaryName();
 
     /**
-     * A string documenting this command (e.g., what it does, any arguments it
-     * takes).
-     */
-    String getDoc();
-
-    /**
      * @return true if the command requires an active ZooKeeperServer or a
      *     synced peer in order to resolve
      */
     boolean isServerRequired();
+
+    /**
+     * @return AuthRequest associated to the command. Null means auth check is not required.
+     */
+    AuthRequest getAuthRequest();
 
     /**
      * Run this command for HTTP GET request. Commands take a ZooKeeperServer, String-valued keyword

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/CommandBase.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/CommandBase.java
@@ -26,24 +26,27 @@ public abstract class CommandBase implements Command {
 
     private final String primaryName;
     private final Set<String> names;
-    private final String doc;
     private final boolean serverRequired;
+    private final AuthRequest authRequest;
 
     /**
      * @param names The possible names of this command, with the primary name first.
      */
     protected CommandBase(List<String> names) {
-        this(names, true, null);
+        this(names, true);
     }
     protected CommandBase(List<String> names, boolean serverRequired) {
         this(names, serverRequired, null);
     }
 
-    protected CommandBase(List<String> names, boolean serverRequired, String doc) {
+    protected CommandBase(List<String> names, boolean serverRequired, AuthRequest authRequest) {
+        if (authRequest != null && !serverRequired) {
+            throw new IllegalArgumentException("An active server is required for auth check");
+        }
         this.primaryName = names.get(0);
         this.names = new HashSet<>(names);
-        this.doc = doc;
         this.serverRequired = serverRequired;
+        this.authRequest = authRequest;
     }
 
     @Override
@@ -56,14 +59,15 @@ public abstract class CommandBase implements Command {
         return names;
     }
 
-    @Override
-    public String getDoc() {
-        return doc;
-    }
 
     @Override
     public boolean isServerRequired() {
         return serverRequired;
+    }
+
+    @Override
+    public AuthRequest getAuthRequest() {
+        return authRequest;
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/GetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/GetCommand.java
@@ -36,6 +36,10 @@ public abstract class GetCommand extends CommandBase {
         super(names, serverRequired);
     }
 
+    protected GetCommand(List<String> names, boolean serverRequired, AuthRequest authRequest) {
+        super(names, serverRequired, authRequest);
+    }
+
     @Override
     public CommandResponse runPost(ZooKeeperServer zkServer, InputStream inputStream) {
         return null;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/PostCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/PostCommand.java
@@ -26,8 +26,8 @@ import java.util.Map;
 import org.apache.zookeeper.server.ZooKeeperServer;
 
 public abstract class PostCommand extends CommandBase {
-    protected PostCommand(List<String> names) {
-        super(names);
+    protected PostCommand(List<String> names, boolean serverRequired, AuthRequest authRequest) {
+        super(names, serverRequired, authRequest);
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/StreamOutputter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/StreamOutputter.java
@@ -46,7 +46,7 @@ public class StreamOutputter implements CommandOutputter{
         try (final InputStream is = response.getInputStream()){
             IOUtils.copyBytes(is, os, 1024, true);
         } catch (final IOException e) {
-            LOG.error("Exception occurred when streaming out data to {}", clientIP, e);
+            LOG.warn("Exception streaming out data to {}", clientIP, e);
         }
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/AuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/AuthenticationProvider.java
@@ -18,7 +18,11 @@
 
 package org.apache.zookeeper.server.auth;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.ServerCnxn;
 
 /**
@@ -48,6 +52,21 @@ public interface AuthenticationProvider {
      * @return TODO
      */
     KeeperException.Code handleAuthentication(ServerCnxn cnxn, byte[] authData);
+
+    /**
+     * This method is called when admin server command passes authentication data for this
+     * scheme.
+     *
+     * @param request
+     *                the request that contains the authentication information.
+     * @param authData
+     *                the authentication data received.
+     * @return Ids
+     *                the list of Id. Empty list means not authenticated
+     */
+    default List<Id> handleAuthentication(HttpServletRequest request, byte[] authData) {
+        return new ArrayList<>();
+    }
 
     /**
      * This method is called to see if the given id matches the given id

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
@@ -21,6 +21,10 @@ package org.apache.zookeeper.server.auth;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.ServerCnxn;
@@ -123,18 +127,19 @@ public class DigestAuthenticationProvider implements AuthenticationProvider {
     }
 
     public KeeperException.Code handleAuthentication(ServerCnxn cnxn, byte[] authData) {
-        String id = new String(authData);
-        try {
-            String digest = generateDigest(id);
-            if (digest.equals(superDigest)) {
-                cnxn.addAuthInfo(new Id("super", ""));
-            }
-            cnxn.addAuthInfo(new Id(getScheme(), digest));
-            return KeeperException.Code.OK;
-        } catch (NoSuchAlgorithmException e) {
-            LOG.error("Missing algorithm", e);
+        final List<Id> ids = handleAuthentication(authData);
+        if (ids.isEmpty()) {
+            return KeeperException.Code.AUTHFAILED;
         }
-        return KeeperException.Code.AUTHFAILED;
+        for (Id id : ids) {
+            cnxn.addAuthInfo(id);
+        }
+        return KeeperException.Code.OK;
+    }
+
+    @Override
+    public List<Id> handleAuthentication(HttpServletRequest request, byte[] authData) {
+        return handleAuthentication(authData);
     }
 
     public boolean isAuthenticated() {
@@ -170,4 +175,18 @@ public class DigestAuthenticationProvider implements AuthenticationProvider {
         }
     }
 
+    private List<Id> handleAuthentication(final byte[] authData) {
+        final List<Id> ids = new ArrayList<>();
+        final String id = new String(authData);
+        try {
+            final String digest = generateDigest(id);
+            if (digest.equals(superDigest)) {
+                ids.add(new Id("super", ""));
+            }
+            ids.add(new Id(getScheme(), digest));
+        } catch (final NoSuchAlgorithmException e) {
+            LOG.error("Missing algorithm", e);
+        }
+        return Collections.unmodifiableList(ids);
+    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/IPAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/IPAuthenticationProvider.java
@@ -18,6 +18,9 @@
 
 package org.apache.zookeeper.server.auth;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.StringTokenizer;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.zookeeper.KeeperException;
@@ -25,7 +28,7 @@ import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.ServerCnxn;
 
 public class IPAuthenticationProvider implements AuthenticationProvider {
-    private static final String X_FORWARDED_FOR_HEADER_NAME = "X-Forwarded-For";
+    public static final String X_FORWARDED_FOR_HEADER_NAME = "X-Forwarded-For";
 
     public String getScheme() {
         return "ip";
@@ -35,6 +38,16 @@ public class IPAuthenticationProvider implements AuthenticationProvider {
         String id = cnxn.getRemoteSocketAddress().getAddress().getHostAddress();
         cnxn.addAuthInfo(new Id(getScheme(), id));
         return KeeperException.Code.OK;
+    }
+
+    @Override
+    public List<Id> handleAuthentication(HttpServletRequest request, byte[] authData) {
+        final List<Id> ids = new ArrayList<>();
+
+        final String ip = getClientIPAddress(request);
+        ids.add(new Id(getScheme(), ip));
+
+        return Collections.unmodifiableList(ids);
     }
 
     // This is a bit weird but we need to return the address and the number of

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/WrappedAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/WrappedAuthenticationProvider.java
@@ -18,7 +18,10 @@
 
 package org.apache.zookeeper.server.auth;
 
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.ServerCnxn;
 
 /**
@@ -50,6 +53,17 @@ class WrappedAuthenticationProvider extends ServerAuthenticationProvider {
     @Override
     public KeeperException.Code handleAuthentication(ServerObjs serverObjs, byte[] authData) {
         return implementation.handleAuthentication(serverObjs.getCnxn(), authData);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * forwards to older method {@link #handleAuthentication(HttpServletRequest, byte[])}
+     * @return
+     */
+    @Override
+    public List<Id> handleAuthentication(HttpServletRequest request, byte[] authData) {
+        return implementation.handleAuthentication(request, authData);
     }
 
     /**

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/CommandAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/CommandAuthTest.java
@@ -1,0 +1,410 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.admin;
+
+import static org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE;
+import static org.apache.zookeeper.server.admin.Commands.AUTH_INFO_SEPARATOR;
+import static org.apache.zookeeper.server.admin.Commands.ROOT_PATH;
+import static org.apache.zookeeper.server.admin.JettyAdminServerTest.HTTPS_URL_FORMAT;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.File;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.client.ZKClientConfig;
+import org.apache.zookeeper.common.ClientX509Util;
+import org.apache.zookeeper.common.QuorumX509Util;
+import org.apache.zookeeper.common.X509Exception;
+import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.data.Id;
+import org.apache.zookeeper.server.NettyServerCnxnFactory;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.apache.zookeeper.server.auth.DigestAuthenticationProvider;
+import org.apache.zookeeper.server.auth.ProviderRegistry;
+import org.apache.zookeeper.server.auth.X509AuthenticationProvider;
+import org.apache.zookeeper.test.ClientBase;
+import org.eclipse.jetty.http.HttpHeader;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class CommandAuthTest extends ZKTestCase {
+    private static final String DIGEST_SCHEMA = "digest";
+    private static final String X509_SCHEMA = "x509";
+    private static final String IP_SCHEMA = "ip";
+    private static final String ROOT_USER = "root";
+    private static final String ROOT_PASSWORD = "root_passwd";
+    private static final String AUTH_TEST_COMMAND_NAME = "authtest";
+    private static final String X509_SUBJECT_PRINCIPAL = "CN=localhost,OU=ZooKeeper,O=Apache,L=Unknown,ST=Unknown,C=Unknown";
+
+    public enum AuthSchema {
+        DIGEST,
+        X509,
+        IP
+    }
+
+    private final int jettyAdminPort = PortAssignment.unique();
+    private final String hostPort = "127.0.0.1:" + PortAssignment.unique();
+    private final ClientX509Util clientX509Util = new ClientX509Util();
+    private final QuorumX509Util quorumX509Util = new QuorumX509Util();
+    private ZooKeeperServer zks;
+    private ServerCnxnFactory cnxnFactory;
+    private JettyAdminServer adminServer;
+    private ZooKeeper zk;
+
+    @TempDir
+    static File dataDir;
+
+    @TempDir
+    static File logDir;
+
+    @BeforeAll
+    public void setup() throws Exception {
+        Commands.registerCommand(new AuthTestCommand(true, ZooDefs.Perms.ALL, ROOT_PATH));
+
+        setupTLS();
+
+        // start ZookeeperServer
+        System.setProperty("zookeeper.4lw.commands.whitelist", "*");
+        zks = new ZooKeeperServer(dataDir, logDir, 3000);
+        final int port = Integer.parseInt(hostPort.split(":")[1]);
+        cnxnFactory = ServerCnxnFactory.createFactory(port, -1);
+        cnxnFactory.startup(zks);
+        assertTrue(ClientBase.waitForServerUp(hostPort, 120000));
+
+        // start AdminServer
+        System.setProperty("zookeeper.admin.enableServer", "true");
+        System.setProperty("zookeeper.admin.serverPort", String.valueOf(jettyAdminPort));
+        adminServer = new JettyAdminServer();
+        adminServer.setZooKeeperServer(zks);
+        adminServer.start();
+    }
+
+    @AfterAll
+    public void tearDown() throws Exception {
+        clearTLS();
+
+        System.clearProperty("zookeeper.4lw.commands.whitelist");
+        System.clearProperty("zookeeper.admin.enableServer");
+        System.clearProperty("zookeeper.admin.serverPort");
+
+        if (adminServer != null) {
+            adminServer.shutdown();
+        }
+
+        if (cnxnFactory != null) {
+            cnxnFactory.shutdown();
+        }
+
+        if (zks != null) {
+            zks.shutdown();
+        }
+    }
+
+    @BeforeEach
+    public void setupEach() throws Exception {
+        zk = ClientBase.createZKClient(hostPort);
+    }
+
+    @AfterEach
+    public void tearDownEach() throws Exception {
+        if (zk != null) {
+            zk.close();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(AuthSchema.class)
+    public void testAuthCheck_authorized(final AuthSchema authSchema) throws Exception {
+        setupRootACL(authSchema);
+        try {
+            final HttpURLConnection authTestConn = sendAuthTestCommandRequest(authSchema, true);
+            assertEquals(HttpURLConnection.HTTP_OK, authTestConn.getResponseCode());
+        } finally {
+            addAuthInfo(zk, authSchema);
+            resetRootACL(zk);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AuthSchema.class, names = {"DIGEST"})
+    public void testAuthCheck_notAuthorized(final AuthSchema authSchema) throws Exception {
+        setupRootACL(authSchema);
+        try {
+            final HttpURLConnection authTestConn = sendAuthTestCommandRequest(authSchema, false);
+            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, authTestConn.getResponseCode());
+        } finally {
+            addAuthInfo(zk, authSchema);
+            resetRootACL(zk);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(AuthSchema.class)
+    public void testAuthCheck_noACL(final AuthSchema authSchema) throws Exception {
+        final HttpURLConnection authTestConn = sendAuthTestCommandRequest(authSchema, false);
+        assertEquals(HttpURLConnection.HTTP_OK, authTestConn.getResponseCode());
+    }
+
+    @Test
+    public void testAuthCheck_invalidServerRequiredConfig() {
+        assertThrows("An active server is required for auth check",
+        IllegalArgumentException.class,
+        () -> new AuthTestCommand(false, ZooDefs.Perms.ALL, ROOT_PATH));
+    }
+
+    @Test
+    public void testAuthCheck_noAuthInfo() {
+        testAuthCheck_invalidAuthInfo(null);
+    }
+
+    @Test
+    public void testAuthCheck_noAuthInfoSeparator() {
+        final String invalidAuthInfo =  String.format("%s%s%s:%s", DIGEST_SCHEMA, "", ROOT_USER, ROOT_PASSWORD);
+        testAuthCheck_invalidAuthInfo(invalidAuthInfo);
+    }
+
+    @Test
+    public void testAuthCheck_invalidAuthInfoSeparator() {
+        final String invalidAuthInfo =  String.format("%s%s%s:%s", DIGEST_SCHEMA, ":", ROOT_USER, ROOT_PASSWORD);
+        testAuthCheck_invalidAuthInfo(invalidAuthInfo);
+    }
+
+    @Test
+    public void testAuthCheck_invalidAuthSchema() {
+        final String invalidAuthInfo =  String.format("%s%s%s:%s", "InvalidAuthSchema", AUTH_INFO_SEPARATOR, ROOT_USER, ROOT_PASSWORD);
+        testAuthCheck_invalidAuthInfo(invalidAuthInfo);
+    }
+
+    @Test
+    public void testAuthCheck_authProviderNotFound() {
+        final String invalidAuthInfo =  String.format("%s%s%s:%s", "sasl", AUTH_INFO_SEPARATOR, ROOT_USER, ROOT_PASSWORD);
+        testAuthCheck_invalidAuthInfo(invalidAuthInfo);
+    }
+
+    private void testAuthCheck_invalidAuthInfo(final String invalidAuthInfo) {
+        final CommandResponse commandResponse = Commands.runGetCommand(AUTH_TEST_COMMAND_NAME, zks, new HashMap<>(), invalidAuthInfo, null);
+        assertEquals(HttpServletResponse.SC_UNAUTHORIZED, commandResponse.getStatusCode());
+    }
+
+    private static class AuthTestCommand extends GetCommand {
+        public AuthTestCommand(final boolean serverRequired, final int perm, final String path) {
+            super(Arrays.asList(AUTH_TEST_COMMAND_NAME, "at"), serverRequired, new AuthRequest(perm, path));
+        }
+
+        @Override
+        public CommandResponse runGet(ZooKeeperServer zkServer, Map<String, String> kwargs) {
+            return initializeResponse();
+        }
+    }
+
+    private void setupTLS() throws Exception {
+        System.setProperty("zookeeper.authProvider.x509", "org.apache.zookeeper.server.auth.X509AuthenticationProvider");
+        String testDataPath = System.getProperty("test.data.dir", "src/test/resources/data");
+
+        System.setProperty(clientX509Util.getSslKeystoreLocationProperty(), testDataPath + "/ssl/testKeyStore.jks");
+        System.setProperty(clientX509Util.getSslKeystorePasswdProperty(), "testpass");
+        System.setProperty(clientX509Util.getSslTruststoreLocationProperty(), testDataPath + "/ssl/testTrustStore.jks");
+        System.setProperty(clientX509Util.getSslTruststorePasswdProperty(), "testpass");
+
+        // client
+        System.setProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET, "org.apache.zookeeper.ClientCnxnSocketNetty");
+        System.setProperty(ZKClientConfig.SECURE_CLIENT, "true");
+
+        // server
+        System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY, "org.apache.zookeeper.server.NettyServerCnxnFactory");
+        System.setProperty(NettyServerCnxnFactory.PORT_UNIFICATION_KEY, Boolean.TRUE.toString());
+
+        // admin server
+        System.setProperty(quorumX509Util.getSslKeystoreLocationProperty(), testDataPath + "/ssl/testKeyStore.jks");
+        System.setProperty(quorumX509Util.getSslKeystorePasswdProperty(), "testpass");
+        System.setProperty(quorumX509Util.getSslTruststoreLocationProperty(), testDataPath + "/ssl/testTrustStore.jks");
+        System.setProperty(quorumX509Util.getSslTruststorePasswdProperty(), "testpass");
+        System.setProperty("zookeeper.admin.forceHttps", "true");
+        System.setProperty("zookeeper.admin.needClientAuth", "true");
+
+        // create SSLContext
+        final SSLContext sslContext = SSLContext.getInstance(ClientX509Util.DEFAULT_PROTOCOL);
+        final X509AuthenticationProvider authProvider = (X509AuthenticationProvider) ProviderRegistry.getProvider("x509");
+        if (authProvider == null) {
+            throw new X509Exception.SSLContextException("Could not create SSLContext with x509 auth provider");
+        }
+        sslContext.init(new X509KeyManager[]{authProvider.getKeyManager()}, new X509TrustManager[]{authProvider.getTrustManager()}, null);
+
+        // set SSLSocketFactory
+        HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
+    }
+
+    public void clearTLS() {
+        System.clearProperty("zookeeper.authProvider.x509");
+
+        System.clearProperty(clientX509Util.getSslKeystoreLocationProperty());
+        System.clearProperty(clientX509Util.getSslKeystorePasswdProperty());
+        System.clearProperty(clientX509Util.getSslTruststoreLocationProperty());
+        System.clearProperty(clientX509Util.getSslTruststorePasswdProperty());
+
+        // client side
+        System.clearProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET);
+        System.clearProperty(ZKClientConfig.SECURE_CLIENT);
+
+        // server side
+        System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
+        System.clearProperty(NettyServerCnxnFactory.PORT_UNIFICATION_KEY);
+
+        // admin server
+        System.clearProperty(quorumX509Util.getSslKeystoreLocationProperty());
+        System.clearProperty(quorumX509Util.getSslKeystorePasswdProperty());
+        System.clearProperty(quorumX509Util.getSslTruststoreLocationProperty());
+        System.clearProperty(quorumX509Util.getSslTruststorePasswdProperty());
+        System.clearProperty("zookeeper.admin.forceHttps");
+        System.clearProperty("zookeeper.admin.needClientAuth");
+    }
+
+    private void setupRootACL(final AuthSchema authSchema) throws Exception {
+        switch (authSchema) {
+            case DIGEST:
+                setupRootACLForDigest(zk);
+                break;
+            case X509:
+                setupRootACLForX509(zk);
+                break;
+            case IP:
+                setupRootACLForIP(zk);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown auth schema");
+        }
+    }
+
+    private HttpURLConnection sendAuthTestCommandRequest(final AuthSchema authSchema, final boolean validAuthInfo) throws Exception  {
+        final URL authTestURL = new URL(String.format(HTTPS_URL_FORMAT + "/" + AUTH_TEST_COMMAND_NAME, jettyAdminPort));
+        final HttpURLConnection authTestConn = (HttpURLConnection) authTestURL.openConnection();
+        addAuthHeader(authTestConn, authSchema, validAuthInfo);
+        authTestConn.setRequestMethod("GET");
+        return authTestConn;
+    }
+
+    private void addAuthInfo(final ZooKeeper zk, final AuthSchema authSchema) {
+        switch (authSchema) {
+            case DIGEST:
+                addAuthInfoForDigest(zk);
+                break;
+            case X509:
+                addAuthInfoForX509(zk);
+                break;
+            case IP:
+                addAuthInfoForIP(zk);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown auth schema");
+        }
+    }
+
+    public static void resetRootACL(final ZooKeeper zk) throws Exception {
+        zk.setACL(Commands.ROOT_PATH, OPEN_ACL_UNSAFE, -1);
+    }
+
+    public static void setupRootACLForDigest(final ZooKeeper zk) throws Exception  {
+        final String idPassword = String.format("%s:%s", ROOT_USER, ROOT_PASSWORD);
+        final String digest = DigestAuthenticationProvider.generateDigest(idPassword);
+
+        final ACL acl = new ACL(ZooDefs.Perms.ALL, new Id(DIGEST_SCHEMA, digest));
+        zk.setACL(Commands.ROOT_PATH, Collections.singletonList(acl), -1);
+    }
+
+    private static void setupRootACLForX509(final ZooKeeper zk) throws Exception  {
+        final ACL acl = new ACL(ZooDefs.Perms.ALL, new Id(X509_SCHEMA, X509_SUBJECT_PRINCIPAL));
+        zk.setACL(Commands.ROOT_PATH, Collections.singletonList(acl), -1);
+    }
+
+    private static void setupRootACLForIP(final ZooKeeper zk) throws Exception  {
+        final ACL acl = new ACL(ZooDefs.Perms.ALL, new Id(IP_SCHEMA, "127.0.0.1"));
+        zk.setACL(Commands.ROOT_PATH, Collections.singletonList(acl), -1);
+    }
+
+    public static void addAuthInfoForDigest(final ZooKeeper zk) {
+        final String idPassword = String.format("%s:%s", ROOT_USER, ROOT_PASSWORD);
+        zk.addAuthInfo(DIGEST_SCHEMA, idPassword.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static void addAuthInfoForX509(final ZooKeeper zk) {
+        zk.addAuthInfo(X509_SCHEMA, X509_SUBJECT_PRINCIPAL.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void addAuthInfoForIP(final ZooKeeper zk) {
+        zk.addAuthInfo(IP_SCHEMA, "127.0.0.1".getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static void addAuthHeader(final HttpURLConnection conn, final AuthSchema authSchema, final boolean validAuthInfo) {
+        String authInfo;
+        switch (authSchema) {
+            case DIGEST:
+                authInfo = validAuthInfo ? buildAuthorizationForDigest() : buildInvalidAuthorizationForDigest();
+                break;
+            case X509:
+                authInfo = buildAuthorizationForX509();
+                break;
+            case IP:
+                authInfo = buildAuthorizationForIP();
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown auth schema");
+        }
+        conn.setRequestProperty(HttpHeader.AUTHORIZATION.asString(), authInfo);
+    }
+
+    public static String buildAuthorizationForDigest() {
+        return  String.format("%s%s%s:%s", DIGEST_SCHEMA, Commands.AUTH_INFO_SEPARATOR, ROOT_USER, ROOT_PASSWORD);
+    }
+
+    private static String buildInvalidAuthorizationForDigest() {
+        return  String.format("%s%s%s:%s", DIGEST_SCHEMA, Commands.AUTH_INFO_SEPARATOR, "InvalidUser", "InvalidPassword");
+    }
+
+    private static String buildAuthorizationForX509() {
+        return  String.format("%s%s", X509_SCHEMA, Commands.AUTH_INFO_SEPARATOR);
+    }
+
+    private static String buildAuthorizationForIP() {
+        return  String.format("%s%s", IP_SCHEMA, Commands.AUTH_INFO_SEPARATOR);
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/RestoreQuorumTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/RestoreQuorumTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server.admin;
+
+import static org.apache.zookeeper.server.ZooKeeperServer.ZOOKEEPER_SERIALIZE_LAST_PROCESSED_ZXID_ENABLED;
+import static org.apache.zookeeper.server.admin.Commands.ADMIN_RATE_LIMITER_INTERVAL;
+import static org.apache.zookeeper.server.admin.Commands.RestoreCommand.ADMIN_RESTORE_ENABLED;
+import static org.apache.zookeeper.server.admin.Commands.SnapshotCommand.ADMIN_SNAPSHOT_ENABLED;
+import static org.apache.zookeeper.server.admin.SnapshotAndRestoreCommandTest.performRestoreAndValidate;
+import static org.apache.zookeeper.server.admin.SnapshotAndRestoreCommandTest.takeSnapshotAndValidate;
+import java.io.File;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.server.quorum.QuorumPeerTestBase;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RestoreQuorumTest extends QuorumPeerTestBase {
+    @Test
+    public void testRestoreAfterQuorumLost() throws Exception {
+        setupAdminServerProperties();
+
+        int SERVER_COUNT = 3;
+        final int NODE_COUNT = 10;
+        final String PATH = "/testRestoreAfterQuorumLost";
+
+        try {
+            // start up servers
+            servers = LaunchServers(SERVER_COUNT);
+            int leaderId = servers.findLeader();
+
+            // create data
+            servers.zk[leaderId].create(PATH, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            for (int i = 0; i < NODE_COUNT; i++) {
+                servers.zk[leaderId].create(PATH + "/" + i, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            }
+
+            // take snapshot
+            final File snapshotFile = takeSnapshotAndValidate(servers.adminPorts[leaderId], ClientBase.testBaseDir);
+
+            // create more data
+            for (int i = NODE_COUNT; i < NODE_COUNT * 2; i++) {
+                servers.zk[leaderId].create(PATH + "/" + i, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            }
+
+            // shutdown all servers to simulate quorum lost
+            servers.shutDownAllServers();
+            waitForAll(servers, ZooKeeper.States.CONNECTING);
+
+            // restart the servers
+            for (int i = 0; i < SERVER_COUNT; i++) {
+                System.setProperty("zookeeper.admin.serverPort", String.valueOf(servers.adminPorts[i]));
+                servers.mt[i].start();
+                servers.restartClient(i, this);
+            }
+            waitForAll(servers, ZooKeeper.States.CONNECTED);
+
+            // restore servers
+            for (int i = 0; i < SERVER_COUNT; i++) {
+                performRestoreAndValidate(servers.adminPorts[i], snapshotFile);
+            }
+
+            // validate all servers are restored
+            for (int i = 0; i < SERVER_COUNT; i++) {
+                servers.restartClient(i, this);
+                Assertions.assertEquals(NODE_COUNT, servers.zk[i].getAllChildrenNumber(PATH));
+            }
+
+            // create more data after restore
+            for (int i = NODE_COUNT * 2; i < NODE_COUNT * 3; i++) {
+                servers.zk[leaderId].create(PATH + "/" + i, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+            }
+
+            // validate all servers have expected data
+            for (int i = 0; i < SERVER_COUNT; i++) {
+                Assertions.assertEquals(NODE_COUNT * 2, servers.zk[i].getAllChildrenNumber(PATH));
+            }
+        } finally {
+            clearAdminServerProperties();
+        }
+    }
+
+    private void setupAdminServerProperties() {
+        System.setProperty("zookeeper.admin.enableServer", "true");
+        System.setProperty(ADMIN_RATE_LIMITER_INTERVAL, "0");
+        System.setProperty(ADMIN_SNAPSHOT_ENABLED, "true");
+        System.setProperty(ZOOKEEPER_SERIALIZE_LAST_PROCESSED_ZXID_ENABLED, "true");
+        System.setProperty(ADMIN_RESTORE_ENABLED, "true");
+    }
+
+    private void clearAdminServerProperties() {
+        System.clearProperty("zookeeper.admin.enableServer");
+        System.clearProperty("zookeeper.admin.serverPort");
+        System.clearProperty(ADMIN_RATE_LIMITER_INTERVAL);
+        System.clearProperty(ADMIN_SNAPSHOT_ENABLED);
+        System.clearProperty(ZOOKEEPER_SERIALIZE_LAST_PROCESSED_ZXID_ENABLED);
+        System.clearProperty(ADMIN_RESTORE_ENABLED);
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerTestBase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerTestBase.java
@@ -402,11 +402,12 @@ public class QuorumPeerTestBase extends ZKTestCase implements Watcher {
     }
 
     // This class holds the servers and clients for those servers
-    protected static class Servers {
+    public static class Servers {
 
-        MainThread[] mt;
-        ZooKeeper[] zk;
+        public MainThread[] mt;
+        public ZooKeeper[] zk;
         public int[] clientPorts;
+        public int[] adminPorts;
 
         public void shutDownAllServers() throws InterruptedException {
             for (MainThread t : mt) {
@@ -415,9 +416,12 @@ public class QuorumPeerTestBase extends ZKTestCase implements Watcher {
         }
 
         public void restartAllServersAndClients(Watcher watcher) throws IOException, InterruptedException {
+            int index = 0;
             for (MainThread t : mt) {
                 if (!t.isAlive()) {
+                    System.setProperty("zookeeper.admin.serverPort", String.valueOf(adminPorts[index]));
                     t.start();
+                    index++;
                 }
             }
             for (int i = 0; i < zk.length; i++) {
@@ -510,6 +514,12 @@ public class QuorumPeerTestBase extends ZKTestCase implements Watcher {
                     i, PortAssignment.unique(), PortAssignment.unique(), role,
                     svrs.clientPorts[i]));
         }
+
+        svrs.adminPorts = new int[SERVER_COUNT];
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            svrs.adminPorts[i] = PortAssignment.unique();
+        }
+
         String quorumCfgSection = sb.toString();
 
         svrs.mt = new MainThread[SERVER_COUNT];
@@ -520,6 +530,7 @@ public class QuorumPeerTestBase extends ZKTestCase implements Watcher {
             } else {
                 svrs.mt[i] = new MainThread(i, svrs.clientPorts[i], quorumCfgSection, otherConfigs);
             }
+            System.setProperty("zookeeper.admin.serverPort", String.valueOf(svrs.adminPorts[i]));
             svrs.mt[i].start();
             svrs.restartClient(i, this);
         }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/IPAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/IPAuthTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import java.util.Arrays;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.data.Id;
+import org.apache.zookeeper.server.auth.IPAuthenticationProvider;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class IPAuthTest extends ZKTestCase {
+    @Test
+    public void testHandleAuthentication_Forwarded() {
+        final IPAuthenticationProvider provider = new IPAuthenticationProvider();
+
+        final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        final String forwardedForHeader = "fc00:0:0:0:0:0:0:4, 192.168.0.6, 10.0.0.8, 172.16.0.9";
+        Mockito.doReturn(forwardedForHeader).when(mockRequest).getHeader(IPAuthenticationProvider.X_FORWARDED_FOR_HEADER_NAME);
+        Mockito.doReturn("192.168.0.5").when(mockRequest).getRemoteAddr();
+
+        // validate it returns the leftmost IP from the X-Forwarded-For header
+        final List<Id> expectedIds = Arrays.asList(new Id(provider.getScheme(), "fc00:0:0:0:0:0:0:4"));
+        assertEquals(expectedIds, provider.handleAuthentication(mockRequest, null));
+    }
+
+    @Test
+    public void testHandleAuthentication_NoForwarded() {
+        final IPAuthenticationProvider provider = new IPAuthenticationProvider();
+
+        final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        Mockito.doReturn(null).when(mockRequest).getHeader(IPAuthenticationProvider.X_FORWARDED_FOR_HEADER_NAME);
+        Mockito.doReturn("192.168.0.6").when(mockRequest).getRemoteAddr();
+
+        // validate it returns the remote address
+        final List<Id> expectedIds = Arrays.asList(new Id(provider.getScheme(), "192.168.0.6"));
+        assertEquals(expectedIds, provider.handleAuthentication(mockRequest, null));
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ObserverMasterTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ObserverMasterTest.java
@@ -293,7 +293,7 @@ public class ObserverMasterTest extends ObserverMasterTestBase {
 
         // test stats collection
         final Map<String, String> emptyMap = Collections.emptyMap();
-        Map<String, Object> stats = Commands.runGetCommand("mntr", q3.getQuorumPeer().getActiveServer(), emptyMap).toMap();
+        Map<String, Object> stats = Commands.runGetCommand("mntr", q3.getQuorumPeer().getActiveServer(), emptyMap, null, null).toMap();
         assertTrue(stats.containsKey("observer_master_id"), "observer not emitting observer_master_id");
 
         // check the stats for the first peer


### PR DESCRIPTION
Provide auth support including digest, x509 and IP for admin server commands.

Author: Li Wang [liwang@apple.com](mailto:liwang@apple.com)
