### PR TITLE
ZOOKEEPER-4216: Fix a race condition in WatcherCleanerTest.testDeadWatcherMetrics

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ZKTestCase.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ZKTestCase.java
@@ -46,6 +46,7 @@ public class ZKTestCase {
     protected static final File testBaseDir = new File(System.getProperty("build.test.dir", "build"));
     private static final Logger LOG = LoggerFactory.getLogger(ZKTestCase.class);
     public static final int DEFAULT_METRIC_TIMEOUT = 30;
+    public static final int METRIC_POLL_INTERVAL_MS = 100;
 
     static {
         // Disable System.exit in tests.
@@ -115,7 +116,7 @@ public class ZKTestCase {
             if (condition.evaluate()) {
                 return;
             }
-            Thread.sleep(100);
+            Thread.sleep(METRIC_POLL_INTERVAL_MS);
         }
         fail(msg);
     }
@@ -133,7 +134,8 @@ public class ZKTestCase {
             if (!matcher.matches(actual)) {
                 Description description = new StringDescription();
                 matcher.describeMismatch(actual, description);
-                LOG.info("match failed for metric {}: {}", metricKey, description);
+                LOG.info("metric {} does not yet match expected value: {}. Checking again in {}ms",
+                    metricKey, description, METRIC_POLL_INTERVAL_MS);
                 return false;
             }
             return true;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/FileTxnSnapLogMetricsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/FileTxnSnapLogMetricsTest.java
@@ -79,8 +79,7 @@ public class FileTxnSnapLogMetricsTest extends ZKTestCase {
         }
 
         // It is possible that above writes will trigger more than one snapshot due to randomization.
-        WaitForCondition newSnapshot = () -> (long) MetricsUtils.currentServerMetrics().get("cnt_snapshottime") >= 2L;
-        waitFor("no snapshot in 10s", newSnapshot, 10);
+        waitForMetric("cnt_snapshottime", greaterThanOrEqualTo(2L), 10);
 
         // Pauses snapshot and logs more txns.
         cnxnFactory.getZooKeeperServer().getTxnLogFactory().snapLog.close();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerMetricsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LearnerMetricsTest.java
@@ -26,10 +26,8 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.metrics.MetricsUtils;
 import org.apache.zookeeper.server.ServerMetrics;
 import org.apache.zookeeper.test.ClientBase;
-import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -38,7 +36,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public class LearnerMetricsTest extends QuorumPeerTestBase {
 
-    private static final int TIMEOUT_SECONDS = 30;
     private static final int SERVER_COUNT = 4; // 1 observer, 3 participants
     private final QuorumPeerTestBase.MainThread[] mt = new QuorumPeerTestBase.MainThread[SERVER_COUNT];
     private ZooKeeper zk_client;
@@ -111,18 +108,6 @@ public class LearnerMetricsTest extends QuorumPeerTestBase {
         waitForMetric("learner_commit_received_count", is(6L));
         waitForMetric("cnt_commit_propagation_latency", is(6L));
         waitForMetric("min_commit_propagation_latency", greaterThanOrEqualTo(0L));
-    }
-
-    private void waitForMetric(final String metricKey, final Matcher<Long> matcher) throws InterruptedException {
-        final String errorMessage = String.format("unable to match on metric: %s", metricKey);
-        waitFor(errorMessage, () -> {
-            long actual = (long) MetricsUtils.currentServerMetrics().get(metricKey);
-            if (!matcher.matches(actual)) {
-                LOG.info("match failed on {}, actual value: {}", metricKey, actual);
-                return false;
-            }
-            return true;
-        }, TIMEOUT_SECONDS);
     }
 
     @AfterEach


### PR DESCRIPTION
Because the metrics were updated _after_ the listener is invoked, the listener does not always see the fresh metric value. This fixes it so that the test waits for the value to become what we expect.