### PR TITLE
ZOOKEEPER-4713: ObserverZooKeeperServer.shutdown() is redundant

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverZooKeeperServer.java
@@ -128,18 +128,6 @@ public class ObserverZooKeeperServer extends LearnerZooKeeperServer {
     }
 
     @Override
-    public synchronized void shutdown() {
-        if (!canShutdown()) {
-            LOG.debug("ZooKeeper server is not running, so not proceeding to shutdown!");
-            return;
-        }
-        super.shutdown();
-        if (syncRequestProcessorEnabled && syncProcessor != null) {
-            syncProcessor.shutdown();
-        }
-    }
-
-    @Override
     public void dumpMonitorValues(BiConsumer<String, Object> response) {
         super.dumpMonitorValues(response);
         response.accept("observer_master_id", getObserver().getLearnerMasterId());


### PR DESCRIPTION
Remove ObserverZooKeeperServer.shutdown(), which is redundant and unused.