### PR TITLE
ZOOKEEPER-4787: Fix quorum join failure due to inconsistent wire message charset during leader election

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FastLeaderElection.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FastLeaderElection.java
@@ -425,7 +425,7 @@ public class FastLeaderElection implements Election {
                                         self.getPeerState(),
                                         response.sid,
                                         v.getPeerEpoch(),
-                                        qv.toString().getBytes());
+                                        qv.toString().getBytes(UTF_8));
                                     sendqueue.offer(notmsg);
                                 }
                             } else {
@@ -461,7 +461,7 @@ public class FastLeaderElection implements Election {
                                         self.getPeerState(),
                                         response.sid,
                                         current.getPeerEpoch(),
-                                        qv.toString().getBytes());
+                                        qv.toString().getBytes(UTF_8));
                                     sendqueue.offer(notmsg);
                                 }
                             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -490,7 +490,7 @@ public class QuorumCnxManager {
 
             String addr = addressesToSend.stream()
                     .map(NetUtils::formatInetAddr).collect(Collectors.joining("|"));
-            byte[] addr_bytes = addr.getBytes();
+            byte[] addr_bytes = addr.getBytes(UTF_8);
             dout.writeInt(addr_bytes.length);
             dout.write(addr_bytes);
             dout.flush();


### PR DESCRIPTION
JIRA:https://issues.apache.org/jira/browse/ZOOKEEPER-4787