### PR TITLE
ZOOKEEPER-3624: Fix flaky `QuorumPeerMainTest::testFailedTxnAsPartOfQuorumLoss`

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -1578,6 +1578,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
                     } else {
                         try {
                             reconfigFlagClear();
+                            checkSuspended();
                             if (shuttingDownLE) {
                                 shuttingDownLE = false;
                                 startLeaderElection();


### PR DESCRIPTION
```
org.opentest4j.AssertionFailedError: create /zk2 should have failed
	at org.apache.zookeeper.server.quorum.QuorumPeerMainTest.testFailedTxnAsPartOfQuorumLoss(QuorumPeerMainTest.java:762)
```

The test starts other members before the `create` operation. This causes
the old leader rejoin with them to form quorum.

This pr moves starting of stopped members after `create`.
