### PR TITLE
ZOOKEEPER-4850: Enhance zkCli Tool to Support Reading and Writing Binary Data

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/Base64OutputFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/Base64OutputFormatter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zookeeper.cli;
 
 import java.util.Base64;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/Base64OutputFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/Base64OutputFormatter.java
@@ -1,0 +1,13 @@
+package org.apache.zookeeper.cli;
+
+import java.util.Base64;
+
+public class Base64OutputFormatter implements OutputFormatter {
+
+    public static final Base64OutputFormatter INSTANCE = new Base64OutputFormatter();
+
+    @Override
+    public String format(byte[] data) {
+        return Base64.getEncoder().encodeToString(data);
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CliCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CliCommand.java
@@ -20,6 +20,8 @@ package org.apache.zookeeper.cli;
 
 import java.io.PrintStream;
 import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.commons.cli.Options;
 import org.apache.zookeeper.ZooKeeper;
 
 /**
@@ -32,6 +34,8 @@ public abstract class CliCommand {
     protected PrintStream err;
     private String cmdStr;
     private String optionStr;
+    @Nullable
+    private Options options;
 
     /**
      * a CLI command with command string and options.
@@ -40,10 +44,22 @@ public abstract class CliCommand {
      * @param optionStr the string used to call this command
      */
     public CliCommand(String cmdStr, String optionStr) {
+        this(cmdStr, optionStr, null);
+    }
+
+    /**
+     * a CLI command with command string and options.
+     * Using System.out and System.err for printing
+     * @param cmdStr the string used to call this command
+     * @param optionStr the string used to call this command
+     * @param options the command options
+     */
+    public CliCommand(String cmdStr, String optionStr, Options options) {
         this.out = System.out;
         this.err = System.err;
         this.cmdStr = cmdStr;
         this.optionStr = optionStr;
+        this.options = options;
     }
 
     /**
@@ -88,7 +104,7 @@ public abstract class CliCommand {
      * get a usage string, contains the command and the options
      */
     public String getUsageStr() {
-        return cmdStr + " " + optionStr;
+        return CommandUsageHelper.getUsage(cmdStr + " " + optionStr, options);
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CommandUsageHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CommandUsageHelper.java
@@ -20,20 +20,23 @@ package org.apache.zookeeper.cli;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import javax.annotation.Nullable;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 
 public class CommandUsageHelper {
 
-    public static String getUsage(String commandSyntax, Options options) {
+    public static String getUsage(String commandSyntax, @Nullable Options options) {
         StringBuilder buffer = new StringBuilder();
         buffer.append(commandSyntax);
-        buffer.append(System.lineSeparator());
-        StringWriter out = new StringWriter();
-        HelpFormatter formatter = new HelpFormatter();
-        formatter.printOptions(new PrintWriter(out), formatter.getWidth(), options, formatter.getLeftPadding(),
-                formatter.getDescPadding());
-        buffer.append(out);
+        if (options != null && !options.getOptions().isEmpty()) {
+            buffer.append(System.lineSeparator());
+            StringWriter out = new StringWriter();
+            HelpFormatter formatter = new HelpFormatter();
+            formatter.printOptions(new PrintWriter(out), formatter.getWidth(), options, formatter.getLeftPadding(),
+                    formatter.getDescPadding());
+            buffer.append(out);
+        }
         return buffer.toString();
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CommandUsageHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CommandUsageHelper.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.cli;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+
+public class CommandUsageHelper {
+
+    public static String getUsage(String commandSyntax, Options options) {
+        StringBuilder buffer = new StringBuilder();
+        buffer.append(commandSyntax);
+        buffer.append(System.lineSeparator());
+        StringWriter out = new StringWriter();
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printOptions(new PrintWriter(out), formatter.getWidth(), options, formatter.getLeftPadding(),
+                formatter.getDescPadding());
+        buffer.append(out);
+        return buffer.toString();
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
@@ -18,7 +18,6 @@
 
 package org.apache.zookeeper.cli;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
@@ -38,10 +38,12 @@ public class GetCommand extends CliCommand {
     static {
         options.addOption("s", false, "stats");
         options.addOption("w", false, "watch");
+        options.addOption("b", false, "base64");
+        options.addOption("x", false, "hexdump");
     }
 
     public GetCommand() {
-        super("get", "[-s] [-w] path");
+        super("get", "[-s] [-w] [-b] [-x] path");
     }
 
     @Override
@@ -92,8 +94,15 @@ public class GetCommand extends CliCommand {
         } catch (KeeperException | InterruptedException ex) {
             throw new CliWrapperException(ex);
         }
+        OutputFormatter formatter = PlainOutputFormatter.INSTANCE;
+        if (cl.hasOption("b")) {
+            formatter = Base64OutputFormatter.INSTANCE;
+        }
+        if (cl.hasOption("x")) {
+            formatter = HexDumpOutputFormatter.INSTANCE;
+        }
         data = (data == null) ? "null".getBytes() : data;
-        out.println(new String(data, UTF_8));
+        out.println(formatter.format(data));
         if (cl.hasOption("s")) {
             new StatPrinter(out).print(stat);
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
@@ -18,7 +18,6 @@
 
 package org.apache.zookeeper.cli;
 
-import static org.apache.zookeeper.cli.CommandUsageHelper.getUsage;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -43,7 +42,7 @@ public class GetCommand extends CliCommand {
     }
 
     public GetCommand() {
-        super("get", getUsage("[-s] [-w] [-b] [-x] path", options));
+        super("get", "[-s] [-w] [-b] [-x] path", options);
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/GetCommand.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.cli;
 
+import static org.apache.zookeeper.cli.CommandUsageHelper.getUsage;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -35,14 +36,14 @@ public class GetCommand extends CliCommand {
     private CommandLine cl;
 
     static {
-        options.addOption("s", false, "stats");
-        options.addOption("w", false, "watch");
-        options.addOption("b", false, "base64");
-        options.addOption("x", false, "hexdump");
+        options.addOption("s", false, "Print znode stats additionally");
+        options.addOption("w", false, "Watch for changes on the znode");
+        options.addOption("b", false, "Output data in base64 format");
+        options.addOption("x", false, "Output data in hexdump format");
     }
 
     public GetCommand() {
-        super("get", "[-s] [-w] [-b] [-x] path");
+        super("get", getUsage("[-s] [-w] [-b] [-x] path", options));
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/HexDumpOutputFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/HexDumpOutputFormatter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zookeeper.cli;
 
 import io.netty.buffer.ByteBuf;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/HexDumpOutputFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/HexDumpOutputFormatter.java
@@ -1,0 +1,16 @@
+package org.apache.zookeeper.cli;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+
+public class HexDumpOutputFormatter implements OutputFormatter {
+
+    public static final HexDumpOutputFormatter INSTANCE = new HexDumpOutputFormatter();
+
+    @Override
+    public String format(byte[] data) {
+        ByteBuf buf = Unpooled.wrappedBuffer(data);
+        return ByteBufUtil.prettyHexDump(buf);
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/OutputFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/OutputFormatter.java
@@ -1,0 +1,6 @@
+package org.apache.zookeeper.cli;
+
+public interface OutputFormatter {
+
+    String format(byte[] data);
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/OutputFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/OutputFormatter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zookeeper.cli;
 
 public interface OutputFormatter {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/PlainOutputFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/PlainOutputFormatter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zookeeper.cli;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/PlainOutputFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/PlainOutputFormatter.java
@@ -1,0 +1,13 @@
+package org.apache.zookeeper.cli;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class PlainOutputFormatter implements OutputFormatter {
+
+    public static final PlainOutputFormatter INSTANCE = new PlainOutputFormatter();
+
+    @Override
+    public String format(byte[] data) {
+        return new String(data, UTF_8);
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.cli;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import java.util.Base64;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -38,10 +39,11 @@ public class SetCommand extends CliCommand {
     static {
         options.addOption("s", false, "stats");
         options.addOption("v", true, "version");
+        options.addOption("b", false, "base64");
     }
 
     public SetCommand() {
-        super("set", "[-s] [-v version] path data");
+        super("set", "[-s] [-v version] [-b] path data");
     }
 
     @Override
@@ -63,7 +65,12 @@ public class SetCommand extends CliCommand {
     @Override
     public boolean exec() throws CliException {
         String path = args[1];
-        byte[] data = args[2].getBytes(UTF_8);
+        byte[] data;
+        if (cl.hasOption("b")) {
+            data = Base64.getDecoder().decode(args[2]);
+        } else {
+            data = args[2].getBytes(UTF_8);
+        }
         int version;
         if (cl.hasOption("v")) {
             version = Integer.parseInt(cl.getOptionValue("v"));

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
@@ -44,7 +44,7 @@ public class SetCommand extends CliCommand {
     }
 
     public SetCommand() {
-        super("set", getUsage("set path data [-s] [-v version] [-b]", options));
+        super("set", getUsage("path data [-s] [-v version] [-b]", options));
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
@@ -19,7 +19,6 @@
 package org.apache.zookeeper.cli;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.zookeeper.cli.CommandUsageHelper.getUsage;
 import java.util.Base64;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -44,7 +43,7 @@ public class SetCommand extends CliCommand {
     }
 
     public SetCommand() {
-        super("set", getUsage("path data [-s] [-v version] [-b]", options));
+        super("set", "path data [-s] [-v version] [-b]", options);
     }
 
     @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/SetCommand.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.cli;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.zookeeper.cli.CommandUsageHelper.getUsage;
 import java.util.Base64;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -37,13 +38,13 @@ public class SetCommand extends CliCommand {
     private CommandLine cl;
 
     static {
-        options.addOption("s", false, "stats");
-        options.addOption("v", true, "version");
-        options.addOption("b", false, "base64");
+        options.addOption("s", false, "Print znode stats additionally");
+        options.addOption("v", true, "Set with an expected version");
+        options.addOption("b", false, "Supply data in base64 format");
     }
 
     public SetCommand() {
-        super("set", "[-s] [-v version] [-b] path data");
+        super("set", getUsage("set path data [-s] [-v version] [-b]", options));
     }
 
     @Override


### PR DESCRIPTION
Currently, the `get` and `set` commands in the zkCli tool only support reading and writing text data. However, znode data can be an arbitrary byte array. It would be useful to read and write binary data in `base64` or `hexdump` format.

This PR provides two options for the `get` command:
- `get -b /foo`: Outputs data in base64 format.
- `get -x /foo`: Outputs data in hexdump format.

Additionally, it provides a `-b` option for the `set` command to allow users to set binary data in `base64` format for a znode. For instance: `set -b /foo em9va2VlcGVy`.