### PR TITLE
Remove maven-antrun-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
   <url>http://zookeeper.apache.org</url>
   <inceptionYear>2008</inceptionYear>
   <!-- Set here so we can consistently use the correct name, even on branches with
-       an ASF parent pom older than v15. Also uses the url from v18.
-    -->
+    an ASF parent pom older than v15. Also uses the url from v18.
+  -->
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -248,10 +248,10 @@
       <timezone>-8</timezone>
     </developer>
     <developer>
-        <id>eolivelli</id>
-        <name>Enrico Olivelli</name>
-        <email>eolivelli@apache.org</email>
-        <timezone>+1</timezone>
+      <id>eolivelli</id>
+      <name>Enrico Olivelli</name>
+      <email>eolivelli@apache.org</email>
+      <timezone>+1</timezone>
     </developer>
     <developer>
       <id>nkalmar</id>
@@ -304,44 +304,44 @@
       </modules>
     </profile>
     <profile>
-        <id>apache-release</id>
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.apache.resources</groupId>
-                            <artifactId>apache-source-release-assembly-descriptor</artifactId>
-                            <version>1.0.6</version>
-                        </dependency>
-                    </dependencies>
-                    <executions>
-                        <execution>
-                            <id>source-release-assembly-tar-gz</id>
-                            <phase>initialize</phase>
-                            <goals>
-                                <goal>single</goal>
-                            </goals>
-                            <configuration>
-                                <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
-                                <descriptorRefs>
-                                    <!-- defined in Apache Parent Pom -->
-                                    <descriptorRef>${sourceReleaseAssemblyDescriptor}</descriptorRef>
-                                </descriptorRefs>
-                                <finalName>apache-zookeeper-${project.version}</finalName>
-                                <appendAssemblyId>false</appendAssemblyId>
-                                <formats>
-                                    <format>tar.gz</format>
-                                </formats>
-                                <tarLongFileMode>posix</tarLongFileMode>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </build>
+      <id>apache-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.apache.resources</groupId>
+                <artifactId>apache-source-release-assembly-descriptor</artifactId>
+                <version>1.0.6</version>
+              </dependency>
+            </dependencies>
+            <executions>
+              <execution>
+                <id>source-release-assembly-tar-gz</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+                <configuration>
+                  <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
+                  <descriptorRefs>
+                    <!-- defined in Apache Parent Pom -->
+                    <descriptorRef>${sourceReleaseAssemblyDescriptor}</descriptorRef>
+                  </descriptorRefs>
+                  <finalName>apache-zookeeper-${project.version}</finalName>
+                  <appendAssemblyId>false</appendAssemblyId>
+                  <formats>
+                    <format>tar.gz</format>
+                  </formats>
+                  <tarLongFileMode>posix</tarLongFileMode>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>m2e</id>
@@ -370,19 +370,6 @@
                         <versionRange>[0,)</versionRange>
                         <goals>
                           <goal>exec</goal>
-                        </goals>
-                      </pluginExecutionFilter>
-                      <action>
-                        <ignore />
-                      </action>
-                    </pluginExecution>
-                    <pluginExecution>
-                      <pluginExecutionFilter>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <versionRange>[0,)</versionRange>
-                        <goals>
-                          <goal>run</goal>
                         </goals>
                       </pluginExecutionFilter>
                       <action>
@@ -481,8 +468,8 @@
               </includes>
               <excludes>
                 <exclude>org/apache/zookeeper/version/**/*</exclude>
-                  <exclude>**/ReadOnlyModeTest.java</exclude>
-                  <exclude>**/KeeperStateTest.java</exclude>
+                <exclude>**/ReadOnlyModeTest.java</exclude>
+                <exclude>**/KeeperStateTest.java</exclude>
               </excludes>
             </configuration>
             <executions>
@@ -527,7 +514,7 @@
                 <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
                 <sonar.core.codeCoveragePlugin>clover</sonar.core.codeCoveragePlugin>
                 <sonar.clover.reportPath>${project.build.directory}/clover/clover.xml</sonar.clover.reportPath>
