### PR TITLE
ZOOKEEPER-3860 Avoid reverse DNS lookup for hostname verification when hostnames are provided in the connection url

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/NetUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/NetUtils.java
@@ -28,16 +28,13 @@ import java.net.InetSocketAddress;
 public class NetUtils {
 
     public static String formatInetAddr(InetSocketAddress addr) {
+        String hostString = addr.getHostString();
         InetAddress ia = addr.getAddress();
 
-        if (ia == null) {
-            return String.format("%s:%s", addr.getHostString(), addr.getPort());
-        }
-
-        if (ia instanceof Inet6Address) {
-            return String.format("[%s]:%s", ia.getHostAddress(), addr.getPort());
+        if (ia instanceof Inet6Address && hostString.contains(":")) {
+            return String.format("[%s]:%s", hostString, addr.getPort());
         } else {
-            return String.format("%s:%s", ia.getHostAddress(), addr.getPort());
+            return String.format("%s:%s", hostString, addr.getPort());
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/NetUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/NetUtils.java
@@ -27,6 +27,10 @@ import java.net.InetSocketAddress;
  */
 public class NetUtils {
 
+    /**
+     * Prefer using the hostname for formatting, but without requesting reverse DNS lookup.
+     * Fall back to IP address if hostname is unavailable and use [] brackets for IPv6 literal.
+     */
     public static String formatInetAddr(InetSocketAddress addr) {
         String hostString = addr.getHostString();
         InetAddress ia = addr.getAddress();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKTrustManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKTrustManager.java
@@ -174,13 +174,16 @@ public class ZKTrustManager extends X509ExtendedTrustManager {
         String hostName = "";
         try {
             hostAddress = inetAddress.getHostAddress();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Trying to verify host address first: {}", hostAddress);
+            }
             hostnameVerifier.verify(hostAddress, certificate);
         } catch (SSLException addressVerificationException) {
             try {
                 hostName = inetAddress.getHostName();
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(
-                        "Failed to verify host address: {} attempting to verify host name: {}",
+                        "Failed to verify host address: {}, trying to verify host name: {}",
                         hostAddress, hostName);
                 }
                 hostnameVerifier.verify(hostName, certificate);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKTrustManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKTrustManager.java
@@ -88,7 +88,9 @@ public class ZKTrustManager extends X509ExtendedTrustManager {
         Socket socket) throws CertificateException {
         x509ExtendedTrustManager.checkClientTrusted(chain, authType, socket);
         if (clientHostnameVerificationEnabled) {
-            LOG.debug("Check client trusted socket.getInetAddress(): {}, {}", socket.getInetAddress(), socket);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Check client trusted socket.getInetAddress(): {}, {}", socket.getInetAddress(), socket);
+            }
             performHostVerification(socket.getInetAddress(), chain[0]);
         }
     }
@@ -100,7 +102,9 @@ public class ZKTrustManager extends X509ExtendedTrustManager {
         Socket socket) throws CertificateException {
         x509ExtendedTrustManager.checkServerTrusted(chain, authType, socket);
         if (serverHostnameVerificationEnabled) {
-            LOG.debug("Check server trusted socket.getInetAddress(): {}, {}", socket.getInetAddress(), socket);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Check server trusted socket.getInetAddress(): {}, {}", socket.getInetAddress(), socket);
+            }
             performHostVerification(socket.getInetAddress(), chain[0]);
         }
     }
@@ -113,7 +117,9 @@ public class ZKTrustManager extends X509ExtendedTrustManager {
         x509ExtendedTrustManager.checkClientTrusted(chain, authType, engine);
         if (clientHostnameVerificationEnabled) {
             try {
-                LOG.debug("Check client trusted engine.getPeerHost(): {}, {}", engine.getPeerHost(), engine);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Check client trusted engine.getPeerHost(): {}, {}", engine.getPeerHost(), engine);
+                }
                 performHostVerification(InetAddress.getByName(engine.getPeerHost()), chain[0]);
             } catch (UnknownHostException e) {
                 throw new CertificateException("Failed to verify host", e);
@@ -130,7 +136,9 @@ public class ZKTrustManager extends X509ExtendedTrustManager {
         x509ExtendedTrustManager.checkServerTrusted(chain, authType, engine);
         if (serverHostnameVerificationEnabled) {
             try {
-                LOG.debug("Check server trusted engine.getPeerHost(): {}, {}", engine.getPeerHost(), engine);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Check server trusted engine.getPeerHost(): {}, {}", engine.getPeerHost(), engine);
+                }
                 performHostVerification(InetAddress.getByName(engine.getPeerHost()), chain[0]);
             } catch (UnknownHostException e) {
                 throw new CertificateException("Failed to verify host", e);
@@ -161,7 +169,9 @@ public class ZKTrustManager extends X509ExtendedTrustManager {
         X509Certificate certificate) throws CertificateException {
         try {
             String hostname = inetAddress.getHostName();
-            LOG.debug("Verifying hostname: {} for InetAddress: {}", hostname, inetAddress);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Verifying hostname: {} for InetAddress: {}", hostname, inetAddress);
+            }
             hostnameVerifier.verify(hostname, certificate);
         } catch (SSLException e) {
             LOG.error("Failed to verify hostname for InetAddress: {}", inetAddress, e);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKTrustManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKTrustManager.java
@@ -19,7 +19,6 @@
 package org.apache.zookeeper.common;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.security.cert.CertificateException;
@@ -159,8 +158,9 @@ public class ZKTrustManager extends X509ExtendedTrustManager {
     /**
      * Compares peer's hostname with the one stored in the provided certificate. Performs verification
      * with the help of provided HostnameVerifier.
+     *
      * Attempts to verify the IP address first, if it fails, check the hostname. Performs reverse DNS lookup
-     * if hostname is not available. (for client verification)
+     * if hostname is not available. (Mostly the case in client verifications.)
      *
      * @param inetAddress Peer's inet address.
      * @param certificate Peer's certificate

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/NetUtilsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/NetUtilsTest.java
@@ -39,7 +39,7 @@ public class NetUtilsTest extends ZKTestCase {
     @Test
     public void testFormatInetAddrGoodIpv4() {
         InetSocketAddress isa = new InetSocketAddress(v4addr, port);
-        assertEquals("127.0.0.1:1234", NetUtils.formatInetAddr(isa));
+        assertEquals(v4local, NetUtils.formatInetAddr(isa));
     }
 
     @Test
@@ -59,7 +59,6 @@ public class NetUtilsTest extends ZKTestCase {
     @Test
     public void testFormatInetAddrGoodHostname() {
         InetSocketAddress isa = new InetSocketAddress("localhost", 1234);
-
         assertThat(NetUtils.formatInetAddr(isa), equalTo("localhost:1234"));
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/NetUtilsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/NetUtilsTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.zookeeper.common;
 
-import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,7 +60,7 @@ public class NetUtilsTest extends ZKTestCase {
     public void testFormatInetAddrGoodHostname() {
         InetSocketAddress isa = new InetSocketAddress("localhost", 1234);
 
-        assertThat(NetUtils.formatInetAddr(isa), anyOf(equalTo(v4local), equalTo(v6local)));
+        assertThat(NetUtils.formatInetAddr(isa), equalTo("localhost:1234"));
     }
 
     @Test

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/ZKTrustManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/ZKTrustManagerTest.java
@@ -34,7 +34,6 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -189,21 +188,17 @@ public class ZKTrustManagerTest extends ZKTestCase {
 
     @Test
     public void testServerHostnameVerificationWithIPAddress() throws Exception {
-        final String MY_IP = "127.1.1.1";
-        final Socket mysocket = mock(Socket.class);
-        when(mysocket.getInetAddress()).thenAnswer((Answer) invocationOnMock -> InetAddress.getByName(MY_IP));
-
         VerifiableHostnameVerifier hostnameVerifier = new VerifiableHostnameVerifier();
         ZKTrustManager zkTrustManager = new ZKTrustManager(mockX509ExtendedTrustManager, true, false,
                 hostnameVerifier);
 
-        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(MY_IP, null);
-        zkTrustManager.checkServerTrusted(certificateChain, null, mysocket);
-        verify(mysocket, times(1)).getInetAddress();
+        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(IP_ADDRESS, null);
+        zkTrustManager.checkServerTrusted(certificateChain, null, mockSocket);
+        verify(mockSocket, times(1)).getInetAddress();
 
-        assertEquals(Arrays.asList(MY_IP), hostnameVerifier.hosts);
+        assertEquals(Arrays.asList(IP_ADDRESS), hostnameVerifier.hosts);
 
-        verify(mockX509ExtendedTrustManager, times(1)).checkServerTrusted(certificateChain, null, mysocket);
+        verify(mockX509ExtendedTrustManager, times(1)).checkServerTrusted(certificateChain, null, mockSocket);
     }
 
     @Test
@@ -216,7 +211,7 @@ public class ZKTrustManagerTest extends ZKTestCase {
         zkTrustManager.checkServerTrusted(certificateChain, null, mockSocket);
         verify(mockSocket, times(1)).getInetAddress();
 
-        assertEquals(Arrays.asList(HOSTNAME), hostnameVerifier.hosts);
+        assertEquals(Arrays.asList(IP_ADDRESS, HOSTNAME), hostnameVerifier.hosts);
 
         verify(mockX509ExtendedTrustManager, times(1)).checkServerTrusted(certificateChain, null, mockSocket);
     }
@@ -231,7 +226,7 @@ public class ZKTrustManagerTest extends ZKTestCase {
         zkTrustManager.checkClientTrusted(certificateChain, null, mockSocket);
         verify(mockSocket, times(1)).getInetAddress();
 
-        assertEquals(Arrays.asList(HOSTNAME), hostnameVerifier.hosts);
+        assertEquals(Arrays.asList(IP_ADDRESS, HOSTNAME), hostnameVerifier.hosts);
 
         verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mockSocket);
     }
@@ -253,22 +248,17 @@ public class ZKTrustManagerTest extends ZKTestCase {
 
     @Test
     public void testClientHostnameVerificationWithIPAddress() throws Exception {
-        final String MY_IP = "127.1.1.1";
-        final Socket mysocket = mock(Socket.class);
-        when(mysocket.getInetAddress()).thenAnswer((Answer) invocationOnMock -> InetAddress.getByName(MY_IP));
-
         VerifiableHostnameVerifier hostnameVerifier = new VerifiableHostnameVerifier();
         ZKTrustManager zkTrustManager = new ZKTrustManager(mockX509ExtendedTrustManager, true, true,
                 hostnameVerifier);
 
-        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(MY_IP, null);
+        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(IP_ADDRESS, null);
+        zkTrustManager.checkClientTrusted(certificateChain, null, mockSocket);
+        verify(mockSocket, times(1)).getInetAddress();
 
-        zkTrustManager.checkClientTrusted(certificateChain, null, mysocket);
-        verify(mysocket, times(1)).getInetAddress();
+        assertEquals(Arrays.asList(IP_ADDRESS), hostnameVerifier.hosts);
 
-        assertEquals(Collections.singletonList(MY_IP), hostnameVerifier.hosts);
-
-        verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mysocket);
+        verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mockSocket);
     }
 
     @Test
@@ -281,7 +271,7 @@ public class ZKTrustManagerTest extends ZKTestCase {
         zkTrustManager.checkClientTrusted(certificateChain, null, mockSocket);
         verify(mockSocket, times(1)).getInetAddress();
 
-        assertEquals(Arrays.asList(HOSTNAME), hostnameVerifier.hosts);
+        assertEquals(Arrays.asList(IP_ADDRESS, HOSTNAME), hostnameVerifier.hosts);
 
         verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mockSocket);
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/ZKTrustManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/ZKTrustManagerTest.java
@@ -34,6 +34,7 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -188,17 +189,21 @@ public class ZKTrustManagerTest extends ZKTestCase {
 
     @Test
     public void testServerHostnameVerificationWithIPAddress() throws Exception {
+        final String MY_IP = "127.1.1.1";
+        final Socket mysocket = mock(Socket.class);
+        when(mysocket.getInetAddress()).thenAnswer((Answer) invocationOnMock -> InetAddress.getByName(MY_IP));
+
         VerifiableHostnameVerifier hostnameVerifier = new VerifiableHostnameVerifier();
         ZKTrustManager zkTrustManager = new ZKTrustManager(mockX509ExtendedTrustManager, true, false,
                 hostnameVerifier);
 
-        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(IP_ADDRESS, null);
-        zkTrustManager.checkServerTrusted(certificateChain, null, mockSocket);
-        verify(mockSocket, times(1)).getInetAddress();
+        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(MY_IP, null);
+        zkTrustManager.checkServerTrusted(certificateChain, null, mysocket);
+        verify(mysocket, times(1)).getInetAddress();
 
-        assertEquals(Arrays.asList(IP_ADDRESS), hostnameVerifier.hosts);
+        assertEquals(Arrays.asList(MY_IP), hostnameVerifier.hosts);
 
-        verify(mockX509ExtendedTrustManager, times(1)).checkServerTrusted(certificateChain, null, mockSocket);
+        verify(mockX509ExtendedTrustManager, times(1)).checkServerTrusted(certificateChain, null, mysocket);
     }
 
     @Test
@@ -211,7 +216,7 @@ public class ZKTrustManagerTest extends ZKTestCase {
         zkTrustManager.checkServerTrusted(certificateChain, null, mockSocket);
         verify(mockSocket, times(1)).getInetAddress();
 
-        assertEquals(Arrays.asList(IP_ADDRESS, HOSTNAME), hostnameVerifier.hosts);
+        assertEquals(Arrays.asList(HOSTNAME), hostnameVerifier.hosts);
 
         verify(mockX509ExtendedTrustManager, times(1)).checkServerTrusted(certificateChain, null, mockSocket);
     }
@@ -226,7 +231,7 @@ public class ZKTrustManagerTest extends ZKTestCase {
         zkTrustManager.checkClientTrusted(certificateChain, null, mockSocket);
         verify(mockSocket, times(1)).getInetAddress();
 
-        assertEquals(Arrays.asList(IP_ADDRESS, HOSTNAME), hostnameVerifier.hosts);
+        assertEquals(Arrays.asList(HOSTNAME), hostnameVerifier.hosts);
 
         verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mockSocket);
     }
@@ -248,17 +253,22 @@ public class ZKTrustManagerTest extends ZKTestCase {
 
     @Test
     public void testClientHostnameVerificationWithIPAddress() throws Exception {
+        final String MY_IP = "127.1.1.1";
+        final Socket mysocket = mock(Socket.class);
+        when(mysocket.getInetAddress()).thenAnswer((Answer) invocationOnMock -> InetAddress.getByName(MY_IP));
+
         VerifiableHostnameVerifier hostnameVerifier = new VerifiableHostnameVerifier();
         ZKTrustManager zkTrustManager = new ZKTrustManager(mockX509ExtendedTrustManager, true, true,
                 hostnameVerifier);
 
-        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(IP_ADDRESS, null);
-        zkTrustManager.checkClientTrusted(certificateChain, null, mockSocket);
-        verify(mockSocket, times(1)).getInetAddress();
+        X509Certificate[] certificateChain = createSelfSignedCertifcateChain(MY_IP, null);
 
-        assertEquals(Arrays.asList(IP_ADDRESS), hostnameVerifier.hosts);
+        zkTrustManager.checkClientTrusted(certificateChain, null, mysocket);
+        verify(mysocket, times(1)).getInetAddress();
 
-        verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mockSocket);
+        assertEquals(Collections.singletonList(MY_IP), hostnameVerifier.hosts);
+
+        verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mysocket);
     }
 
     @Test
@@ -271,7 +281,7 @@ public class ZKTrustManagerTest extends ZKTestCase {
         zkTrustManager.checkClientTrusted(certificateChain, null, mockSocket);
         verify(mockSocket, times(1)).getInetAddress();
 
-        assertEquals(Arrays.asList(IP_ADDRESS, HOSTNAME), hostnameVerifier.hosts);
+        assertEquals(Arrays.asList(HOSTNAME), hostnameVerifier.hosts);
 
         verify(mockX509ExtendedTrustManager, times(1)).checkClientTrusted(certificateChain, null, mockSocket);
     }


### PR DESCRIPTION
Instead of altering the behaviour of `ZKTrustManager`, I'll add the following improvements:

1. `NetUtils.formatInetAddr()` should prefer using the hostname of resolved addresses when converting InetSocketAddress to String. Previously it only picked the hostname if address was missing, e.g. the hostname was unresolved. This change has the advantage of sending the hostname in the InitialMessage instead of the IP address, which will help avoiding unnecessary reverse DNS lookups in the election protocol when TLS is enabled.

2. Add extra debug logs to `ZKTrustManager` and remove logging the exception stack trace when IP verification failed. Logging of stack traces makes sense to me in error log entries only. Many times we hit into this when user turns on debug logging, seeing a big stack trace and believes it's an error in ZooKeeper.

Target branches: master, branch-3.8