### PR TITLE
ZOOKEEPER-4601: Fix get config watcher path to "/zookeeper/config"

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -855,10 +855,22 @@ public class ClientCnxn {
         private boolean isFirstConnect = true;
         private volatile ZooKeeperSaslClient zooKeeperSaslClient;
 
-        private String stripChroot(String serverPath) {
+        String stripChroot(String serverPath) {
             if (serverPath.startsWith(chrootPath)) {
                 if (serverPath.length() == chrootPath.length()) {
                     return "/";
+                } else if (serverPath.charAt(chrootPath.length()) != '/') {
+                    // Corner-case:
+                    // * Event for config node "/zookeeper/config".
+                    // * Chroot "/zoo".
+                    //
+                    // We can't simply deliver "/zookeeper/config" in all cases, as
+                    // getData("/config") in chroot "/zookeeper" expect "/config".
+                    // But at least, we should not deliver abnormal path here.
+                    //
+                    // It might be better to move chroot out of here as ZOOKEEPER-838
+                    // suggested, but it is another story.
+                    return serverPath;
                 }
                 return serverPath.substring(chrootPath.length());
             } else if (serverPath.startsWith(ZooDefs.ZOOKEEPER_NODE_SUBTREE)) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/PathWatcher.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/PathWatcher.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper;
+
+import java.util.Objects;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Intercepts {@link Watcher#process(WatchedEvent)} to pass given {@link #path} as {@link WatchedEvent#getPath()}.
+ */
+@InterfaceAudience.Private
+class PathWatcher implements Watcher {
+    private final String path;
+    private final Watcher watcher;
+
+    public PathWatcher(String path, Watcher watcher) {
+        this.path = Objects.requireNonNull(path);
+        this.watcher = Objects.requireNonNull(watcher);
+    }
+
+    @Override
+    public void process(WatchedEvent event) {
+        if (event.getType() != Event.EventType.None) {
+            event = new WatchedEvent(event.getType(), event.getState(), path);
+        }
+        watcher.process(event);
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof PathWatcher
+            && this.path.equals(((PathWatcher) other).path)
+            && this.watcher.equals(((PathWatcher) other).watcher);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, watcher);
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZKWatchManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZKWatchManager.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.server.watch.PathParentIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +35,8 @@ import org.slf4j.LoggerFactory;
  * This class is intended to be packaged-private so that it doesn't serve
  * as part of ZooKeeper client API.
  */
-class ZKWatchManager implements ClientWatchManager {
+@InterfaceAudience.Private
+public class ZKWatchManager implements ClientWatchManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZKWatchManager.class);
 
@@ -52,7 +54,7 @@ class ZKWatchManager implements ClientWatchManager {
         this.defaultWatcher = defaultWatcher;
     }
 
-    void setDefaultWatcher(Watcher defaultWatcher) {
+    public void setDefaultWatcher(Watcher defaultWatcher) {
         this.defaultWatcher = defaultWatcher;
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/BlockingQueueWatcher.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/BlockingQueueWatcher.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.time.Duration;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+
+public class BlockingQueueWatcher implements Watcher {
+    private final BlockingQueue<WatchedEvent> events = new LinkedBlockingQueue<>();
+
+    @Override
+    public void process(WatchedEvent event) {
+        assertTrue(events.add(event));
+    }
+
+    public WatchedEvent pollEvent(Duration timeout) throws InterruptedException {
+        return events.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Format {@link Duration} with suffix "ms" or "s".
+     *
+     * <p>I guess {@link Duration#toString()} is verbose and not intuitive.
+     */
+    private String formatTimeout(Duration timeout) {
+        long millis = timeout.toMillis();
+        if (millis < TimeUnit.SECONDS.toMillis(1)) {
+            return millis + "ms";
+        }
+        long secs = millis / TimeUnit.SECONDS.toMillis(1);
+        millis %= TimeUnit.SECONDS.toMillis(1);
+        // We are test code, second unit is large enough.
+        if (millis == 0) {
+            return secs + "s";
+        }
+        return secs + "s" + millis + "ms";
+    }
+
+    private Supplier<String> noEventMessage(Duration timeout) {
+        return () -> String.format("no event after %s", formatTimeout(timeout));
+    }
+
+    public WatchedEvent takeEvent(Duration timeout) throws InterruptedException {
+        WatchedEvent event = pollEvent(timeout);
+        assertNotNull(event, noEventMessage(timeout));
+        return event;
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ChrootTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ChrootTest.java
@@ -25,15 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.junit.jupiter.api.Test;
@@ -61,25 +58,6 @@ public class ChrootTest extends ClientBase {
             return path.equals(eventPath);
         }
 
-    }
-
-    @Test
-    public void testChrootWithZooKeeperPathWatcher() throws Exception {
-        ZooKeeper zk1 = createClient(hostPort + "/chroot");
-        BlockingQueue<WatchedEvent> events = new LinkedBlockingQueue<>();
-        byte[] config = zk1.getConfig(events::add, null);
-
-        ZooKeeper zk2 = createClient();
-        zk2.addAuthInfo("digest", "super:test".getBytes());
-        zk2.setData(ZooDefs.CONFIG_NODE, config, -1);
-
-        waitFor("config watcher receive no event", () -> !events.isEmpty(), 10);
-
-        WatchedEvent event = events.poll();
-        assertNotNull(event);
-        assertEquals(Watcher.Event.KeeperState.SyncConnected, event.getState());
-        assertEquals(Watcher.Event.EventType.NodeDataChanged, event.getType());
-        assertEquals(ZooDefs.CONFIG_NODE, event.getPath());
     }
 
     @Test

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ConfigWatcherPathTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ConfigWatcherPathTest.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.common.PathUtils;
+import org.junit.jupiter.api.Test;
+
+public class ConfigWatcherPathTest extends ClientBase {
+    private void join(Consumer<CompletableFuture<Void>> task) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        task.accept(future);
+        future.join();
+    }
+
+    private AsyncCallback.DataCallback complete(CompletableFuture<Void> future) {
+        return (rc, path, ctx, data, stat) -> {
+            if (rc == 0) {
+                future.complete(null);
+            } else {
+                future.completeExceptionally(KeeperException.create(KeeperException.Code.get(rc), path));
+            }
+        };
+    }
+
+    private void testGetConfigWatcherPathWithChroot(String chroot) throws Exception {
+        ZooKeeper zk1 = createClient(hostPort + chroot);
+
+        BlockingQueueWatcher configWatcher = new BlockingQueueWatcher();
+
+        // given|>config watcher: attach to config node multiple times
+        byte[] configData = zk1.getConfig(configWatcher, null);
+        join(future -> zk1.getConfig(configWatcher, complete(future), null));
+
+        // given|>default watcher: attach to config node multiple times
+        BlockingQueueWatcher defaultWatcher = new BlockingQueueWatcher();
+        zk1.getWatchManager().setDefaultWatcher(defaultWatcher);
+        zk1.getConfig(true, null);
+        zk1.getConfig(defaultWatcher, null);
+
+        // when: make change to config node
+        ZooKeeper zk2 = createClient();
+        zk2.addAuthInfo("digest", "super:test".getBytes());
+        zk2.setData(ZooDefs.CONFIG_NODE, configData, -1);
+
+        // then|>config watcher: only one event with path "/zookeeper/config"
+        WatchedEvent configEvent = configWatcher.takeEvent(Duration.ofSeconds(10));
+        assertEquals("/zookeeper/config", configEvent.getPath());
+        assertNull(configWatcher.pollEvent(Duration.ofMillis(10)));
+
+        // then|>default watcher: only one event with path "/zookeeper/config"
+        WatchedEvent defaultWatcherEvent = defaultWatcher.takeEvent(Duration.ofSeconds(10));
+        assertEquals("/zookeeper/config", defaultWatcherEvent.getPath());
+        assertNull(defaultWatcher.pollEvent(Duration.ofMillis(10)));
+
+        // given: all watchers fired
+        // when: make change to config node
+        zk2.setData(ZooDefs.CONFIG_NODE, configData, -1);
+
+        // then: no more events
+        assertNull(configWatcher.pollEvent(Duration.ofMillis(10)));
+        assertNull(defaultWatcher.pollEvent(Duration.ofMillis(10)));
+    }
+
+    @Test
+    public void testGetConfigWatcherPathWithNoChroot() throws Exception {
+        testGetConfigWatcherPathWithChroot("");
+    }
+
+    @Test
+    public void testGetConfigWatcherPathWithShortChroot() throws Exception {
+        testGetConfigWatcherPathWithChroot("/short");
+    }
+
+    @Test
+    public void testGetConfigWatcherPathWithLongChroot() throws Exception {
+        testGetConfigWatcherPathWithChroot("/pretty-long-chroot-path");
+    }
+
+    @Test
+    public void testGetConfigWatcherPathWithChrootZooKeeperTree() throws Exception {
+        testGetConfigWatcherPathWithChroot("/zookeeper");
+        testGetConfigWatcherPathWithChroot("/zookeeper/a");
+        testGetConfigWatcherPathWithChroot("/zookeeper/config");
+        testGetConfigWatcherPathWithChroot("/zookeeper/config/a");
+    }
+
+    @Test
+    public void testGetConfigWatcherPathWithChrootZoo() throws Exception {
+        // "/zoo" is prefix of "/zookeeper/config"
+        testGetConfigWatcherPathWithChroot("/zoo");
+    }
+
+    private void testGetDataWatcherPathWithChroot(String chroot) throws Exception {
+        assertTrue("/zookeeper/config".startsWith(chroot));
+        String leafPath = "/zookeeper/config".substring(chroot.length());
+        String dataPath = leafPath.isEmpty() ? "/" : leafPath;
+        PathUtils.validatePath(dataPath);
+
+        ZooKeeper zk1 = createClient(hostPort + chroot);
+
+        BlockingQueueWatcher dataWatcher = new BlockingQueueWatcher();
+        BlockingQueueWatcher configWatcher = new BlockingQueueWatcher();
+
+        // given|>config watcher: attach to config node multiple times
+        byte[] configData = zk1.getConfig(configWatcher, null);
+        zk1.getConfig(configWatcher, null);
+
+        // given|>data watcher: attach to config node through getData multiple times
+        zk1.getData(dataPath, dataWatcher, null);
+        join(future -> zk1.getData(dataPath, dataWatcher, complete(future), null));
+
+        // given|>default watcher: attach to config node through getData and getConfig multiple times
+        BlockingQueueWatcher defaultWatcher = new BlockingQueueWatcher();
+        zk1.getWatchManager().setDefaultWatcher(defaultWatcher);
+        zk1.getData(dataPath, true, null);
+        zk1.getData(dataPath, defaultWatcher, null);
+        zk1.getConfig(true, null);
+        zk1.getConfig(defaultWatcher, null);
+
+        // when: make change to config node
+        ZooKeeper zk2 = createClient();
+        zk2.addAuthInfo("digest", "super:test".getBytes());
+        zk2.setData(ZooDefs.CONFIG_NODE, configData, -1);
+
+        // then|>data watcher: only one event with path dataPath
+        WatchedEvent dataEvent = dataWatcher.takeEvent(Duration.ofSeconds(10));
+        assertEquals(dataPath, dataEvent.getPath());
+        assertNull(dataWatcher.pollEvent(Duration.ofMillis(10)));
+
+        // then|>config watcher: only one event with path "/zookeeper/config"
+        WatchedEvent configEvent = configWatcher.takeEvent(Duration.ofSeconds(10));
+        assertEquals("/zookeeper/config", configEvent.getPath());
+        assertNull(configWatcher.pollEvent(Duration.ofMillis(10)));
+
+        if (dataPath.equals("/zookeeper/config")) {
+            // then|>default watcher: only one event with path "/zookeeper/config"
+            WatchedEvent defaultWatcherEvent = defaultWatcher.takeEvent(Duration.ofSeconds(10));
+            assertEquals("/zookeeper/config", defaultWatcherEvent.getPath());
+        } else {
+            // then|>default watcher: two events with path dataPath and "/zookeeper/config"
+            Set<String> defaultWatcherPaths = new HashSet<>();
+            defaultWatcherPaths.add(dataPath);
+            defaultWatcherPaths.add("/zookeeper/config");
+
+            WatchedEvent defaultWatcherEvent1 = defaultWatcher.takeEvent(Duration.ofSeconds(10));
+            assertThat(defaultWatcherPaths, hasItem(defaultWatcherEvent1.getPath()));
+            defaultWatcherPaths.remove(defaultWatcherEvent1.getPath());
+
+            WatchedEvent defaultWatcherEvent2 = defaultWatcher.takeEvent(Duration.ofSeconds(10));
+            assertNotNull(defaultWatcherEvent2);
+            assertThat(defaultWatcherPaths, hasItem(defaultWatcherEvent2.getPath()));
+        }
+        assertNull(defaultWatcher.pollEvent(Duration.ofMillis(10)));
+
+        // given: all watchers fired
+        // when: make change to config node
+        zk2.setData(ZooDefs.CONFIG_NODE, configData, -1);
+
+        // then: no more events
+        assertNull(dataWatcher.pollEvent(Duration.ofMillis(10)));
+        assertNull(configWatcher.pollEvent(Duration.ofMillis(10)));
+        assertNull(defaultWatcher.pollEvent(Duration.ofMillis(10)));
+    }
+
+    @Test
+    public void testGetDataWatcherPathWithNoChroot() throws Exception {
+        testGetDataWatcherPathWithChroot("");
+    }
+
+    @Test
+    public void testGetDataWatcherPathWithChrootZooKeeper() throws Exception {
+        testGetDataWatcherPathWithChroot("/zookeeper");
+    }
+
+    @Test
+    public void testGetDataWatcherPathWithChrootZooKeeperConfig() throws Exception {
+        testGetDataWatcherPathWithChroot("/zookeeper/config");
+    }
+}


### PR DESCRIPTION
Previously, get config watcher behaved different in chroots:

* In chroot "/short", the watcher receives "/zookeeper/config" after ZOOKEEPER-4565. Before that, it got abnormal path "eper/config".
* In chroot "/pretty-long-chroot-path", the watcher receives "/zookeeper/config".
* In chroot "/zoo", the watcher receives abnormal path "keeper/config". ZOOKEEPER-4565 should fix this, but failed to do so.
* In chroot "/zookeeper" or "/zookeeper/config", the watcher got no event as `getConfig` register watcher in path "/zookeeper/config". But config node path got stripped to "/config" or "/" before event delivery.

This commit fixes get config watcher path to "/zookeeper/config".

In long term, it might be better to move chroot out of ClientCnxn as ZOOKEEPER-838 suggested, but it is apparently a much bigger change.