### PR TITLE
ZOOKEEPER-4699: Fix hostname use-after-free in the C client

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -2558,8 +2558,9 @@ int zookeeper_interest(zhandle_t *zh, socket_t *fd, int *interest,
             *tv = get_timeval(zh->recv_timeout/60);
             zh->delay = 0;
 
-            LOG_WARN(LOGCALLBACK(zh), "Delaying connection after exhaustively trying all servers [%s]",
-                     zh->hostname);
+            lock_reconfig(zh);
+            LOG_WARN(LOGCALLBACK(zh), "Delaying connection after exhaustively trying all servers [%s]", zh->hostname);
+            unlock_reconfig(zh);
         } else {
             if (addr_rw_server) {
                 zh->addr_cur = *addr_rw_server;


### PR DESCRIPTION
When the user calls ZOOAPI zoo_set_servers() and free zh->hostname, resulting in use-after-free in zookeeper_interest().