### PR TITLE
ZOOKEEPER-4898: FastLeaderElection WorkerSender/WorkerReceiver don't need to be Thread

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FastLeaderElection.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FastLeaderElection.java
@@ -470,7 +470,7 @@ public class FastLeaderElection implements Election {
                         LOG.warn("Interrupted Exception while waiting for new message", e);
                     }
                 }
-                LOG.info("WorkerReceiver is down");
+                LOG.info("{} is down", getName());
             }
 
         }
@@ -504,7 +504,7 @@ public class FastLeaderElection implements Election {
                         break;
                     }
                 }
-                LOG.info("WorkerSender is down");
+                LOG.info("{} is down", getName());
             }
 
             /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FastLeaderElection.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FastLeaderElection.java
@@ -223,8 +223,8 @@ public class FastLeaderElection implements Election {
             volatile boolean stop;
             QuorumCnxManager manager;
 
-            WorkerReceiver(QuorumCnxManager manager) {
-                super("WorkerReceiver");
+            WorkerReceiver(QuorumCnxManager manager, String threadName) {
+                super(threadName);
                 this.stop = false;
                 this.manager = manager;
             }
@@ -485,8 +485,8 @@ public class FastLeaderElection implements Election {
             volatile boolean stop;
             QuorumCnxManager manager;
 
-            WorkerSender(QuorumCnxManager manager) {
-                super("WorkerSender");
+            WorkerSender(QuorumCnxManager manager, String threadName) {
+                super(threadName);
                 this.stop = false;
                 this.manager = manager;
             }
@@ -523,8 +523,6 @@ public class FastLeaderElection implements Election {
 
         WorkerSender ws;
         WorkerReceiver wr;
-        Thread wsThread = null;
-        Thread wrThread = null;
 
         /**
          * Constructor of class Messenger.
@@ -533,23 +531,19 @@ public class FastLeaderElection implements Election {
          */
         Messenger(QuorumCnxManager manager) {
 
-            this.ws = new WorkerSender(manager);
+            this.ws = new WorkerSender(manager, "WorkerSender[myid=" + self.getMyId() + "]");
+            this.ws.setDaemon(true);
 
-            this.wsThread = new Thread(this.ws, "WorkerSender[myid=" + self.getMyId() + "]");
-            this.wsThread.setDaemon(true);
-
-            this.wr = new WorkerReceiver(manager);
-
-            this.wrThread = new Thread(this.wr, "WorkerReceiver[myid=" + self.getMyId() + "]");
-            this.wrThread.setDaemon(true);
+            this.wr = new WorkerReceiver(manager, "WorkerReceiver[myid=" + self.getMyId() + "]");
+            this.wr.setDaemon(true);
         }
 
         /**
          * Starts instances of WorkerSender and WorkerReceiver
          */
         void start() {
-            this.wsThread.start();
-            this.wrThread.start();
+            this.ws.start();
+            this.wr.start();
         }
 
         /**


### PR DESCRIPTION
WorkerSender inherits from ZooKeeperThread. When using WorkerSender, a WorkerSender thread is created first, followed by the creation of a new thread where WorkerSender is passed as a task. At this point, the ExceptionHandler in ZooKeeperThread does not take effect.