### PR TITLE
fix violation of Sonarqube rule java:S2111

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/metric/AvgMinMaxCounter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/metric/AvgMinMaxCounter.java
@@ -69,7 +69,7 @@ public class AvgMinMaxCounter extends Metric implements Summary {
         long currentTotal = total.get();
         if (currentCount > 0) {
             double avgLatency = currentTotal / (double) currentCount;
-            BigDecimal bg = new BigDecimal(avgLatency);
+            BigDecimal bg = BigDecimal.valueOf(avgLatency);
             return bg.setScale(4, RoundingMode.HALF_UP).doubleValue();
         }
         return 0;


### PR DESCRIPTION
Hello,

This PR fixes 1 violation of Sonarqube Rule java:S2111 : ['"BigDecimal(double)" should not be used'](https://rules.sonarsource.com/java/RSPEC-2111).
For more details, please see [CERT, NUM10-J.](https://wiki.sei.cmu.edu/confluence/x/kzdGBQ)

The patch was automatically generated using the ViolationFixer tool.