### PR TITLE
ZOOKEEPER-4846 Failure to reload database due to missing ACL

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -462,8 +462,9 @@ public class DataTree {
             // we did for the global sessions.
             Long acls = aclCache.convertAcls(acl);
 
-            Set<String> children = parent.getChildren();
-            if (children.contains(childName)) {
+            DataNode existingChild = nodes.get(path);
+            if (existingChild != null) {
+                existingChild.acl = acls;
                 throw new NodeExistsException();
             }
 


### PR DESCRIPTION
In the scenario when ZooKeeper restore from fuzzy snapshot, there's possibility that we have a znode in the snapshot, but the attached ACL is missing from the ACL cache. In this case ZK will fast forward to znode's createTxn and replays it. While we skip re-creating the existing znode, we have a chance to fix the potentially wrong ACL reference.