### PR TITLE
ZOOKEEPER-4734: FuzzySnapshotRelatedTest becomes flaky when transient disk failure appears

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -1144,9 +1144,25 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
         super.start();
     }
 
+    private static final String LOAD_DATABASE_RETRY = "zookeeper.loadDataBaseRetry";
+    private static final int DEFAULT_LOAD_DATABASE_MAX_RETRY = 3;
+
     private void loadDataBase() {
         try {
-            zkDb.loadDataBase();
+            final Integer maxRetry = Integer.getInteger(LOAD_DATABASE_RETRY,
+                    DEFAULT_LOAD_DATABASE_MAX_RETRY);
+            int numRetries = 0;
+            while (numRetries < maxRetry) {	    
+	        try {	
+                    zkDb.loadDataBase();
+		    break;
+	        } catch (IOException e) {
+		    if (++numRetries == maxRetry) {
+		        LOG.info("Loading dataset failed times exceeds maxReries:{}, stop retrying.", maxRetry);
+		        throw e;  
+		    }
+	        }
+	    } 
 
             // load the epochs
             long lastProcessedZxid = zkDb.getDataTree().lastProcessedZxid;


### PR DESCRIPTION
See [ZOOKEEPER-4734](https://issues.apache.org/jira/browse/ZOOKEEPER-4734)  for details on the symptom and diagnostic.

The fix of [ZOOKEEPER-4734](https://issues.apache.org/jira/browse/ZOOKEEPER-4734) is implemented. In my local machine, it is able to pass all test cases.

I add some configurable retry mechanism to ZkDataBase#loadDataBase() to tolerate possible transient disk failure. 

Any comments and suggestions would be appreciated.