### PR TITLE
ZOOKEEPER-4728: force to re-resolve hostname into IP when binding.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -309,6 +309,10 @@ public class Leader extends LearnerMaster {
         this.zk = zk;
     }
 
+    InetSocketAddress recreateInetSocketAddr(String hostString, int port) {
+        return new InetSocketAddress(hostString, port);
+    }
+
     Optional<ServerSocket> createServerSocket(InetSocketAddress address, boolean portUnification, boolean sslQuorum) {
         ServerSocket serverSocket;
         try {
@@ -318,7 +322,7 @@ public class Leader extends LearnerMaster {
                 serverSocket = new ServerSocket();
             }
             serverSocket.setReuseAddress(true);
-            serverSocket.bind(new InetSocketAddress(address.getHostString(), address.getPort()));
+            serverSocket.bind(recreateInetSocketAddr(address.getHostString(), address.getPort()));
             return Optional.of(serverSocket);
         } catch (IOException e) {
             LOG.error("Couldn't bind to {}", address.toString(), e);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -318,7 +318,7 @@ public class Leader extends LearnerMaster {
                 serverSocket = new ServerSocket();
             }
             serverSocket.setReuseAddress(true);
-            serverSocket.bind(address);
+            serverSocket.bind(new InetSocketAddress(address.getHostString(), address.getPort()));
             return Optional.of(serverSocket);
         } catch (IOException e) {
             LOG.error("Couldn't bind to {}", address.toString(), e);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/LeaderBeanTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
@@ -47,6 +48,7 @@ import org.apache.zookeeper.txn.TxnHeader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -90,6 +92,15 @@ public class LeaderBeanTest {
     @AfterEach
     public void tearDown() throws IOException {
         fileTxnSnapLog.close();
+    }
+
+    @Test
+    public void testCreateServerSocketWillRecreateInetSocketAddr() {
+        Leader spyLeader = Mockito.spy(leader);
+        InetSocketAddress addr = new InetSocketAddress("localhost", PortAssignment.unique());
+        spyLeader.createServerSocket(addr, false, false);
+        // make sure the address to be bound will be recreated with expected hostString and port
+        Mockito.verify(spyLeader, times(1)).recreateInetSocketAddr(addr.getHostString(), addr.getPort());
     }
 
     @Test


### PR DESCRIPTION
When the leader tried to bind the host/IP to get connection from followers, if the DNS is not ready at first, it'll always stay in `<unresolved>` state forever. This PR tries to resolve hostname into IP each time we tried to bind.

Note: The same solution we also applied in `QuorumCnxManager` (i.e. https://github.com/apache/zookeeper/pull/1524)
https://github.com/apache/zookeeper/blob/688c69c19dc64836e91dc9ae97aeaeaf462f0556/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java#L1140