-                <sonar.surefire.reportsPath>target/surefire-reports</sonar.surefire.reportsPath>
+                <sonar.surefire.reportsPath>${project.build.directory}/surefire-reports</sonar.surefire.reportsPath>
                 <sonar.core.codeCoveragePlugin>clover</sonar.core.codeCoveragePlugin>
                 <sonar.clover.version>${clover-maven-plugin.version}</sonar.clover.version>
               </configuration>
@@ -736,10 +723,10 @@
         <artifactId>metrics-core</artifactId>
         <version>${dropwizard.version}</version>
         <exclusions>
-           <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-api</artifactId>
-           </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -784,17 +771,17 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-             <showWarnings>true</showWarnings>
-             <compilerArgs>
-               <compilerArg>-Werror</compilerArg>
-               <compilerArg>-Xlint:deprecation</compilerArg>
-               <compilerArg>-Xlint:unchecked</compilerArg>
-               <compilerArg>-Xlint:-options</compilerArg>
-               <compilerArg>-Xdoclint:-missing</compilerArg>
-               <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->
-               <compilerArg>-Xpkginfo:always</compilerArg>
-              </compilerArgs>
-            </configuration>
+            <showWarnings>true</showWarnings>
+            <compilerArgs>
+              <compilerArg>-Werror</compilerArg>
+              <compilerArg>-Xlint:deprecation</compilerArg>
+              <compilerArg>-Xlint:unchecked</compilerArg>
+              <compilerArg>-Xlint:-options</compilerArg>
+              <compilerArg>-Xdoclint:-missing</compilerArg>
+              <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->
+              <compilerArg>-Xpkginfo:always</compilerArg>
+            </compilerArgs>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -827,10 +814,6 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-scm-plugin</artifactId>
           <version>1.11.2</version>
         </plugin>
@@ -838,13 +821,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-              <trimStackTrace>false</trimStackTrace>
-              <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
+            <trimStackTrace>false</trimStackTrace>
+            <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-antrun-plugin</artifactId>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -866,7 +845,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <groupId>net.nicoulaj.maven.plugins</groupId>
@@ -918,8 +897,8 @@
           <artifactId>maven-remote-resources-plugin</artifactId>
           <executions>
             <execution>
-               <id>process-resource-bundles</id>
-               <phase>none</phase>
+              <id>process-resource-bundles</id>
+              <phase>none</phase>
             </execution>
           </executions>
         </plugin>
@@ -932,7 +911,7 @@
           <groupId>org.cyclonedx</groupId>
           <artifactId>cyclonedx-maven-plugin</artifactId>
           <version>2.7.9</version>
-       </plugin>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -951,21 +930,23 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
+          <execution>
+            <id>parse-version</id>
+            <goals>
+              <goal>parse-version</goal>
+            </goals>
+          </execution>
           <execution>
             <id>set-hostname-property</id>
             <phase>validate</phase>
             <goals>
-              <goal>run</goal>
+              <goal>hostname</goal>
             </goals>
             <configuration>
-              <exportAntProperties>true</exportAntProperties>
-              <target>
-                <property environment="env" />
-                <exec executable="hostname" outputproperty="host.name" />
-              </target>
+              <hostnameProperty>host.name</hostnameProperty>
             </configuration>
           </execution>
         </executions>
@@ -1103,48 +1084,17 @@
         </configuration>
       </plugin>
       <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <inherited>false</inherited>
