### PR TITLE
ZOOKEEPER-4790: Make client hostname verification configurable

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1741,7 +1741,7 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
 
 * *ssl.clientHostnameVerification* and *ssl.quorum.clientHostnameVerification* :
     (Java system properties: **zookeeper.ssl.clientHostnameVerification** and **zookeeper.ssl.quorum.clientHostnameVerification**)
-    **New in (INSERT VERSION HERE):**
+    **New in 3.9.4:**
     Specifies whether the client's hostname verification is enabled in client and quorum TLS negotiation process.
     Default: true for quorum, false for clients
 

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1743,6 +1743,7 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     (Java system properties: **zookeeper.ssl.clientHostnameVerification** and **zookeeper.ssl.quorum.clientHostnameVerification**)
     **New in 3.9.4:**
     Specifies whether the client's hostname verification is enabled in client and quorum TLS negotiation process.
+    This option requires the corresponding *hostnameVerification* option to be `true`, or it will be ignored.
     Default: true for quorum, false for clients
 
 * *ssl.crl* and *ssl.quorum.crl* :

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1739,6 +1739,12 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     Disabling it only recommended for testing purposes.
     Default: true
 
+* *ssl.clientHostnameVerification* and *ssl.quorum.clientHostnameVerification* :
+    (Java system properties: **zookeeper.ssl.clientHostnameVerification** and **zookeeper.ssl.quorum.clientHostnameVerification**)
+    **New in (INSERT VERSION HERE):**
+    Specifies whether the client's hostname verification is enabled in client and quorum TLS negotiation process.
+    Default: true for quorum, false for clients
+
 * *ssl.crl* and *ssl.quorum.crl* :
     (Java system properties: **zookeeper.ssl.crl** and **zookeeper.ssl.quorum.crl**)
     **New in 3.5.5:**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
@@ -196,6 +196,7 @@ public abstract class X509Util implements Closeable, AutoCloseable {
     private final String sslTruststoreTypeProperty = getConfigPrefix() + "trustStore.type";
     private final String sslContextSupplierClassProperty = getConfigPrefix() + "context.supplier.class";
     private final String sslHostnameVerificationEnabledProperty = getConfigPrefix() + "hostnameVerification";
+    private final String sslClientHostnameVerificationEnabledProperty = getConfigPrefix() + "clientHostnameVerification";
     private final String sslCrlEnabledProperty = getConfigPrefix() + "crl";
     private final String sslOcspEnabledProperty = getConfigPrefix() + "ocsp";
     private final String sslClientAuthProperty = getConfigPrefix() + "clientAuth";
@@ -270,6 +271,10 @@ public abstract class X509Util implements Closeable, AutoCloseable {
         return sslHostnameVerificationEnabledProperty;
     }
 
+    public String getSslClientHostnameVerificationEnabledProperty() {
+        return sslClientHostnameVerificationEnabledProperty;
+    }
+
     public String getSslCrlEnabledProperty() {
         return sslCrlEnabledProperty;
     }
@@ -305,7 +310,8 @@ public abstract class X509Util implements Closeable, AutoCloseable {
     }
 
     public boolean isClientHostnameVerificationEnabled(ZKConfig config) {
-        return isServerHostnameVerificationEnabled(config) && shouldVerifyClientHostname();
+        return isServerHostnameVerificationEnabled(config)
+            && config.getBoolean(this.getSslClientHostnameVerificationEnabledProperty(), shouldVerifyClientHostname());
     }
 
     public SSLContext getDefaultSSLContext() throws X509Exception.SSLContextException {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKConfig.java
@@ -127,6 +127,7 @@ public class ZKConfig {
         properties.put(x509Util.getSslTruststorePasswdPathProperty(), System.getProperty(x509Util.getSslTruststorePasswdPathProperty()));
         properties.put(x509Util.getSslTruststoreTypeProperty(), System.getProperty(x509Util.getSslTruststoreTypeProperty()));
         properties.put(x509Util.getSslContextSupplierClassProperty(), System.getProperty(x509Util.getSslContextSupplierClassProperty()));
+        properties.put(x509Util.getSslClientHostnameVerificationEnabledProperty(), System.getProperty(x509Util.getSslClientHostnameVerificationEnabledProperty()));
         properties.put(x509Util.getSslHostnameVerificationEnabledProperty(), System.getProperty(x509Util.getSslHostnameVerificationEnabledProperty()));
         properties.put(x509Util.getSslCrlEnabledProperty(), System.getProperty(x509Util.getSslCrlEnabledProperty()));
         properties.put(x509Util.getSslOcspEnabledProperty(), System.getProperty(x509Util.getSslOcspEnabledProperty()));


### PR DESCRIPTION
FIPS mode _technically_ covers this, in a sort of sledgehammery way, but I think it's still worthwhile to have an explicit option for this and only this. Especially since FIPS compliance is a pretty broad thing (see [ZOOKEEPER-4832](https://issues.apache.org/jira/browse/ZOOKEEPER-4832)) that will likely expand in the future to cover a lot of things that may or may not be desired.