### PR TITLE
ZOOKEEPER-4703: Datadir and DatalogDir size are incorrect

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -655,7 +655,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         if (zkDb == null) {
             return 0L;
         }
-        File path = zkDb.snapLog.getDataDir();
+        File path = zkDb.snapLog.getSnapDir();
         return getDirSize(path);
     }
 
@@ -664,7 +664,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         if (zkDb == null) {
             return 0L;
         }
-        File path = zkDb.snapLog.getSnapDir();
+        File path = zkDb.snapLog.getDataDir();
         return getDirSize(path);
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -51,10 +51,10 @@ import org.slf4j.LoggerFactory;
  */
 public class FileTxnSnapLog {
 
-    //the directory containing the
+    //the directory containing
     //the transaction logs
     final File dataDir;
-    //the directory containing the
+    //the directory containing
     //the snapshot directory
     final File snapDir;
     TxnLog txnLog;


### PR DESCRIPTION
As in the class `FileTxnSnapLog`
```java
    //the directory containing
    //the transaction logs
    final File dataDir;
    //the directory containing
    //the snapshot directory
    final File snapDir;
```
The `DataDir` is the one for logs. Therefore, the file path for `DataDirSize` and `LogDirSize` should be swapped.