-          <configuration>
-            <!-- update the version inside the C sources -->
-            <preparationGoals>clean verify -DskipTests antrun:run@replace-cclient-files-during-release scm:add@add-cclient-files-during-release scm:checkin@commit-cclient-files-during-release</preparationGoals>
-            <completionGoals>clean verify -DskipTests antrun:run@replace-cclient-files-during-release scm:add@add-cclient-files-during-release scm:checkin@commit-cclient-files-during-release</completionGoals>
-            <pushChanges>false</pushChanges>
-            <localCheckout>true</localCheckout>
-            <autoVersionSubmodules>true</autoVersionSubmodules>
-            <tagNameFormat>release-@{project.version}</tagNameFormat>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-scm-plugin</artifactId>
-          <inherited>false</inherited>
-          <executions>
-             <execution>
-               <id>add-cclient-files-during-release</id>
-               <phase>none</phase>
-               <goals>
-                 <goal>add</goal>
-               </goals>
-               <configuration>
-                 <pushChanges>false</pushChanges>
-                 <includes>zookeeper-client/zookeeper-client-c/CMakeLists.txt,zookeeper-client/zookeeper-client-c/configure.ac,zookeeper-client/zookeeper-client-c/include/zookeeper_version.h</includes>
-               </configuration>
-            </execution>
-            <execution>
-               <id>commit-cclient-files-during-release</id>
-               <phase>none</phase>
-               <goals>
-                   <!-- git commit -->
-                <goal>checkin</goal>
-              </goals>
-              <configuration>
-                 <pushChanges>false</pushChanges>
-                 <message>Prepared ${project.version}</message>
-              </configuration>
-            </execution>
-        </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <inherited>false</inherited>
+        <configuration>
+          <preparationGoals>clean verify -DskipTests</preparationGoals>
+          <completionGoals>clean verify -DskipTests</completionGoals>
+          <pushChanges>false</pushChanges>
+          <localCheckout>true</localCheckout>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <tagNameFormat>release-@{project.version}</tagNameFormat>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/zookeeper-client/zookeeper-client-c/pom.xml
+++ b/zookeeper-client/zookeeper-client-c/pom.xml
@@ -37,7 +37,7 @@
 
   <build>
     <plugins>
-        <plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <executions>
@@ -69,7 +69,7 @@
               <executable>${project.basedir}/configure</executable>
               <environmentVariables>
                 <base_dir>${project.basedir}/../..</base_dir>
-                <CALLER>ANT</CALLER>
+                <CALLER>EXECMAVENPLUGIN</CALLER>
               </environmentVariables>
               <arguments>
                 <argument>--with-openssl=${c-client-openssl}</argument>
@@ -79,64 +79,63 @@
               </arguments>
             </configuration>
           </execution>
+          <execution>
+            <id>build-c-client</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <workingDirectory>${project.build.directory}/c</workingDirectory>
+              <executable>make</executable>
+              <arguments>
+                <argument>clean</argument>
+                <argument>install</argument>
+              </arguments>
+              <environmentVariables>
+                <LD_LIBRARY_PATH>${env.LD_LIBRARY_PATH}${path.separator}/usr/lib</LD_LIBRARY_PATH>
+                <PATH>${env.PATH}${path.separator}${basedir}</PATH>
+                <CALLER>EXECMAVENPLUGIN</CALLER>
+                <CLOVER_HOME>${basedir}/../../zookeeper-server/target</CLOVER_HOME>
+                <base_dir>${basedir}/../..</base_dir>
+              </environmentVariables>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
+        <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>
-            <id>generate-sources</id>
+            <id>mkdir-target-c</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/c</outputDirectory>
+              <resources />
+            </configuration>
+          </execution>
+          <execution>
+            <id>prepare-filtered-c-source</id>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
             <phase>generate-sources</phase>
             <configuration>
-              <target>
-                <mkdir dir="target/c" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>build-c-client</id>
-            <phase>compile</phase>
-            <configuration>
-              <target>
-                <exec dir="${basedir}/target/c" executable="make" failonerror="true">
-                  <env key="LD_LIBRARY_PATH" value="${env.LD_LIBRARY_PATH};/usr/lib" />
-                  <env key="PATH" path="${env.PATH};${basedir};" />
-                  <env key="CALLER" value="ANT" />
-                  <env key="CLOVER_HOME" value="${basedir}/../../zookeeper-server/target" />
-                  <env key="base_dir" value="${basedir}/../.." />
-                  <arg line="clean install" />
-                </exec>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>replace-cclient-files-during-release</id>
-            <phase>none</phase>
-            <goals>
-               <goal>run</goal>
-            </goals>
-            <configuration>
-               <target>
-                  <replaceregexp file="include/zookeeper_version.h" match="project.*" replace="project(zookeeper VERSION ${project.version})" byline="true" />
-                  <replace file="include/zookeeper_version.h" value="">
-                      <replaceToken>-SNAPSHOT</replaceToken>
-                  </replace>
-                  <replaceregexp file="CMakeLists.txt" match="project.*" replace="project(zookeeper VERSION ${project.version})" byline="true" />
-                  <replace file="CMakeLists.txt" value="">
-                      <replaceToken>-SNAPSHOT</replaceToken>
-                  </replace>
-                  <replaceregexp file="configure.ac" match="AC_INIT.*" replace="AC_INIT([zookeeper C client],${project.version},[user@zookeeper.apache.org],[zookeeper])" byline="true" />
-                  <replace file="configure.ac" value="">
-                      <replaceToken>-SNAPSHOT</replaceToken>
-                  </replace>
-               </target>
+              <outputDirectory>./</outputDirectory>
+              <useDefaultDelimiters>false</useDefaultDelimiters>
+              <delimiters>
+                <delimiter>@</delimiter>
+              </delimiters>
+              <resources>
+                <resource>
+                  <directory>src/main/c-filtered</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
             </configuration>
           </execution>
         </executions>
