### PR TITLE
ZOOKEEPER-4768: Fix flaky test org.apache.zookeeper.metrics.prometheus.ExportJvmInfoTest#exportInfo

### DIFF
--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/ExportJvmInfoTest.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/ExportJvmInfoTest.java
@@ -19,7 +19,6 @@
 package org.apache.zookeeper.metrics.prometheus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import io.prometheus.client.CollectorRegistry;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +26,7 @@ import org.junit.jupiter.api.Test;
  * Tests about Prometheus Metrics Provider. Please note that we are not testing
  * Prometheus but our integration.
  */
-public class ExportJvmInfoTest {
+public class ExportJvmInfoTest extends PrometheusMetricsTestBase {
 
     @Test
     public void exportInfo() throws Exception {
@@ -40,7 +39,6 @@ public class ExportJvmInfoTest {
     }
 
     private void runTest(boolean exportJvmInfo) throws Exception {
-        CollectorRegistry.defaultRegistry.clear();
         PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
         try {
             Properties configuration = new Properties();

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderConfigTest.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderConfigTest.java
@@ -18,19 +18,17 @@
 
 package org.apache.zookeeper.metrics.prometheus;
 
-import io.prometheus.client.CollectorRegistry;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Properties;
 import org.apache.zookeeper.metrics.MetricsProviderLifeCycleException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
-public class PrometheusMetricsProviderConfigTest {
+public class PrometheusMetricsProviderConfigTest extends PrometheusMetricsTestBase {
 
     @Test
     public void testInvalidPort() {
-        Assert.assertThrows(MetricsProviderLifeCycleException.class, () -> {
-            CollectorRegistry.defaultRegistry.clear();
+        assertThrows(MetricsProviderLifeCycleException.class, () -> {
             PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
             Properties configuration = new Properties();
             configuration.setProperty("httpPort", "65536");
@@ -42,8 +40,7 @@ public class PrometheusMetricsProviderConfigTest {
 
     @Test
     public void testInvalidAddr() {
-        Assert.assertThrows(MetricsProviderLifeCycleException.class, () -> {
-            CollectorRegistry.defaultRegistry.clear();
+        assertThrows(MetricsProviderLifeCycleException.class, () -> {
             PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
             Properties configuration = new Properties();
             configuration.setProperty("httpHost", "master");
@@ -54,7 +51,6 @@ public class PrometheusMetricsProviderConfigTest {
 
     @Test
     public void testValidConfig() throws MetricsProviderLifeCycleException {
-        CollectorRegistry.defaultRegistry.clear();
         PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
         Properties configuration = new Properties();
         configuration.setProperty("httpHost", "0.0.0.0");

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderTest.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import io.prometheus.client.CollectorRegistry;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -56,7 +55,6 @@ import org.apache.zookeeper.server.util.QuotaMetricsUtils;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,14 +63,13 @@ import org.junit.jupiter.api.Test;
  * Tests about Prometheus Metrics Provider. Please note that we are not testing
  * Prometheus but only our integration.
  */
-public class PrometheusMetricsProviderTest {
+public class PrometheusMetricsProviderTest extends PrometheusMetricsTestBase {
 
     private static final String URL_FORMAT = "http://localhost:%d/metrics";
     private PrometheusMetricsProvider provider;
 
     @BeforeEach
     public void setup() throws Exception {
-        CollectorRegistry.defaultRegistry.clear();
         provider = new PrometheusMetricsProvider();
         Properties configuration = new Properties();
         configuration.setProperty("numWorkerThreads", "0"); // sync behavior for test
@@ -88,7 +85,6 @@ public class PrometheusMetricsProviderTest {
         if (provider != null) {
             provider.stop();
         }
-        CollectorRegistry.defaultRegistry.clear();
     }
 
     @Test
@@ -416,7 +412,7 @@ public class PrometheusMetricsProviderTest {
         HttpURLConnection conn = (HttpURLConnection) new URL(metricsUrl).openConnection();
         conn.setRequestMethod("TRACE");
         conn.connect();
-        Assert.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, conn.getResponseCode());
+        assertEquals(HttpURLConnection.HTTP_FORBIDDEN, conn.getResponseCode());
     }
 
     @Test

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsTestBase.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsTestBase.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.metrics.prometheus;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.hotspot.DefaultExports;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * The base test for prometheus metrics unit tests.
+ */
+public abstract class PrometheusMetricsTestBase {
+
+    @BeforeEach
+    void setUp() throws Exception {
+        CollectorRegistry.defaultRegistry.clear();
+        resetDefaultExportsInitializedFlag();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        CollectorRegistry.defaultRegistry.clear();
+        resetDefaultExportsInitializedFlag();
+    }
+
+    protected void resetDefaultExportsInitializedFlag() throws Exception {
+        Field initializedField = DefaultExports.class.getDeclaredField("initialized");
+        initializedField.setAccessible(true);
+        initializedField.set(null, false);
+    }
+}


### PR DESCRIPTION
If the `io.prometheus.client.hotspot.DefaultExports#initialize` method has been executed by other test cases before running the `org.apache.zookeeper.metrics.prometheus.ExportJvmInfoTest#exportInfo` test case, then this test case will fail.