### PR TITLE
ZOOKEEPER-3766: [ADDENDUM] Fix TestSASLAuth failure

### DIFF
--- a/zookeeper-client/zookeeper-client-c/tests/zkServer.sh
+++ b/zookeeper-client/zookeeper-client-c/tests/zkServer.sh
@@ -109,7 +109,7 @@ export CLASSPATH
 read_only=
 # shellcheck disable=SC2206
 PROPERTIES=($EXTRA_JVM_ARGS "-Dzookeeper.extendedTypesEnabled=true" "-Dznode.container.checkIntervalMs=100")
-if [[ $1 == "xstartRequireSASLAuth" ]]; then
+if [[ $1 == "startRequireSASLAuth" ]]; then
   PROPERTIES=("-Dzookeeper.sessionRequireClientSASLAuth=true" "${PROPERTIES[@]}"
     "-Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider")
   if [[ -n $2 ]]; then


### PR DESCRIPTION
A fixup to #2224, see https://github.com/apache/zookeeper/pull/2224#issuecomment-2764519504.