### PR TITLE
ZOOKEEPER-4770: zkSnapshotRecursiveSummaryToolkit.sh Error: Could not find or load main class

### DIFF
--- a/bin/zkSnapshotRecursiveSummaryToolkit.sh
+++ b/bin/zkSnapshotRecursiveSummaryToolkit.sh
@@ -33,7 +33,7 @@ else
   . "$ZOOBINDIR"/zkEnv.sh
 fi
 
-"$JAVA" -cp "$CLASSPATH" "$JVMFLAGS" \
+"$JAVA" -cp "$CLASSPATH" $JVMFLAGS \
      org.apache.zookeeper.server.SnapshotRecursiveSummary "$@"
 
 


### PR DESCRIPTION
When I execute the following code to analyze the snapshot file:
```
./bin/zkSnapshotRecursiveSummaryToolkit.sh /data/version-2/snapshot.c00000009 / 2 
```

Getting this error:
```
Error: Could not find or load main class 
```

I checked the source code and found that $JVMFLAGS was surrounded by quotation marks. This problem occurs when the variable $JVMFLAGS is empty.
```
"$JAVA" -cp "$CLASSPATH" "$JVMFLAGS" \
     org.apache.zookeeper.server.SnapshotRecursiveSummary "$@" 
```

The correct code should be like this
```
"$JAVA" -cp "$CLASSPATH" $JVMFLAGS \
     org.apache.zookeeper.server.SnapshotRecursiveSummary "$@"
```
