### PR TITLE
ZOOKEEPER-4391: Unable to use newer JVM memory settings as Xmx overrides

### DIFF
--- a/bin/zkEnv.sh
+++ b/bin/zkEnv.sh
@@ -136,8 +136,16 @@ export CLASSPATH
 
 # default heap for zookeeper server
 ZK_SERVER_HEAP="${ZK_SERVER_HEAP:-1000}"
-export SERVER_JVMFLAGS="-Xmx${ZK_SERVER_HEAP}m $SERVER_JVMFLAGS"
+if [[ ${ZK_SERVER_HEAP} =~ ^[0-9]+.*[0-9]+$ ]]; then
+  export SERVER_JVMFLAGS="-Xmx${ZK_SERVER_HEAP}m $SERVER_JVMFLAGS"
+else
+  export SERVER_JVMFLAGS="${ZK_SERVER_HEAP} $SERVER_JVMFLAGS"
+fi
 
 # default heap for zookeeper client
 ZK_CLIENT_HEAP="${ZK_CLIENT_HEAP:-256}"
-export CLIENT_JVMFLAGS="-Xmx${ZK_CLIENT_HEAP}m $CLIENT_JVMFLAGS"
+if [[ ${ZK_CLIENT_HEAP} =~ ^[0-9]+.*[0-9]+$ ]]; then
+  export CLIENT_JVMFLAGS="-Xmx${ZK_CLIENT_HEAP}m $CLIENT_JVMFLAGS"
+else
+  export CLIENT_JVMFLAGS="${ZK_CLIENT_HEAP} $CLIENT_JVMFLAGS"
+fi

--- a/bin/zkEnv.sh
+++ b/bin/zkEnv.sh
@@ -136,16 +136,16 @@ export CLASSPATH
 
 # default heap for zookeeper server
 ZK_SERVER_HEAP="${ZK_SERVER_HEAP:-1000}"
-if [[ ${ZK_SERVER_HEAP} =~ ^[0-9]+.*[0-9]+$ ]]; then
+if [[ $ZK_SERVER_HEAP =~ ^[1-9][0-9]*$ ]]; then
   export SERVER_JVMFLAGS="-Xmx${ZK_SERVER_HEAP}m $SERVER_JVMFLAGS"
 else
-  export SERVER_JVMFLAGS="${ZK_SERVER_HEAP} $SERVER_JVMFLAGS"
+  export SERVER_JVMFLAGS="$ZK_SERVER_HEAP $SERVER_JVMFLAGS"
 fi
 
 # default heap for zookeeper client
 ZK_CLIENT_HEAP="${ZK_CLIENT_HEAP:-256}"
-if [[ ${ZK_CLIENT_HEAP} =~ ^[0-9]+.*[0-9]+$ ]]; then
+if [[ $ZK_CLIENT_HEAP =~ ^[1-9][0-9]*$ ]]; then
   export CLIENT_JVMFLAGS="-Xmx${ZK_CLIENT_HEAP}m $CLIENT_JVMFLAGS"
 else
-  export CLIENT_JVMFLAGS="${ZK_CLIENT_HEAP} $CLIENT_JVMFLAGS"
+  export CLIENT_JVMFLAGS="$ZK_CLIENT_HEAP $CLIENT_JVMFLAGS"
 fi


### PR DESCRIPTION
allows a more flexible usage of the ZK_SERVER_HEAP/ZK_CLIENT_HEAP environment variable to specify heap related JVM settings.
It also keeps the old setting of a megabyte number for -Xmx 
ZK_SERVER_HEAP="1500" sets  "-Xmx1500m"
ZK_SERVER_HEAP="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75"
skips the -Xmx<number>m and adds the ZK_SERVER_HEAP as specified to the SERVER_JVM_FLAGS

same for the client settings.
