### PR TITLE
Fix typos in docs & comments

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -2873,7 +2873,7 @@ static void finalize_session_establishment(zhandle_t *zh) {
     PROCESS_SESSION_EVENT(zh, zh->state);
 
     if (has_sasl_client(zh)) {
-        /* some packets might have been delayed during SASL negotiaton. */
+        /* some packets might have been delayed during SASL negotiation. */
         adaptor_send_queue(zh, 0);
     }
 }
@@ -3830,7 +3830,7 @@ int zookeeper_close(zhandle_t *zh)
          * completions from calling zookeeper_close before we have
          * completed the adaptor_finish call below. */
 
-    /* Signal any syncronous completions before joining the threads */
+    /* Signal any synchronous completions before joining the threads */
         enter_critical(zh);
         free_completions(zh,1,ZCLOSING);
         leave_critical(zh);

--- a/zookeeper-contrib/zookeeper-contrib-loggraph/README.md
+++ b/zookeeper-contrib/zookeeper-contrib-loggraph/README.md
@@ -44,7 +44,7 @@ To filter by time simply move the slider to the desired start time. The time win
 Content filtering uses a adhoc filtering language, using prefix notation. The language looks somewhat similar to lisp. A statement in the language takes the form (op arg arg ....). A statement resolves to a boolean value. Statements can be nested. 
 
 ### 4.1 - Filter arguments
-An argument can be a number, a string or a symbol. A number is any argument which starts with -, + or 0 to 9. If the number starts with 0x it is interpretted as hexidecimal. Otherwise it is interpretted as decimal. If the argument begins with a double-quote, (") it is interpretted as a string. Anything else is interpretted as a symbol.
+An argument can be a number, a string or a symbol. A number is any argument which starts with -, + or 0 to 9. If the number starts with 0x it is interpretted as hexadecimal. Otherwise it is interpretted as decimal. If the argument begins with a double-quote, (") it is interpretted as a string. Anything else is interpretted as a symbol.
 
 ### 4.2 - Filter symbols
 The possible filter symbols are: 

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperUseCases.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperUseCases.md
@@ -37,7 +37,7 @@ limitations under the License.
 
 ### [Eclipse Communication Framework](http://www.eclipse.org/ecf)
   - The Eclipse ECF project provides an implementation of its Abstract Discovery services using Zookeeper. ECF itself
-  is used in many projects providing base functionallity for communication, all based on OSGi [1].
+  is used in many projects providing base functionality for communication, all based on OSGi [1].
 
 ### [Eclipse Gyrex](http://www.eclipse.org/gyrex)
   - The Eclipse Gyrex project provides a platform for building your own Java OSGi based clouds. 
@@ -60,7 +60,7 @@ limitations under the License.
 
 ### [Neo4j](https://neo4j.com/)
   - Neo4j is a Graph Database. It's a disk based, ACID compliant transactional storage engine for big graphs and fast graph traversals,
-    using external indicies like Lucene/Solr for global searches.
+    using external indices like Lucene/Solr for global searches.
   - We use ZooKeeper in the Neo4j High Availability components for write-master election,
     read slave coordination and other cool stuff. ZooKeeper is a great and focused project - we like! [1].
 


### PR DESCRIPTION
Fix typos in docs & comments:

`zookeeper-client/zookeeper-client-c/src/zookeeper.c`
`zookeeper-contrib/zookeeper-contrib-loggraph/README.md`
`zookeeper-docs/src/main/resources/markdown/zookeeperUseCases.md`
