### PR TITLE
[ZOOKEEPER-4831] update slf4j from 1.x to 2.0.13, logback to 1.3.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -550,8 +550,8 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
 
     <!-- dependency versions -->
-    <slf4j.version>1.7.30</slf4j.version>
-    <logback-version>1.2.13</logback-version>
+    <slf4j.version>2.0.13</slf4j.version>
+    <logback-version>1.3.14</logback-version>
     <audience-annotations.version>0.12.0</audience-annotations.version>
     <jmockit.version>1.48</jmockit.version>
     <junit.version>5.6.2</junit.version>

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -436,7 +436,7 @@ in the unlikely event a recent log has become corrupted). This
 can be run as a cron job on the ZooKeeper server machines to
 clean up the logs daily.
 
-    java -cp zookeeper.jar:lib/slf4j-api-1.7.30.jar:lib/logback-classic-1.2.10.jar:lib/logback-core-1.2.10.jar:conf org.apache.zookeeper.server.PurgeTxnLog <dataDir> <snapDir> -n <count>
+    java -cp zookeeper.jar:lib/slf4j-api-2.0.13.jar:lib/logback-classic-1.2.10.jar:lib/logback-core-1.2.10.jar:conf org.apache.zookeeper.server.PurgeTxnLog <dataDir> <snapDir> -n <count>
 
 
 Automatic purging of the snapshots and corresponding

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -436,7 +436,7 @@ in the unlikely event a recent log has become corrupted). This
 can be run as a cron job on the ZooKeeper server machines to
 clean up the logs daily.
 
-    java -cp zookeeper.jar:lib/slf4j-api-2.0.13.jar:lib/logback-classic-1.2.10.jar:lib/logback-core-1.2.10.jar:conf org.apache.zookeeper.server.PurgeTxnLog <dataDir> <snapDir> -n <count>
+    CLASSPATH='lib/*:conf' java org.apache.zookeeper.server.PurgeTxnLog <dataDir> <snapDir> -n <count>
 
 
 Automatic purging of the snapshots and corresponding

--- a/zookeeper-server/src/main/resources/LICENSE.txt
+++ b/zookeeper-server/src/main/resources/LICENSE.txt
@@ -210,6 +210,6 @@ This distribution bundles jline 2.14.6, which is available under the
 2-clause BSD License. For details, see a copy of the license in
 lib/jline-2.14.6.LICENSE.txt
 
-This distribution bundles SLF4J 1.7.30, which is available under the MIT
+This distribution bundles SLF4J 2.0.13, which is available under the MIT
 License. For details, see a copy of the license in
-lib/slf4j-1.7.30.LICENSE.txt
+lib/slf4j-2.0.13.LICENSE.txt

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigExceptionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigExceptionTest.java
@@ -48,7 +48,7 @@ public class ReconfigExceptionTest extends ZKTestCase {
     // Use DigestAuthenticationProvider.base64Encode or
     // run ZooKeeper jar with org.apache.zookeeper.server.auth.DigestAuthenticationProvider to generate password.
     // An example:
-    // java -cp zookeeper.jar:lib/slf4j-api-2.0.13.jar:lib/logback-classic-1.2.10.jar:lib/logback-core-1.2.10.jar:conf
+    // CLASSPATH='lib/*:conf' java
     // org.apache.zookeeper.server.auth.DigestAuthenticationProvider super:test
     // The password here is 'test'.
     private static String superDigest = "super:D/InIHSb7yEEbrWz8b9l71RjZJU=";

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigExceptionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigExceptionTest.java
@@ -48,7 +48,7 @@ public class ReconfigExceptionTest extends ZKTestCase {
     // Use DigestAuthenticationProvider.base64Encode or
     // run ZooKeeper jar with org.apache.zookeeper.server.auth.DigestAuthenticationProvider to generate password.
     // An example:
-    // java -cp zookeeper.jar:lib/slf4j-api-1.7.30.jar:lib/logback-classic-1.2.10.jar:lib/logback-core-1.2.10.jar:conf
+    // java -cp zookeeper.jar:lib/slf4j-api-2.0.13.jar:lib/logback-classic-1.2.10.jar:lib/logback-core-1.2.10.jar:conf
     // org.apache.zookeeper.server.auth.DigestAuthenticationProvider super:test
     // The password here is 'test'.
     private static String superDigest = "super:D/InIHSb7yEEbrWz8b9l71RjZJU=";


### PR DESCRIPTION
Update slf4j to 2.x, logback to 1.3.14. This is a backward-compatible change. 


## slf4j
SLF4J API version 2.0.0 requires Java 8 and introduces a backward-compatible fluent logging API. By backward-compatible, we mean that existing logging frameworks do not have to be changed in order for the user to benefit from the fluent logging API.

## logback
Version 1.3.x supports Java EE, while version 1.4.x supports Jakarta EE. The two versions are feature identical.

Both 1.3.x and 1.4.x series require SLF4J 2.0.x or later.

The 1.3.x series requires Java 8 at runtime.