### PR TITLE
ZOOKEEPER-4859: Fix openssl gencerts failure due to too long hostname in github ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,13 @@ jobs:
         name: failsafe-reports-${{ matrix.profile.name }}
         path: ./**/target/failsafe-reports/
         if-no-files-found: ignore
+    - name: Upload cppunit test logs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: cppunit-logs-${{ matrix.profile.name }}
+        path: ./zookeeper-client/zookeeper-client-c/target/c/TEST-*.txt
+        if-no-files-found: ignore
   typo-check:
     name: Typo Check
     # only run on pull requests because of security reasons

--- a/zookeeper-client/zookeeper-client-c/tests/zkServer.sh
+++ b/zookeeper-client/zookeeper-client-c/tests/zkServer.sh
@@ -183,7 +183,10 @@ start|startClean|startRequireSASLAuth|startCleanReadOnly)
     mkdir -p "${certs_dir}"
     cp ${tests_dir}/../ssl/gencerts.sh "${certs_dir}/"  > /dev/null
     cd ${certs_dir} > /dev/null
-    ./gencerts.sh > ./gencerts.stdout 2> ./gencerts.stderr
+    # GitHub is providing us hostnames with more than 64 characters now.
+    # And there are no cppunit tests do hostname verification currently,
+    # so we could set CN to arbitrary hostname for now.
+    ./gencerts.sh tests.zookeeper.apache.org > ./gencerts.stdout 2> ./gencerts.stderr
     cd - > /dev/null
 
 


### PR DESCRIPTION
Github is providing us hostnames with more than 64 characters quite often now.

Say:

* `fv-az1272-448.grsihaubamwerhiryzjrxtypna.phxx.internal.cloudapp.net` (67 characters)
* `fv-az1383-210.ikz3ofujitfebmhnxoyjuylfjd.ex.internal.cloudapp.net` (65 characters)

This fails tls certs generation in cppunit tests.