### PR TITLE
ZOOKEEPER-4814: Re-introduce support for clients incompatible with the 3.5+ `readOnly` extension

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/compat/ProtocolManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/compat/ProtocolManager.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.compat;
 
 import java.io.IOException;
 import org.apache.jute.InputArchive;
+import org.apache.jute.OutputArchive;
 import org.apache.zookeeper.proto.ConnectRequest;
 import org.apache.zookeeper.proto.ConnectResponse;
 
@@ -117,5 +118,9 @@ public final class ProtocolManager {
         response.setPasswd(inputArchive.readBuffer("passwd"));
         inputArchive.endRecord("connect");
         return response;
+    }
+
+    public void serializeConnectResponse(final ConnectResponse response, OutputArchive outputArchive) throws IOException {
+        response.serialize(outputArchive, "connect");
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/compat/ProtocolManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/compat/ProtocolManager.java
@@ -120,7 +120,37 @@ public final class ProtocolManager {
         return response;
     }
 
+    /**
+     * The serialization of {@link ConnectResponse} has to be handled
+     * specially as clients earlier than 3.5 might not expect the
+     * {@code readOnly} flag.
+     *
+     * @param response the response to serialize
+     * @param outputArchive the serialization destination
+     * @see #deserializeConnectRequest(InputArchive)
+     */
     public void serializeConnectResponse(final ConnectResponse response, OutputArchive outputArchive) throws IOException {
+        serializeConnectResponse(response, outputArchive, isReadonlyAvailable());
+    }
+
+    private static void serializeConnectResponse(final ConnectResponse response, OutputArchive outputArchive, boolean withReadonly) throws IOException {
+        if (withReadonly) {
+            serializeConnectResponseWithReadonly(response, outputArchive);
+        } else {
+            serializeConnectResponseWithoutReadonly(response, outputArchive);
+        }
+    }
+
+    private static void serializeConnectResponseWithReadonly(ConnectResponse response, OutputArchive outputArchive) throws IOException {
         response.serialize(outputArchive, "connect");
+    }
+
+    private static void serializeConnectResponseWithoutReadonly(ConnectResponse response, OutputArchive outputArchive) throws IOException {
+        outputArchive.startRecord(response, "connect");
+        outputArchive.writeInt(response.getProtocolVersion(), "protocolVersion");
+        outputArchive.writeInt(response.getTimeOut(), "timeOut");
+        outputArchive.writeLong(response.getSessionId(), "sessionId");
+        outputArchive.writeBuffer(response.getPasswd(), "passwd");
+        outputArchive.endRecord(response, "connect");
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -1170,7 +1170,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             BinaryOutputArchive bos = BinaryOutputArchive.getArchive(baos);
             bos.writeInt(-1, "len");
-            rsp.serialize(bos, "connect");
+            cnxn.protocolManager.serializeConnectResponse(rsp, bos);
             baos.close();
             ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray());
             bb.putInt(bb.remaining() - 4).rewind();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/compat/ProtocolManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/compat/ProtocolManagerTest.java
@@ -1,0 +1,149 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.compat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.jute.BinaryInputArchive;
+import org.apache.jute.BinaryOutputArchive;
+import org.apache.jute.InputArchive;
+import org.apache.jute.OutputArchive;
+import org.apache.zookeeper.proto.ConnectRequest;
+import org.apache.zookeeper.proto.ConnectResponse;
+import org.junit.jupiter.api.Test;
+
+public class ProtocolManagerTest {
+
+    private static byte[] serializeConnectRequest(ConnectRequest request, boolean withReadOnly) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputArchive oa = BinaryOutputArchive.getArchive(baos);
+        request.serialize(oa, "connect");
+        baos.close();
+        byte[] bytes = baos.toByteArray();
+
+        if (withReadOnly) {
+            return bytes;
+        } else {
+            return Arrays.copyOf(bytes, bytes.length - 1);
+        }
+    }
+
+    @Test
+    public void testDeserializeConnectRequestWithReadonly() throws IOException {
+        ProtocolManager protocolManager = new ProtocolManager();
+
+        ConnectRequest req1 = new ConnectRequest();
+        req1.setPasswd(new byte[16]);
+        req1.setReadOnly(true);
+
+        byte[] bytes = serializeConnectRequest(req1, true);
+
+        // Current protocol.
+        assertEquals(45, bytes.length);
+
+        InputArchive ia = BinaryInputArchive.getArchive(new ByteArrayInputStream(bytes));
+        ConnectRequest req2 = protocolManager.deserializeConnectRequest(ia);
+
+        assertEquals(true, protocolManager.isReadonlyAvailable());
+        assertEquals(true, req2.getReadOnly());
+    }
+
+    @Test
+    public void testDeserializeConnectRequestWithoutReadonly() throws IOException {
+        ProtocolManager protocolManager = new ProtocolManager();
+
+        ConnectRequest req1 = new ConnectRequest();
+        req1.setPasswd(new byte[16]);
+        // Should get truncated.
+        req1.setReadOnly(true);
+
+        byte[] bytes = serializeConnectRequest(req1, false);
+
+        // 3.4 protocol.
+        assertEquals(44, bytes.length);
+
+        InputArchive ia = BinaryInputArchive.getArchive(new ByteArrayInputStream(bytes));
+        ConnectRequest req2 = protocolManager.deserializeConnectRequest(ia);
+
+        assertEquals(false, protocolManager.isReadonlyAvailable());
+        assertEquals(false, req2.getReadOnly());
+    }
+
+    private static ProtocolManager prepareProtocolManager(boolean withReadOnly) throws IOException {
+        ProtocolManager protocolManager = new ProtocolManager();
+
+        ConnectRequest req1 = new ConnectRequest();
+        req1.setPasswd(new byte[16]);
+        req1.setReadOnly(true);
+
+        byte[] bytes = serializeConnectRequest(req1, withReadOnly);
+
+        InputArchive ia = BinaryInputArchive.getArchive(new ByteArrayInputStream(bytes));
+        // Detects the current protocol.
+        ConnectRequest req2 = protocolManager.deserializeConnectRequest(ia);
+
+        return protocolManager;
+    }
+
+    @Test
+    public void testSerializeConnectResponseWithReadonly() throws IOException {
+        ProtocolManager protocolManager = prepareProtocolManager(true);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        BinaryOutputArchive os = BinaryOutputArchive.getArchive(baos);
+
+        ConnectResponse rsp = new ConnectResponse();
+        rsp.setPasswd(new byte[16]);
+        rsp.setReadOnly(true);
+
+        // Should use the current protocol.
+        protocolManager.serializeConnectResponse(rsp, os);
+
+        baos.close();
+
+        byte[] bytes = baos.toByteArray();
+
+        assertEquals(37, bytes.length);
+        assertEquals(1, bytes[bytes.length - 1]);
+    }
+
+    @Test
+    public void testSerializeConnectResponseWithoutReadonly() throws IOException {
+        ProtocolManager protocolManager = prepareProtocolManager(false);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        BinaryOutputArchive os = BinaryOutputArchive.getArchive(baos);
+
+        ConnectResponse rsp = new ConnectResponse();
+        rsp.setPasswd(new byte[16]);
+        rsp.setReadOnly(true);
+
+        // Should use the 3.4 protocol.
+        protocolManager.serializeConnectResponse(rsp, os);
+
+        baos.close();
+
+        byte[] bytes = baos.toByteArray();
+
+        assertEquals(36, bytes.length);
+    }
+}


### PR DESCRIPTION
The `ProtocolManager` class knows whether the client sent a `readOnly` flag as part of the `ConnectRequest`, and can use that information to, in turn, avoid the extra byte when serializing the `ConnectResponse`.