### PR TITLE
ZOOKEEPER-2623: [ADDENDUM] Forbid OpCode.check outside OpCode.multi

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
@@ -50,7 +50,6 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.proto.AddWatchRequest;
-import org.apache.zookeeper.proto.CheckVersionRequest;
 import org.apache.zookeeper.proto.CheckWatchesRequest;
 import org.apache.zookeeper.proto.Create2Response;
 import org.apache.zookeeper.proto.CreateResponse;
@@ -355,10 +354,8 @@ public class FinalRequestProcessor implements RequestProcessor {
             }
             case OpCode.check: {
                 lastOp = "CHEC";
-                CheckVersionRequest checkVersionRequest = request.readRequestRecord(CheckVersionRequest::new);
-                path = checkVersionRequest.getPath();
-                handleCheckVersionRequest(checkVersionRequest, cnxn, request.authInfo);
-                requestPathMetricsCollector.registerRequest(request.type, path);
+                rsp = new SetDataResponse(rc.stat);
+                err = Code.get(rc.err);
                 break;
             }
             case OpCode.exists: {
@@ -653,19 +650,6 @@ public class FinalRequestProcessor implements RequestProcessor {
         Stat stat = new Stat();
         byte[] b = zks.getZKDatabase().getData(path, stat, getDataRequest.getWatch() ? cnxn : null);
         return new GetDataResponse(b, stat);
-    }
-
-    private void handleCheckVersionRequest(CheckVersionRequest request, ServerCnxn cnxn, List<Id> authInfo) throws KeeperException {
-        String path = request.getPath();
-        DataNode n = zks.getZKDatabase().getNode(path);
-        if (n == null) {
-            throw new KeeperException.NoNodeException();
-        }
-        zks.checkACL(cnxn, zks.getZKDatabase().aclForNode(n), ZooDefs.Perms.READ, authInfo, path, null);
-        int version = request.getVersion();
-        if (version != -1 && version != n.stat.getVersion()) {
-            throw new KeeperException.BadVersionException(path);
-        }
     }
 
     private boolean closeSession(ServerCnxnFactory serverCnxnFactory, long sessionId) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -806,6 +806,10 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                 SetACLRequest setAclRequest = request.readRequestRecord(SetACLRequest::new);
                 pRequest2Txn(request.type, zks.getNextZxid(), request, setAclRequest);
                 break;
+            case OpCode.check:
+                CheckVersionRequest checkRequest = request.readRequestRecord(CheckVersionRequest::new);
+                pRequest2Txn(request.type, zks.getNextZxid(), request, checkRequest);
+                break;
             case OpCode.multi:
                 MultiOperationRecord multiRequest;
                 try {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
@@ -295,8 +295,8 @@ public class Request {
         // make sure this is always synchronized with Zoodefs!!
         switch (type) {
         case OpCode.notification:
-            return false;
         case OpCode.check:
+            return false;
         case OpCode.closeSession:
         case OpCode.create:
         case OpCode.create2:
@@ -352,6 +352,7 @@ public class Request {
         case OpCode.deleteContainer:
         case OpCode.setACL:
         case OpCode.setData:
+        case OpCode.check:
         case OpCode.multi:
         case OpCode.reconfig:
             return true;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/CommitProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/CommitProcessor.java
@@ -181,6 +181,7 @@ public class CommitProcessor extends ZooKeeperCriticalThread implements RequestP
         case OpCode.reconfig:
         case OpCode.multi:
         case OpCode.setACL:
+        case OpCode.check:
             return true;
         case OpCode.sync:
             return matchSyncs;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerRequestProcessor.java
@@ -108,6 +108,7 @@ public class FollowerRequestProcessor extends ZooKeeperCriticalThread implements
                 case OpCode.reconfig:
                 case OpCode.setACL:
                 case OpCode.multi:
+                case OpCode.check:
                     zks.getFollower().request(request);
                     break;
                 case OpCode.createSession:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverRequestProcessor.java
@@ -109,6 +109,7 @@ public class ObserverRequestProcessor extends ZooKeeperCriticalThread implements
                 case OpCode.reconfig:
                 case OpCode.setACL:
                 case OpCode.multi:
+                case OpCode.check:
                     zks.getObserver().request(request);
                     break;
                 case OpCode.createSession:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ReadOnlyRequestProcessor.java
@@ -85,6 +85,7 @@ public class ReadOnlyRequestProcessor extends ZooKeeperCriticalThread implements
                 case OpCode.reconfig:
                 case OpCode.setACL:
                 case OpCode.multi:
+                case OpCode.check:
                     sendErrorResponse(request);
                     continue;
                 case OpCode.closeSession:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/RequestPathMetricsCollector.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/RequestPathMetricsCollector.java
@@ -147,6 +147,7 @@ public class RequestPathMetricsCollector {
         case ZooDefs.OpCode.reconfig:
         case ZooDefs.OpCode.setACL:
         case ZooDefs.OpCode.multi:
+        case ZooDefs.OpCode.check:
             return true;
         }
         return false;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/CheckTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/CheckTest.java
@@ -77,14 +77,7 @@ public class CheckTest extends ClientBase {
     private void testOperations(TestableZooKeeper zk) throws Exception {
         Stat stat = new Stat();
         zk.getData("/", false, stat);
-        checkVersion(zk, "/", -1);
-        checkVersion(zk, "/", stat.getVersion());
-        assertThrows(KeeperException.BadVersionException.class, () -> {
-            checkVersion(zk, "/", stat.getVersion() + 1);
-        });
-        assertThrows(KeeperException.NoNodeException.class, () -> {
-            checkVersion(zk, "/no-node", Integer.MAX_VALUE);
-        });
+        assertThrows(KeeperException.UnimplementedException.class, () -> checkVersion(zk, "/", -1));
     }
 
     @Test
@@ -96,7 +89,7 @@ public class CheckTest extends ClientBase {
     public void testStandaloneDatabaseReloadAfterCheck() throws Exception {
         try {
             testOperations(createClient());
-        } catch (Exception ignored) {
+        } catch (Throwable ignored) {
             // Ignore to test database reload after check
         }
         stopServer();
@@ -131,7 +124,7 @@ public class CheckTest extends ClientBase {
 
             try {
                 testOperations(qb.createClient(new CountdownWatcher(), QuorumPeer.ServerState.LEADING));
-            } catch (Exception ignored) {
+            } catch (Throwable ignored) {
                 // Ignore to test database reload after check
             }
             qb.shutdown(leader);


### PR DESCRIPTION
Individual `OpCode.check` will get `UnimplementedException`.


JIRA: ZOOKEEPER-2623
Discussion thread: https://lists.apache.org/thread/vl816jfrklvqz29coz5qnwpom9q41pcg

This pr reworks/reverts #1988, which return an empty response for individual `OpCode.check`, for the following reasons:
* The individual `OpCode.check` is covered by `OpCode.exists`.
* In certain situation, we may want to differentiate the two(individual or not), say statistics. This could cause maintenance burden for us.
* Exposing opcode without explicit API is probably not a good.

Open this pr for easy evaluation. I will reply the discussion thread for reference.

I plan to open a draft backport on branch-3.9 to ease code review if we are willing to go this direction.