### PR TITLE
ZOOKEEPER-2789 Reassign `ZXID` for solving 32bit overflow problem

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-loggraph/src/main/java/org/apache/zookeeper/graph/JsonGenerator.java
+++ b/zookeeper-contrib/zookeeper-contrib-loggraph/src/main/java/org/apache/zookeeper/graph/JsonGenerator.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.zookeeper.server.util.ZxidUtils;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import java.util.HashSet;
@@ -116,8 +117,8 @@ public class JsonGenerator {
 				else if ((m = newElectionP.matcher(e.getEntry())).find()) {
 					Iterator<Integer> iterator = servers.iterator();
 					long zxid = Long.valueOf(m.group(2));
-					int count = (int)zxid;// & 0xFFFFFFFFL;
-					int epoch = (int)Long.rotateRight(zxid, 32);// >> 32;
+					int count = ZxidUtils.getCounterFromZxid(zxid);
+					int epoch = ZxidUtils.getEpochFromZxid(zxid);
 
 					if (leader != 0 && epoch > curEpoch) {
 						JsonNode stateChange = add("stateChange", e.getTimestamp(), leader, "INIT");
@@ -149,8 +150,8 @@ public class JsonGenerator {
 					int dst = e.getNode();
 					long epoch2 = Long.valueOf(m.group(3));
 
-					int count = (int)zxid;// & 0xFFFFFFFFL;
-					int epoch = (int)Long.rotateRight(zxid, 32);// >> 32;
+					int count = ZxidUtils.getCounterFromZxid(zxid);
+					int epoch = ZxidUtils.getEpochFromZxid(zxid);
 
 					if (leader != 0 && epoch > curEpoch) {
 						JsonNode stateChange = add("stateChange", e.getTimestamp(), leader, "INIT");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
@@ -25,6 +25,7 @@ import javax.management.JMException;
 import org.apache.jute.Record;
 import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.metrics.MetricsContext;
+import org.apache.zookeeper.server.util.ZxidUtils;
 import org.apache.zookeeper.server.ExitCode;
 import org.apache.zookeeper.server.FinalRequestProcessor;
 import org.apache.zookeeper.server.Request;
@@ -200,7 +201,7 @@ public class FollowerZooKeeperServer extends LearnerZooKeeperServer {
     private Request buildRequestToProcess(final TxnHeader hdr, final Record txn, final TxnDigest digest) {
         final Request request = new Request(hdr.getClientId(), hdr.getCxid(), hdr.getType(), hdr, txn, hdr.getZxid());
         request.setTxnDigest(digest);
-        if ((request.zxid & 0xffffffffL) != 0) {
+        if (ZxidUtils.getCounterFromZxid(request.zxid) != 0) {
             pendingTxns.add(request);
         }
         return request;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -335,6 +335,10 @@ public class Leader extends LearnerMaster {
         this.self = self;
         this.proposalStats = new BufferStats();
 
+        // A new Leader node has been elected, therefore the zxid bit length is synchronously increased.
+        ZxidUtils.setEpochHighPosition40();
+        self.setCurrentEpochPosition(40);
+
         Set<InetSocketAddress> addresses;
         if (self.getQuorumListenOnAllIPs()) {
             addresses = self.getQuorumAddress().getWildcardAddresses();
@@ -743,7 +747,7 @@ public class Leader extends LearnerMaster {
             /**
              * WARNING: do not use this for anything other than QA testing
              * on a real cluster. Specifically to enable verification that quorum
-             * can handle the lower 32bit roll-over issue identified in
+             * can handle the lower 40bit roll-over issue identified in
              * ZOOKEEPER-1277. Without this option it would take a very long
              * time (on order of a month say) to see the 4 billion writes
              * necessary to cause the roll-over to occur.
@@ -1291,11 +1295,11 @@ public class Leader extends LearnerMaster {
             ServiceUtils.requestSystemExit(ExitCode.UNEXPECTED_ERROR.getValue());
         }
         /**
-         * Address the rollover issue. All lower 32bits set indicate a new leader
+         * Address the rollover issue. All lower 40bits set indicate a new leader
          * election. Force a re-election instead. See ZOOKEEPER-1277
          */
         if (ZxidUtils.getCounterFromZxid(request.zxid) == ZxidUtils.getCounterLowPosition()) {
-            String msg = "zxid lower 32 bits have rolled over, forcing re-election, and therefore new epoch start";
+            String msg = "zxid lower 40 bits have rolled over, forcing re-election, and therefore new epoch start";
             shutdown(msg);
             throw new XidRolloverException(msg);
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -662,7 +662,7 @@ public class Leader extends LearnerMaster {
 
             newLeaderProposal.packet = new QuorumPacket(NEWLEADER, zk.getZxid(), null, null);
 
-            if ((newLeaderProposal.packet.getZxid() & 0xffffffffL) != 0) {
+            if (ZxidUtils.getCounterFromZxid(newLeaderProposal.packet.getZxid()) != 0) {
                 LOG.info("NEWLEADER proposal has Zxid of {}", Long.toHexString(newLeaderProposal.packet.getZxid()));
             }
 
@@ -755,7 +755,7 @@ public class Leader extends LearnerMaster {
             String initialZxid = System.getProperty("zookeeper.testingonly.initialZxid");
             if (initialZxid != null) {
                 long zxid = Long.parseLong(initialZxid);
-                zk.setZxid((zk.getZxid() & 0xffffffff00000000L) | zxid);
+                zk.setZxid(ZxidUtils.clearCounter(zk.getZxid()) | zxid);
             }
 
             if (!System.getProperty("zookeeper.leaderServes", "yes").equals("no")) {
@@ -1058,7 +1058,7 @@ public class Leader extends LearnerMaster {
             LOG.trace("outstanding proposals all");
         }
 
-        if ((zxid & 0xffffffffL) == 0) {
+        if (ZxidUtils.getCounterFromZxid(zxid) == 0) {
             /*
              * We no longer process NEWLEADER ack with this method. However,
              * the learner sends an ack back to the leader after it gets
@@ -1294,7 +1294,7 @@ public class Leader extends LearnerMaster {
          * Address the rollover issue. All lower 32bits set indicate a new leader
          * election. Force a re-election instead. See ZOOKEEPER-1277
          */
-        if ((request.zxid & 0xffffffffL) == 0xffffffffL) {
+        if (ZxidUtils.getCounterFromZxid(request.zxid) == ZxidUtils.getCounterLowPosition()) {
             String msg = "zxid lower 32 bits have rolled over, forcing re-election, and therefore new epoch start";
             shutdown(msg);
             throw new XidRolloverException(msg);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
@@ -789,7 +789,7 @@ public class LearnerHandler extends ZooKeeperThread {
          * zxid in our history. In this case, we will ignore TRUNC logic and
          * always send DIFF if we have old enough history
          */
-        boolean isPeerNewEpochZxid = (peerLastZxid & 0xffffffffL) == 0;
+        boolean isPeerNewEpochZxid = ZxidUtils.getCounterFromZxid(peerLastZxid) == 0;
         // Keep track of the latest zxid which already queued
         long currentZxid = peerLastZxid;
         boolean needSnap = true;
@@ -949,7 +949,7 @@ public class LearnerHandler extends ZooKeeperThread {
      * @return last zxid of the queued proposal
      */
     protected long queueCommittedProposals(Iterator<Proposal> itr, long peerLastZxid, Long maxZxid, Long lastCommittedZxid) {
-        boolean isPeerNewEpochZxid = (peerLastZxid & 0xffffffffL) == 0;
+        boolean isPeerNewEpochZxid = ZxidUtils.getCounterFromZxid(peerLastZxid) == 0;
         long queuedZxid = peerLastZxid;
         // as we look through proposals, this variable keeps track of previous
         // proposal Id.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
@@ -525,15 +525,16 @@ public class LearnerHandler extends ZooKeeperThread {
             long newEpoch = learnerMaster.getEpochToPropose(this.getSid(), lastAcceptedEpoch);
             long newLeaderZxid = ZxidUtils.makeZxid(newEpoch, 0);
 
-            if (this.getVersion() < 0x10000) {
-                // we are going to have to extrapolate the epoch information
-                long epoch = ZxidUtils.getEpochFromZxid(zxid);
-                ss = new StateSummary(epoch, zxid);
-                // fake the message
-                learnerMaster.waitForEpochAck(this.getSid(), ss);
+            /**
+             * When the Leader switches to a new mode
+             * lower version Observers or Followers are not allowed to join the cluster, thus the zxid bit length has changed.
+             */
+            if (this.getVersion() < 0x11000) {
+                LOG.error("sid:{} version too old", this.sid);
+                return;
             } else {
                 byte[] ver = new byte[4];
-                ByteBuffer.wrap(ver).putInt(0x10000);
+                ByteBuffer.wrap(ver).putInt(0x11000);
                 QuorumPacket newEpochPacket = new QuorumPacket(Leader.LEADERINFO, newLeaderZxid, ver, null);
                 oa.writeRecord(newEpochPacket, "packet");
                 messageTracker.trackSent(Leader.LEADERINFO);
@@ -597,13 +598,8 @@ public class LearnerHandler extends ZooKeeperThread {
             // the version of this quorumVerifier will be set by leader.lead() in case
             // the leader is just being established. waitForEpochAck makes sure that readyToStart is true if
             // we got here, so the version was set
-            if (getVersion() < 0x10000) {
-                QuorumPacket newLeaderQP = new QuorumPacket(Leader.NEWLEADER, newLeaderZxid, null, null);
-                oa.writeRecord(newLeaderQP, "packet");
-            } else {
-                QuorumPacket newLeaderQP = new QuorumPacket(Leader.NEWLEADER, newLeaderZxid, learnerMaster.getQuorumVerifierBytes(), null);
-                queuedPackets.add(newLeaderQP);
-            }
+            QuorumPacket newLeaderQP = new QuorumPacket(Leader.NEWLEADER, newLeaderZxid, learnerMaster.getQuorumVerifierBytes(), null);
+            queuedPackets.add(newLeaderQP);
             bufferedOutput.flush();
 
             // Start thread that blast packets in the queue to learner

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/ZxidUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/ZxidUtils.java
@@ -19,18 +19,40 @@
 package org.apache.zookeeper.server.util;
 
 public class ZxidUtils {
+    private static final long EPOCH_HIGH_POSITION = 40L;
+    private static final long COUNTER_LOW_POSITION = 0xffffffffffL;
+    private static final long CLEAR_EPOCH = 0x000000ffffffffffL;
+    private static final long CLEAR_COUNTER = 0xffffff0000000000L;
 
-    public static long getEpochFromZxid(long zxid) {
-        return zxid >> 32L;
+    static public long getEpochFromZxid(long zxid) {
+        return zxid >> EPOCH_HIGH_POSITION;
     }
-    public static long getCounterFromZxid(long zxid) {
-        return zxid & 0xffffffffL;
+
+    static public long getCounterFromZxid(long zxid) {
+        return zxid & COUNTER_LOW_POSITION;
     }
-    public static long makeZxid(long epoch, long counter) {
-        return (epoch << 32L) | (counter & 0xffffffffL);
+
+    static public long makeZxid(long epoch, long counter) {
+        return (epoch << EPOCH_HIGH_POSITION) | (counter & COUNTER_LOW_POSITION);
     }
-    public static String zxidToString(long zxid) {
+
+    static public long clearEpoch(long zxid) {
+        return zxid & CLEAR_EPOCH;
+    }
+
+    static public long clearCounter(long zxid) {
+        return zxid & CLEAR_COUNTER;
+    }
+
+    static public String zxidToString(long zxid) {
         return Long.toHexString(zxid);
     }
 
+    public static long getEpochHighPosition() {
+        return EPOCH_HIGH_POSITION;
+    }
+
+    public static long getCounterLowPosition() {
+        return COUNTER_LOW_POSITION;
+    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/ZxidUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/ZxidUtils.java
@@ -18,30 +18,45 @@
 
 package org.apache.zookeeper.server.util;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 public class ZxidUtils {
-    private static final long EPOCH_HIGH_POSITION = 40L;
-    private static final long COUNTER_LOW_POSITION = 0xffffffffffL;
-    private static final long CLEAR_EPOCH = 0x000000ffffffffffL;
-    private static final long CLEAR_COUNTER = 0xffffff0000000000L;
+    // 40L
+    private static final long EPOCH_HIGH_POSITION32 = 32L;
+    private static final long EPOCH_HIGH_POSITION40 = 40L;
+
+    private static final long COUNTER_LOW_POSITION32 = 0xffffffffL;
+    private static final long CLEAR_EPOCH32 = 0x00000000ffffffffL;
+    private static final long CLEAR_COUNTER32 = 0xffffffff00000000L;
+
+    private static final long COUNTER_LOW_POSITION40 = 0xffffffffffL;
+    private static final long CLEAR_EPOCH40 = 0x000000ffffffffffL;
+    private static final long CLEAR_COUNTER40 = 0xffffff0000000000L;
+
+    private static AtomicLong EPOCH_HIGH_POSITION = new AtomicLong(EPOCH_HIGH_POSITION32);
+
+    private static AtomicLong COUNTER_LOW_POSITION = new AtomicLong(COUNTER_LOW_POSITION32);
+    private static AtomicLong CLEAR_EPOCH = new AtomicLong(CLEAR_EPOCH32);
+    private static AtomicLong CLEAR_COUNTER = new AtomicLong(CLEAR_COUNTER32);
 
     static public long getEpochFromZxid(long zxid) {
-        return zxid >> EPOCH_HIGH_POSITION;
+        return zxid >> EPOCH_HIGH_POSITION.get();
     }
 
     static public long getCounterFromZxid(long zxid) {
-        return zxid & COUNTER_LOW_POSITION;
+        return zxid & COUNTER_LOW_POSITION.get();
     }
 
     static public long makeZxid(long epoch, long counter) {
-        return (epoch << EPOCH_HIGH_POSITION) | (counter & COUNTER_LOW_POSITION);
+        return (epoch << EPOCH_HIGH_POSITION.get()) | (counter & COUNTER_LOW_POSITION.get());
     }
 
     static public long clearEpoch(long zxid) {
-        return zxid & CLEAR_EPOCH;
+        return zxid & CLEAR_EPOCH.get();
     }
 
     static public long clearCounter(long zxid) {
-        return zxid & CLEAR_COUNTER;
+        return zxid & CLEAR_COUNTER.get();
     }
 
     static public String zxidToString(long zxid) {
@@ -49,10 +64,37 @@ public class ZxidUtils {
     }
 
     public static long getEpochHighPosition() {
-        return EPOCH_HIGH_POSITION;
+        return EPOCH_HIGH_POSITION.get();
     }
 
     public static long getCounterLowPosition() {
-        return COUNTER_LOW_POSITION;
+        return COUNTER_LOW_POSITION.get();
     }
+
+    public static void setEpochHighPosition40() {
+        EPOCH_HIGH_POSITION.set(EPOCH_HIGH_POSITION40);
+
+        COUNTER_LOW_POSITION.set(COUNTER_LOW_POSITION40);
+        CLEAR_EPOCH.set(CLEAR_EPOCH40);
+        CLEAR_COUNTER.set(CLEAR_COUNTER40);
+    }
+
+    public static void setEpochHighPosition32() {
+        EPOCH_HIGH_POSITION.set(EPOCH_HIGH_POSITION32);
+
+        COUNTER_LOW_POSITION.set(COUNTER_LOW_POSITION32);
+        CLEAR_EPOCH.set(CLEAR_EPOCH32);
+        CLEAR_COUNTER.set(CLEAR_COUNTER32);
+    }
+
+    public static void setEpochHighPosition(long position) {
+        if (position == 32) {
+            setEpochHighPosition32();
+        } else if (position == 40) {
+            setEpochHighPosition40();
+        } else {
+            throw new IllegalArgumentException("Invalid epoch high position:" + position + ", should is 32 or 40.");
+        }
+    }
+
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZxidRolloverTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZxidRolloverTest.java
@@ -28,6 +28,7 @@ import org.apache.zookeeper.KeeperException.ConnectionLossException;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.server.util.ZxidUtils;
 import org.apache.zookeeper.test.ClientBase;
 import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
 import org.apache.zookeeper.test.ClientTest;
@@ -210,7 +211,7 @@ public class ZxidRolloverTest extends ZKTestCase {
 
     /** Reset the next zxid to be near epoch end */
     private void adjustEpochNearEnd() {
-        zksLeader.setZxid((zksLeader.getZxid() & 0xffffffff00000000L) | 0xfffffffcL);
+        zksLeader.setZxid(ZxidUtils.clearCounter(zksLeader.getZxid()) | 0xfffffffffcL);
     }
 
     @AfterEach

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
@@ -516,7 +516,7 @@ public class Zab1_0Test extends ZKTestCase {
                 assertEquals(1, l.self.getCurrentEpoch());
 
                 /* we test a normal run. everything should work out well. */
-                LearnerInfo li = new LearnerInfo(1, 0x10000, 0);
+                LearnerInfo li = new LearnerInfo(1, 0x11000, 0);
                 byte[] liBytes = RequestRecord.fromRecord(li).readBytes();
                 QuorumPacket qp = new QuorumPacket(Leader.FOLLOWERINFO, 1, liBytes, null);
                 oa.writeRecord(qp, null);
@@ -524,7 +524,7 @@ public class Zab1_0Test extends ZKTestCase {
                 readPacketSkippingPing(ia, qp);
                 assertEquals(Leader.LEADERINFO, qp.getType());
                 assertEquals(ZxidUtils.makeZxid(2, 0), qp.getZxid());
-                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x10000);
+                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x11000);
                 assertEquals(2, l.self.getAcceptedEpoch());
                 assertEquals(1, l.self.getCurrentEpoch());
 
@@ -594,14 +594,14 @@ public class Zab1_0Test extends ZKTestCase {
                     assertEquals(qp.getZxid(), 0);
                     LearnerInfo learnInfo = new LearnerInfo();
                     ByteBufferInputStream.byteBuffer2Record(ByteBuffer.wrap(qp.getData()), learnInfo);
-                    assertEquals(learnInfo.getProtocolVersion(), 0x10000);
+                    assertEquals(learnInfo.getProtocolVersion(), 0x11000);
                     assertEquals(learnInfo.getServerid(), 0);
 
                     // We are simulating an established leader, so the epoch is 1
                     qp.setType(Leader.LEADERINFO);
                     qp.setZxid(ZxidUtils.makeZxid(1, 0));
                     byte[] protoBytes = new byte[4];
-                    ByteBuffer.wrap(protoBytes).putInt(0x10000);
+                    ByteBuffer.wrap(protoBytes).putInt(0x11000);
                     qp.setData(protoBytes);
                     oa.writeRecord(qp, null);
 
@@ -728,14 +728,14 @@ public class Zab1_0Test extends ZKTestCase {
                     assertEquals(qp.getZxid(), 0);
                     LearnerInfo learnInfo = new LearnerInfo();
                     ByteBufferInputStream.byteBuffer2Record(ByteBuffer.wrap(qp.getData()), learnInfo);
-                    assertEquals(learnInfo.getProtocolVersion(), 0x10000);
+                    assertEquals(learnInfo.getProtocolVersion(), 0x11000);
                     assertEquals(learnInfo.getServerid(), 0);
 
                     // We are simulating an established leader, so the epoch is 1
                     qp.setType(Leader.LEADERINFO);
                     qp.setZxid(ZxidUtils.makeZxid(1, 0));
                     byte[] protoBytes = new byte[4];
-                    ByteBuffer.wrap(protoBytes).putInt(0x10000);
+                    ByteBuffer.wrap(protoBytes).putInt(0x11000);
                     qp.setData(protoBytes);
                     oa.writeRecord(qp, null);
 
@@ -828,7 +828,7 @@ public class Zab1_0Test extends ZKTestCase {
                 assertEquals(0, l.self.getCurrentEpoch());
 
                 /* we test a normal run. everything should work out well. */
-                LearnerInfo li = new LearnerInfo(1, 0x10000, 0);
+                LearnerInfo li = new LearnerInfo(1, 0x11000, 0);
                 byte[] liBytes = RequestRecord.fromRecord(li).readBytes();
                 QuorumPacket qp = new QuorumPacket(Leader.FOLLOWERINFO, 0, liBytes, null);
                 oa.writeRecord(qp, null);
@@ -836,7 +836,7 @@ public class Zab1_0Test extends ZKTestCase {
                 readPacketSkippingPing(ia, qp);
                 assertEquals(Leader.LEADERINFO, qp.getType());
                 assertEquals(ZxidUtils.makeZxid(1, 0), qp.getZxid());
-                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x10000);
+                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x11000);
                 assertEquals(1, l.self.getAcceptedEpoch());
                 assertEquals(0, l.self.getCurrentEpoch());
 
@@ -868,7 +868,7 @@ public class Zab1_0Test extends ZKTestCase {
                 assertEquals(0, l.self.getAcceptedEpoch());
                 assertEquals(0, l.self.getCurrentEpoch());
 
-                LearnerInfo li = new LearnerInfo(1, 0x10000, 0);
+                LearnerInfo li = new LearnerInfo(1, 0x11000, 0);
                 byte[] liBytes = RequestRecord.fromRecord(li).readBytes();
                 QuorumPacket qp = new QuorumPacket(Leader.FOLLOWERINFO, 0, liBytes, null);
                 oa.writeRecord(qp, null);
@@ -876,7 +876,7 @@ public class Zab1_0Test extends ZKTestCase {
                 readPacketSkippingPing(ia, qp);
                 assertEquals(Leader.LEADERINFO, qp.getType());
                 assertEquals(ZxidUtils.makeZxid(1, 0), qp.getZxid());
-                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x10000);
+                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x11000);
                 assertEquals(1, l.self.getAcceptedEpoch());
                 assertEquals(0, l.self.getCurrentEpoch());
 
@@ -958,14 +958,14 @@ public class Zab1_0Test extends ZKTestCase {
                     assertEquals(qp.getZxid(), 0);
                     LearnerInfo learnInfo = new LearnerInfo();
                     ByteBufferInputStream.byteBuffer2Record(ByteBuffer.wrap(qp.getData()), learnInfo);
-                    assertEquals(learnInfo.getProtocolVersion(), 0x10000);
+                    assertEquals(learnInfo.getProtocolVersion(), 0x11000);
                     assertEquals(learnInfo.getServerid(), 0);
 
                     // We are simulating an established leader, so the epoch is 1
                     qp.setType(Leader.LEADERINFO);
                     qp.setZxid(ZxidUtils.makeZxid(1, 0));
                     byte[] protoBytes = new byte[4];
-                    ByteBuffer.wrap(protoBytes).putInt(0x10000);
+                    ByteBuffer.wrap(protoBytes).putInt(0x11000);
                     qp.setData(protoBytes);
                     oa.writeRecord(qp, null);
 
@@ -1070,7 +1070,7 @@ public class Zab1_0Test extends ZKTestCase {
         testLeaderConversation(new LeaderConversation() {
             public void converseWithLeader(InputArchive ia, OutputArchive oa, Leader l) throws IOException {
                 /* we test a normal run. everything should work out well. */
-                LearnerInfo li = new LearnerInfo(1, 0x10000, 0);
+                LearnerInfo li = new LearnerInfo(1, 0x11000, 0);
                 byte[] liBytes = RequestRecord.fromRecord(li).readBytes();
                 /* we are going to say we last acked epoch 20 */
                 QuorumPacket qp = new QuorumPacket(Leader.FOLLOWERINFO, ZxidUtils.makeZxid(20, 0), liBytes, null);
@@ -1078,7 +1078,7 @@ public class Zab1_0Test extends ZKTestCase {
                 readPacketSkippingPing(ia, qp);
                 assertEquals(Leader.LEADERINFO, qp.getType());
                 assertEquals(ZxidUtils.makeZxid(21, 0), qp.getZxid());
-                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x10000);
+                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x11000);
                 qp = new QuorumPacket(Leader.ACKEPOCH, 0, new byte[4], null);
                 oa.writeRecord(qp, null);
                 readPacketSkippingPing(ia, qp);
@@ -1107,14 +1107,14 @@ public class Zab1_0Test extends ZKTestCase {
         testLeaderConversation(new LeaderConversation() {
             public void converseWithLeader(InputArchive ia, OutputArchive oa, Leader l) throws IOException, InterruptedException {
                 /* we test a normal run. everything should work out well. */
-                LearnerInfo li = new LearnerInfo(1, 0x10000, 0);
+                LearnerInfo li = new LearnerInfo(1, 0x11000, 0);
                 byte[] liBytes = RequestRecord.fromRecord(li).readBytes();
                 QuorumPacket qp = new QuorumPacket(Leader.FOLLOWERINFO, 0, liBytes, null);
                 oa.writeRecord(qp, null);
                 readPacketSkippingPing(ia, qp);
                 assertEquals(Leader.LEADERINFO, qp.getType());
                 assertEquals(ZxidUtils.makeZxid(1, 0), qp.getZxid());
-                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x10000);
+                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x11000);
                 Thread.sleep(l.self.getInitLimit() * l.self.getTickTime() + 5000);
 
                 // The leader didn't get a quorum of acks - make sure that leader's current epoch is not advanced

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/FollowerResyncConcurrencyTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/FollowerResyncConcurrencyTest.java
@@ -43,6 +43,7 @@ import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.quorum.Leader;
+import org.apache.zookeeper.server.util.ZxidUtils;
 import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -562,8 +563,8 @@ public class FollowerResyncConcurrencyTest extends ZKTestCase {
     private void verifyState(QuorumUtil qu, int index, Leader leader) {
         LOG.info("Verifying state");
         assertTrue(qu.getPeer(index).peer.follower != null, "Not following");
-        long epochF = (qu.getPeer(index).peer.getActiveServer().getZxid() >> 32L);
-        long epochL = (leader.getEpoch() >> 32L);
+        long epochF = ZxidUtils.getEpochFromZxid(qu.getPeer(index).peer.getActiveServer().getZxid());
+        long epochL = ZxidUtils.getEpochFromZxid(leader.getEpoch());
         assertTrue(epochF == epochL,
                 "Zxid: " + qu.getPeer(index).peer.getActiveServer().getZKDatabase().getDataTreeLastProcessedZxid()
                 + "Current epoch: " + epochF);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
@@ -934,7 +934,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
             String configStr = testServerHasConfig(zkArr[i], null, null);
             QuorumVerifier qv = qu.getPeer(i).peer.configFromString(configStr);
             long version = qv.getVersion();
-            assertTrue(version == 0x100000000L);
+            assertTrue(version == 0x10000000000L);
         }
     }
 


### PR DESCRIPTION
The original PR link: https://github.com/apache/zookeeper/pull/262
Since the aforementioned PR does not support rolling hot updates, this PR aims to add rolling upgrade capabilities. The goal of this PR is to change the counter bit length from 32 to 40 and the epoch bit length from 32 to 20 through a rolling upgrade approach.