### PR TITLE
ZOOKEEPER-4738: Refactor assertFalse(equals()) with assertNotEquals

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ReferenceCountedACLCacheTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ReferenceCountedACLCacheTest.java
@@ -19,7 +19,7 @@
 package org.apache.zookeeper.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -61,7 +61,7 @@ public class ReferenceCountedACLCacheTest {
         testACL2.add(new ACL(ZooDefs.Perms.WRITE, new Id("scheme", "rw")));
         testACL2.add(new ACL(ZooDefs.Perms.READ, new Id("scheme", "ro")));
 
-        assertFalse(aclId.equals(cache.convertAcls(testACL2)));
+        assertNotEquals(aclId, cache.convertAcls(testACL2));
     }
 
     @Test
@@ -90,7 +90,7 @@ public class ReferenceCountedACLCacheTest {
         List<ACL> testACL3 = createACL("differentId");
 
         Long aclId3 = cache.convertAcls(testACL3);
-        assertFalse(aclId3.equals(aclId));
+        assertNotEquals(aclId3, aclId);
         assertEquals(2, cache.size());
     }
 
@@ -126,7 +126,7 @@ public class ReferenceCountedACLCacheTest {
         assertEquals(1, cache.size());
 
         Long newId = cache.convertAcls(testACL);
-        assertFalse(aclId.equals(newId));
+        assertNotEquals(aclId, newId);
     }
 
     @Test
@@ -255,9 +255,9 @@ public class ReferenceCountedACLCacheTest {
         assertEquals(2, deserializedCache.size());
         assertEquals(aclId1, deserializedCache.convertAcls(acl1));
         assertEquals(aclId2, deserializedCache.convertAcls(acl2));
-        assertFalse(acl3.equals(deserializedCache.convertAcls(acl3)));
-        assertFalse(acl4.equals(deserializedCache.convertAcls(acl4)));
-        assertFalse(acl5.equals(deserializedCache.convertAcls(acl5)));
+        assertNotEquals(acl3, deserializedCache.convertAcls(acl3));
+        assertNotEquals(acl4, deserializedCache.convertAcls(acl4));
+        assertNotEquals(acl5, deserializedCache.convertAcls(acl5));
     }
 
     private void callAddUsageNTimes(ReferenceCountedACLCache deserializedCache, Long aclId, int num) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/util/AdHashTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/util/AdHashTest.java
@@ -19,7 +19,7 @@
 package org.apache.zookeeper.server.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -78,7 +78,7 @@ public class AdHashTest extends ZKTestCase {
         addListOfDigests(hashall, bucket3);
         addListOfDigests(hashall, bucket4);
         addListOfDigests(hashall, bucket5);
-        assertFalse(hashall.equals(hash21), "digest of different set not different");
+        assertNotEquals(hashall, hash21, "digest of different set not different");
         removeListOfDigests(hashall, bucket4);
         removeListOfDigests(hashall, bucket5);
         addListOfDigests(hash21, bucket3);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/CreateTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/CreateTest.java
@@ -19,7 +19,7 @@
 package org.apache.zookeeper.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import java.io.IOException;
@@ -65,7 +65,7 @@ public class CreateTest extends ClientBase {
         Stat stat = createWithStatVerifyResult("/foo");
         Stat childStat = createWithStatVerifyResult("/foo/child");
         // Don't expect to get the same stats for different creates.
-        assertFalse(stat.equals(childStat));
+        assertNotEquals(stat, childStat);
     }
 
     @Test

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/MultiOperationTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/MultiOperationTest.java
@@ -667,9 +667,9 @@ public class MultiOperationTest extends ClientBase {
 
     private void opEquals(OpResult expected, OpResult value, OpResult near) {
         assertEquals(value, value);
-        assertFalse(value.equals(new Object()));
-        assertFalse(value.equals(near));
-        assertFalse(value.equals(value instanceof CreateResult ? new ErrorResult(1) : new CreateResult("nope2")));
+        assertNotEquals(value, new Object());
+        assertNotEquals(value, near);
+        assertNotEquals(value, (value instanceof CreateResult ? new ErrorResult(1) : new CreateResult("nope2")));
         assertTrue(value.equals(expected));
     }
 


### PR DESCRIPTION
I am working on research that investigates test smell refactoring in which we identify alternative implementations of test cases, study how commonly used these refactorings are, and assess how acceptable they are in practice.

This smell occurs when inappropriate assertions are used, while there exist better alternatives. For example, in [CreateTest.java](https://github.com/apache/zookeeper/commit/e978917d7f72685dc684ddb26e5fa13eb2375b6d#diff-1af986ce48b5d4bb4b8e51374a70cc6e109a04c70d9f450be3df8f302010341c), I refactored `assertFalse(stat.equals(childStat));` with `assertNotEquals(stat, childStat);`.

I would like to get your feedback on this particular test smell and its refactoring. Thanks in advance for your input.