### PR TITLE
ZOOKEEPER-4689: Fix inaccessible node due to inconsistent ACL index after SNAP sync

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ReferenceCountedACLCache.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ReferenceCountedACLCache.java
@@ -95,6 +95,19 @@ public class ReferenceCountedACLCache {
         return acls;
     }
 
+    /**
+     * checks if longval is cached (convertLong can convert it to ACLs).
+     *
+     * @param longVal
+     * @return true if it's cached.
+     */
+    public synchronized boolean isLongCached(long longVal) {
+        if (longVal == OPEN_UNSAFE_ACL_ID) {
+            return true;
+        }
+        return longKeyMap.containsKey(longVal);
+    }
+
     private long incrementIndex() {
         return ++aclIndex;
     }


### PR DESCRIPTION
Please refer to JIRA for details on the bug and why I chose to fix it this way.

An additional benefit of the patch is that we now no longer miscount refcount when replaying transactions. So we don't need to wait until next time we load snapshot to remove those unused ACL cache entries.