### PR TITLE
ZOOKEEPER-4837: Network issue causes ephemeral node unremoved after t…

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapShot.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/SnapShot.java
@@ -41,6 +41,16 @@ public interface SnapShot {
     long deserialize(DataTree dt, Map<Long, Integer> sessions) throws IOException;
 
     /**
+     * deserialize a data tree from the last valid snapshot before the checkpoint zxid and return the last zxid that was deserialized
+     * 
+     * @param dt       the datatree to be deserialized into
+     * @param sessions the sessions to be deserialized into
+     * @return the last zxid that was deserialized from the snapshot
+     * @throws IOException
+     */
+    long deserialize(DataTree dt, Map<Long, Integer> sessions, long zxid) throws IOException;
+
+    /**
      * persist the datatree and the sessions into a persistence storage
      * @param dt the datatree to be serialized
      * @param sessions the session timeouts to be serialized

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeDeletionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeDeletionTest.java
@@ -47,6 +47,96 @@ public class EphemeralNodeDeletionTest extends QuorumPeerTestBase {
     private static int SERVER_COUNT = 3;
     private MainThread[] mt = new MainThread[SERVER_COUNT];
 
+    @Test
+    @Timeout(value = 300)
+    public void testEphemeralNodeDeletionNewBug() throws Exception {
+        final int[] clientPorts = new int[SERVER_COUNT];
+        StringBuilder sb = new StringBuilder();
+        String server;
+
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            clientPorts[i] = PortAssignment.unique();
+            server = "server." + i + "=127.0.0.1:" + PortAssignment.unique() + ":" + PortAssignment.unique()
+                    + ":participant;127.0.0.1:" + clientPorts[i];
+            sb.append(server + "\n");
+        }
+        String currentQuorumCfgSection = sb.toString();
+        // start all the servers
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            final int customId = i;
+            mt[i] = new MainThread(i, clientPorts[i], currentQuorumCfgSection, false) {
+                @Override
+                public TestQPMain getTestQPMain() {
+                    return new MockTestQPMain();
+                }
+            };
+            Thread.sleep(1000);
+            mt[i].start();
+        }
+
+        // ensure all servers started
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPorts[i], CONNECTION_TIMEOUT),
+                    "waiting for server " + i + " being up");
+        }
+
+        // Check that node 1 is the initial leader
+        assertEquals(1, mt[1].getQuorumPeer().getLeaderId());
+
+        CountdownWatcher watch = new CountdownWatcher();
+        // QuorumPeer l = getByServerState(mt, ServerState.LEADING);
+        ZooKeeper zk = new ZooKeeper("127.0.0.1:" + clientPorts[0], ClientBase.CONNECTION_TIMEOUT, watch);
+        watch.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
+
+        Stat firstEphemeralNode = new Stat();
+
+        // 1: create ephemeral node
+        String nodePath = "/e1";
+        zk.create(nodePath, "1".getBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL, firstEphemeralNode);
+
+        // 2: Inject network error
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            CustomQuorumPeer cqp = (CustomQuorumPeer) mt[i].getQuorumPeer();
+            cqp.setInjectError(true);
+        }
+
+        // 3: Quit
+        zk.close();
+
+        // 4: Wait until node 1 and node 2 have removed the ephemeral node
+        while (true) {
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+
+            if (mt[1].getQuorumPeer().getZkDb().getSessionCount() == 0
+                    && mt[2].getQuorumPeer().getZkDb().getSessionCount() == 0) {
+
+                // Double check
+                Thread.sleep(1000);
+                if (mt[1].getQuorumPeer().getZkDb().getSessionCount() == 0
+                        && mt[2].getQuorumPeer().getZkDb().getSessionCount() == 0) {
+                    break;
+                }
+            }
+        }
+
+        // 5: Remove network error
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            CustomQuorumPeer cqp = (CustomQuorumPeer) mt[i].getQuorumPeer();
+            cqp.setInjectError(false);
+        }
+
+        // Node must have been deleted from 1 and 2
+        assertNodeNotExist(nodePath, 2);
+        assertNodeNotExist(nodePath, 1);
+
+        // Node is not deleted from 0
+        assertNodeNotExist(nodePath, 0);
+    }
+
     /**
      * Test case for https://issues.apache.org/jira/browse/ZOOKEEPER-2355.
      * ZooKeeper ephemeral node is never deleted if follower fail while reading
@@ -154,6 +244,18 @@ public class EphemeralNodeDeletionTest extends QuorumPeerTestBase {
         // ephemeral node is getting deleted.
         assertNull(nodeAtFollower, "After session close ephemeral node must be deleted");
         followerZK.close();
+    }
+
+    void assertNodeNotExist(String nodePath, int idx) throws Exception {
+        QuorumPeer qp = mt[idx].getQuorumPeer();
+
+        CountdownWatcher watch = new CountdownWatcher();
+        ZooKeeper zk = new ZooKeeper("127.0.0.1:" + qp.getClientPort(), ClientBase.CONNECTION_TIMEOUT, watch);
+        watch.waitForConnected(ClientBase.CONNECTION_TIMEOUT);
+
+        Stat exists = zk.exists(nodePath, false);
+        zk.close();
+        assertNull(exists, "Node must have been deleted from the node " + idx);
     }
 
     @AfterEach


### PR DESCRIPTION
…he session expiration

The core part of this fix is
```
// if this snapshot has a higher zxid than the checkpoint zxid, skip and continue to the previous snapshot
if (snapZxid > zxid) {
    continue;
}
```
However, the zxid must be propagated from tuncateLog(), which is why I added another loadDatabase, deserialize, and restore with zxid as its additional parameter.