### PR TITLE
[ZOOKEEPER-4820] Fix propagation of Logback dependencies

### DIFF
--- a/zookeeper-assembly/pom.xml
+++ b/zookeeper-assembly/pom.xml
@@ -104,6 +104,10 @@
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
        <groupId>io.dropwizard.metrics</groupId>
        <artifactId>metrics-core</artifactId>
     </dependency>

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
@@ -91,13 +91,9 @@
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -80,6 +80,12 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <scope>provided</scope>
@@ -167,11 +173,6 @@
     <dependency>
       <groupId>org.burningwave</groupId>
       <artifactId>tools</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -80,14 +80,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <scope>provided</scope>
@@ -175,6 +167,11 @@
     <dependency>
       <groupId>org.burningwave</groupId>
       <artifactId>tools</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Java libraries should not have `runtime` dependencies on logging backends, since they are often included in third-party applications that might make a different choice of backend.

This PR:

* removes the Logback dependency from the runtime scope of the `zookeeper` artifact and moves it into the `test` Maven scope,
* adds Logback to `zookeeper-assembly`, which is used to produce the standalone [binary distribution](https://zookeeper.apache.org/releases) available on Zookeeper's site.