### PR TITLE
ZOOKEEPER-4852: Fix the bad "*uuuuu" mark in the ASF license

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ByteBufferRequestRecord.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ByteBufferRequestRecord.java
@@ -8,7 +8,7 @@
  * with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *uuuuu
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ByteBufferRequestRecord.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ByteBufferRequestRecord.java
@@ -10,7 +10,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  *uuuuu
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "/RequuuAS IS" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
@@ -8,7 +8,7 @@
  * with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *uuuuu
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
@@ -10,7 +10,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  *uuuuu
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "/RequuuAS IS" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/RequestRecord.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/RequestRecord.java
@@ -8,7 +8,7 @@
  * with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *uuuuu
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/RequestRecord.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/RequestRecord.java
@@ -10,7 +10,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  *uuuuu
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "/RequuuAS IS" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/SimpleRequestRecord.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/SimpleRequestRecord.java
@@ -8,7 +8,7 @@
  * with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *uuuuu
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/SimpleRequestRecord.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/SimpleRequestRecord.java
@@ -10,7 +10,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  *uuuuu
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "/RequuuAS IS" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.


### PR DESCRIPTION
Fix Apache License Header Formatting in Java Files
Description
This pull request addresses a minor documentation formatting issue within the Apache License headers across several Java files. Specifically, the license header contained an incorrect *uuuuu mark, which affected readability and consistency. This update ensures the license header aligns with the official Apache License format.

Changes Made

Corrected the erroneous *uuuuu entry in the license header to reflect the standard Apache License text.
Verified formatting across affected files to maintain consistency.
Files Updated

Updated four Java files under the org.apache.zookeeper.server package.
Why This Change is Needed
Ensuring the license header follows the standard format improves code readability and maintains compliance with ASF documentation standards.

