### PR TITLE
Use create2 only when required

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
@@ -1490,7 +1490,7 @@ public class ZooKeeper implements AutoCloseable {
         final String serverPath = prependChroot(clientPath);
 
         RequestHeader h = new RequestHeader();
-        setCreateHeader(createMode, h);
+        setCreateHeader(createMode, h, stat != null);
         Create2Response response = new Create2Response();
         Record record = makeCreateRecord(createMode, serverPath, data, acl, ttl);
         ReplyHeader r = cnxn.submitRequest(h, record, response, null);
@@ -1503,11 +1503,19 @@ public class ZooKeeper implements AutoCloseable {
         return chroot.strip(response.getPath());
     }
 
-    private void setCreateHeader(CreateMode createMode, RequestHeader h) {
+    private void setCreateHeader(CreateMode createMode, RequestHeader h, boolean requestStat) {
         if (createMode.isTTL()) {
             h.setType(ZooDefs.OpCode.createTTL);
         } else {
-            h.setType(createMode.isContainer() ? ZooDefs.OpCode.createContainer : ZooDefs.OpCode.create2);
+            if (createMode.isContainer()) {
+                h.setType(ZooDefs.OpCode.createContainer);
+            } else {
+                if (requestStat) {
+                    h.setType(ZooDefs.OpCode.create2);
+                } else {
+                    h.setType(ZooDefs.OpCode.create);
+                }
+            }
         }
     }
 
@@ -1599,7 +1607,7 @@ public class ZooKeeper implements AutoCloseable {
         cb = chroot.interceptCallback(cb);
 
         RequestHeader h = new RequestHeader();
-        setCreateHeader(createMode, h);
+        setCreateHeader(createMode, h, false);
         ReplyHeader r = new ReplyHeader();
         Create2Response response = new Create2Response();
         Record record = makeCreateRecord(createMode, serverPath, data, acl, ttl);


### PR DESCRIPTION
If the client is not requesting stat, then the basic `create` operation is enough.

This makes the client library compatible with servers that do not implement all ZooKeeper protocol features. Concretely, ClickHouse Keeper does not implement `create2`.

See:
* https://github.com/ClickHouse/ClickHouse/issues/55595#issuecomment-2138066919

## Background

I was testing if an application that uses Apache Curator to talk to a ZooKeeper could work with a ClickHouse Keeper instead. This would avoid having to run both ZooKeeper and ClickHouse Keeper in our environment.

With a patch like this I was able to get things to work and I couldn't find any other way to instruct the client library to avoid using `create2`.

This is mostly a compatibility issue with a third party, so arguably should be fixed there, but since I'm much more familiar with Java than C++ I thought I'd try changing the client library here.

I'm hoping someone more familiar with the codebase can take a look and comment if this is sensible or not.