### PR TITLE
ZOOKEEPER-4778: Patch CVE-2023-6378, CVE-2023-44487, CVE-2023-36478

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -551,7 +551,7 @@
 
     <!-- dependency versions -->
     <slf4j.version>1.7.30</slf4j.version>
-    <logback-version>1.2.10</logback-version>
+    <logback-version>1.2.13</logback-version>
     <audience-annotations.version>0.12.0</audience-annotations.version>
     <jmockit.version>1.48</jmockit.version>
     <junit.version>5.6.2</junit.version>
@@ -559,8 +559,8 @@
     <mockito.version>4.9.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <commons-cli.version>1.5.0</commons-cli.version>
-    <netty.version>4.1.94.Final</netty.version>
-    <jetty.version>9.4.52.v20230823</jetty.version>
+    <netty.version>4.1.100.Final</netty.version>
+    <jetty.version>9.4.53.v20231009</jetty.version>
     <jackson.version>2.15.2</jackson.version>
     <jline.version>2.14.6</jline.version>
     <snappy.version>1.1.10.5</snappy.version>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/ZOOKEEPER-4778.

We are using versions of dependencies that currently have high severity vulnerabilities that should be taken care of. The first one appeared from io.netty_netty-codec:4.1.94.Final which has had a fix 58 days ago - https://nvd.nist.gov/vuln/detail/CVE-2023-44487. I have simply updated it to the recommended version in Prisma Cloud which is 4.1.100. 

The second vulnerability is in org.eclipse.jetty_jetty-io:9.4.52.v20230823 which has fix since 49 days ago in versions 11.0.16, 10.0.16, 9.4.53 - https://nvd.nist.gov/vuln/detail/CVE-2023-36478. I simply just patched it instead of using a new major version.

The final vulnerability is in two logback dependencies we use ch.qos.logback_logback-core and ch.qos.logback_logback-classic versions 1.2.10. Fixes were found 16 days ago in versions 1.2.13, 1.3.12, and 1.4.12 - https://nvd.nist.gov/vuln/detail/CVE-2023-6378. I simply patched it instead of updating minor versions.