### PR TITLE
ZOOKEEPER-4825:Updating logback version from 1.2.13 to 1.4.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -551,7 +551,7 @@
 
     <!-- dependency versions -->
     <slf4j.version>1.7.30</slf4j.version>
-    <logback-version>1.2.13</logback-version>
+    <logback-version>1.4.12</logback-version>
     <audience-annotations.version>0.12.0</audience-annotations.version>
     <jmockit.version>1.48</jmockit.version>
     <junit.version>5.6.2</junit.version>


### PR DESCRIPTION
[ZOOKEEPER-4825](https://issues.apache.org/jira/browse/ZOOKEEPER-4825) - updating the logback version to 1.4.12 since the current version(1.2.13) has CVE-2023-6378 vulnerability. 
Refer - https://logback.qos.ch/news.html for more details on the release notes.
referred - https://mvnrepository.com/artifact/ch.qos.logback/logback-classic , for vulnerabilities in different versions