### PR TITLE
ZOOKEEPER-4710 Fix ZkUtil deleteInBatch() by releasing semaphore after set flag (#2020)

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZKUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZKUtil.java
@@ -109,10 +109,10 @@ public class ZKUtil {
         List<Op> ops = new ArrayList<>();
         BatchedDeleteCbContext context = new BatchedDeleteCbContext(rateLimit);
         MultiCallback cb = (rc, path, ctx, opResults) -> {
-            ((BatchedDeleteCbContext) ctx).sem.release();
             if (rc != Code.OK.intValue()) {
                 ((BatchedDeleteCbContext) ctx).success.set(false);
             }
+            ((BatchedDeleteCbContext) ctx).sem.release();
         };
 
         // Delete the leaves first and eventually get rid of the root


### PR DESCRIPTION
This PR aims to pick #2020 into the `branch-3.8`.