### PR TITLE
ZOOKEEPER-4792: Use jvm as the prefix for the memory env log.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Environment.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Environment.java
@@ -85,9 +85,9 @@ public class Environment {
         // Get memory information.
         Runtime runtime = Runtime.getRuntime();
         int mb = 1024 * 1024;
-        put(l, "os.memory.free", runtime.freeMemory() / mb + "MB");
-        put(l, "os.memory.max", runtime.maxMemory() / mb + "MB");
-        put(l, "os.memory.total", runtime.totalMemory() / mb + "MB");
+        put(l, "jvm.memory.free", runtime.freeMemory() / mb + "MB");
+        put(l, "jvm.memory.max", runtime.maxMemory() / mb + "MB");
+        put(l, "jvm.memory.total", runtime.totalMemory() / mb + "MB");
 
         return l;
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/CommandsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/CommandsTest.java
@@ -155,7 +155,7 @@ public class CommandsTest extends ClientBase {
 
     @Test
     public void testEnvironment() throws IOException, InterruptedException {
-        testCommand("environment", new Field("zookeeper.version", String.class), new Field("host.name", String.class), new Field("java.version", String.class), new Field("java.vendor", String.class), new Field("java.home", String.class), new Field("java.class.path", String.class), new Field("java.library.path", String.class), new Field("java.io.tmpdir", String.class), new Field("java.compiler", String.class), new Field("os.name", String.class), new Field("os.arch", String.class), new Field("os.version", String.class), new Field("user.name", String.class), new Field("user.home", String.class), new Field("user.dir", String.class), new Field("os.memory.free", String.class), new Field("os.memory.max", String.class), new Field("os.memory.total", String.class));
+        testCommand("environment", new Field("zookeeper.version", String.class), new Field("host.name", String.class), new Field("java.version", String.class), new Field("java.vendor", String.class), new Field("java.home", String.class), new Field("java.class.path", String.class), new Field("java.library.path", String.class), new Field("java.io.tmpdir", String.class), new Field("java.compiler", String.class), new Field("os.name", String.class), new Field("os.arch", String.class), new Field("os.version", String.class), new Field("user.name", String.class), new Field("user.home", String.class), new Field("user.dir", String.class), new Field("jvm.memory.free", String.class), new Field("jvm.memory.max", String.class), new Field("jvm.memory.total", String.class));
     }
 
     @Test


### PR DESCRIPTION
Use jvm as the prefix for the memory env log.