### PR TITLE
ZOOKEEPER-4889: Fallback to DIGEST-MD5 auth mech should be disabled in Fips mode - doc change  (ADDENDUM)

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1866,10 +1866,14 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
 * *fips-mode* :
     (Java system property: **zookeeper.fips-mode**)
     **New in 3.8.2:**
-    Enable FIPS compatibility mode in ZooKeeper. If enabled, the custom trust manager (`ZKTrustManager`) that is used for 
-    hostname verification will be disabled in order to comply with FIPS requirements. As a consequence, hostname verification is not
-    available in the Quorum protocol, but still can be set in client-server communication. Default: **true** (3.9.0+), 
-    **false** (3.8.x)
+    Enable FIPS compatibility mode in ZooKeeper. If enabled, the following things will be changed in order to comply 
+    with FIPS requirements:
+    * Custom trust manager (`ZKTrustManager`) that is used for hostname verification will be disabled. As a consequence, 
+      hostname verification is not available in the Quorum protocol, but still can be set in client-server communication. 
+    * DIGEST-MD5 Sasl auth mechanism will be disabled in Quorum and ZooKeeper Sasl clients. Only GSSAPI (Kerberos)
+      can be used.
+    
+    Default: **true** (3.9.0+), **false** (3.8.x)
 
 <a name="Experimental+Options%2FFeatures"></a>
 


### PR DESCRIPTION
@eolivelli @symat 