### PR TITLE
ZOOKEEPER-4846: Failure to reload database due to missing ACL

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -447,7 +447,7 @@ public class DataTree {
         }
         List<ACL> parentAcl;
         synchronized (parent) {
-            parentAcl = getACL(parent);
+            parentAcl = getACL(parent, false);
 
             // Add the ACL to ACL cache first, to avoid the ACL not being
             // created race condition during fuzzy snapshot sync.
@@ -566,7 +566,7 @@ public class DataTree {
         List<ACL> acl;
         nodes.remove(path);
         synchronized (node) {
-            acl = getACL(node);
+            acl = getACL(node, false);
             aclCache.removeUsage(node.acl);
             nodeDataSize.addAndGet(-getNodeSize(path, node.data));
         }
@@ -576,7 +576,7 @@ public class DataTree {
         // separate patch.
         List<ACL> parentAcl;
         synchronized (parent) {
-            parentAcl = getACL(parent);
+            parentAcl = getACL(parent, false);
             long owner = node.stat.getEphemeralOwner();
             EphemeralType ephemeralType = EphemeralType.get(owner);
             if (ephemeralType == EphemeralType.CONTAINER) {
@@ -638,7 +638,7 @@ public class DataTree {
         List<ACL> acl;
         byte[] lastData;
         synchronized (n) {
-            acl = getACL(n);
+            acl = getACL(n, false);
             lastData = n.data;
             nodes.preChange(path, n);
             n.data = data;
@@ -790,8 +790,12 @@ public class DataTree {
     }
 
     public List<ACL> getACL(DataNode node) {
+        return getACL(node, true);
+    }
+
+    private List<ACL> getACL(DataNode node, boolean mustSucceed) {
         synchronized (node) {
-            return aclCache.convertLong(node.acl);
+            return aclCache.convertLong(node.acl, mustSucceed);
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ReferenceCountedACLCache.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ReferenceCountedACLCache.java
@@ -80,7 +80,11 @@ public class ReferenceCountedACLCache {
      * @param longVal
      * @return a list of ACLs that map to the long
      */
-    public synchronized List<ACL> convertLong(Long longVal) {
+    public List<ACL> convertLong(Long longVal) {
+        return convertLong(longVal, true);
+    }
+
+    public synchronized List<ACL> convertLong(Long longVal, boolean mustSucceed) {
         if (longVal == null) {
             return null;
         }
@@ -89,8 +93,12 @@ public class ReferenceCountedACLCache {
         }
         List<ACL> acls = longKeyMap.get(longVal);
         if (acls == null) {
-            LOG.error("ERROR: ACL not available for long {}", longVal);
-            throw new RuntimeException("Failed to fetch acls for " + longVal);
+            if (!mustSucceed) {
+                LOG.warn("ACL not available for long {}", longVal);
+            } else {
+                LOG.error("ERROR: ACL not available for long {}", longVal);
+                throw new RuntimeException("Failed to fetch acls for " + longVal);
+            }
         }
         return acls;
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/WatchManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/WatchManager.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
@@ -186,7 +187,7 @@ public class WatchManager implements IWatchManager {
                 continue;
             }
             if (w instanceof ServerWatcher) {
-                ((ServerWatcher) w).process(e, acl);
+                ((ServerWatcher) w).process(e, Objects.requireNonNull(acl));
             } else {
                 w.process(e);
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/WatchManagerOptimized.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/watch/WatchManagerOptimized.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -236,7 +237,7 @@ public class WatchManagerOptimized implements IWatchManager, IDeadWatcherListene
                 }
 
                 if (w instanceof ServerWatcher) {
-                    ((ServerWatcher) w).process(e, acl);
+                    ((ServerWatcher) w).process(e, Objects.requireNonNull(acl));
                 } else {
                     w.process(e);
                 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/watch/WatchManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/watch/WatchManagerTest.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.metrics.MetricsUtils;
 import org.apache.zookeeper.server.DumbWatcher;
 import org.apache.zookeeper.server.ServerCnxn;
@@ -133,7 +134,7 @@ public class WatchManagerTest extends ZKTestCase {
         public void run() {
             while (!stopped) {
                 String path = PATH_PREFIX + r.nextInt(paths);
-                WatcherOrBitSet s = manager.triggerWatch(path, EventType.NodeDeleted, -1, null);
+                WatcherOrBitSet s = manager.triggerWatch(path, EventType.NodeDeleted, -1, Ids.OPEN_ACL_UNSAFE);
                 if (s != null) {
                     triggeredCount.addAndGet(s.size());
                 }
@@ -756,7 +757,7 @@ public class WatchManagerTest extends ZKTestCase {
         //path2 is watched by watcher1
         manager.addWatch(path2, watcher1);
 
-        manager.triggerWatch(path3, EventType.NodeCreated, 1, null);
+        manager.triggerWatch(path3, EventType.NodeCreated, 1, Ids.OPEN_ACL_UNSAFE);
         //path3 is not being watched so metric is 0
         checkMetrics("node_created_watch_count", 0L, 0L, 0D, 0L, 0L);
         // Watchers shouldn't have received any events yet so the zxid should be -1.
@@ -764,19 +765,19 @@ public class WatchManagerTest extends ZKTestCase {
         checkMostRecentWatchedEvent(watcher2, null, null, -1);
 
         //path1 is watched by two watchers so two fired
-        manager.triggerWatch(path1, EventType.NodeCreated, 2, null);
+        manager.triggerWatch(path1, EventType.NodeCreated, 2, Ids.OPEN_ACL_UNSAFE);
         checkMetrics("node_created_watch_count", 2L, 2L, 2D, 1L, 2L);
         checkMostRecentWatchedEvent(watcher1, path1, EventType.NodeCreated, 2);
         checkMostRecentWatchedEvent(watcher2, path1, EventType.NodeCreated, 2);
 
         //path2 is watched by one watcher so one fired now total is 3
-        manager.triggerWatch(path2, EventType.NodeCreated, 3, null);
+        manager.triggerWatch(path2, EventType.NodeCreated, 3, Ids.OPEN_ACL_UNSAFE);
         checkMetrics("node_created_watch_count", 1L, 2L, 1.5D, 2L, 3L);
         checkMostRecentWatchedEvent(watcher1, path2, EventType.NodeCreated, 3);
         checkMostRecentWatchedEvent(watcher2, path1, EventType.NodeCreated, 2);
 
         //watches on path1 are no longer there so zero fired
-        manager.triggerWatch(path1, EventType.NodeDataChanged, 4, null);
+        manager.triggerWatch(path1, EventType.NodeDataChanged, 4, Ids.OPEN_ACL_UNSAFE);
         checkMetrics("node_changed_watch_count", 0L, 0L, 0D, 0L, 0L);
         checkMostRecentWatchedEvent(watcher1, path2, EventType.NodeCreated, 3);
         checkMostRecentWatchedEvent(watcher2, path1, EventType.NodeCreated, 2);
@@ -788,12 +789,12 @@ public class WatchManagerTest extends ZKTestCase {
         //path2 is watched by watcher1
         manager.addWatch(path2, watcher1);
 
-        manager.triggerWatch(path1, EventType.NodeDataChanged, 5, null);
+        manager.triggerWatch(path1, EventType.NodeDataChanged, 5, Ids.OPEN_ACL_UNSAFE);
         checkMetrics("node_changed_watch_count", 2L, 2L, 2D, 1L, 2L);
         checkMostRecentWatchedEvent(watcher1, path1, EventType.NodeDataChanged, 5);
         checkMostRecentWatchedEvent(watcher2, path1, EventType.NodeDataChanged, 5);
 
-        manager.triggerWatch(path2, EventType.NodeDeleted, 6, null);
+        manager.triggerWatch(path2, EventType.NodeDeleted, 6, Ids.OPEN_ACL_UNSAFE);
         checkMetrics("node_deleted_watch_count", 1L, 1L, 1D, 1L, 1L);
         checkMostRecentWatchedEvent(watcher1, path2, EventType.NodeDeleted, 6);
         checkMostRecentWatchedEvent(watcher2, path1, EventType.NodeDataChanged, 5);


### PR DESCRIPTION
ZooKeeper snapshots are *fuzzy*, as the server does not stop processing requests while ACLs and nodes are being streamed to disk.

ACLs, notably, are streamed *first*, as a mapping between the full serialized ACL and an "ACL ID" referenced by the node.

Consequently, a snapshot can very well contain ACL IDs which do not exist in the mapping. Prior to ZOOKEEPER-4799, such situations would produce harmless (if annoying) "Ignoring acl XYZ as it does not exist in the cache" INFO entries in the server logs.

With ZOOKEEPER-4799, we started "eagerly" fetching the referenced ACLs in `DataTree` operations such as `createNode`, `deleteNode`, etc.—as opposed to just fetching them from request processors.

This can result in fatal errors during the `fastForwardFromEdits` phase of restoring a database, when transactions are processed on top of an inconsistent data tree—preventing the server from starting.

The errors are thrown in this code path:

``` java
// ReferenceCountedACLCache.java:90
List<ACL> acls = longKeyMap.get(longVal);
if (acls == null) {
    LOG.error("ERROR: ACL not available for long {}", longVal);
    throw new RuntimeException("Failed to fetch acls for " + longVal);
}
```

Here is a scenario leading to such a failure:

- An existing node `/foo`, sporting an unique ACL, is deleted. This is recorded in transaction log `$SNAP-1`; said ACL is also deallocated;
- Snapshot `$SNAP` is started;
- The ACL map is serialized to `$SNAP`;
- A new node `/foo` sporting the same unique ACL is created in a portion of the data tree which still has to be serialized;
- Node `/foo` is serialized to `$SNAP`—but its ACL isn't;
- The server is restarted;
- The `DataTree` is initialized from `$SNAP`, including node `/foo` with a dangling ACL reference;
- Transaction log `$SNAP-1` is being replayed, leading to a `deleteNode("/foo")`;
- `getACL(node)` panics.
