### PR TITLE
ZOOKEEPER-4622 Add Netty-TcNative OpenSSL Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -704,13 +704,10 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-handler</artifactId>
+        <artifactId>netty-bom</artifactId>
         <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport-native-epoll</artifactId>
-        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1767,6 +1767,14 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     **New in 3.5.5:**
     TBD
 
+* *ssl.sslProvider* :
+    (Java system property: **zookeeper.ssl.sslProvider**)
+    **New in 3.9.0:**
+    Allows to select SSL provider in the client-server communication when TLS is enabled. Netty-tcnative native library
+    has been added to ZooKeeper in version 3.9.0 which allows us to use native SSL libraries like OpenSSL on supported
+    platforms. If specified, this property forces ZooKeeper to use a specific library, otherwise the best available will be
+    automatically selected. Please look at Netty-tcnative documentation to see the available options.
+
 * *sslQuorumReloadCertFiles* :
     (No Java system property)
     **New in  3.5.5, 3.6.0:**

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1772,8 +1772,7 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     **New in 3.9.0:**
     Allows to select SSL provider in the client-server communication when TLS is enabled. Netty-tcnative native library
     has been added to ZooKeeper in version 3.9.0 which allows us to use native SSL libraries like OpenSSL on supported
-    platforms. If specified, this property forces ZooKeeper to use a specific library, otherwise the best available will be
-    automatically selected. Please look at Netty-tcnative documentation to see the available options.
+    platforms. See the available options in Netty-tcnative documentation. Default value is "JDK".
 
 * *sslQuorumReloadCertFiles* :
     (No Java system property)

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -69,6 +69,11 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
@@ -446,7 +446,7 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
         private synchronized void initSSL(ChannelPipeline pipeline)
             throws X509Exception.KeyManagerException, X509Exception.TrustManagerException, SSLException {
             if (sslContext == null) {
-                try (X509Util x509Util = new ClientX509Util()) {
+                try (ClientX509Util x509Util = new ClientX509Util()) {
                     sslContext = x509Util.createNettySslContextForClient(clientConfig);
                 }
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
@@ -18,7 +18,6 @@
 
 package org.apache.zookeeper;
 
-import static org.apache.zookeeper.common.X509Exception.SSLContextException;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -33,7 +32,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.SslContext;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import java.io.IOException;
@@ -48,14 +47,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLException;
 import org.apache.zookeeper.ClientCnxn.EndOfStreamException;
 import org.apache.zookeeper.ClientCnxn.Packet;
 import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.common.NettyUtils;
+import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.common.X509Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -425,13 +423,11 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
      * connection implementation.
      */
     private class ZKClientPipelineFactory extends ChannelInitializer<SocketChannel> {
+        private SslContext sslContext = null;
+        private final String host;
+        private final int port;
 
-        private SSLContext sslContext = null;
-        private SSLEngine sslEngine = null;
-        private String host;
-        private int port;
-
-        public ZKClientPipelineFactory(String host, int port) {
+        private ZKClientPipelineFactory(String host, int port) {
             this.host = host;
             this.port = port;
         }
@@ -445,25 +441,16 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
             pipeline.addLast("handler", new ZKClientHandler());
         }
 
-        // The synchronized is to prevent the race on shared variable "sslEngine".
+        // The synchronized is to prevent the race on shared variable "sslContext".
         // Basically we only need to create it once.
-        private synchronized void initSSL(ChannelPipeline pipeline) throws SSLContextException {
-            if (sslContext == null || sslEngine == null) {
+        private synchronized void initSSL(ChannelPipeline pipeline)
+            throws X509Exception.KeyManagerException, X509Exception.TrustManagerException, SSLException {
+            if (sslContext == null) {
                 try (X509Util x509Util = new ClientX509Util()) {
-                    sslContext = x509Util.createSSLContext(clientConfig);
-                    sslEngine = sslContext.createSSLEngine(host, port);
-                    sslEngine.setUseClientMode(true);
-                    if (x509Util.getFipsMode(clientConfig) && x509Util.isServerHostnameVerificationEnabled(clientConfig)) {
-                        SSLParameters sslParameters = sslEngine.getSSLParameters();
-                        sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
-                        sslEngine.setSSLParameters(sslParameters);
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Server hostname verification: enabled HTTPS style endpoint identification algorithm");
-                        }
-                    }
+                    sslContext = x509Util.createNettySslContextForClient(clientConfig);
                 }
             }
-            pipeline.addLast("ssl", new SslHandler(sslEngine));
+            pipeline.addLast("ssl", sslContext.newHandler(pipeline.channel().alloc(), host, port));
             LOG.info("SSL handler added for channel: {}", pipeline.channel());
         }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
@@ -54,7 +54,6 @@ import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.common.NettyUtils;
 import org.apache.zookeeper.common.X509Exception;
-import org.apache.zookeeper.common.X509Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ClientX509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ClientX509Util.java
@@ -18,9 +18,28 @@
 
 package org.apache.zookeeper.common;
 
+import io.netty.handler.ssl.DelegatingSslContext;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import java.util.Arrays;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.TrustManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * X509 utilities specific for client-server communication framework.
+ */
 public class ClientX509Util extends X509Util {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ClientX509Util.class);
+
     private final String sslAuthProviderProperty = getConfigPrefix() + "authProvider";
+    private final String sslProviderProperty = getConfigPrefix() + "sslProvider";
 
     @Override
     protected String getConfigPrefix() {
@@ -36,4 +55,166 @@ public class ClientX509Util extends X509Util {
         return sslAuthProviderProperty;
     }
 
+    @Override
+    public String getSslProviderProperty() {
+        return sslProviderProperty;
+    }
+
+    public SslContext createNettySslContextForClient(ZKConfig config)
+        throws X509Exception.KeyManagerException, X509Exception.TrustManagerException, SSLException {
+        String keyStoreLocation = config.getProperty(getSslKeystoreLocationProperty(), "");
+        String keyStorePassword = getPasswordFromConfigPropertyOrFile(config, getSslKeystorePasswdProperty(),
+            getSslKeystorePasswdPathProperty());
+        String keyStoreType = config.getProperty(getSslKeystoreTypeProperty());
+
+        SslContextBuilder sslContextBuilder = SslContextBuilder.forClient();
+
+        if (keyStoreLocation.isEmpty()) {
+            LOG.warn("{} not specified", getSslKeystoreLocationProperty());
+        } else {
+            sslContextBuilder.keyManager(createKeyManager(keyStoreLocation, keyStorePassword, keyStoreType));
+        }
+
+        String trustStoreLocation = config.getProperty(getSslTruststoreLocationProperty(), "");
+        String trustStorePassword = getPasswordFromConfigPropertyOrFile(config, getSslTruststorePasswdProperty(),
+            getSslTruststorePasswdPathProperty());
+        String trustStoreType = config.getProperty(getSslTruststoreTypeProperty());
+
+        boolean sslCrlEnabled = config.getBoolean(getSslCrlEnabledProperty());
+        boolean sslOcspEnabled = config.getBoolean(getSslOcspEnabledProperty());
+        boolean sslServerHostnameVerificationEnabled = isServerHostnameVerificationEnabled(config);
+        boolean sslClientHostnameVerificationEnabled = isClientHostnameVerificationEnabled(config);
+
+        if (trustStoreLocation.isEmpty()) {
+            LOG.warn("{} not specified", getSslTruststoreLocationProperty());
+        } else {
+            sslContextBuilder.trustManager(createTrustManager(trustStoreLocation, trustStorePassword, trustStoreType,
+                sslCrlEnabled, sslOcspEnabled, sslServerHostnameVerificationEnabled,
+                sslClientHostnameVerificationEnabled, getFipsMode(config)));
+        }
+
+        sslContextBuilder.enableOcsp(sslOcspEnabled);
+        sslContextBuilder.protocols(getEnabledProtocols(config));
+        sslContextBuilder.ciphers(getCipherSuites(config));
+
+        SslProvider sslProvider = getSslProvider(config);
+        if (sslProvider != null) {
+            sslContextBuilder.sslProvider(getSslProvider(config));
+        }
+
+        SslContext sslContext1 = sslContextBuilder.build();
+
+        if (getFipsMode(config) && isServerHostnameVerificationEnabled(config)) {
+            return addHostnameVerification(sslContext1, "Server");
+        } else {
+            return sslContext1;
+        }
+    }
+
+    public SslContext createNettySslContextForServer(ZKConfig config)
+        throws X509Exception.SSLContextException, X509Exception.KeyManagerException, X509Exception.TrustManagerException, SSLException {
+        String keyStoreLocation = config.getProperty(getSslKeystoreLocationProperty(), "");
+        String keyStorePassword = getPasswordFromConfigPropertyOrFile(config, getSslKeystorePasswdProperty(),
+            getSslKeystorePasswdPathProperty());
+        String keyStoreType = config.getProperty(getSslKeystoreTypeProperty());
+
+        if (keyStoreLocation.isEmpty()) {
+            throw new X509Exception.SSLContextException(
+                "Keystore is required for SSL server: " + getSslKeystoreLocationProperty());
+        }
+
+        KeyManager km = createKeyManager(keyStoreLocation, keyStorePassword, keyStoreType);
+
+        String trustStoreLocation = config.getProperty(getSslTruststoreLocationProperty(), "");
+        String trustStorePassword = getPasswordFromConfigPropertyOrFile(config, getSslTruststorePasswdProperty(),
+            getSslTruststorePasswdPathProperty());
+        String trustStoreType = config.getProperty(getSslTruststoreTypeProperty());
+
+        boolean sslCrlEnabled = config.getBoolean(getSslCrlEnabledProperty());
+        boolean sslOcspEnabled = config.getBoolean(getSslOcspEnabledProperty());
+        boolean sslServerHostnameVerificationEnabled = isServerHostnameVerificationEnabled(config);
+        boolean sslClientHostnameVerificationEnabled = isClientHostnameVerificationEnabled(config);
+
+        TrustManager tm = null;
+
+        if (trustStoreLocation.isEmpty()) {
+            LOG.warn("{} not specified", getSslTruststoreLocationProperty());
+        } else {
+            tm = createTrustManager(trustStoreLocation, trustStorePassword, trustStoreType,
+                sslCrlEnabled, sslOcspEnabled, sslServerHostnameVerificationEnabled,
+                sslClientHostnameVerificationEnabled, getFipsMode(config));
+        }
+
+        return createNettySslContextForServer(config, km, tm);
+    }
+
+    public SslContext createNettySslContextForServer(ZKConfig config, KeyManager keyManager, TrustManager trustManager) throws SSLException {
+        SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(keyManager);
+
+        if (trustManager != null) {
+            sslContextBuilder.trustManager(trustManager);
+        }
+
+        sslContextBuilder.enableOcsp(config.getBoolean(getSslOcspEnabledProperty()));
+        sslContextBuilder.protocols(getEnabledProtocols(config));
+        sslContextBuilder.clientAuth(getClientAuth(config).toNettyClientAuth());
+        sslContextBuilder.ciphers(getCipherSuites(config));
+
+        SslProvider sslProvider = getSslProvider(config);
+        if (sslProvider != null) {
+            sslContextBuilder.sslProvider(getSslProvider(config));
+        }
+
+        SslContext sslContext1 = sslContextBuilder.build();
+
+        if (getFipsMode(config) && isClientHostnameVerificationEnabled(config)) {
+            return addHostnameVerification(sslContext1, "Client");
+        } else {
+            return sslContext1;
+        }
+    }
+
+    private SslContext addHostnameVerification(SslContext sslContext, String clientOrServer) {
+        return new DelegatingSslContext(sslContext) {
+            @Override
+            protected void initEngine(SSLEngine sslEngine) {
+                SSLParameters sslParameters = sslEngine.getSSLParameters();
+                sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+                sslEngine.setSSLParameters(sslParameters);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("{} hostname verification: enabled HTTPS style endpoint identification algorithm", clientOrServer);
+                }
+            }
+        };
+    }
+
+    private String[] getEnabledProtocols(final ZKConfig config) {
+        String enabledProtocolsInput = config.getProperty(getSslEnabledProtocolsProperty());
+        if (enabledProtocolsInput == null) {
+            return new String[]{ config.getProperty(getSslProtocolProperty(), DEFAULT_PROTOCOL) };
+        }
+        return enabledProtocolsInput.split(",");
+    }
+
+    private X509Util.ClientAuth getClientAuth(final ZKConfig config) {
+        return X509Util.ClientAuth.fromPropertyValue(config.getProperty(getSslClientAuthProperty()));
+    }
+
+    private Iterable<String> getCipherSuites(final ZKConfig config) {
+        String cipherSuitesInput = config.getProperty(getSslCipherSuitesProperty());
+        if (cipherSuitesInput == null) {
+            return Arrays.asList(X509Util.getDefaultCipherSuites());
+        } else {
+            return Arrays.asList(cipherSuitesInput.split(","));
+        }
+    }
+
+    public SslProvider getSslProvider(ZKConfig config) {
+        String propertyValue = config.getProperty(getSslProviderProperty());
+        if (propertyValue != null && !propertyValue.isEmpty()) {
+            return SslProvider.valueOf(propertyValue);
+        } else {
+            return null;
+        }
+    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ClientX509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ClientX509Util.java
@@ -22,7 +22,6 @@ import io.netty.handler.ssl.DelegatingSslContext;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
-
 import java.util.Arrays;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLEngine;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/QuorumX509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/QuorumX509Util.java
@@ -18,6 +18,9 @@
 
 package org.apache.zookeeper.common;
 
+/**
+ * X509 utilities specific for server-server (quorum) communication framework.
+ */
 public class QuorumX509Util extends X509Util {
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/SSLContextAndOptions.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/SSLContextAndOptions.java
@@ -19,13 +19,11 @@
 package org.apache.zookeeper.common;
 
 import static java.util.Objects.requireNonNull;
-import io.netty.handler.ssl.DelegatingSslContext;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.Arrays;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
@@ -49,7 +47,6 @@ public class SSLContextAndOptions {
     private final X509Util.ClientAuth clientAuth;
     private final SSLContext sslContext;
     private final int handshakeDetectionTimeoutMillis;
-    private final ZKConfig config;
 
 
     /**
@@ -66,7 +63,6 @@ public class SSLContextAndOptions {
         this.cipherSuites = getCipherSuites(config);
         this.clientAuth = getClientAuth(config);
         this.handshakeDetectionTimeoutMillis = getHandshakeDetectionTimeoutMillis(config);
-        this.config = config;
     }
 
     public SSLContext getSSLContext() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/SSLContextAndOptions.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/SSLContextAndOptions.java
@@ -20,15 +20,10 @@ package org.apache.zookeeper.common;
 
 import static java.util.Objects.requireNonNull;
 import io.netty.handler.ssl.DelegatingSslContext;
-import io.netty.handler.ssl.IdentityCipherSuiteFilter;
-import io.netty.handler.ssl.JdkSslContext;
-import io.netty.handler.ssl.SslContext;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
@@ -51,7 +46,6 @@ public class SSLContextAndOptions {
     private final X509Util x509Util;
     private final String[] enabledProtocols;
     private final String[] cipherSuites;
-    private final List<String> cipherSuitesAsList;
     private final X509Util.ClientAuth clientAuth;
     private final SSLContext sslContext;
     private final int handshakeDetectionTimeoutMillis;
@@ -69,9 +63,7 @@ public class SSLContextAndOptions {
         this.x509Util = requireNonNull(x509Util);
         this.sslContext = requireNonNull(sslContext);
         this.enabledProtocols = getEnabledProtocols(requireNonNull(config), sslContext);
-        String[] ciphers = getCipherSuites(config);
-        this.cipherSuites = ciphers;
-        this.cipherSuitesAsList = Collections.unmodifiableList(Arrays.asList(ciphers));
+        this.cipherSuites = getCipherSuites(config);
         this.clientAuth = getClientAuth(config);
         this.handshakeDetectionTimeoutMillis = getHandshakeDetectionTimeoutMillis(config);
         this.config = config;
@@ -104,34 +96,6 @@ public class SSLContextAndOptions {
     public SSLServerSocket createSSLServerSocket(int port) throws IOException {
         SSLServerSocket sslServerSocket = (SSLServerSocket) sslContext.getServerSocketFactory().createServerSocket(port);
         return configureSSLServerSocket(sslServerSocket);
-    }
-
-    public SslContext createNettyJdkSslContext(SSLContext sslContext) {
-        SslContext sslContext1 = new JdkSslContext(
-                sslContext,
-                false,
-                cipherSuitesAsList,
-                IdentityCipherSuiteFilter.INSTANCE,
-                null,
-                clientAuth.toNettyClientAuth(),
-                enabledProtocols,
-                false);
-
-        if (x509Util.getFipsMode(config) && x509Util.isClientHostnameVerificationEnabled(config)) {
-            return new DelegatingSslContext(sslContext1) {
-                @Override
-                protected void initEngine(SSLEngine sslEngine) {
-                    SSLParameters sslParameters = sslEngine.getSSLParameters();
-                    sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
-                    sslEngine.setSSLParameters(sslParameters);
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Client hostname verification: enabled HTTPS style endpoint identification algorithm");
-                    }
-                }
-            };
-        } else {
-            return sslContext1;
-        }
     }
 
     public int getHandshakeDetectionTimeoutMillis() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
@@ -18,8 +18,6 @@
 
 package org.apache.zookeeper.common;
 
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -35,7 +33,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import java.security.cert.PKIXBuilderParameters;
 import java.security.cert.X509CertSelector;
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -43,7 +40,6 @@ import javax.net.ssl.CertPathTrustManagerParameters;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.TrustManager;
@@ -655,113 +651,6 @@ public abstract class X509Util implements Closeable, AutoCloseable {
             }
             trustStoreFileWatcher = newTrustStoreFileWatcher;
             trustStoreFileWatcher.start();
-        }
-    }
-
-    public SslContext createNettySslContextForClient(ZKConfig config)
-        throws KeyManagerException, TrustManagerException, SSLException {
-        String keyStoreLocation = config.getProperty(sslKeystoreLocationProperty, "");
-        String keyStorePassword = getPasswordFromConfigPropertyOrFile(config, sslKeystorePasswdProperty, sslKeystorePasswdPathProperty);
-        String keyStoreType = config.getProperty(sslKeystoreTypeProperty);
-
-        SslContextBuilder sslContextBuilder = SslContextBuilder.forClient();
-
-        if (keyStoreLocation.isEmpty()) {
-            LOG.warn("{} not specified", getSslKeystoreLocationProperty());
-        } else {
-            sslContextBuilder.keyManager(createKeyManager(keyStoreLocation, keyStorePassword, keyStoreType));
-        }
-
-        String trustStoreLocation = config.getProperty(sslTruststoreLocationProperty, "");
-        String trustStorePassword = getPasswordFromConfigPropertyOrFile(config, sslTruststorePasswdProperty, sslTruststorePasswdPathProperty);
-        String trustStoreType = config.getProperty(sslTruststoreTypeProperty);
-
-        boolean sslCrlEnabled = config.getBoolean(this.sslCrlEnabledProperty);
-        boolean sslOcspEnabled = config.getBoolean(this.sslOcspEnabledProperty);
-        boolean sslServerHostnameVerificationEnabled = config.getBoolean(this.getSslHostnameVerificationEnabledProperty(), true);
-        boolean sslClientHostnameVerificationEnabled = sslServerHostnameVerificationEnabled && shouldVerifyClientHostname();
-
-        if (trustStoreLocation.isEmpty()) {
-            LOG.warn("{} not specified", getSslTruststoreLocationProperty());
-        } else {
-            sslContextBuilder.trustManager(createTrustManager(trustStoreLocation, trustStorePassword, trustStoreType,
-                sslCrlEnabled, sslOcspEnabled, sslServerHostnameVerificationEnabled, sslClientHostnameVerificationEnabled));
-        }
-
-        sslContextBuilder.enableOcsp(sslOcspEnabled);
-        sslContextBuilder.protocols(getEnabledProtocols(config));
-        sslContextBuilder.ciphers(getCipherSuites(config));
-
-        return sslContextBuilder.build();
-    }
-
-    public SslContext createNettySslContextForServer(ZKConfig config)
-        throws SSLContextException, KeyManagerException, TrustManagerException, SSLException {
-        String keyStoreLocation = config.getProperty(sslKeystoreLocationProperty, "");
-        String keyStorePassword = getPasswordFromConfigPropertyOrFile(config, sslKeystorePasswdProperty, sslKeystorePasswdPathProperty);
-        String keyStoreType = config.getProperty(sslKeystoreTypeProperty);
-
-        if (keyStoreLocation.isEmpty()) {
-            throw new SSLContextException(
-                "Keystore is required for SSL server: " + sslKeystoreLocationProperty);
-        }
-
-        KeyManager km = createKeyManager(keyStoreLocation, keyStorePassword, keyStoreType);
-
-        String trustStoreLocation = config.getProperty(sslTruststoreLocationProperty, "");
-        String trustStorePassword = getPasswordFromConfigPropertyOrFile(config, sslTruststorePasswdProperty, sslTruststorePasswdPathProperty);
-        String trustStoreType = config.getProperty(sslTruststoreTypeProperty);
-
-        boolean sslCrlEnabled = config.getBoolean(this.sslCrlEnabledProperty);
-        boolean sslOcspEnabled = config.getBoolean(this.sslOcspEnabledProperty);
-        boolean sslServerHostnameVerificationEnabled = config.getBoolean(this.getSslHostnameVerificationEnabledProperty(), true);
-        boolean sslClientHostnameVerificationEnabled = sslServerHostnameVerificationEnabled && shouldVerifyClientHostname();
-
-        TrustManager tm = null;
-
-        if (trustStoreLocation.isEmpty()) {
-            LOG.warn("{} not specified", getSslTruststoreLocationProperty());
-        } else {
-            tm = createTrustManager(trustStoreLocation, trustStorePassword, trustStoreType,
-                sslCrlEnabled, sslOcspEnabled, sslServerHostnameVerificationEnabled, sslClientHostnameVerificationEnabled);
-        }
-
-        return createNettySslContextForServer(config, km, tm);
-    }
-
-    public SslContext createNettySslContextForServer(ZKConfig config, KeyManager keyManager, TrustManager trustManager) throws SSLException {
-        SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(keyManager);
-
-        if (trustManager != null) {
-            sslContextBuilder.trustManager(trustManager);
-        }
-
-        sslContextBuilder.enableOcsp(config.getBoolean(this.sslOcspEnabledProperty));
-        sslContextBuilder.protocols(getEnabledProtocols(config));
-        sslContextBuilder.clientAuth(getClientAuth(config).toNettyClientAuth());
-        sslContextBuilder.ciphers(getCipherSuites(config));
-
-        return sslContextBuilder.build();
-    }
-
-    private String[] getEnabledProtocols(final ZKConfig config) {
-        String enabledProtocolsInput = config.getProperty(sslEnabledProtocolsProperty);
-        if (enabledProtocolsInput == null) {
-            return new String[]{ config.getProperty(sslProtocolProperty, DEFAULT_PROTOCOL) };
-        }
-        return enabledProtocolsInput.split(",");
-    }
-
-    private X509Util.ClientAuth getClientAuth(final ZKConfig config) {
-        return X509Util.ClientAuth.fromPropertyValue(config.getProperty(sslClientAuthProperty));
-    }
-
-    private Iterable<String> getCipherSuites(final ZKConfig config) {
-        String cipherSuitesInput = config.getProperty(cipherSuitesProperty);
-        if (cipherSuitesInput == null) {
-            return Arrays.asList(X509Util.getDefaultCipherSuites());
-        } else {
-            return Arrays.asList(cipherSuitesInput.split(","));
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKConfig.java
@@ -106,6 +106,7 @@ public class ZKConfig {
         try (ClientX509Util clientX509Util = new ClientX509Util()) {
             putSSLProperties(clientX509Util);
             properties.put(clientX509Util.getSslAuthProviderProperty(), System.getProperty(clientX509Util.getSslAuthProviderProperty()));
+            properties.put(clientX509Util.getSslProviderProperty(), System.getProperty(clientX509Util.getSslProviderProperty()));
         }
 
         try (X509Util x509Util = new QuorumX509Util()) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -18,9 +18,11 @@
 
 package org.apache.zookeeper.server.auth;
 
+import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -149,7 +151,8 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
 
     @Override
     public KeeperException.Code handleAuthentication(ServerCnxn cnxn, byte[] authData) {
-        X509Certificate[] certChain = (X509Certificate[]) cnxn.getClientCertificateChain();
+        List<Certificate> certs = Arrays.asList(cnxn.getClientCertificateChain());
+        X509Certificate[] certChain = certs.toArray(new X509Certificate[certs.size()]);
 
         final Collection<Id> ids = handleAuthentication(certChain);
         if (ids.isEmpty()) {

--- a/zookeeper-server/src/main/resources/lib/netty-bom-4.1.94.Final.LICENSE.txt
+++ b/zookeeper-server/src/main/resources/lib/netty-bom-4.1.94.Final.LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 1999-2005 The Apache Software Foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientSSLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientSSLTest.java
@@ -27,13 +27,12 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.netty.handler.ssl.SslProvider;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.stream.Stream;
-
-import io.netty.handler.ssl.SslProvider;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZooDefs;
@@ -50,9 +49,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 public class ClientSSLTest extends QuorumPeerTestBase {
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientSSLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientSSLTest.java
@@ -70,6 +70,16 @@ public class ClientSSLTest extends QuorumPeerTestBase {
         return result.stream();
     }
 
+    public static Stream<Arguments> negativeTestData() {
+        ArrayList<Arguments> result = new ArrayList<>();
+        for (SslProvider sslProvider : SslProvider.values()) {
+            for (String fipsEnabled : new String[] { "true", "false" }) {
+                result.add(Arguments.of(sslProvider, fipsEnabled));
+            }
+        }
+        return result.stream();
+    }
+
     @BeforeEach
     public void setup() {
         System.setProperty(NettyServerCnxnFactory.PORT_UNIFICATION_KEY, Boolean.TRUE.toString());
@@ -98,6 +108,7 @@ public class ClientSSLTest extends QuorumPeerTestBase {
         System.clearProperty(clientX509Util.getSslTruststorePasswdPathProperty());
         System.clearProperty(clientX509Util.getFipsModeProperty());
         System.clearProperty(clientX509Util.getSslHostnameVerificationEnabledProperty());
+        System.clearProperty(clientX509Util.getSslProviderProperty());
         clientX509Util.close();
     }
 
@@ -152,10 +163,11 @@ public class ClientSSLTest extends QuorumPeerTestBase {
     /**
      * This test covers the negative scenarios for hostname verification.
      */
-    @ParameterizedTest(name = "fipsEnabled={0}")
-    @ValueSource(booleans = { true, false })
-    public void testClientServerSSL_negative(boolean fipsEnabled) {
+    @ParameterizedTest(name = "sslProvider={0}, fipsEnabled={1}")
+    @MethodSource("negativeTestData")
+    public void testClientServerSSL_negative(SslProvider sslProvider, boolean fipsEnabled) {
         // Arrange
+        System.setProperty(clientX509Util.getSslProviderProperty(), sslProvider.toString());
         System.setProperty(clientX509Util.getFipsModeProperty(), Boolean.toString(fipsEnabled));
         System.setProperty(clientX509Util.getSslHostnameVerificationEnabledProperty(), "true");
 


### PR DESCRIPTION
Use SslContextBuilder to create SSL context for Netty on both client and server side. This will allow users to enable OpenSSL (or other native SSL lib) support if it's installed in the OS and classpath is set up properly.

Usage guide: https://netty.io/wiki/forked-tomcat-native.html

OpenSSL support enabled on Ubuntu 20.04 looks like this:
```
2023-06-14 17:09:00,453 [myid:] - DEBUG [nioEventLoopGroup-8-1:o.a.z.c.X509Util@581] - Using Java9+ optimized cipher suites for Java version 11
2023-06-14 17:09:00,470 [myid:] - DEBUG [nioEventLoopGroup-8-1:i.n.u.i.NativeLibraryLoader@384] - Successfully loaded the library /tmp/libnetty_tcnative_linux_x86_643947969347517419998.so
2023-06-14 17:09:00,470 [myid:] - DEBUG [nioEventLoopGroup-8-1:i.n.h.s.OpenSsl@162] - Initialize netty-tcnative using engine: 'default'
2023-06-14 17:09:00,471 [myid:] - DEBUG [nioEventLoopGroup-8-1:i.n.h.s.OpenSsl@189] - netty-tcnative using native library: OpenSSL 1.0.2g  1 Mar 2016
...
023-06-14 17:09:00,546 [myid:] - DEBUG [nioEventLoopGroup-8-1:i.n.h.s.OpenSsl@442] - Supported protocols (OpenSSL): [SSLv2Hello, TLSv1, TLSv1.1, TLSv1.2] 
2023-06-14 17:09:00,546 [myid:] - DEBUG [nioEventLoopGroup-8-1:i.n.h.s.OpenSsl@443] - Default cipher suites (OpenSSL): [TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384...
```

Without that setup, Netty will fallback to JDK SSL context which is the original behaviour.

cc @symat @eolivelli @hyperxpro