### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 12.0.0.beta0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -560,7 +560,7 @@
     <hamcrest.version>2.2</hamcrest.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <netty.version>4.1.94.Final</netty.version>
-    <jetty.version>9.4.51.v20230217</jetty.version>
+    <jetty.version>12.0.0.beta0</jetty.version>
     <jackson.version>2.15.2</jackson.version>
     <jline.version>2.14.6</jline.version>
     <snappy.version>1.1.10.1</snappy.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 9.4.51.v20230217
- [CVE-2023-26049](https://www.oscs1024.com/hd/CVE-2023-26049)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 9.4.51.v20230217 to 12.0.0.beta0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS