### PR TITLE
ZOOKEEPER-4393: [ADDENDUM] Turn off FIPS-mode by default on branch-3.8

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
@@ -258,7 +258,7 @@ public abstract class X509Util implements Closeable, AutoCloseable {
     }
 
     public boolean getFipsMode(ZKConfig config) {
-        return config.getBoolean(FIPS_MODE_PROPERTY, true);
+        return config.getBoolean(FIPS_MODE_PROPERTY, false);
     }
 
     public boolean isServerHostnameVerificationEnabled(ZKConfig config) {


### PR DESCRIPTION
Accidentally enabled for 3.8 too when cherry-picked from master. We need to switch this off to maintain compatibility.

cc @symat 