### PR TITLE
ZOOKEEPER-4915: Default znode.container.maxNeverUsedIntervalMs to 5 minutes

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -2132,8 +2132,9 @@ Both subsystems need to have sufficient amount of threads to achieve peak read t
     maximum interval in milliseconds that a container that has never had
     any children is retained. Should be long enough for your client to
     create the container, do any needed work and then create children.
-    Default is "0" which is used to indicate that containers
-    that have never had any children are never deleted.
+    Default is "300000"(a.k.a. 5 minutes) since 3.10.0, for earlier versions,
+    it is "0" which is used to indicate that containers that have never had
+    any children are never deleted.
 
 <a name="sc_debug_observability_config"></a>
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ContainerManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ContainerManager.java
@@ -54,6 +54,20 @@ public class ContainerManager {
      * @param zkDb the ZK database
      * @param requestProcessor request processor - used to inject delete
      *                         container requests
+     */
+    public ContainerManager(ZKDatabase zkDb, RequestProcessor requestProcessor) {
+        this(
+            zkDb, requestProcessor,
+            Integer.getInteger("znode.container.checkIntervalMs", (int) TimeUnit.MINUTES.toMillis(1)),
+            Integer.getInteger("znode.container.maxPerMinute", 10000),
+            Long.getLong("znode.container.maxNeverUsedIntervalMs", TimeUnit.MINUTES.toMillis(5))
+        );
+    }
+
+    /**
+     * @param zkDb the ZK database
+     * @param requestProcessor request processor - used to inject delete
+     *                         container requests
      * @param checkIntervalMs how often to check containers in milliseconds
      * @param maxPerMinute the max containers to delete per second - avoids
      *                     herding of container deletions

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServerMain.java
@@ -20,7 +20,6 @@ package org.apache.zookeeper.server;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import javax.management.JMException;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.audit.ZKAuditProvider;
@@ -168,13 +167,7 @@ public class ZooKeeperServerMain {
                 secureCnxnFactory.startup(zkServer, needStartZKServer);
             }
 
-            containerManager = new ContainerManager(
-                zkServer.getZKDatabase(),
-                zkServer.firstProcessor,
-                Integer.getInteger("znode.container.checkIntervalMs", (int) TimeUnit.MINUTES.toMillis(1)),
-                Integer.getInteger("znode.container.maxPerMinute", 10000),
-                Long.getLong("znode.container.maxNeverUsedIntervalMs", 0)
-            );
+            containerManager = new ContainerManager(zkServer.getZKDatabase(), zkServer.firstProcessor);
             containerManager.start();
             ZKAuditProvider.addZKStartStopAuditLog();
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LeaderZooKeeperServer.java
@@ -19,7 +19,6 @@
 package org.apache.zookeeper.server.quorum;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import javax.management.JMException;
 import org.apache.zookeeper.KeeperException.SessionExpiredException;
@@ -78,13 +77,7 @@ public class LeaderZooKeeperServer extends QuorumZooKeeperServer {
     }
 
     private synchronized void setupContainerManager() {
-        containerManager = new ContainerManager(
-            getZKDatabase(),
-            prepRequestProcessor,
-            Integer.getInteger("znode.container.checkIntervalMs", (int) TimeUnit.MINUTES.toMillis(1)),
-            Integer.getInteger("znode.container.maxPerMinute", 10000),
-            Long.getLong("znode.container.maxNeverUsedIntervalMs", 0)
-        );
+        containerManager = new ContainerManager(getZKDatabase(), prepRequestProcessor);
     }
 
     @Override


### PR DESCRIPTION
This will delete container nodes that never had any children after approximately 5 minutes.

> Given this property, you should be prepared to get `KeeperException.NoNodeException`
> when creating children inside of this container node

Container nodes are supposed to be deleted after all children deleted, so from client's perspective this change has no harm. And also, it leaves no unused nodes in data tree.