### PR TITLE
ZOOKEEPER-4236 Java Client SendThread create many unnecessary Login objects

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -1258,9 +1258,9 @@ public class ClientCnxn {
             }
             eventThread.queueEvent(new WatchedEvent(Event.EventType.None, Event.KeeperState.Closed, null));
 
-            if (loginRef.get() != null) {
-                loginRef.get().shutdown();
-                loginRef.set(null);
+            Login l = loginRef.getAndSet(null);
+            if (l != null) {
+                l.shutdown();
             }
             ZooTrace.logTraceMessage(
                 LOG,

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.security.auth.login.LoginException;
 import javax.security.sasl.SaslException;
 import org.apache.jute.BinaryInputArchive;
@@ -842,6 +843,7 @@ public class ClientCnxn {
         private final ClientCnxnSocket clientCnxnSocket;
         private boolean isFirstConnect = true;
         private volatile ZooKeeperSaslClient zooKeeperSaslClient;
+        private final AtomicReference<Login> loginRef = new AtomicReference<>();
 
         void readResponse(ByteBuffer incomingBuffer) throws IOException {
             ByteBufferInputStream bbis = new ByteBufferInputStream(incomingBuffer);
@@ -1087,10 +1089,8 @@ public class ClientCnxn {
             setName(getName().replaceAll("\\(.*\\)", "(" + hostPort + ")"));
             if (clientConfig.isSaslClientEnabled()) {
                 try {
-                    if (zooKeeperSaslClient != null) {
-                        zooKeeperSaslClient.shutdown();
-                    }
-                    zooKeeperSaslClient = new ZooKeeperSaslClient(SaslServerPrincipal.getServerPrincipal(addr, clientConfig), clientConfig);
+                    zooKeeperSaslClient = new ZooKeeperSaslClient(
+                        SaslServerPrincipal.getServerPrincipal(addr, clientConfig), clientConfig, loginRef);
                 } catch (LoginException e) {
                     // An authentication error occurred when the SASL client tried to initialize:
                     // for Kerberos this means that the client failed to authenticate with the KDC.
@@ -1258,8 +1258,8 @@ public class ClientCnxn {
             }
             eventThread.queueEvent(new WatchedEvent(Event.EventType.None, Event.KeeperState.Closed, null));
 
-            if (zooKeeperSaslClient != null) {
-                zooKeeperSaslClient.shutdown();
+            if (loginRef.get() != null) {
+                loginRef.get().shutdown();
             }
             ZooTrace.logTraceMessage(
                 LOG,

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -843,7 +843,7 @@ public class ClientCnxn {
         private final ClientCnxnSocket clientCnxnSocket;
         private boolean isFirstConnect = true;
         private volatile ZooKeeperSaslClient zooKeeperSaslClient;
-        private final AtomicReference<Login> loginRef = new AtomicReference<>();
+        final AtomicReference<Login> loginRef = new AtomicReference<>();
 
         void readResponse(ByteBuffer incomingBuffer) throws IOException {
             ByteBufferInputStream bbis = new ByteBufferInputStream(incomingBuffer);
@@ -1260,6 +1260,7 @@ public class ClientCnxn {
 
             if (loginRef.get() != null) {
                 loginRef.get().shutdown();
+                loginRef.set(null);
             }
             ZooTrace.logTraceMessage(
                 LOG,

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -843,7 +843,7 @@ public class ClientCnxn {
         private final ClientCnxnSocket clientCnxnSocket;
         private boolean isFirstConnect = true;
         private volatile ZooKeeperSaslClient zooKeeperSaslClient;
-        final AtomicReference<Login> loginRef = new AtomicReference<>();
+        private final AtomicReference<Login> loginRef = new AtomicReference<>();
 
         void readResponse(ByteBuffer incomingBuffer) throws IOException {
             ByteBufferInputStream bbis = new ByteBufferInputStream(incomingBuffer);
@@ -1431,6 +1431,11 @@ public class ClientCnxn {
 
         public ZooKeeperSaslClient getZooKeeperSaslClient() {
             return zooKeeperSaslClient;
+        }
+
+        // VisibleForTesting
+        Login getLogin() {
+            return loginRef.get();
         }
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/SaslAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/SaslAuthTest.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.zookeeper.ClientCnxn.EventThread;
 import org.apache.zookeeper.ClientCnxn.SendThread;
 import org.apache.zookeeper.Watcher.Event.KeeperState;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/SaslAuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/SaslAuthTest.java
@@ -243,7 +243,7 @@ public class SaslAuthTest extends ClientBase {
             eventThread.join(CONNECTION_TIMEOUT);
             // If login is null, this means ZooKeeperSaslClient#shutdown method has been called which in turns
             // means that Login#shutdown has been called.
-            assertNull(sendThread.loginRef.get());
+            assertNull(sendThread.getLogin());
             assertFalse(sendThread.isAlive(), "SendThread did not shutdown after authFail");
             assertFalse(eventThread.isAlive(), "EventThread did not shutdown after authFail");
         } finally {
@@ -269,7 +269,7 @@ public class SaslAuthTest extends ClientBase {
             sendThreadField.setAccessible(true);
             SendThread sendThread = (SendThread) sendThreadField.get(clientCnxn);
 
-            Login l1 = sendThread.loginRef.get();
+            Login l1 = sendThread.getLogin();
             assertNotNull(l1);
 
             stopServer();
@@ -278,7 +278,7 @@ public class SaslAuthTest extends ClientBase {
             watcher.waitForConnected(CONNECTION_TIMEOUT);
             zk.getData("/", false, null);
 
-            assertSame("Login thread should not been recreated on disconnect", l1, sendThread.loginRef.get());
+            assertSame("Login thread should not been recreated on disconnect", l1, sendThread.getLogin());
         } finally {
             if (zk != null) {
                 zk.close();


### PR DESCRIPTION
Move `Login` thread up one level to `SendThread`, instead of re-creating it every time a new ZooKeeperSaslClient is needed. This will avoid bombarding the KDC server with login request when the server is unavailable. It would be nice to back off in the client as well as suggested in [ZOOKEEPER-2869](https://issues.apache.org/jira/browse/ZOOKEEPER-2869).

cc @rvaleti @dbwong You guys might want to take a look.

Since we use AtomicReference for creating / destroying Login instances, this patch will resolve [ZOOKEEPER-4235](https://issues.apache.org/jira/browse/ZOOKEEPER-4235) too.