### PR TITLE
ZOOKEEPER-4726: Upgrade snappy-java version to v1.1.10.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -563,7 +563,7 @@
     <jetty.version>9.4.51.v20230217</jetty.version>
     <jackson.version>2.15.2</jackson.version>
     <jline.version>2.14.6</jline.version>
-    <snappy.version>1.1.10.1</snappy.version>
+    <snappy.version>1.1.10.3</snappy.version>
     <kerby.version>2.0.0</kerby.version>
     <bouncycastle.version>1.75</bouncycastle.version>
     <commons-collections.version>4.4</commons-collections.version>


### PR DESCRIPTION
This PR fixes the s390x builds on Apache Zookeeper Jenkins CI.

changes done are as follows:
- Updated Snappy-java version to 1.1.10.3 as Snappy-java v1.1.10.1 is broken for s390x arch and has been fixed in v1.1.10.3. 

Could any of the developers please review these changes? Thanks