### PR TITLE
ZOOKEEPER-4868. Bump commons-io to resolve CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -479,7 +479,7 @@
     <spotbugsannotations.version>4.0.2</spotbugsannotations.version>
     <checkstyle.version>8.39</checkstyle.version>
     <enforcer.version>3.0.0-M3</enforcer.version>
-    <commons-io.version>2.11.0</commons-io.version>
+    <commons-io.version>2.17.0</commons-io.version>
     <burningwave.mockdns.version>0.25.4</burningwave.mockdns.version>
 
     <!-- parameters to pass to C client build -->


### PR DESCRIPTION
backport #2196