@@ -162,29 +161,31 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>test-cppunit</id>
                 <phase>test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
                 <configuration>
+                  <workingDirectory>${project.build.directory}/c</workingDirectory>
+                  <executable>make</executable>
+                  <arguments>
+                    <argument>check</argument>
+                  </arguments>
                   <!-- do not run cpp tests if tests are globally skipped -->
                   <skip>${skipTests}</skip>
-                  <target>
-                    <exec dir="${basedir}/target/c" executable="make" failonerror="true">
-                      <env key="LD_LIBRARY_PATH" value="${env.LD_LIBRARY_PATH};/usr/lib" />
-                      <env key="PATH" path="${env.PATH};${basedir};" />
-                      <env key="CALLER" value="ANT" />
-                      <env key="CLOVER_HOME" value="${basedir}/../../zookeeper-server/target" />
-                      <env key="base_dir" value="${basedir}/../.." />
-                      <arg line="check" />
-                    </exec>
-                  </target>
+                  <environmentVariables>
+                    <LD_LIBRARY_PATH>${env.LD_LIBRARY_PATH}${path.separator}/usr/lib</LD_LIBRARY_PATH>
+                    <PATH>${env.PATH}${path.separator}${basedir}</PATH>
+                    <CALLER>EXECMAVENPLUGIN</CALLER>
+                    <CLOVER_HOME>${basedir}/../../zookeeper-server/target</CLOVER_HOME>
+                    <base_dir>${basedir}/../..</base_dir>
+                  </environmentVariables>
                 </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
               </execution>
             </executions>
           </plugin>

