### PR TITLE
ZOOKEEPER-4830 Replace references to zk_followers

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-huebrowser/zkui/src/zkui/templates/view.mako
+++ b/zookeeper-contrib/zookeeper-contrib-huebrowser/zkui/src/zkui/templates/view.mako
@@ -96,7 +96,7 @@ ${shared.info_button(url('zkui.views.tree', id=cluster['id'], path='/'), 'View Z
     ${show_stats(leader)}
     
     <tr><td>Followers</td>
-      <td>${leader.get('zk_followers', '')}</td>
+      <td>${leader.get('zk_learners', '')}</td>
     </tr>
 
     <tr><td>Synced Followers</td>

--- a/zookeeper-contrib/zookeeper-contrib-monitoring/ganglia/zookeeper.pyconf
+++ b/zookeeper-contrib/zookeeper-contrib-monitoring/ganglia/zookeeper.pyconf
@@ -43,7 +43,7 @@ collection_group {
   metric { name = "zk_approximate_data_size" }
   metric { name = "zk_open_file_descriptor_count" }
   metric { name = "zk_max_file_descriptor_count" }
-  metric { name = "zk_followers" }
+  metric { name = "zk_learners" }
   metric { name = "zk_synced_followers" }
   metric { name = "zk_pending_syncs" }
   metric { name = "zk_last_proposal_size" }

--- a/zookeeper-contrib/zookeeper-contrib-monitoring/ganglia/zookeeper_ganglia.py
+++ b/zookeeper-contrib/zookeeper-contrib-monitoring/ganglia/zookeeper_ganglia.py
@@ -212,7 +212,7 @@ def metric_init(params=None):
         'zk_approximate_data_size': {'units': 'bytes'},
         'zk_open_file_descriptor_count': {'units': 'descriptors'},
         'zk_max_file_descriptor_count': {'units': 'descriptors'},
-        'zk_followers': {'units': 'nodes'},
+        'zk_learners': {'units': 'nodes'},
         'zk_synced_followers': {'units': 'nodes'},
         'zk_pending_syncs': {'units': 'syncs'},
         'zk_last_proposal_size': {'units': 'bytes'},

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -2490,7 +2490,7 @@ Moving forward, Four Letter Words will be deprecated, please use
                   zk_watch_count  0
                   zk_ephemerals_count 0
                   zk_approximate_data_size    27
-                  zk_followers    4                   - only exposed by the Leader
+                  zk_learners    4                    - only exposed by the Leader
                   zk_synced_followers 4               - only exposed by the Leader
                   zk_pending_syncs    0               - only exposed by the Leader
                   zk_open_file_descriptor_count 23    - only available on Unix platforms


### PR DESCRIPTION
`zk_followers` was renamed to `zk_learners` in 290f1fc4b907c7d51ec / [ZOOKEEPER-3117](https://issues.apache.org/jira/browse/ZOOKEEPER-3117), but many references weren't updated.

Note that the example output for `mntr` is out of date. In my Zookeeper 3.8.4 install, `mntr` produces almost 600 lines of output, not just the 15 shown. Someone more familiar with this project might want to consider reworking or removing that section.

Please let me know if there's anything else I can do to help.