### PR TITLE
ZOOKEEPER-4742: Fix connection loss due to abnormal `getConfig` watcher path

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -859,6 +859,18 @@ public class ClientCnxn {
             if (serverPath.startsWith(chrootPath)) {
                 if (serverPath.length() == chrootPath.length()) {
                     return "/";
+                } else if (serverPath.charAt(chrootPath.length()) != '/') {
+                    // Corner-case:
+                    // * Event for config node "/zookeeper/config".
+                    // * Chroot "/zoo".
+                    //
+                    // We can't simply deliver "/zookeeper/config" in all cases, as
+                    // getData("/config") in chroot "/zookeeper" expect "/config".
+                    // But at least, we should not deliver abnormal path here.
+                    //
+                    // It might be better to move chroot out of here as ZOOKEEPER-838
+                    // suggested, but it is another story.
+                    return serverPath;
                 }
                 return serverPath.substring(chrootPath.length());
             } else if (serverPath.startsWith(ZooDefs.ZOOKEEPER_NODE_SUBTREE)) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ChrootTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ChrootTest.java
@@ -63,10 +63,7 @@ public class ChrootTest extends ClientBase {
 
     }
 
-    @Test
-    public void testChrootWithZooKeeperPathWatcher() throws Exception {
-        // "/zoo" is short enough and a prefix of "/zookeeper/config".
-        String chroot = "/zoo";
+    private void assertChrootWithZooKeeperPathWatcher(String chroot) throws Exception {
         ZooKeeper zk1 = createClient(hostPort + chroot);
         BlockingQueue<WatchedEvent> events = new LinkedBlockingQueue<>();
         byte[] config = zk1.getConfig(events::add, null);
@@ -82,6 +79,16 @@ public class ChrootTest extends ClientBase {
         assertEquals(Watcher.Event.KeeperState.SyncConnected, event.getState());
         assertEquals(Watcher.Event.EventType.NodeDataChanged, event.getType());
         assertEquals(ZooDefs.CONFIG_NODE, event.getPath());
+    }
+
+    @Test
+    public void testChrootWithZooKeeperPathWatcher() throws Exception {
+        assertChrootWithZooKeeperPathWatcher("/chroot");
+    }
+
+    @Test
+    public void testChrootWithOverlappingZooKeeperPathWatcher() throws Exception {
+        assertChrootWithZooKeeperPathWatcher("/zoo");
     }
 
     @Test

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ChrootTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ChrootTest.java
@@ -65,7 +65,9 @@ public class ChrootTest extends ClientBase {
 
     @Test
     public void testChrootWithZooKeeperPathWatcher() throws Exception {
-        ZooKeeper zk1 = createClient(hostPort + "/chroot");
+        // "/zoo" is short enough and a prefix of "/zookeeper/config".
+        String chroot = "/zoo";
+        ZooKeeper zk1 = createClient(hostPort + chroot);
         BlockingQueue<WatchedEvent> events = new LinkedBlockingQueue<>();
         byte[] config = zk1.getConfig(events::add, null);
 


### PR DESCRIPTION
Currently, `ClientCnxn` will strip path "/zookeeper/config" to "keeper/config" for chroot "/zoo". This causes exception and finally connection loss.

This is a leftover of ZOOKEEPER-4565.