### PR TITLE
ZOOKEEPER-4739: Disable ClientSSLTest for s390x arch

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientSSLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ClientSSLTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import io.netty.handler.ssl.SslProvider;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -147,6 +148,8 @@ public class ClientSSLTest extends QuorumPeerTestBase {
     @ParameterizedTest(name = "sslProvider={0}, fipsEnabled={1}, hostnameVerification={2}")
     @MethodSource("positiveTestData")
     public void testClientServerSSL_positive(SslProvider sslProvider, String fipsEnabled, String hostnameVerification) throws Exception {
+        //Skipping this test for s390x arch as netty-tc-native is not supported
+        assumeFalse(System.getProperty("os.arch").contains("s390x"), " Skipping for s390x arch as netty-tcnative is not yet supported.");
         // Arrange
         System.setProperty(clientX509Util.getSslProviderProperty(), sslProvider.toString());
         System.setProperty(clientX509Util.getFipsModeProperty(), fipsEnabled);


### PR DESCRIPTION
As netty-tc-native is not supported for s390x arch, there were TC failures observed in ClientSSLTest, hence skipping this TC for s390x arch only.

