### PR TITLE
ZOOKEEPER-4705 Restrict GitHub merge button to allow squash commit only

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,6 +41,10 @@ github:
     wiki: false
     issues: false
     projects: false
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false
 
 notifications:
   jira_options: link label worklog


### PR DESCRIPTION
Target branches: master