### PR TITLE
ZOOKEEPER-4827 Bump bouncycastl version from 1.75 to 1.78

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,7 +565,7 @@
     <jline.version>2.14.6</jline.version>
     <snappy.version>1.1.10.5</snappy.version>
     <kerby.version>2.0.0</kerby.version>
-    <bouncycastle.version>1.75</bouncycastle.version>
+    <bouncycastle.version>1.78</bouncycastle.version>
     <commons-collections.version>4.4</commons-collections.version>
     <dropwizard.version>4.1.12.1</dropwizard.version>
     <spotbugsannotations.version>4.0.2</spotbugsannotations.version>


### PR DESCRIPTION
### Motivation

Upgrade Bouncy Castle to 1.78 to address CVEs
https://bouncycastle.org/releasenotes.html#r1rv78

- https://www.cve.org/CVERecord?id=CVE-2024-29857 (reserved)
  - https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6613079
- https://www.cve.org/CVERecord?id=CVE-2024-30171 (reserved)
  - https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6613076
- https://www.cve.org/CVERecord?id=CVE-2024-30172 (reserved)
  - https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6612984

See also https://github.com/apache/pulsar/pull/22509