### PR TITLE
ZOOKEEPER-4843: Encountering an 'Unreasonable Length' error when configuring jute.maxbuffer to 1GB or more

### DIFF
--- a/zookeeper-jute/src/main/java/org/apache/jute/BinaryInputArchive.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/BinaryInputArchive.java
@@ -47,9 +47,8 @@ public class BinaryInputArchive implements InputArchive {
         }
     }
 
-    private DataInput in;
-    private int maxBufferSize;
-    private int extraMaxBufferSize;
+    private final DataInput in;
+    private final int totalBufferSize;
 
     public static BinaryInputArchive getArchive(InputStream strm) {
         return new BinaryInputArchive(new DataInputStream(strm));
@@ -80,8 +79,11 @@ public class BinaryInputArchive implements InputArchive {
 
     public BinaryInputArchive(DataInput in, int maxBufferSize, int extraMaxBufferSize) {
         this.in = in;
-        this.maxBufferSize = maxBufferSize;
-        this.extraMaxBufferSize = extraMaxBufferSize;
+        if ((long) maxBufferSize + extraMaxBufferSize > Integer.MAX_VALUE) {
+            this.totalBufferSize = Integer.MAX_VALUE;
+        } else {
+            this.totalBufferSize = maxBufferSize + extraMaxBufferSize;
+        }
     }
 
     public byte readByte(String tag) throws IOException {
@@ -162,7 +164,7 @@ public class BinaryInputArchive implements InputArchive {
     // make up for extra fields, etc. (otherwise e.g. clients may be able to
     // write buffers larger than we can read from disk!)
     private void checkLength(int len) throws IOException {
-        if (len < 0 || len > maxBufferSize + extraMaxBufferSize) {
+        if (len < 0 || len > totalBufferSize) {
             throw new IOException(UNREASONBLE_LENGTH + len);
         }
     }

--- a/zookeeper-jute/src/test/java/org/apache/jute/BinaryInputArchiveTest.java
+++ b/zookeeper-jute/src/test/java/org/apache/jute/BinaryInputArchiveTest.java
@@ -195,4 +195,17 @@ public class BinaryInputArchiveTest {
     return buf.array();
   }
 
+    @Test
+    public void testTotalBufferSizeShouldNotBeMoreThanIntegerMaxValue()
+            throws IOException {
+        int maxBufferSize = 1 * 1024 * 1024 * 1024; // buffer size 1GB
+        int extraMaxBufferSize = maxBufferSize;
+        int recordSize = 1000;
+        BinaryInputArchive ia =
+                getBinaryInputArchive(recordSize, maxBufferSize, extraMaxBufferSize);
+        String s = ia.readString("");
+        assertNotNull(s);
+        assertEquals(recordSize, s.getBytes().length);
+    }
+
 }


### PR DESCRIPTION
This is a branch-3.8 specific pull request for the original PR: https://github.com/apache/zookeeper/pull/2175