### PR TITLE
ZOOKEEPER-4712: Follower.shutdown() and Observer.shutdown() do not correctly shutdown the syncProcessor, which may lead to data inconsistency

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -943,7 +943,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
      * @param fullyShutDown true if another server using the same database will not replace this one in the same process
      * @return true if the server is successfully shutdown, false if the server cannot be shutdown.
      */
-    public synchronized boolean shutdownZKServer(boolean fullyShutDown) {
+    protected synchronized boolean shutdownZKServer(boolean fullyShutDown) {
         if (!canShutdown()) {
             if (fullyShutDown && zkDb != null) {
                 zkDb.clear();
@@ -985,7 +985,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
      * Update zk database during shutdown
      * @param fullyShutDown true if another server using the same database will not replace this one in the same process
      */
-    public synchronized void updateZKDatabase(boolean fullyShutDown) {
+    protected synchronized void updateZKDatabase(boolean fullyShutDown) {
         if (zkDb != null) {
             if (fullyShutDown) {
                 zkDb.clear();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerZooKeeperServer.java
@@ -172,4 +172,18 @@ public abstract class LearnerZooKeeperServer extends QuorumZooKeeperServer {
         }
     }
 
+    @Override
+    public void shutdown(boolean fullyShutDown) {
+        if (shutdownZKServer(fullyShutDown)) {
+            try {
+                if (syncProcessor != null) {
+                    syncProcessor.shutdown();
+                }
+            } catch (Exception e) {
+                LOG.warn("Ignoring unexpected exception in syncprocessor shutdown", e);
+            }
+            updateZKDatabase(fullyShutDown);
+        }
+    }
+
 }


### PR DESCRIPTION
See [ZOOKEEPER-4712](https://issues.apache.org/jira/browse/ZOOKEEPER-4712) for more details.

This fix ensures that Follower.shutdown() and Observer.shutdown() will invoke syncProcessor.shutdown() correctly. 
Besides, it ensures that syncProcessor.shutdown() will happen before zkDb.fastForwardDataBase(), which avoids possible data inconsistency. 