### PR TITLE
feature：Configurable summarySetBlackList to set monitoring blacklist.

### DIFF
--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/main/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProvider.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/main/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProvider.java
@@ -54,6 +54,8 @@ import org.apache.zookeeper.metrics.SummarySet;
 import org.apache.zookeeper.server.RateLogger;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.apache.zookeeper.metrics.impl.BaseMetricsProvider;
+import org.apache.zookeeper.metrics.impl.NullMetricsProvider;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
@@ -66,7 +68,7 @@ import org.slf4j.LoggerFactory;
  *
  * @since 3.6.0
  */
-public class PrometheusMetricsProvider implements MetricsProvider {
+public class PrometheusMetricsProvider extends BaseMetricsProvider implements MetricsProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(PrometheusMetricsProvider.class);
     private static final String LABEL = "key";
@@ -348,6 +350,9 @@ public class PrometheusMetricsProvider implements MetricsProvider {
 
         @Override
         public SummarySet getSummarySet(String name, DetailLevel detailLevel) {
+            if (getSummarySetBlackList().contains(name)) {
+                return new NullMetricsProvider.NullSummarySet();
+            }
             if (detailLevel == DetailLevel.BASIC) {
                 return basicSummarySets.computeIfAbsent(name, (n) -> {
                     if (summarySets.containsKey(n)) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/impl/BaseMetricsProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/impl/BaseMetricsProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.metrics.impl;
+
+import org.apache.zookeeper.metrics.MetricsProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Base implementation of {@link MetricsProvider}.<br>
+ * 提供默认的实现，当前包含summarySet黑名单功能。
+ */
+public class BaseMetricsProvider {
+    public static String summarySetBlackList = "zookeeper.summarySetBlackList";
+
+    public static final List<String> getSummarySetBlackList() {
+        String summarySetBlackListConfig = System.getProperty(summarySetBlackList);
+        List<String> blackList = new ArrayList<>();
+        if (summarySetBlackListConfig != null) {
+            String[] list = summarySetBlackListConfig.split(",");
+            for (String name : list) {
+                if (!name.trim().isEmpty()) {
+                    blackList.add(name.trim());
+                }
+            }
+        }
+        return blackList;
+    }
+
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/impl/DefaultMetricsProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/impl/DefaultMetricsProvider.java
@@ -46,7 +46,7 @@ import org.apache.zookeeper.server.metric.SimpleCounterSet;
  * It is mostly useful to make the legacy 4 letter words interface work as
  * expected.
  */
-public class DefaultMetricsProvider implements MetricsProvider {
+public class DefaultMetricsProvider extends BaseMetricsProvider implements MetricsProvider {
 
     private final DefaultMetricsContext rootMetricsContext = new DefaultMetricsContext();
 
@@ -155,6 +155,9 @@ public class DefaultMetricsProvider implements MetricsProvider {
 
         @Override
         public SummarySet getSummarySet(String name, DetailLevel detailLevel) {
+            if (getSummarySetBlackList().contains(name)) {
+                return new NullMetricsProvider.NullSummarySet();
+            }
             if (detailLevel == DetailLevel.BASIC) {
                 return basicSummarySets.computeIfAbsent(name, (n) -> {
                     if (summarySets.containsKey(n)) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/impl/NullMetricsProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/metrics/impl/NullMetricsProvider.java
@@ -36,7 +36,7 @@ import org.apache.zookeeper.metrics.SummarySet;
 public class NullMetricsProvider implements MetricsProvider {
 
     /**
-     * Instance of NullMetricsProvider useful for tests.
+     * Instance of NullMetricsProvider useful for tests and balck list.
      */
     public static final MetricsProvider INSTANCE = new NullMetricsProvider();
 
@@ -146,7 +146,7 @@ public class NullMetricsProvider implements MetricsProvider {
 
     }
 
-    private static final class NullSummarySet implements SummarySet {
+    public static final class NullSummarySet implements SummarySet {
 
         private static final NullSummarySet INSTANCE = new NullSummarySet();
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/metric/SummarySetBlackListTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/metric/SummarySetBlackListTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.metric;
+
+import org.apache.zookeeper.metrics.impl.BaseMetricsProvider;
+import org.apache.zookeeper.metrics.impl.DefaultMetricsProvider;
+import org.apache.zookeeper.server.ServerMetrics;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
+
+public class SummarySetBlackListTest {
+
+    @Test
+    public void testMetrics() {
+        System.setProperty(BaseMetricsProvider.summarySetBlackList, "write_per_namespace,read_per_namespace");
+        ServerMetrics.metricsProviderInitialized(new DefaultMetricsProvider());
+        ServerMetrics.getMetrics().WRITE_PER_NAMESPACE.add("testNamespace", 1);
+        ServerMetrics.getMetrics().READ_PER_NAMESPACE.add("testNamespace", 1);
+
+        Set<String> metricNames = new HashSet<>();
+        ServerMetrics.getMetrics().getMetricsProvider().dump((k, v) -> metricNames.add(k));
+        assertTrue(!metricNames.contains("cnt_testNamespace_write_per_namespace"));
+        assertTrue(!metricNames.contains("cnt_testNamespace_read_per_namespace"));
+        System.clearProperty(BaseMetricsProvider.summarySetBlackList);
+        ServerMetrics.metricsProviderInitialized(new DefaultMetricsProvider());
+    }
+
+}


### PR DESCRIPTION
Issue:
- The current ZooKeeper (ZK) cluster frequently experiences excessively long Full Garbage Collection (FGC) events (averaging once a week) that last over 10 seconds, leading to occasional, unexpected leader elections in the ZK cluster.
- The cluster currently fails to collect mntr monitoring data.

Root Cause:
- The ZK cluster uses the direct child nodes under the root directory (/) as Namespaces, At the Namespace level, the following have been implemented:
- Monitoring of MIN, CNT, AVG, MAX, and SUM request counts, which can be obtained via mntr monitoring.
- monitoring for Namespaces only accounts for additions and not removals, tasks are created directly under the root directory (/), with tasks older than seven days being cleaned daily.
- This leads to the following phenomenon: The number of Namespaces stored in ZK nodes (157,376) is significantly greater than the actual number of Namespaces in the ZK cluster (5,856).

Solution:
Provide a new version of the ZK server that supports configurable Namespace monitoring.