### PR TITLE
ZOOKEEPER-4818 Add metric JVM_HEAP_BYTES_USED, JVM_HEAP_BYTES_MAX, and JVM_HEAP_BYTES_FREE

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
@@ -267,6 +267,9 @@ public final class ServerMetrics {
         WATCH_BYTES = metricsContext.getCounter("watch_bytes");
 
         JVM_PAUSE_TIME = metricsContext.getSummary("jvm_pause_time_ms", DetailLevel.ADVANCED);
+        JVM_HEAP_BYTES_USED = metricsContext.getSummary("jvm_memory_bytes_used", DetailLevel.ADVANCED);
+        JVM_HEAP_BYTES_MAX = metricsContext.getSummary("jvm_memory_bytes_max", DetailLevel.ADVANCED);
+        JVM_HEAP_BYTES_FREE = metricsContext.getSummary("jvm_memory_bytes_free", DetailLevel.ADVANCED);
 
         QUOTA_EXCEEDED_ERROR_PER_NAMESPACE = metricsContext.getCounterSet(QuotaMetricsUtils.QUOTA_EXCEEDED_ERROR_PER_NAMESPACE);
     }
@@ -544,6 +547,12 @@ public final class ServerMetrics {
     public final Counter WATCH_BYTES;
 
     public final Summary JVM_PAUSE_TIME;
+
+    public final Summary JVM_HEAP_BYTES_USED;
+
+    public final Summary JVM_HEAP_BYTES_MAX;
+
+    public final Summary JVM_HEAP_BYTES_FREE;
 
     public final CounterSet QUOTA_EXCEEDED_ERROR_PER_NAMESPACE;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/JvmPauseMonitor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/JvmPauseMonitor.java
@@ -205,6 +205,13 @@ public class JvmPauseMonitor {
                 }
                 totalGcExtraSleepTime += extraSleepTime;
                 gcTimesBeforeSleep = gcTimesAfterSleep;
+
+                long heapSize = Runtime.getRuntime().totalMemory();
+                long heapMaxSize = Runtime.getRuntime().maxMemory();
+                long heapFreeSize = Runtime.getRuntime().freeMemory();
+                ServerMetrics.getMetrics().JVM_HEAP_BYTES_USED.add(heapSize);
+                ServerMetrics.getMetrics().JVM_HEAP_BYTES_MAX.add(heapMaxSize);
+                ServerMetrics.getMetrics().JVM_HEAP_BYTES_FREE.add(heapFreeSize);
             }
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZOOKEEPER-4818