### PR TITLE
ZOOKEEPER-4706: Support 64-bit sequential nodes using zxid

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperProgrammers.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperProgrammers.md
@@ -215,6 +215,12 @@ counter used to store the next sequence number is a signed int
 overflow when incremented beyond 2147483647 (resulting in a
 name "<path>-2147483648").
 
+**Added in 3.10.0**: A signed long (8 bytes) sequential version is introduced
+to overcome this overflow and the undefined behavior after that point. We
+recommend you to start with this in newer ZooKeeper version, but we also do
+suggest you to reevaluate your usages in case you are either experiencing or
+worrying about above overflow.
+
 <a name="Container+Nodes"></a>
 
 #### Container Nodes

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/CreateMode.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/CreateMode.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper;
 
 import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,8 +36,29 @@ public enum CreateMode {
     /**
      * The znode will not be automatically deleted upon client's disconnect,
      * and its name will be appended with a monotonically increasing number.
+     *
+     * @apiNote This number is 32-bit and unique to the parent znode. It is
+     *          formatted with %010d, that is 10 digits with 0 (zero) padding,
+     *          to simplify sorting, i.e. "0000000001". The counter used to
+     *          store the sequence number is a signed int (4bytes) maintained
+     *          by the parent node, it will overflow when incremented beyond
+     *          2147483647 (resulting in a name "-2147483648").
+     * @implNote The behavior after overflow is undefined.
      */
     PERSISTENT_SEQUENTIAL(2, false, true, false, false),
+    /**
+     * The znode will not be automatically deleted upon client's disconnect,
+     * and its name will be appended with a monotonically increasing number.
+     *
+     * @apiNote This number is 64-bit and unique to the parent znode. It is
+     *          formatted with %019d, that is 19 digits with 0 (zero) padding
+     *          so to simplify sorting, i.e. "0000000000000000001".
+     * @apiNote It is not guaranteed to be consecutive.
+     * @implNote The number is {@link Stat#getCzxid()} for created node, so
+     *           multiple creations with same prefix path in {@link ZooKeeper#multi(Iterable)}
+     *           will fail with {@link KeeperException.NodeExistsException}.
+     */
+    PERSISTENT_SEQUENTIAL_LONG(7, false, true, false, false, true),
     /**
      * The znode will be deleted upon the client's disconnect.
      */
@@ -44,8 +66,29 @@ public enum CreateMode {
     /**
      * The znode will be deleted upon the client's disconnect, and its name
      * will be appended with a monotonically increasing number.
+     *
+     * @apiNote This number is 32-bit and unique to the parent znode. It is
+     *          formatted with %010d, that is 10 digits with 0 (zero) padding,
+     *          to simplify sorting, i.e. "0000000001". The counter used to
+     *          store the sequence number is a signed int (4bytes) maintained
+     *          by the parent node, it will overflow when incremented beyond
+     *          2147483647 (resulting in a name "-2147483648").
+     * @implNote The behavior after overflow is undefined.
      */
     EPHEMERAL_SEQUENTIAL(3, true, true, false, false),
+    /**
+     * The znode will be deleted upon the client's disconnect, and its name
+     * will be appended with a monotonically increasing number.
+     *
+     * @apiNote This number is 64-bit and unique to the parent znode. It is
+     *          formatted with %019d, that is 19 digits with 0 (zero) padding
+     *          so to simplify sorting, i.e. "0000000000000000001".
+     * @apiNote It is not guaranteed to be consecutive.
+     * @implNote The number is {@link Stat#getCzxid()} for created node, so
+     *           multiple creations with same prefix path in {@link ZooKeeper#multi(Iterable)}
+     *           will fail with {@link KeeperException.NodeExistsException}.
+     */
+    EPHEMERAL_SEQUENTIAL_LONG(8, true, true, false, false, true),
     /**
      * The znode will be a container node. Container
      * nodes are special purpose nodes useful for recipes such as leader, lock,
@@ -67,23 +110,52 @@ public enum CreateMode {
      * and its name will be appended with a monotonically increasing number.
      * However if the znode has not been modified within the given TTL, it
      * will be deleted once it has no children.
+     *
+     * @apiNote This number is 32-bit and unique to the parent znode. It is
+     *          formatted with %010d, that is 10 digits with 0 (zero) padding,
+     *          to simplify sorting, i.e. "0000000001". The counter used to
+     *          store the sequence number is a signed int (4bytes) maintained
+     *          by the parent node, it will overflow when incremented beyond
+     *          2147483647 (resulting in a name "-2147483648").
+     * @implNote The behavior after overflow is undefined.
      */
-    PERSISTENT_SEQUENTIAL_WITH_TTL(6, false, true, false, true);
+    PERSISTENT_SEQUENTIAL_WITH_TTL(6, false, true, false, true),
+    /**
+     * The znode will not be automatically deleted upon client's disconnect,
+     * and its name will be appended with a monotonically increasing number.
+     * However if the znode has not been modified within the given TTL, it
+     * will be deleted once it has no children.
+     *
+     * @apiNote This number is 64-bit and unique to the parent znode. It is
+     *          formatted with %019d, that is 19 digits with 0 (zero) padding
+     *          so to simplify sorting, i.e. "0000000000000000001".
+     * @apiNote It is not guaranteed to be consecutive.
+     * @implNote The number is {@link Stat#getCzxid()} for created node, so
+     *           multiple creations with same prefix path in {@link ZooKeeper#multi(Iterable)}
+     *           will fail with {@link KeeperException.NodeExistsException}.
+     */
+    PERSISTENT_SEQUENTIAL_LONG_WITH_TTL(9, false, true, false, true, true);
 
     private static final Logger LOG = LoggerFactory.getLogger(CreateMode.class);
 
-    private boolean ephemeral;
-    private boolean sequential;
+    private final boolean ephemeral;
+    private final boolean sequential;
     private final boolean isContainer;
-    private int flag;
-    private boolean isTTL;
+    private final int flag;
+    private final boolean isTTL;
+    private final boolean isLong;
 
-    CreateMode(int flag, boolean ephemeral, boolean sequential, boolean isContainer, boolean isTTL) {
+    CreateMode(int flag, boolean ephemeral, boolean sequential, boolean isContainer, boolean isTTL, boolean isLong) {
         this.flag = flag;
         this.ephemeral = ephemeral;
         this.sequential = sequential;
         this.isContainer = isContainer;
         this.isTTL = isTTL;
+        this.isLong = isLong;
+    }
+
+    CreateMode(int flag, boolean ephemeral, boolean sequential, boolean isContainer, boolean isTTL) {
+        this(flag, ephemeral, sequential, isContainer, isTTL, false);
     }
 
     public boolean isEphemeral() {
@@ -92,6 +164,10 @@ public enum CreateMode {
 
     public boolean isSequential() {
         return sequential;
+    }
+
+    public boolean isLongSequential() {
+        return sequential && isLong;
     }
 
     public boolean isContainer() {
@@ -132,6 +208,15 @@ public enum CreateMode {
         case 6:
             return CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL;
 
+        case 7:
+            return CreateMode.PERSISTENT_SEQUENTIAL_LONG;
+
+        case 8:
+            return CreateMode.EPHEMERAL_SEQUENTIAL_LONG;
+
+        case 9:
+            return CreateMode.PERSISTENT_SEQUENTIAL_LONG_WITH_TTL;
+
         default:
             String errMsg = "Received an invalid flag value: " + flag + " to convert to a CreateMode";
             LOG.error(errMsg);
@@ -164,6 +249,15 @@ public enum CreateMode {
 
         case 6:
             return CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL;
+
+        case 7:
+            return CreateMode.PERSISTENT_SEQUENTIAL_LONG;
+
+        case 8:
+            return CreateMode.EPHEMERAL_SEQUENTIAL_LONG;
+
+        case 9:
+            return CreateMode.PERSISTENT_SEQUENTIAL_LONG_WITH_TTL;
 
         default:
             return defaultMode;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -665,8 +665,11 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
         ChangeRecord parentRecord = getRecordForPath(parentPath);
 
         zks.checkACL(request.cnxn, parentRecord.acl, ZooDefs.Perms.CREATE, request.authInfo, path, listACL);
-        int parentCVersion = parentRecord.stat.getCversion();
-        if (createMode.isSequential()) {
+        if (createMode.isLongSequential()) {
+            long zxid = request.getHdr().getZxid();
+            path = path + String.format(Locale.ENGLISH, "%019d", zxid);
+        } else if (createMode.isSequential()) {
+            int parentCVersion = parentRecord.stat.getCversion();
             path = path + String.format(Locale.ENGLISH, "%010d", parentCVersion);
         }
         validatePath(path, request.sessionId);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/CreateModeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/CreateModeTest.java
@@ -37,31 +37,81 @@ public class CreateModeTest extends ZKTestCase {
         assertEquals(cm.toFlag(), 0);
         assertFalse(cm.isEphemeral());
         assertFalse(cm.isSequential());
+        assertFalse(cm.isLongSequential());
         assertFalse(cm.isContainer());
+        assertFalse(cm.isTTL());
 
         cm = CreateMode.EPHEMERAL;
         assertEquals(cm.toFlag(), 1);
         assertTrue(cm.isEphemeral());
         assertFalse(cm.isSequential());
+        assertFalse(cm.isLongSequential());
         assertFalse(cm.isContainer());
+        assertFalse(cm.isTTL());
 
         cm = CreateMode.PERSISTENT_SEQUENTIAL;
         assertEquals(cm.toFlag(), 2);
         assertFalse(cm.isEphemeral());
         assertTrue(cm.isSequential());
+        assertFalse(cm.isLongSequential());
         assertFalse(cm.isContainer());
+        assertFalse(cm.isTTL());
 
         cm = CreateMode.EPHEMERAL_SEQUENTIAL;
         assertEquals(cm.toFlag(), 3);
         assertTrue(cm.isEphemeral());
         assertTrue(cm.isSequential());
+        assertFalse(cm.isLongSequential());
         assertFalse(cm.isContainer());
+        assertFalse(cm.isTTL());
 
         cm = CreateMode.CONTAINER;
         assertEquals(cm.toFlag(), 4);
         assertFalse(cm.isEphemeral());
         assertFalse(cm.isSequential());
+        assertFalse(cm.isLongSequential());
         assertTrue(cm.isContainer());
+        assertFalse(cm.isTTL());
+
+        cm = CreateMode.PERSISTENT_WITH_TTL;
+        assertEquals(cm.toFlag(), 5);
+        assertFalse(cm.isEphemeral());
+        assertFalse(cm.isSequential());
+        assertFalse(cm.isLongSequential());
+        assertFalse(cm.isContainer());
+        assertTrue(cm.isTTL());
+
+        cm = CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL;
+        assertEquals(cm.toFlag(), 6);
+        assertFalse(cm.isEphemeral());
+        assertTrue(cm.isSequential());
+        assertFalse(cm.isLongSequential());
+        assertFalse(cm.isContainer());
+        assertTrue(cm.isTTL());
+
+        cm = CreateMode.PERSISTENT_SEQUENTIAL_LONG;
+        assertEquals(cm.toFlag(), 7);
+        assertFalse(cm.isEphemeral());
+        assertTrue(cm.isSequential());
+        assertTrue(cm.isLongSequential());
+        assertFalse(cm.isContainer());
+        assertFalse(cm.isTTL());
+
+        cm = CreateMode.EPHEMERAL_SEQUENTIAL_LONG;
+        assertEquals(cm.toFlag(), 8);
+        assertTrue(cm.isEphemeral());
+        assertTrue(cm.isSequential());
+        assertTrue(cm.isLongSequential());
+        assertFalse(cm.isContainer());
+        assertFalse(cm.isTTL());
+
+        cm = CreateMode.PERSISTENT_SEQUENTIAL_LONG_WITH_TTL;
+        assertEquals(cm.toFlag(), 9);
+        assertFalse(cm.isEphemeral());
+        assertTrue(cm.isSequential());
+        assertTrue(cm.isLongSequential());
+        assertFalse(cm.isContainer());
+        assertTrue(cm.isTTL());
     }
 
     @Test
@@ -89,6 +139,8 @@ public class CreateModeTest extends ZKTestCase {
         } catch (KeeperException ke) {
             assertEquals(Code.BADARGUMENTS, ke.code());
         }
+
+        assertEquals(CreateMode.PERSISTENT, CreateMode.fromFlag(-1, CreateMode.PERSISTENT));
     }
 
 }


### PR DESCRIPTION
It is somewhat well-known that ZooKeeper's sequential node number will overflow finally. It is ok for most usages, but it could also be annoying to handle this overflow in client side in certain cases. It would be really nice for ZooKeeper to support 64-bit sequential number to avoid overflow for long running and high frequency usages.

This pr introduces new `CreateMode`s to not break existing usages and uses `zxid` as the sequence number to not change on-disk wire format.

The consequence is that:
* Not consecutive. There could be hole in two adjacent sequential number.
* Fail to create through `multi` with same prefix path. But `multi` does not work well with same path modifications anyway. See [ZOOKEEPER-4695](https://issues.apache.org/jira/browse/ZOOKEEPER-4695).

## ZooKeeper docs about overflow
> When creating a znode you can also request that ZooKeeper append a monotonically increasing counter to the end of path. This counter is unique to the parent znode. The counter has a format of %010d -- that is 10 digits with 0 (zero) padding (the counter is formatted in this way to simplify sorting), i.e. "0000000001". See [Queue Recipe](https://zookeeper.apache.org/doc/r3.9.0/recipes.html#sc_recipes_Queues) for an example use of this feature. Note: the counter used to store the next sequence number is a signed int (4bytes) maintained by the parent node, the counter will overflow when incremented beyond 2147483647 (resulting in a name "-2147483648").

## BookKeeper "depends on" this overflow
BookKeeper's [LongZkLedgerIdGenerator](https://github.com/apache/bookkeeper/blob/1666d820a3d98ee6702e39c7cb0ebe51b1fdfd32/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongZkLedgerIdGenerator.java#L299) will fallback to (or rollover) its long version in case of ephemeral sequence overflow.

## Blockers
As I documented above, this pr does not work well with `multi`. I created ZOOKEEPER-4695 months ago in discussion of ZOOKEEPER-4655(#1950). If it is good for us to forbid multiple mutations of one key in `multi`, I think this pr is possibly promising as it breaks no implicit dependencies and requires no on-disk wire format change.