### PR TITLE
ZOOKEEPER-4679: Fix CI failure and warning 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,9 @@ jobs:
     - name: Show the first log message
       run: git log -n1
     - name: Install C Dependencies
-      run: sudo apt-get install libcppunit-dev libsasl2-dev
+      run: |
+        sudo apt update
+        sudo apt install -y libcppunit-dev libsasl2-dev
     - name: Build with Maven (${{ matrix.profile.name }})
       run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ matrix.profile.args }}
       env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
 
 # This workflow will build a Java project with Maven
 # See also:
@@ -52,11 +50,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK ${{ matrix.profile.jdk }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.profile.jdk }}
     - name: Cache local maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.m2/repository/
@@ -75,16 +73,15 @@ jobs:
         MAVEN_OPTS: -Djansi.force=true
     - name: Upload unit test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: surefire-reports-${{ matrix.profile.name }}
         path: ./**/target/surefire-reports/
         if-no-files-found: ignore
     - name: Upload integration test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: failsafe-reports-${{ matrix.profile.name }}
         path: ./**/target/failsafe-reports/
         if-no-files-found: ignore
-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.profile.jdk }}
+        distribution: temurin
     - name: Cache local maven repository
       uses: actions/cache@v3
       with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,11 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.jdk }}
       - name: Cache local maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2/repository/

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,7 +47,9 @@ jobs:
       - name: Show the first log message
         run: git log -n1
       - name: Install C Dependencies
-        run: sudo apt-get install libcppunit-dev libsasl2-dev
+        run: |
+          sudo apt update
+          sudo apt install -y libcppunit-dev libsasl2-dev
       - name: Build with Maven
         run: mvn -B -V -e -ntp "-Dstyle.color=always" package -DskipTests
         env:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.jdk }}
+          distribution: temurin
       - name: Cache local maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -63,7 +63,9 @@ jobs:
     - name: Show the first log message
       run: git log -n1
     - name: Install C Dependencies
-      run: sudo apt-get install libcppunit-dev libsasl2-dev
+      run: |
+        sudo apt update
+        sudo apt install -y libcppunit-dev libsasl2-dev
     - name: Build with Maven
       run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ github.event.inputs.mvnOpts }} ${{ github.event.inputs.goals }}
       env:

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -50,6 +50,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: 11
+        distribution: temurin
     - name: Cache local maven repository
       uses: actions/cache@v3
       with:

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
 
 # This workflow will build a Java project with Maven
 # See also:
@@ -49,11 +47,11 @@ jobs:
       with:
         ref: ${{ github.event.inputs.buildRef }}
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 11
     - name: Cache local maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.m2/repository/
@@ -72,16 +70,15 @@ jobs:
         MAVEN_OPTS: -Djansi.force=true
     - name: Upload unit test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: surefire-reports
         path: ./**/target/surefire-reports/
         if-no-files-found: ignore
     - name: Upload integration test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: failsafe-reports
         path: ./**/target/failsafe-reports/
         if-no-files-found: ignore
-


### PR DESCRIPTION
1. Run `apt update` before installing C deps to avoid 404.
2. Update actions version to avoid set-output deprecation warnings.