### PR TITLE
Fix some typos in class ConnectStringParser and IOUtils

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ConnectStringParser.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ConnectStringParser.java
@@ -44,7 +44,7 @@ public final class ConnectStringParser {
     private final ArrayList<InetSocketAddress> serverAddresses = new ArrayList<>();
 
     /**
-     * Parse host and port by spliting client connectString
+     * Parse host and port by splitting client connectString
      * with support for IPv6 literals
      * @throws IllegalArgumentException
      *             for an invalid chroot path.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/IOUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/IOUtils.java
@@ -70,7 +70,7 @@ public class IOUtils {
      * Copies from one stream to another.
      *
      * @param in
-     *            InputStrem to read from
+     *            InputStream to read from
      * @param out
      *            OutputStream to write to
      * @param buffSize
@@ -100,7 +100,7 @@ public class IOUtils {
      * Copies from one stream to another.
      *
      * @param in
-     *            InputStrem to read from
+     *            InputStream to read from
      * @param out
      *            OutputStream to write to
      * @param buffSize


### PR DESCRIPTION
### Motivation

Fix some typos in class ConnectStringParser and IOUtils

### Changes

fix typos: 
`spliting` => `splitting`
`InputStrem` => `InputStream`