### PR TITLE
ZOOKEEPER-4757 JSON logging example for logback

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -30,6 +30,7 @@
   <property name="zookeeper.log.threshold" value="INFO" />
   <property name="zookeeper.log.maxfilesize" value="256MB" />
   <property name="zookeeper.log.maxbackupindex" value="20" />
+  <property name="zookeeper.log.service.nodename" value="${HOSTNAME}" />
 
   <!--
     console
@@ -37,7 +38,22 @@
   -->
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n</pattern>
+          <pattern>%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n</pattern>
+        </encoder>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>${zookeeper.console.threshold}</level>
+    </filter>
+  </appender>
+
+  <!--
+  console in JSON format
+  Add "console-json" to root logger if you want to use this
+-->
+  <appender name="CONSOLE-JSON" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="co.elastic.logging.logback.EcsEncoder">
+      <serviceName>${zookeeper.log.service.name:-zookeeper}</serviceName>
+      <serviceNodeName>${zookeeper.log.service.nodename}</serviceNodeName>
+      <includeMarkers>true</includeMarkers>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>${zookeeper.console.threshold}</level>
@@ -109,6 +125,6 @@
   </logger-->
 
   <root level="INFO">
-    <appender-ref ref="CONSOLE" />
+    <appender-ref ref="${zookeeper.log.appender:-CONSOLE}" />
   </root>
 </configuration>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -38,7 +38,7 @@
   -->
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-          <pattern>%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n</pattern>
+      <pattern>%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n</pattern>
         </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>${zookeeper.console.threshold}</level>

--- a/pom.xml
+++ b/pom.xml
@@ -552,6 +552,7 @@
     <!-- dependency versions -->
     <slf4j.version>1.7.30</slf4j.version>
     <logback-version>1.2.10</logback-version>
+    <logback-ecs-encoder.version>1.5.0</logback-ecs-encoder.version>
     <audience-annotations.version>0.12.0</audience-annotations.version>
     <jmockit.version>1.48</jmockit.version>
     <junit.version>5.6.2</junit.version>
@@ -665,6 +666,11 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logback-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>co.elastic.logging</groupId>
+        <artifactId>logback-ecs-encoder</artifactId>
+        <version>${logback-ecs-encoder.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jmockit</groupId>

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -519,6 +519,13 @@ For more information about SLF4J, see
 For more information about Logback, see
 [Logback website](http://logback.qos.ch/).
 
+#### Logging in JSON format
+
+Through its pluggable and flexible log framework, Zookeeper can easily be configured to log in JSON format.
+An example of JSON logging using the popular [ECS schema](https://doc.wikimedia.org/ecs/) is provided as a logback appender in `logback.xml`.
+You can test it by enabling the `CONSOLE-JSON` appender, e.g. by starting Zookeeper with
+the system property: `-Dzookeeper.log.appender=CONSOLE-JSON`.
+
 <a name="sc_troubleshooting"></a>
 
 ### Troubleshooting

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -88,6 +88,10 @@
       <artifactId>logback-classic</artifactId>
     </dependency>
     <dependency>
+      <groupId>co.elastic.logging</groupId>
+      <artifactId>logback-ecs-encoder</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
This is take2 on providing JSON logging after feedback in #2076 

It adds a library `logback-ecs-encoder` for encoding log lines as ECS format JSON, one object per line, as well as an appender snippet in `logback.xml` to demonstrate its use.

This PR also makes the default appender-ref configurable through system property for conveniece, meaning you can enable JSON logging through this simple command:

```bash
export SERVER_JVMFLAGS=-Dzookeeper.log.appender=CONSOLE-JSON
bin/zkServer.sh start-foreground
```