### PR TITLE
Bump org.burningwave:tools from 0.25.4 to 0.27.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -572,7 +572,7 @@
     <checkstyle.version>8.39</checkstyle.version>
     <enforcer.version>3.0.0-M3</enforcer.version>
     <commons-io.version>2.17.0</commons-io.version>
-    <burningwave.mockdns.version>0.25.4</burningwave.mockdns.version>
+    <burningwave.mockdns.version>0.27.2</burningwave.mockdns.version>
     <clover-maven-plugin.version>4.4.1</clover-maven-plugin.version>
     <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
 


### PR DESCRIPTION
Update to the new library version that is compatible with the JDK 24