### PR TITLE
Fix leader election recipe doc

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/recipes.md
+++ b/zookeeper-docs/src/main/resources/markdown/recipes.md
@@ -391,7 +391,7 @@ be a leader:
 
 1. Create znode z with path "ELECTION/guid-n_" with both SEQUENCE and
   EPHEMERAL flags;
-1. Let C be the children of "ELECTION", and I am the sequence
+1. Let C be the children of "ELECTION", and i is the sequence
   number of z;
 1. Watch for changes on "ELECTION/guid-n_j", where j is the largest
   sequence number such that j < i and n_j is a znode in C;


### PR DESCRIPTION
The doc refers to `i` as the sequence number of node z in step 3, but in the doc, it is written as `I am`. `i` was not defined anywhere else.

Hi @eolivelli,  @kalmar, @hanm

This phrase is important to understand  this recipe. Without this update, readers would be very confused since they don't know where `i` comes from when it's referred in step 3. . Can you please review and approve?

<img width="1264" alt="Screenshot 2023-08-12 at 3 32 09 PM" src="https://github.com/apache/zookeeper/assets/63071572/1b1d7492-35dd-4b15-b865-d3c8421ff0e2">
