### PR TITLE
ZOOKEEPER-4889: Fallback to DIGEST-MD5 auth mech should be disabled in Fips mode (branch-3.8)

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1810,10 +1810,14 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
 * *fips-mode* :
     (Java system property: **zookeeper.fips-mode**)
     **New in 3.8.2:**
-    Enable FIPS compatibility mode in ZooKeeper. If enabled, the custom trust manager (`ZKTrustManager`) that is used for 
-    hostname verification will be disabled in order to comply with FIPS requirements. As a consequence, hostname verification is not
-    available in the Quorum protocol, but still can be set in client-server communication. Default: **true** (3.9.0+), 
-    **false** (3.8.x)
+    Enable FIPS compatibility mode in ZooKeeper. If enabled, the following things will be changed in order to comply 
+    with FIPS requirements:
+    * Custom trust manager (`ZKTrustManager`) that is used for hostname verification will be disabled. As a consequence, 
+      hostname verification is not available in the Quorum protocol, but still can be set in client-server communication. 
+    * DIGEST-MD5 Sasl auth mechanism will be disabled in Quorum and ZooKeeper Sasl clients. Only GSSAPI (Kerberos)
+      can be used.
+    
+    Default: **true** (3.9.0+), **false** (3.8.x)
 
 <a name="Experimental+Options%2FFeatures"></a>
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java
@@ -247,7 +247,7 @@ public class ZooKeeperSaslClient {
                     l.startThreadIfNeeded();
                 }
             }
-            return SecurityUtils.createSaslClient(loginRef.get().getSubject(),
+            return SecurityUtils.createSaslClient(clientConfig, loginRef.get().getSubject(),
                 servicePrincipal, "zookeeper", "zk-sasl-md5", LOG, "Client");
         } catch (LoginException e) {
             // We throw LoginExceptions...

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
@@ -69,6 +69,7 @@ public abstract class X509Util implements Closeable, AutoCloseable {
 
     private static final String REJECT_CLIENT_RENEGOTIATION_PROPERTY = "jdk.tls.rejectClientInitiatedRenegotiation";
     private static final String FIPS_MODE_PROPERTY = "zookeeper.fips-mode";
+    private static final boolean FIPS_MODE_DEFAULT = false;
 
     static {
         // Client-initiated renegotiation in TLS is unsafe and
@@ -259,8 +260,8 @@ public abstract class X509Util implements Closeable, AutoCloseable {
         return FIPS_MODE_PROPERTY;
     }
 
-    public boolean getFipsMode(ZKConfig config) {
-        return config.getBoolean(FIPS_MODE_PROPERTY, false);
+    public static boolean getFipsMode(ZKConfig config) {
+        return config.getBoolean(FIPS_MODE_PROPERTY, FIPS_MODE_DEFAULT);
     }
 
     public boolean isServerHostnameVerificationEnabled(ZKConfig config) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -98,7 +98,7 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
                     x509Util.getSslTruststorePasswdProperty(),
                     x509Util.getSslTruststorePasswdPathProperty());
             String trustStoreTypeProp = config.getProperty(x509Util.getSslTruststoreTypeProperty());
-            boolean fipsMode = x509Util.getFipsMode(config);
+            boolean fipsMode = X509Util.getFipsMode(config);
 
             if (trustStoreLocation.isEmpty()) {
                 LOG.warn("Truststore not specified for client connection");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/auth/SaslQuorumAuthLearner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/auth/SaslQuorumAuthLearner.java
@@ -88,6 +88,7 @@ public class SaslQuorumAuthLearner implements QuorumAuthLearner {
             DataInputStream din = new DataInputStream(sock.getInputStream());
             byte[] responseToken = new byte[0];
             sc = SecurityUtils.createSaslClient(
+                new ZKConfig(),
                 learnerLogin.getSubject(),
                 principalConfig,
                 QuorumAuth.QUORUM_SERVER_PROTOCOL_NAME,

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/util/SecurityUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/util/SecurityUtils.java
@@ -28,6 +28,8 @@ import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 import org.apache.zookeeper.SaslClientCallbackHandler;
+import org.apache.zookeeper.common.X509Util;
+import org.apache.zookeeper.common.ZKConfig;
 import org.apache.zookeeper.server.auth.KerberosName;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSCredential;
@@ -55,6 +57,7 @@ public final class SecurityUtils {
      * @throws SaslException
      */
     public static SaslClient createSaslClient(
+        ZKConfig config,
         final Subject subject,
         final String servicePrincipal,
         final String protocol,
@@ -67,6 +70,11 @@ public final class SecurityUtils {
         if (subject.getPrincipals().isEmpty()) {
             // no principals: must not be GSSAPI: use DIGEST-MD5 mechanism
             // instead.
+            // FIPS-mode: don't try DIGEST-MD5, just return error
+            if (X509Util.getFipsMode(config)) {
+                LOG.warn("{} will not use DIGEST-MD5 as SASL mechanism, because FIPS mode is enabled.", entity);
+                return null;
+            }
             LOG.info("{} will use DIGEST-MD5 as SASL mechanism.", entity);
             String[] mechs = {"DIGEST-MD5"};
             String username = (String) (subject.getPublicCredentials().toArray()[0]);


### PR DESCRIPTION
Backported from #2213 and #2214 