### PR TITLE
ZOOKEEPER-4682. Make FileSnap.deserialize a static method

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/SnapshotComparer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/SnapshotComparer.java
@@ -259,14 +259,13 @@ public class SnapshotComparer {
    * @throws Exception
    */
   private static DataTree getSnapshot(File file) throws Exception {
-    FileSnap fileSnap = new FileSnap(null);
     DataTree dataTree = new DataTree();
     Map<Long, Integer> sessions = new HashMap<>();
     CheckedInputStream snapIS = SnapStream.getInputStream(file);
 
     long beginning = System.nanoTime();
     InputArchive ia = BinaryInputArchive.getArchive(snapIS);
-    fileSnap.deserialize(dataTree, sessions, ia);
+    FileSnap.deserialize(dataTree, sessions, ia);
     long end = System.nanoTime();
     System.out.println(String.format("Deserialized snapshot in %s in %f seconds", file.getName(),
         (((double) (end - beginning) / 1000000)) / 1000));

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/SnapshotFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/SnapshotFormatter.java
@@ -96,12 +96,10 @@ public class SnapshotFormatter {
         try (InputStream is = SnapStream.getInputStream(snapshotFile)) {
             InputArchive ia = BinaryInputArchive.getArchive(is);
 
-            FileSnap fileSnap = new FileSnap(null);
-
             DataTree dataTree = new DataTree();
             Map<Long, Integer> sessions = new HashMap<>();
 
-            fileSnap.deserialize(dataTree, sessions, ia);
+            FileSnap.deserialize(dataTree, sessions, ia);
             long fileNameZxid = Util.getZxidFromName(snapshotFile.getName(), SNAPSHOT_FILE_PREFIX);
 
             if (dumpJson) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/SnapshotRecursiveSummary.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/SnapshotRecursiveSummary.java
@@ -67,12 +67,9 @@ import org.apache.zookeeper.server.persistence.SnapStream;
     try (InputStream is = SnapStream.getInputStream(snapshotFile)) {
       InputArchive ia = BinaryInputArchive.getArchive(is);
 
-      FileSnap fileSnap = new FileSnap(null);
-
       DataTree dataTree = new DataTree();
       Map<Long, Integer> sessions = new HashMap<>();
-
-      fileSnap.deserialize(dataTree, sessions, ia);
+      FileSnap.deserialize(dataTree, sessions, ia);
 
       printZnodeDetails(dataTree, startingNode, maxDepth);
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
@@ -637,8 +637,7 @@ public class ZKDatabase {
 
         // deserialize data tree
         final DataTree dataTree = getDataTree();
-        final FileSnap filesnap = new FileSnap(snapLog.getSnapDir());
-        filesnap.deserialize(dataTree, getSessionWithTimeOuts(), ia);
+        FileSnap.deserialize(dataTree, getSessionWithTimeOuts(), ia);
         SnapStream.checkSealIntegrity(is, ia);
 
         // deserialize digest and check integrity

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileSnap.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileSnap.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.CheckedInputStream;
 import java.util.zip.CheckedOutputStream;
+import javax.annotation.Nonnull;
 import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.InputArchive;
@@ -53,7 +54,7 @@ public class FileSnap implements SnapShot {
 
     public static final String SNAPSHOT_FILE_PREFIX = "snapshot";
 
-    public FileSnap(File snapDir) {
+    public FileSnap(@Nonnull File snapDir) {
         this.snapDir = snapDir;
     }
 
@@ -131,7 +132,7 @@ public class FileSnap implements SnapShot {
      * @param ia the input archive to restore from
      * @throws IOException
      */
-    public void deserialize(DataTree dt, Map<Long, Integer> sessions, InputArchive ia) throws IOException {
+    public static void deserialize(DataTree dt, Map<Long, Integer> sessions, InputArchive ia) throws IOException {
         FileHeader header = new FileHeader();
         header.deserialize(ia, "fileheader");
         if (header.getMagic() != SNAP_MAGIC) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/CRCTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/CRCTest.java
@@ -70,14 +70,14 @@ public class CRCTest extends ZKTestCase {
     }
 
     /** return if checksum matches for a snapshot **/
-    private boolean getCheckSum(FileSnap snap, File snapFile) throws IOException {
+    private boolean getCheckSum(File snapFile) throws IOException {
         DataTree dt = new DataTree();
         Map<Long, Integer> sessions = new ConcurrentHashMap<>();
         InputStream snapIS = new BufferedInputStream(new FileInputStream(snapFile));
         CheckedInputStream crcIn = new CheckedInputStream(snapIS, new Adler32());
         InputArchive ia = BinaryInputArchive.getArchive(crcIn);
         try {
-            snap.deserialize(dt, sessions, ia);
+            FileSnap.deserialize(dt, sessions, ia);
         } catch (IOException ie) {
             // we failed on the most recent snapshot
             // must be incomplete
@@ -154,16 +154,16 @@ public class CRCTest extends ZKTestCase {
         List<File> snapFiles = snap.findNRecentSnapshots(2);
         snapFile = snapFiles.get(0);
         corruptFile(snapFile);
-        boolean cfile = false;
+        boolean cfile;
         try {
-            cfile = getCheckSum(snap, snapFile);
+            cfile = getCheckSum(snapFile);
         } catch (IOException ie) {
-            //the last snapshot seems incompelte
+            //the last snapshot seems incomplete
             // corrupt the last but one
             // and use that
             snapFile = snapFiles.get(1);
             corruptFile(snapFile);
-            cfile = getCheckSum(snap, snapFile);
+            cfile = getCheckSum(snapFile);
         }
         assertTrue(cfile);
     }


### PR DESCRIPTION
FileSnap.deserialize is effectively a static method. Change it to a static method so that we don't need to do some `new FileSnap(null)` hacks for workaround calling this method.

a.k.a. pay back some tech debt.