### PR TITLE
ZOOKEEPER-4755: owaspSuppressions.xml: Temporarily suppress CVE-2023-4586

### DIFF
--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -38,6 +38,13 @@
       <!-- https://github.com/jeremylong/DependencyCheck/issues/1653
            False positive on Netty 4.x-->
       <cve>CVE-2018-12056</cve>
+      <!-- ZOOKEEPER-4755: looks like a real vulnerability in Netty,
+           but no report or patch has been published so far.  This has
+           to be monitored and will probably have to be remediated.
+
+           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4586
+      -->
+      <cve>CVE-2023-4586</cve>
    </suppress>
    <suppress>
       <!-- Seems like false positive - we are not using Prometheus


### PR DESCRIPTION
CVE-2023-4586 looks like a real vulnerability in Netty, but no report or patch has been published so far.  This has to be monitored and will probably have to be remediated.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4586

Relevant discussion and pointers:

https://github.com/jeremylong/DependencyCheck/issues/5912#issuecomment-1699387994