### PR TITLE
ZOOKEEPER-4718: Removing unnecessary heap memory allocation in serialization to help reduce GC pressure

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/SerializeUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/SerializeUtils.java
@@ -175,11 +175,12 @@ public class SerializeUtils {
         if (request == null || request.getHdr() == null) {
             return null;
         }
-        byte[] data = new byte[32];
+        byte[] data;
         try {
             data = Util.marshallTxnEntry(request.getHdr(), request.getTxn(), request.getTxnDigest());
         } catch (IOException e) {
             LOG.error("This really should be impossible", e);
+            data = new byte[32];
         }
         return data;
     }


### PR DESCRIPTION
For each request, we will serialize it to a byte array.
In SerializeUtils#serializeRequest, before serializing the request, it always allocates 32 byte array. It's unnecessary; we can allocate the byte array in the catch code block.

```
    public static byte[] serializeRequest(Request request) {
        if (request == null || request.getHdr() == null) {
            return null;
        }
        byte[] data = new byte[32];
        try {
            data = Util.marshallTxnEntry(request.getHdr(), request.getTxn(), request.getTxnDigest());
        } catch (IOException e) {
            LOG.error("This really should be impossible", e);
        }
        return data;
    }
```
