### PR TITLE
GH autolink to ZOOKEEPER Jira issues

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -45,6 +45,8 @@ github:
     squash:  true
     merge:   false
     rebase:  false
+  autolink_jira:
+    - ZOOKEEPER
 
 notifications:
   jira_options: link label worklog


### PR DESCRIPTION
will ease going to Jira issues from Git commit messages