### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 12.0.0.beta0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -559,7 +559,7 @@
     <hamcrest.version>2.2</hamcrest.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <netty.version>4.1.86.Final</netty.version>
-    <jetty.version>9.4.49.v20220914</jetty.version>
+    <jetty.version>12.0.0.beta0</jetty.version>
     <jackson.version>2.13.4.2</jackson.version>
     <jline.version>2.14.6</jline.version>
     <snappy.version>1.1.9.1</snappy.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 9.4.49.v20220914
- [CVE-2023-26049](https://www.oscs1024.com/hd/CVE-2023-26049)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 9.4.49.v20220914 to 12.0.0.beta0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS