### PR TITLE
ZOOKEEPER-4779: Fix ZKUtilTest which fails to run on WSL

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Shell.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Shell.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.server.ExitCode;
@@ -122,8 +121,8 @@ public abstract class Shell {
             return false;
         }
         final String output = FileUtils.readFileToString(f, StandardCharsets.UTF_8.name());
-        return (output != null) &&
-                System.getProperty("os.name").startsWith("Linux") && output.toLowerCase().contains("microsoft");
+        return (output != null)
+                && System.getProperty("os.name").startsWith("Linux") && output.toLowerCase().contains("microsoft");
     }
 
     /** Set to true on Windows platforms */

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Shell.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Shell.java
@@ -33,10 +33,13 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.server.ExitCode;
 import org.slf4j.Logger;
@@ -103,6 +106,24 @@ public abstract class Shell {
         }
 
         return new String[]{ULIMIT_COMMAND, "-v", String.valueOf(memoryLimit)};
+    }
+
+    /**
+     * Check if running in Windows Subsystem for Linux
+     * @return
+     * @throws IOException
+     */
+    public static boolean isWsl() throws IOException {
+        if (WINDOWS) {
+            return false;
+        }
+        final File f = new File("/proc/version");
+        if (!f.exists()) {
+            return false;
+        }
+        final String output = FileUtils.readFileToString(f, StandardCharsets.UTF_8.name());
+        return (output != null) &&
+                System.getProperty("os.name").startsWith("Linux") && output.toLowerCase().contains("microsoft");
     }
 
     /** Set to true on Windows platforms */

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ZKUtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ZKUtilTest.java
@@ -80,8 +80,9 @@ public class ZKUtilTest extends ClientBase {
 
     @Test
     public void testUnreadableFileInput() throws Exception {
-        //skip this test on Windows, coverage on Linux
-        assumeTrue(!org.apache.zookeeper.Shell.WINDOWS);
+        //skip this test on Windows and WSL, coverage on Linux
+        assumeTrue("Skipping this test on Windows and WSL",
+                !(org.apache.zookeeper.Shell.WINDOWS || org.apache.zookeeper.Shell.isWsl()));
         File file = File.createTempFile("test", ".junit", testData);
         file.setReadable(false, false);
         file.deleteOnExit();


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/ZOOKEEPER-4779
The test testUnreadableFileInput in ZKUtilTest runs fine on linux, but fails to run when running on Windows Subsystem for Linux. A simple fix to avoid failures when developing locally. The test is already skipped on windows.