### PR TITLE
ZOOKEEPER-4907: Stop client packets processing after server channel closed

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -366,12 +366,12 @@ public class NettyServerCnxn extends ServerCnxn {
     void processMessage(ByteBuf buf) {
         checkIsInEventLoop("processMessage");
         LOG.debug("0x{} queuedBuffer: {}", Long.toHexString(sessionId), queuedBuffer);
-        
+
         if (closingChannel) {
-            LOG.info("Closing connection to {}", getRemoteSocketAddress());
+            LOG.debug("Drop incoming message during connection closing for session 0x{}", Long.toHexString(sessionId));
             return;
         }
-        
+
         if (LOG.isTraceEnabled()) {
             LOG.trace("0x{} buf {}", Long.toHexString(sessionId), ByteBufUtil.hexDump(buf));
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxn.java
@@ -537,15 +537,15 @@ public class NettyServerCnxn extends ServerCnxn {
                                 return;
                             }
                         }
-                        if (len < 0 || len > BinaryInputArchive.maxBuffer) {
-                            throw new IOException("Len error " + len);
-                        }
                         ZooKeeperServer zks = this.zkServer;
                         if (zks == null || !zks.isRunning()) {
                             LOG.info("Closing connection to {} because the server is not ready (server state is: {})",
                                 getRemoteSocketAddress(), zks == null ? "unknown" : zks.getState());
                             close(DisconnectReason.IO_EXCEPTION);
                             return;
+                        }
+                        if (len < 0 || len > BinaryInputArchive.maxBuffer) {
+                            throw new IOException("Len error " + len);
                         }
                         // checkRequestSize will throw IOException if request is rejected
                         zks.checkRequestSizeWhenReceivingMessage(len);


### PR DESCRIPTION
Refer to [ZOOKEEPER-4907](https://issues.apache.org/jira/browse/ZOOKEEPER-4907)

We got the error:

2024-11-07 19:03:01,414 [myid:14] - WARN [nioEventLoopGroup-7-25:NettyServerCnxn@537] - Closing connection to /135.224.186.250:47051
java.io.IOException: **Len error** 794913900
at org.apache.zookeeper.server.NettyServerCnxn.receiveMessage(NettyServerCnxn.java:521)
at org.apache.zookeeper.server.NettyServerCnxn.processMessage(NettyServerCnxn.java:374)
at org.apache.zookeeper.server.NettyServerCnxnFactory$CnxnChannelHandler.channelRead(NettyServerCnxnFactory.java:357)
at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead

It cause us very confused about it whether we write some big data into zookeeper. Thus. After trouble shooting, we found that it is just the log/issue when closing the server caused by reelecting the leader sometimes. In actually. We don't send any big data.

So I think we can do one tiny code change to avoid throw the error which causing confusion to reduce trouble shooting effort.