### PR TITLE
fix fd leak problem

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNIO.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNIO.java
@@ -256,11 +256,12 @@ public class ClientCnxnSocketNIO extends ClientCnxnSocket {
      * @throws IOException
      */
     void registerAndConnect(SocketChannel sock, InetSocketAddress addr) throws IOException {
-        sockKey = sock.register(selector, SelectionKey.OP_CONNECT);
         boolean immediateConnect = sock.connect(addr);
+        sockKey = sock.register(selector, SelectionKey.OP_CONNECT);
         if (immediateConnect) {
             sendThread.primeConnection();
         }
+
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNIO.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNIO.java
@@ -250,7 +250,7 @@ public class ClientCnxnSocketNIO extends ClientCnxnSocket {
     }
 
     /**
-     * register with the selection and connect
+     *  with the selection and connect
      * @param sock the {@link SocketChannel}
      * @param addr the address of remote host
      * @throws IOException
@@ -261,7 +261,6 @@ public class ClientCnxnSocketNIO extends ClientCnxnSocket {
         if (immediateConnect) {
             sendThread.primeConnection();
         }
-
     }
 
     @Override


### PR DESCRIPTION
fix: network service problem of zk client host occured, sock.connect(addr) method throws "SocketException: Network is unreachable", because the socket had registered to selector, cleanup() method can't close the  fd ,And SendThread keep doing startConnect() to keep zk client alive ,leading to fd leak.
