### PR TITLE
ZOOKEEPER-4879: Fix log arguments typo

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -2375,7 +2375,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                 try {
                     request.cnxn.sendResponse(rh, null, null);
                 } catch (IOException e) {
-                    LOG.error("IOException", e);
+                    LOG.warn("IOException", e);
                 }
             }
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -1811,7 +1811,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                     }
                 }
             } catch (SaslException e) {
-                LOG.warn("Client {} failed to SASL authenticate: {}", cnxn.getRemoteSocketAddress(), e);
+                LOG.warn("Client {} failed to SASL authenticate", cnxn.getRemoteSocketAddress(), e);
                 if (shouldAllowSaslFailedClientsConnect() && !authHelper.isSaslAuthRequired()) {
                     LOG.warn("Maintaining client connection despite SASL authentication failure.");
                 } else {
@@ -2375,7 +2375,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                 try {
                     request.cnxn.sendResponse(rh, null, null);
                 } catch (IOException e) {
-                    LOG.error("IOException : {}", e);
+                    LOG.error("IOException", e);
                 }
             }
         }


### PR DESCRIPTION
fix log arguments typo, exception stack does not need placeholder.

https://issues.apache.org/jira/browse/ZOOKEEPER-4879