### PR TITLE
ZOOKEEPER-4716: upgrade jackson to 2.15.2, suppress two false positive CVE errors

### DIFF
--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -54,4 +54,16 @@
       <cve>CVE-2021-34429</cve>
    </suppress>
 
+   <suppress>
+      <!-- ZOOKEEPER-4716: jackson related false positives -->
+
+      <!-- according to jackson community, this is not a security issue,
+           see: https://github.com/FasterXML/jackson-databind/issues/3972#issuecomment-1596193098 -->
+      <cve>CVE-2023-35116</cve>
+
+      <!-- the following CVE is not even jackson related, but a vulnerability
+           in json-java which we don't use in ZooKeeper -->
+      <cve>CVE-2022-45688</cve>
+   </suppress>
+
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -560,7 +560,7 @@
     <commons-cli.version>1.5.0</commons-cli.version>
     <netty.version>4.1.86.Final</netty.version>
     <jetty.version>9.4.51.v20230217</jetty.version>
-    <jackson.version>2.13.4.2</jackson.version>
+    <jackson.version>2.15.2</jackson.version>
     <jline.version>2.14.6</jline.version>
     <snappy.version>1.1.9.1</snappy.version>
     <kerby.version>2.0.0</kerby.version>


### PR DESCRIPTION
Our jackson is quite old, I want to upgrade it before release 3.8.2.

Also we have a few false positive CVEs reported by OWASP:

- CVE-2023-35116: according to jackson community, this is not a security issue, see https://github.com/FasterXML/jackson-databind/issues/3972#issuecomment-1596193098
- CVE-2022-45688: the following CVE is not even jackson related, but a vulnerability in json-java which we don't use in ZooKeeper