### PR TITLE
ZOOKEEPER-4020: Fix memory leak from ssl cert in c client

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -1324,8 +1324,6 @@ static zhandle_t *zookeeper_init_internal(const char *host, watcher_fn watcher,
     if (cert) {
         zh->fd->cert = calloc(1, sizeof(zcert_t));
         memcpy(zh->fd->cert, cert, sizeof(zcert_t));
-        free(cert->certstr);
-        free(cert->ca);
     }
 
 #ifdef _WIN32
@@ -3875,6 +3873,7 @@ int zookeeper_close(zhandle_t *zh)
     LOG_INFO(LOGCALLBACK(zh), "Freeing zookeeper resources for sessionId=%#llx\n", zh->client_id.client_id);
     destroy(zh);
     adaptor_destroy(zh);
+    free(zh->fd->cert);
     free(zh->fd);
     free(zh);
 #ifdef _WIN32

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -692,7 +692,6 @@ static void destroy(zhandle_t *zh)
 #ifdef HAVE_OPENSSL_H
     if (zh->fd->cert) {
         free(zh->fd->cert->certstr);
-        free(zh->fd->cert->ca);
         free(zh->fd->cert);
         zh->fd->cert = NULL;
     }
@@ -1455,7 +1454,7 @@ zhandle_t *zookeeper_init_ssl(const char *host, const char *cert, watcher_fn wat
 {
     zcert_t zcert;
     zcert.certstr = strdup(cert);
-    zcert.ca = strtok(strdup(cert), ",");
+    zcert.ca = strtok(zcert.certstr, ",");
     zcert.cert = strtok(NULL, ",");
     zcert.key = strtok(NULL, ",");
     zcert.passwd = strtok(NULL, ",");       

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -1324,8 +1324,8 @@ static zhandle_t *zookeeper_init_internal(const char *host, watcher_fn watcher,
     if (cert) {
         zh->fd->cert = calloc(1, sizeof(zcert_t));
         memcpy(zh->fd->cert, cert, sizeof(zcert_t));
-        free(cert.certstr);
-        free(cert.ca);
+        free(cert->certstr);
+        free(cert->ca);
     }
 
 #ifdef _WIN32

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -1324,6 +1324,8 @@ static zhandle_t *zookeeper_init_internal(const char *host, watcher_fn watcher,
     if (cert) {
         zh->fd->cert = calloc(1, sizeof(zcert_t));
         memcpy(zh->fd->cert, cert, sizeof(zcert_t));
+        free(cert.certstr);
+        free(cert.ca);
     }
 
 #ifdef _WIN32

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -3873,7 +3873,8 @@ int zookeeper_close(zhandle_t *zh)
     LOG_INFO(LOGCALLBACK(zh), "Freeing zookeeper resources for sessionId=%#llx\n", zh->client_id.client_id);
     destroy(zh);
     adaptor_destroy(zh);
-    free(zh->fd->cert);
+    free(zh->fd->cert->certstr);
+    free(zh->fd->cert->ca);
     free(zh->fd);
     free(zh);
 #ifdef _WIN32

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -692,6 +692,7 @@ static void destroy(zhandle_t *zh)
 #ifdef HAVE_OPENSSL_H
     if (zh->fd->cert) {
         free(zh->fd->cert->certstr);
+        free(zh->fd->cert->ca);
         free(zh->fd->cert);
         zh->fd->cert = NULL;
     }
@@ -3873,8 +3874,6 @@ int zookeeper_close(zhandle_t *zh)
     LOG_INFO(LOGCALLBACK(zh), "Freeing zookeeper resources for sessionId=%#llx\n", zh->client_id.client_id);
     destroy(zh);
     adaptor_destroy(zh);
-    free(zh->fd->cert->certstr);
-    free(zh->fd->cert->ca);
     free(zh->fd);
     free(zh);
 #ifdef _WIN32


### PR DESCRIPTION
Fixing memory leak by freeing memory allocated by strdup in cert_t.