--- a/zookeeper-client/zookeeper-client-c/src/main/c-filtered/CMakeLists.txt
+++ b/zookeeper-client/zookeeper-client-c/src/main/c-filtered/CMakeLists.txt
@@ -1,0 +1,293 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.5)
+
+project(zookeeper VERSION @parsedVersion.majorVersion@.@parsedVersion.minorVersion@.@parsedVersion.incrementalVersion@)
+set(email user@zookeeper.apache.org)
+set(description "zookeeper C client")
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../tools/cmake/Modules")
+
+# general options
+if(UNIX)
+  add_compile_options(-Wall -fPIC)
+elseif(WIN32)
+  add_compile_options(/W3)
+endif()
+add_definitions(-DUSE_STATIC_LIB)
+
+# TODO: Enable /WX and /W4 on Windows. Currently there are ~1000 warnings.
+# TODO: Add Solaris support.
+# TODO: Add a shared library option.
+# TODO: Specify symbols to export.
+# TODO: Generate doxygen documentation.
+
+# Sync API option
+option(WANT_SYNCAPI "Enables Sync API support" ON)
+if(WANT_SYNCAPI)
+  add_definitions(-DTHREADED)
+endif()
+
+# CppUnit option
+if(WIN32 OR APPLE)
+  # The tests do not yet compile on Windows or macOS,
+  # so we set this to off by default.
+  #
+  # Note that CMake does not have expressions except in conditionals,
+  # so we're left with this if/else/endif pattern.
+  set(DEFAULT_WANT_CPPUNIT OFF)
+else()
+  set(DEFAULT_WANT_CPPUNIT ON)
+endif()
+option(WANT_CPPUNIT "Enables CppUnit and tests" ${DEFAULT_WANT_CPPUNIT})
+
+# SOCK_CLOEXEC
+option(WANT_SOCK_CLOEXEC "Enables SOCK_CLOEXEC on sockets" OFF)
+include(CheckSymbolExists)
+check_symbol_exists(SOCK_CLOEXEC sys/socket.h HAVE_SOCK_CLOEXEC)
+if(WANT_SOCK_CLOEXEC AND HAVE_SOCK_CLOEXEC)
+  set(SOCK_CLOEXEC_ENABLED 1)
+endif()
+
+# Cyrus SASL 2.x
+option(WITH_CYRUS_SASL "turn ON/OFF Cyrus SASL 2.x support, or define SASL library location (default: ON)" ON)
+message("-- using WITH_CYRUS_SASL=${WITH_CYRUS_SASL}")
+if(NOT WITH_CYRUS_SASL STREQUAL "OFF")
+  if(NOT WITH_CYRUS_SASL STREQUAL "ON")
+    set(CYRUS_SASL_ROOT_DIR "${WITH_CYRUS_SASL}")
+  endif()
+  find_package(CyrusSASL)
+  if(CYRUS_SASL_FOUND)
+    message("-- Cyrus SASL 2.x found! will build with SASL support.")
+  else()
+    message("-- WARNING: unable to find Cyrus SASL 2.x! will build without SASL support.")
+  endif()
+endif()
+
+# The function `to_have(in out)` converts a header name like `arpa/inet.h`
+# into an Autotools style preprocessor definition `HAVE_ARPA_INET_H`.
+# This is then set or unset in `configure_file()` step.
+#
+# Note that CMake functions do not have return values; instead an "out"
+# variable must be passed, and explicitly set with parent scope.
+function(to_have in out)
+  string(TOUPPER ${in} str)
+  string(REGEX REPLACE "/|\\." "_" str ${str})
+  set(${out} "HAVE_${str}" PARENT_SCOPE)
+endfunction()
+
+# include file checks
+foreach(f generated/zookeeper.jute.h generated/zookeeper.jute.c)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${f}")
+    to_have(${f} name)
+    set(${name} 1)
+  else()
+    message(FATAL_ERROR
+      "jute files are missing!\n"
+      "Please run 'ant compile_jute' while in the ZooKeeper top level directory.")
+  endif()
+endforeach()
+
+# header checks
+include(CheckIncludeFile)
+set(check_headers
+  arpa/inet.h
+  dlfcn.h
+  fcntl.h
+  inttypes.h
+  memory.h
+  netdb.h
+  netinet/in.h
+  stdint.h
+  stdlib.h
+  string.h
+  strings.h
+  sys/socket.h
+  sys/stat.h
+  sys/time.h
+  sys/types.h
+  unistd.h
+  sys/utsname.h)
+
+foreach(f ${check_headers})
+  to_have(${f} name)
+  check_include_file(${f} ${name})
+endforeach()
+
+# function checks
+include(CheckFunctionExists)
+set(check_functions
+  getcwd
+  gethostbyname
+  gethostname
+  getlogin
+  getpwuid_r
+  gettimeofday
+  getuid
+  memmove
+  memset
+  poll
+  socket
+  strchr
+  strdup
+  strerror
+  strtol)
+
+foreach(fn ${check_functions})
+  to_have(${fn} name)
+  check_function_exists(${fn} ${name})
+endforeach()
+
+# library checks
+set(check_libraries rt m pthread)
+foreach(lib ${check_libraries})
+  to_have("lib${lib}" name)
+  find_library(${name} ${lib})
+endforeach()
+
+# IPv6 check
+include(CheckStructHasMember)
+check_struct_has_member("struct sockaddr_in6" sin6_addr "netinet/in.h" ZOO_IPV6_ENABLED)
+
+# configure
+configure_file(cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/config.h)
+
+# hashtable library
+set(hashtable_sources src/hashtable/hashtable_itr.c src/hashtable/hashtable.c)
+add_library(hashtable STATIC ${hashtable_sources})
+target_include_directories(hashtable PUBLIC include)
+target_link_libraries(hashtable PUBLIC $<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:FreeBSD>>:m>)
+
+# zookeeper library
+set(zookeeper_sources
+  src/zookeeper.c
+  src/recordio.c
+  generated/zookeeper.jute.c
+  src/zk_log.c
+  src/zk_hashtable.c
+  src/addrvec.c)
+
+if(WANT_SYNCAPI)
+  list(APPEND zookeeper_sources src/mt_adaptor.c)
+else()
+  list(APPEND zookeeper_sources src/st_adaptor.c)
+endif()
+
+if(CYRUS_SASL_FOUND)
+  list(APPEND zookeeper_sources src/zk_sasl.c)
+endif()
+
+if(WIN32)
+  list(APPEND zookeeper_sources src/winport.c)
+endif()
+
+add_library(zookeeper STATIC ${zookeeper_sources})
+target_include_directories(zookeeper PUBLIC include ${CMAKE_CURRENT_BINARY_DIR}/include generated)
+target_link_libraries(zookeeper PUBLIC
+  hashtable
+  $<$<PLATFORM_ID:Linux>:rt> # clock_gettime
+  $<$<PLATFORM_ID:Windows>:ws2_32>) # Winsock 2.0
+
+option(WITH_OPENSSL "turn ON/OFF SSL support, or define openssl library location (default: ON)" ON)
+message("-- using WITH_OPENSSL=${WITH_OPENSSL}")
+if(NOT WITH_OPENSSL STREQUAL "OFF")
+  if(NOT WITH_OPENSSL STREQUAL "ON")
+    set(OPENSSL_ROOT_DIR,${WITH_OPENSSL})
+  endif()
+  find_package(OpenSSL)
+  if(OPENSSL_FOUND)
+    target_compile_definitions(zookeeper PUBLIC HAVE_OPENSSL_H)
+    target_link_libraries(zookeeper PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+    message("-- OpenSSL libraries found! will build with SSL support.")
+  else()
+    message("-- WARNING: unable to find OpenSSL libraries! will build without SSL support.")
+  endif()
+endif()
+
+if(WANT_SYNCAPI AND NOT WIN32)
+  find_package(Threads REQUIRED)
+  target_link_libraries(zookeeper PUBLIC Threads::Threads)
+endif()
+
+if(CYRUS_SASL_FOUND)
+  target_compile_definitions(zookeeper PUBLIC HAVE_CYRUS_SASL_H)
+  target_link_libraries(zookeeper PUBLIC CyrusSASL)
+endif()
+
+# cli executable
+add_executable(cli src/cli.c)
+target_link_libraries(cli zookeeper)
+
+# load_gen executable
+if(WANT_SYNCAPI AND NOT WIN32)
+  add_executable(load_gen src/load_gen.c)
+  target_link_libraries(load_gen zookeeper)
+endif()
+
+# tests
+set(test_sources
+  tests/TestDriver.cc
+  tests/LibCMocks.cc
+  tests/LibCSymTable.cc
+  tests/MocksBase.cc
+  tests/ZKMocks.cc
+  tests/Util.cc
+  tests/ThreadingUtil.cc
+  tests/TestZookeeperInit.cc
+  tests/TestZookeeperClose.cc
+  tests/TestSASLAuth.cc
+  tests/TestReconfig.cc
+  tests/TestReconfigServer.cc
+  tests/TestClientRetry.cc
+  tests/TestOperations.cc
+  tests/TestMulti.cc
+  tests/TestWatchers.cc
+  tests/TestClient.cc
+  tests/ZooKeeperQuorumServer.cc
+  tests/TestReadOnlyClient.cc
+  tests/TestLogClientEnv.cc)
+
+if(WANT_SYNCAPI)
+  list(APPEND test_sources tests/PthreadMocks.cc)
+endif()
+
+if(WANT_CPPUNIT)
+  set (CMAKE_CXX_STANDARD 11)
+  add_executable(zktest ${test_sources})
+  target_include_directories(zktest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+  target_compile_definitions(zktest
+    PRIVATE -DZKSERVER_CMD="${CMAKE_CURRENT_SOURCE_DIR}/tests/zkServer.sh")
+  # TODO: Use `find_library()` for `cppunit`.
+  target_link_libraries(zktest zookeeper cppunit dl)
+
+  # This reads the link flags from the file `tests/wrappers.opt` into
+  # the variable `symbol_wrappers` for use in `target_link_libraries`.
+  # It is a holdover from the original build system.
+  file(STRINGS tests/wrappers.opt symbol_wrappers)
+  if(WANT_SYNCAPI)
+    file(STRINGS tests/wrappers-mt.opt symbol_wrappers_mt)
+  endif()
+
+  target_link_libraries(zktest ${symbol_wrappers} ${symbol_wrappers_mt})
+
+  enable_testing()
+  add_test(NAME zktest_runner COMMAND zktest)
+  set_property(TEST zktest_runner PROPERTY ENVIRONMENT
+    "ZKROOT=${CMAKE_CURRENT_SOURCE_DIR}/../.."
+    "CLASSPATH=$CLASSPATH:$CLOVER_HOME/lib/clover*.jar")
+endif()

--- a/zookeeper-client/zookeeper-client-c/src/main/c-filtered/configure.ac
+++ b/zookeeper-client/zookeeper-client-c/src/main/c-filtered/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ(2.59)
 
-AC_INIT([zookeeper C client],3.10.0,[user@zookeeper.apache.org],[zookeeper])
+AC_INIT([zookeeper C client],@parsedVersion.majorVersion@.@parsedVersion.minorVersion@.@parsedVersion.incrementalVersion@,[user@zookeeper.apache.org],[zookeeper])
 AC_CONFIG_SRCDIR([src/zookeeper.c])
 
 # Save initial CFLAGS and CXXFLAGS values before AC_PROG_CC and AC_PROG_CXX

--- a/zookeeper-client/zookeeper-client-c/src/main/c-filtered/include/zookeeper_version.h
+++ b/zookeeper-client/zookeeper-client-c/src/main/c-filtered/include/zookeeper_version.h
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef ZOOKEEPER_VERSION_H_
+#define ZOOKEEPER_VERSION_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ZOO_VERSION "@parsedVersion.majorVersion@.@parsedVersion.minorVersion@.@parsedVersion.incrementalVersion@"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZOOKEEPER_VERSION_H_ */

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -121,9 +121,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-       <groupId>io.dropwizard.metrics</groupId>
-       <artifactId>metrics-core</artifactId>
-       <scope>provided</scope>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kerby</groupId>
@@ -210,12 +210,6 @@
               <locale>en_US</locale>
               <timeZone>UTC</timeZone>
             </configuration>
-          </execution>
-          <execution>
-            <id>parse-version</id>
-            <goals>
-              <goal>parse-version</goal>
-            </goals>
           </execution>
           <execution>
             <phase>generate-sources</phase>
@@ -346,7 +340,7 @@
           </execution>
         </executions>
       </plugin>
-     </plugins>
+    </plugins>
   </build>
 
 </project>


### PR DESCRIPTION
Replace maven-antrun-plugin with better alternatives:
* Use build-helper-maven-plugin for keeping versions up-to-date in cclient code
* Use build-helper-maven-plugin for retrieving hostname
* Use Maven native `env.*` properties instead of antrun
* Simplify maven-release-plugin to remove extra commit (versions should already be up-to-date from previous SNAPSHOT builds during development)
* Use exec-maven-plugin for calling make
* Use maven-resources-plugin for creating empty working directory
* Use maven-resources-plugin for injecting the version into the cclient files (without the `-SNAPSHOT` suffix)
* [BUGFIX] Fixes the incorrect pattern matching of version in `zookeeper_version.h`

Additionally, perform some minor cleanup of modified files:
* Fix xml indentations in modified pom.xml files
* Use `${project.build.directory}` property instead of target when possible
* [BUGFIX] Fix some paths that used semi-colons as the path separator and use the OS-dependent path separator

This fixes a few bugs (see above notes).