### PR TITLE
ZOOKEEPER-4796: fix xid assignment race condition at request submissions

### DIFF
--- a/zookeeper-client/zookeeper-client-c/Makefile.am
+++ b/zookeeper-client/zookeeper-client-c/Makefile.am
@@ -1,7 +1,7 @@
 # need this for Doxygen integration
 include $(top_srcdir)/aminclude.am
 
-AUTOMAKE_OPTIONS = serial-tests
+AUTOMAKE_OPTIONS = serial-tests subdir-objects
 
 if SOLARIS
   SOLARIS_CPPFLAGS = -D_POSIX_PTHREAD_SEMANTICS

--- a/zookeeper-client/zookeeper-client-c/src/zk_adaptor.h
+++ b/zookeeper-client/zookeeper-client-c/src/zk_adaptor.h
@@ -31,6 +31,10 @@
 #include "zk_hashtable.h"
 #include "addrvec.h"
 
+#ifdef HAVE_CYRUS_SASL_H
+#include "zk_sasl.h"
+#endif
+
 /* predefined xid's values recognized as special by the server */
 #define WATCHER_EVENT_XID -1 
 #define PING_XID -2
@@ -183,8 +187,6 @@ typedef struct _auth_list_head {
      pthread_mutex_t lock;
 #endif
 } auth_list_head_t;
-
-typedef struct _zoo_sasl_client zoo_sasl_client_t;
 
 /**
  * This structure represents the connection to zookeeper.

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -32,10 +32,6 @@
 #include "zookeeper_log.h"
 #include "zk_hashtable.h"
 
-#ifdef HAVE_CYRUS_SASL_H
-#include "zk_sasl.h"
-#endif /* HAVE_CYRUS_SASL_H */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/zookeeper-client/zookeeper-client-c/tests/TestMulti.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestMulti.cc
@@ -277,7 +277,14 @@ public:
         int rc;
         watchctx_t ctx;
         zhandle_t *zk = createClient(&ctx);
-       
+
+        rc = zoo_delete(zk, "/multi1/a", -1);
+        CPPUNIT_ASSERT(rc == ZOK || rc == ZNONODE);
+        rc = zoo_delete(zk, "/multi1/b", -1);
+        CPPUNIT_ASSERT(rc == ZOK || rc == ZNONODE);
+        rc = zoo_delete(zk, "/multi1", -1);
+        CPPUNIT_ASSERT(rc == ZOK || rc == ZNONODE);
+    
         int sz = 512;
         char p1[sz];
         char p2[sz];


### PR DESCRIPTION
This patch fixes a problem in the ZooKeeper client that causes requests to be sent out of order.

When multiple threads attempt to submit requests, it's possible for a request from a thread that acquired its xid earlier to be inserted after a request from a thread that acquired its xid later in the submission queue, which causes a ZRUNTIMEINCONSISTENCY error.

This patch acquires a lock before get_xid() and releases it after request submission.

Another way to fix this is to assign the xid during request submission, but this would disrupt the order of caller submissions: the request submitted first does not necessarily have a smaller xid.