### PR TITLE
ZOOKEEPER-4753: zookeeper-server: Improvement: Explicit handling of D… …IGEST-MD5 vs GSSAPI in quorum auth for branch 3.6

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumKerberosAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumKerberosAuthTest.java
@@ -56,7 +56,7 @@ public class QuorumKerberosAuthTest extends KerberosSecurityTestcase {
                                      + "       debug=false\n"
                                      + "       refreshKrb5Config=true\n"
                                      + "       principal=\""
-                                     + KerberosTestUtils.getServerPrincipal()
+                                     + KerberosTestUtils.replaceHostPattern(KerberosTestUtils.getHostServerPrincipal())
                                      + "\";\n"
                                      + "};\n"
                                      + "QuorumLearner {\n"
@@ -70,7 +70,7 @@ public class QuorumKerberosAuthTest extends KerberosSecurityTestcase {
                                      + "       debug=false\n"
                                      + "       refreshKrb5Config=true\n"
                                      + "       principal=\""
-                                     + KerberosTestUtils.getLearnerPrincipal()
+                                     + KerberosTestUtils.replaceHostPattern(KerberosTestUtils.getHostLearnerPrincipal())
                                      + "\";\n"
                                      + "};\n";
         setupJaasConfig(jaasEntries);
@@ -80,10 +80,10 @@ public class QuorumKerberosAuthTest extends KerberosSecurityTestcase {
     public static void setUp() throws Exception {
         // create keytab
         keytabFile = new File(KerberosTestUtils.getKeytabFile());
-        String learnerPrincipal = KerberosTestUtils.getLearnerPrincipal();
-        String serverPrincipal = KerberosTestUtils.getServerPrincipal();
-        learnerPrincipal = learnerPrincipal.substring(0, learnerPrincipal.lastIndexOf("@"));
-        serverPrincipal = serverPrincipal.substring(0, serverPrincipal.lastIndexOf("@"));
+        String learnerPrincipal = KerberosTestUtils.getHostLearnerPrincipal();
+        String serverPrincipal = KerberosTestUtils.getHostServerPrincipal();
+        learnerPrincipal = KerberosTestUtils.replaceHostPattern(learnerPrincipal.substring(0, learnerPrincipal.lastIndexOf("@")));
+        serverPrincipal = KerberosTestUtils.replaceHostPattern(serverPrincipal.substring(0, serverPrincipal.lastIndexOf("@")));
         getKdc().createPrincipal(keytabFile, learnerPrincipal, serverPrincipal);
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumKerberosHostBasedAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumKerberosHostBasedAuthTest.java
@@ -43,15 +43,17 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
     private static String hostServerPrincipal = KerberosTestUtils.getHostServerPrincipal();
     private static String hostLearnerPrincipal = KerberosTestUtils.getHostLearnerPrincipal();
     private static String hostNamedLearnerPrincipal = KerberosTestUtils.getHostNamedLearnerPrincipal("myHost");
+    private static String hostlessLearnerPrincipal = KerberosTestUtils.getLearnerPrincipal();
 
     static {
-        setupJaasConfigEntries(hostServerPrincipal, hostLearnerPrincipal, hostNamedLearnerPrincipal);
+        setupJaasConfigEntries(hostServerPrincipal, hostLearnerPrincipal, hostNamedLearnerPrincipal, hostlessLearnerPrincipal);
     }
 
     private static void setupJaasConfigEntries(
         String hostServerPrincipal,
         String hostLearnerPrincipal,
-        String hostNamedLearnerPrincipal) {
+        String hostNamedLearnerPrincipal,
+        String hostlessLearnerPrincipal) {
         String keytabFilePath = FilenameUtils.normalize(KerberosTestUtils.getKeytabFile(), true);
 
         // note: we use "refreshKrb5Config=true" to refresh the kerberos config in the JVM,
@@ -92,6 +94,18 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
                              + "       refreshKrb5Config=true\n"
                              + "       principal=\"" + hostNamedLearnerPrincipal
                              + "\";\n"
+                             + "};\n"
+                             + "QuorumLearnerMissingHost {\n"
+                             + "       com.sun.security.auth.module.Krb5LoginModule required\n"
+                             + "       useKeyTab=true\n"
+                             + "       keyTab=\"" + keytabFilePath
+                             + "\"\n"
+                             + "       storeKey=true\n"
+                             + "       useTicketCache=false\n"
+                             + "       debug=false\n"
+                             + "       refreshKrb5Config=true\n"
+                             + "       principal=\"" + hostlessLearnerPrincipal
+                             + "\";\n"
                              + "};\n";
         setupJaasConfig(jaasEntries);
     }
@@ -109,7 +123,11 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
 
         // learner with ipaddress in principal
         String learnerPrincipal2 = hostNamedLearnerPrincipal.substring(0, hostNamedLearnerPrincipal.lastIndexOf("@"));
-        getKdc().createPrincipal(keytabFile, learnerPrincipal, learnerPrincipal2, serverPrincipal);
+
+        // learner without host in principal
+        String learnerPrincipal3 = hostlessLearnerPrincipal.substring(0, hostlessLearnerPrincipal.lastIndexOf("@"));
+
+        getKdc().createPrincipal(keytabFile, learnerPrincipal, learnerPrincipal2, learnerPrincipal3, serverPrincipal);
     }
 
     @After
@@ -211,6 +229,54 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
         try {
             watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT / 3);
             fail("Must throw exception as the myHost is not an authorized one!");
+        } catch (TimeoutException e) {
+            // expected
+        } finally {
+            zk.close();
+            badServer.shutdown();
+            badServer.deleteBaseDir();
+        }
+    }
+
+    /**
+     * Test to verify that the bad server connection to the quorum should be rejected.
+     */
+    @Test
+    @Timeout(value = 120)
+    public void testConnectHostlessPrincipalBadServer() throws Exception {
+        String serverPrincipal = hostServerPrincipal.substring(0, hostServerPrincipal.lastIndexOf("@"));
+        Map<String, String> authConfigs = new HashMap<>();
+        authConfigs.put(QuorumAuth.QUORUM_SASL_AUTH_ENABLED, "true");
+        authConfigs.put(QuorumAuth.QUORUM_SERVER_SASL_AUTH_REQUIRED, "true");
+        authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_AUTH_REQUIRED, "true");
+        authConfigs.put(QuorumAuth.QUORUM_KERBEROS_SERVICE_PRINCIPAL, serverPrincipal);
+        String connectStr = startQuorum(3, authConfigs, 3);
+        CountdownWatcher watcher = new CountdownWatcher();
+        ZooKeeper zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
+        watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
+        for (int i = 0; i < 10; i++) {
+            zk.create("/" + i, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        }
+        zk.close();
+
+        String quorumCfgSection = mt.get(0).getQuorumCfgSection();
+        StringBuilder sb = new StringBuilder();
+        sb.append(quorumCfgSection);
+
+        int myid = mt.size() + 1;
+        final int clientPort = PortAssignment.unique();
+        String server = String.format("server.%d=localhost:%d:%d:participant", myid, PortAssignment.unique(), PortAssignment.unique());
+        sb.append(server + "\n");
+        quorumCfgSection = sb.toString();
+        authConfigs.put(QuorumAuth.QUORUM_LEARNER_SASL_LOGIN_CONTEXT, "QuorumLearnerMissingHost");
+        MainThread badServer = new MainThread(myid, clientPort, quorumCfgSection, authConfigs);
+        badServer.start();
+        watcher = new CountdownWatcher();
+        connectStr = "127.0.0.1:" + clientPort;
+        zk = new ZooKeeper(connectStr, ClientBase.CONNECTION_TIMEOUT, watcher);
+        try {
+            watcher.waitForConnected(ClientBase.CONNECTION_TIMEOUT / 3);
+            fail("Must throw exception as the principal does not include an authorized host!");
         } catch (TimeoutException e) {
             // expected
         } finally {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumKerberosHostBasedAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/auth/QuorumKerberosHostBasedAuthTest.java
@@ -242,7 +242,6 @@ public class QuorumKerberosHostBasedAuthTest extends KerberosSecurityTestcase {
      * Test to verify that the bad server connection to the quorum should be rejected.
      */
     @Test
-    @Timeout(value = 120)
     public void testConnectHostlessPrincipalBadServer() throws Exception {
         String serverPrincipal = hostServerPrincipal.substring(0, hostServerPrincipal.lastIndexOf("@"));
         Map<String, String> authConfigs = new HashMap<>();


### PR DESCRIPTION
[ZOOKEEPER-4753](https://issues.apache.org/jira/browse/ZOOKEEPER-4753): [zookeeper-server](https://issues.apache.org/jira/browse/ZOOKEEPER-server): Improvement: Explicit handling of D…
…IGEST-MD5 vs GSSAPI in quorum auth

Before this, the SASL-based quorum authorizer did not explicitly
distinguish between the DIGEST-MD5 and GSSAPI mechanisms: it was
simply relying on NameCallback and PasswordCallback for authentication
with the former and examining Kerberos principals in AuthorizeCallback
for the latter.

It turns out that some SASL/DIGEST-MD5 configurations cause
authentication and authorization IDs not to match the expected format,
and the DIGEST-MD5-based portions of the quorum test suite to fail
with obscure errors.  (They can be traced to failures to join the
quorum, but only by looking into detailed logs.)

This patch uses the login module name to determine whether DIGEST-MD5
or GSSAPI is used, and relaxes the authentication ID check for the
former.  As a cleanup, it keeps the password-based credential map
empty when Kerberos principals are expected.  It finally adapts a
test, and adds a new one, ensuring "weirdly-shaped" credentials only
cause authentication failures in the GSSAPI case.