### PR TITLE
ZOOKEEPER-4733: non-return function error and asan error in CPPUNIT T…

### DIFF
--- a/zookeeper-client/zookeeper-client-c/tests/TestReconfig.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestReconfig.cc
@@ -499,7 +499,7 @@ public:
             found = seen.find(next.str());
             CPPUNIT_ASSERT_MESSAGE(next.str() + " in seen list",
                                    found == string::npos);
-            seen += found + ", ";
+            seen += next.str() + ", ";
         }
 
         // Now it should start connecting to the old servers
@@ -516,7 +516,7 @@ public:
             // Assert not in seen list then append
             found = seen.find(next.str());
             CPPUNIT_ASSERT(found == string::npos);
-            seen += found + ", ";
+            seen += next.str() + ", ";
         }
 
         // NOW it goes back to normal as we've tried all the new and old

--- a/zookeeper-client/zookeeper-client-c/tests/ZooKeeperQuorumServer.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/ZooKeeperQuorumServer.cc
@@ -197,6 +197,7 @@ getCluster(uint32_t numServers) {
         }
     }
     assert(!"The cluster didn't start for 10 seconds");
+    return {};
 }
 
 std::vector<ZooKeeperQuorumServer*> ZooKeeperQuorumServer::


### PR DESCRIPTION
detail description in https://issues.apache.org/jira/projects/ZOOKEEPER/issues/ZOOKEEPER-4733

This fix is nice to have for sanity check(Werror=return-type check and asan check) for zookeeper C client.