### PR TITLE
ZOOKEEPER-4797: Allow for -XX:MaxRAMPercentage JVM setting

### DIFF
--- a/bin/zkEnv.sh
+++ b/bin/zkEnv.sh
@@ -139,9 +139,15 @@ fi
 
 #echo "CLASSPATH=$CLASSPATH"
 
-# default heap for zookeeper server
-ZK_SERVER_HEAP="${ZK_SERVER_HEAP:-1000}"
-export SERVER_JVMFLAGS="-Xmx${ZK_SERVER_HEAP}m $SERVER_JVMFLAGS"
+# ZK_SERVER_MAXRAMPERCENTAGE has higher precedence over ZK_SERVER_HEAP 
+if [ "x$ZK_SERVER_MAXRAMPERCENTAGE" = "x" ]
+then
+  # default heap for zookeeper server
+  ZK_SERVER_HEAP="${ZK_SERVER_HEAP:-1000}"
+  export SERVER_JVMFLAGS="-Xmx${ZK_SERVER_HEAP}m $SERVER_JVMFLAGS"
+else
+  export SERVER_JVMFLAGS="-XX:MaxRAMPercentage=$ZK_SERVER_MAXRAMPERCENTAGE $SERVER_JVMFLAGS"
+fi
 
 # default heap for zookeeper client
 ZK_CLIENT_HEAP="${ZK_CLIENT_HEAP:-256}"


### PR DESCRIPTION
When running Zk in a containerized environment, it's sometimes desirable to express your heap size in terms of percentage of available memory allocated to a container.

As it stands, zkEnv.sh forces your to have  **-Xmx** set to a value, otherwise it defaults to 1GB. Some environments wanted to set it to more, mostly related to the amount of Ram, not to an absolute value.

This is a request to implement the option of using **-XX:MaxRamPercentage** option when starting zookeeper.

Suggested implementation is to also make a variable **ZK_SERVER_MAXRAMPERCENTAGE** available to be appended to SERVER_JVMFLAGS. If the variable is set, ZK_HEAP_SERVER is ignored, if no ZK_SERVER_MAXRAMPERCENTAGE, ZK_SERVER_HEAP is set as usual.

Example output:

Without any heap size set.
```
./bin/zkServer.sh print-cmd
/usr/bin/java
ZooKeeper JMX enabled by default
Using config: /home/fsc/src/zookeeper/bin/../conf/zoo.cfg
"java"  ....  **-Xmx1000m**   -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false org.apache.zookeeper.server.quorum.QuorumPeerMain "/home/fsc/src/zookeeper/bin/../conf/zoo.cfg" > "/home/fsc/src/zookeeper/bin/../logs/zookeeper-fsc-server-lap.out" 2>&1 < /dev/null
```

With ZK_SERVER_HEAP set to 2000
```
$ ZK_SERVER_HEAP=2000 ./bin/zkServer.sh print-cmd
/usr/bin/java
ZooKeeper JMX enabled by default
Using config: /home/fsc/src/zookeeper/bin/../conf/zoo.cfg
"java"  ...  **-Xmx2000m**   -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false org.apache.zookeeper.server.quorum.QuorumPeerMain "/home/fsc/src/zookeeper/bin/../conf/zoo.cfg" > "/home/fsc/src/zookeeper/bin/../logs/zookeeper-fsc-server-lap.out" 2>&1 < /dev/null
```

When ZK_SERVER_MAXRAMPERCENTAGE is added (with or without ZK_SERVER_HEAP)
```
$ ZK_SERVER_MAXRAMPERCENTAGE=30.0 ZK_SERVER_HEAP=2000 ./bin/zkServer.sh print-cmd (ZK_SERVER_HEAP is ignored)
/usr/bin/java
ZooKeeper JMX enabled by default
Using config: /home/fsc/src/zookeeper/bin/../conf/zoo.cfg
"java" ... **-XX:MaxRAMPercentage=30.0**   -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false org.apache.zookeeper.server.quorum.QuorumPeerMain "/home/fsc/src/zookeeper/bin/../conf/zoo.cfg" > "/home/fsc/src/zookeeper/bin/../logs/zookeeper-fsc-server-lap.out" 2>&1 < /dev/null
```
