### PR TITLE
ZOOKEEPER-4910: fix error when no dep dropwizard java.lang.NoClassDefFoundError: com/…

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
@@ -130,7 +130,7 @@ public class ZooKeeperServerMain {
             } catch (MetricsProviderLifeCycleException error) {
                 throw new IOException("Cannot boot MetricsProvider " + config.getMetricsProviderClassName(), error);
             }
-            ServerMetrics.metricsProviderInitialized(metricsProvider);
+            metricsProviderInitialized();
             ProviderRegistry.initialize();
             // Note that this thread isn't going to be doing anything else,
             // so rather than spawning another thread, we will just call
@@ -294,5 +294,17 @@ public class ZooKeeperServerMain {
     }
 
     protected void serverStarted() {
+    }
+
+    private void metricsProviderInitialized() {
+        try {
+            ServerMetrics.metricsProviderInitialized(metricsProvider);
+        } catch (Exception e) {
+            if (e instanceof ClassNotFoundException) {
+                LOG.warn("Metrics provider not found, metrics will not be reported");
+                return;
+            }
+            throw e;
+        }
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
@@ -299,12 +299,12 @@ public class ZooKeeperServerMain {
     private void metricsProviderInitialized() {
         try {
             ServerMetrics.metricsProviderInitialized(metricsProvider);
-        } catch (Exception e) {
-            if (e instanceof ClassNotFoundException) {
+        } catch (Throwable throwable) {
+            if (throwable instanceof ClassNotFoundException) {
                 LOG.warn("Metrics provider not found, metrics will not be reported");
                 return;
             }
-            throw e;
+            throw throwable;
         }
     }
 }


### PR DESCRIPTION
fix follow error
```
Exception in thread "ZooKeeper Server Starter" java.lang.NoClassDefFoundError: com/codahale/metrics/Reservoir
	at org.apache.zookeeper.metrics.impl.DefaultMetricsProvider$DefaultMetricsContext.lambda$getSummary$2(DefaultMetricsProvider.java:126)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1713)
	at org.apache.zookeeper.metrics.impl.DefaultMetricsProvider$DefaultMetricsContext.getSummary(DefaultMetricsProvider.java:122)
	at org.apache.zookeeper.server.ServerMetrics.<init>(ServerMetrics.java:74)
	at org.apache.zookeeper.server.ServerMetrics.<clinit>(ServerMetrics.java:44)
	at org.apache.zookeeper.server.ZooKeeperServerMain.runFromConfig(ZooKeeperServerMain.java:133)
	at org.apache.dubbo.springboot.demo.provider.EmbeddedZooKeeper$ServerRunnable.run(EmbeddedZooKeeper.java:249)
	at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: java.lang.ClassNotFoundException: com.codahale.metrics.Reservoir
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:528)
	... 8 
```