### PR TITLE
ZOOKEEPER-4923: Add timeout to control brand-new session establishment

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
@@ -697,6 +697,7 @@ public class ZooKeeper implements AutoCloseable {
     ClientCnxn createConnection(
         HostProvider hostProvider,
         int sessionTimeout,
+        long newSessionTimeout,
         ZKClientConfig clientConfig,
         Watcher defaultWatcher,
         ClientCnxnSocket clientCnxnSocket,
@@ -707,6 +708,7 @@ public class ZooKeeper implements AutoCloseable {
         return new ClientCnxn(
             hostProvider,
             sessionTimeout,
+            newSessionTimeout,
             clientConfig,
             defaultWatcher,
             clientCnxnSocket,
@@ -1148,6 +1150,7 @@ public class ZooKeeper implements AutoCloseable {
         cnxn = createConnection(
             hostProvider,
             sessionTimeout,
+            options.getNewSessionTimeoutMs(),
             this.clientConfig,
             watcher,
             getClientCnxnSocket(),

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperBuilder.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperBuilder.java
@@ -39,6 +39,7 @@ import org.apache.zookeeper.admin.ZooKeeperAdmin;
 public class ZooKeeperBuilder {
     private final String connectString;
     private final Duration sessionTimeout;
+    private Duration newSessionTimeout = Duration.ofSeconds(Long.MAX_VALUE, 999_999_999L);
     private Function<Collection<InetSocketAddress>, HostProvider> hostProvider;
     private Watcher defaultWatcher;
     private boolean canBeReadOnly = false;
@@ -118,6 +119,21 @@ public class ZooKeeperBuilder {
     }
 
     /**
+     * Specifies timeout to establish a brand-new session.
+     *
+     * @param timeout timeout to get {@link org.apache.zookeeper.Watcher.Event.KeeperState#Expired} in establishing a
+     *                brand-new session. {@code Duration.ofSeconds(Long.MAX_VALUE, 999_999_999L)}, which is the default,
+     *                means endless retry until connected. {@code Duration.ZERO} means a sensible value deduced from
+     *                specified session timeout, currently, it is approximate {@code sessionTimeout * 4 / 3}.
+     * @return this
+     * @since 3.10.0
+     */
+    public ZooKeeperBuilder withNewSessionTimeout(Duration timeout) {
+        this.newSessionTimeout = timeout;
+        return this;
+    }
+
+    /**
      * Specifies the client config used to construct ZooKeeper instances.
      *
      * @param clientConfig
@@ -143,6 +159,7 @@ public class ZooKeeperBuilder {
         return new ZooKeeperOptions(
             connectString,
             sessionTimeout,
+            newSessionTimeout,
             defaultWatcher,
             hostProvider,
             canBeReadOnly,

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperOptions.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperOptions.java
@@ -33,6 +33,7 @@ import org.apache.zookeeper.Watcher;
 public class ZooKeeperOptions {
     private final String connectString;
     private final Duration sessionTimeout;
+    private final Duration newSessionTimeout;
     private final Watcher defaultWatcher;
     private final Function<Collection<InetSocketAddress>, HostProvider> hostProvider;
     private final boolean canBeReadOnly;
@@ -42,6 +43,7 @@ public class ZooKeeperOptions {
 
     ZooKeeperOptions(String connectString,
                      Duration sessionTimeout,
+                     Duration newSessionTimeout,
                      Watcher defaultWatcher,
                      Function<Collection<InetSocketAddress>, HostProvider> hostProvider,
                      boolean canBeReadOnly,
@@ -50,6 +52,7 @@ public class ZooKeeperOptions {
                      ZKClientConfig clientConfig) {
         this.connectString = connectString;
         this.sessionTimeout = sessionTimeout;
+        this.newSessionTimeout = newSessionTimeout;
         this.hostProvider = hostProvider;
         this.defaultWatcher = defaultWatcher;
         this.canBeReadOnly = canBeReadOnly;
@@ -64,6 +67,14 @@ public class ZooKeeperOptions {
 
     public int getSessionTimeoutMs() {
         return (int) Long.min(Integer.MAX_VALUE, sessionTimeout.toMillis());
+    }
+
+    public long getNewSessionTimeoutMs() {
+        try {
+            return newSessionTimeout.toMillis();
+        } catch (ArithmeticException ignored) {
+            return Long.MAX_VALUE;
+        }
     }
 
     public Watcher getDefaultWatcher() {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ClientCnxnSocketFragilityTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ClientCnxnSocketFragilityTest.java
@@ -96,7 +96,7 @@ public class ClientCnxnSocketFragilityTest extends QuorumPeerTestBase {
                 BusyServer server = new BusyServer();
                 ZooKeeper zk = new ZooKeeper(server.getHostPort(), (int) sessionTimeout.toMillis(), null) {
                 @Override
-                ClientCnxn createConnection(HostProvider hostProvider, int sessionTimeout, ZKClientConfig clientConfig, Watcher defaultWatcher, ClientCnxnSocket clientCnxnSocket, long sessionId, byte[] sessionPasswd, boolean canBeReadOnly) throws IOException {
+                ClientCnxn createConnection(HostProvider hostProvider, int sessionTimeout, long newSessionTimeout, ZKClientConfig clientConfig, Watcher defaultWatcher, ClientCnxnSocket clientCnxnSocket, long sessionId, byte[] sessionPasswd, boolean canBeReadOnly) throws IOException {
                     ClientCnxnSocketNIO socket = spy((ClientCnxnSocketNIO) clientCnxnSocket);
 
                     doAnswer(mock -> {
@@ -110,7 +110,7 @@ public class ClientCnxnSocketFragilityTest extends QuorumPeerTestBase {
                     }).when(socket).createSock();
 
                     nioSelector.set(socket.getSelector());
-                    return super.createConnection(hostProvider, sessionTimeout, clientConfig, defaultWatcher, socket, sessionId, sessionPasswd, canBeReadOnly);
+                    return super.createConnection(hostProvider, sessionTimeout, newSessionTimeout, clientConfig, defaultWatcher, socket, sessionId, sessionPasswd, canBeReadOnly);
                 }
             }) {
 
@@ -328,6 +328,7 @@ public class ClientCnxnSocketFragilityTest extends QuorumPeerTestBase {
         public CustomClientCnxn(
             HostProvider hostProvider,
             int sessionTimeout,
+            long newSessionTimeout,
             ZKClientConfig zkClientConfig,
             Watcher defaultWatcher,
             ClientCnxnSocket clientCnxnSocket,
@@ -338,6 +339,7 @@ public class ClientCnxnSocketFragilityTest extends QuorumPeerTestBase {
             super(
                 hostProvider,
                 sessionTimeout,
+                newSessionTimeout,
                 zkClientConfig,
                 defaultWatcher,
                 clientCnxnSocket,
@@ -403,6 +405,7 @@ public class ClientCnxnSocketFragilityTest extends QuorumPeerTestBase {
         ClientCnxn createConnection(
             HostProvider hostProvider,
             int sessionTimeout,
+            long newSessionTimeout,
             ZKClientConfig clientConfig,
             Watcher defaultWatcher,
             ClientCnxnSocket clientCnxnSocket,
@@ -415,6 +418,7 @@ public class ClientCnxnSocketFragilityTest extends QuorumPeerTestBase {
             ClientCnxnSocketFragilityTest.this.cnxn = new CustomClientCnxn(
                 hostProvider,
                 sessionTimeout,
+                newSessionTimeout,
                 clientConfig,
                 defaultWatcher,
                 clientCnxnSocket,

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/ClientRequestTimeoutTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/ClientRequestTimeoutTest.java
@@ -225,6 +225,7 @@ public class ClientRequestTimeoutTest extends QuorumPeerTestBase {
         CustomClientCnxn(
             HostProvider hostProvider,
             int sessionTimeout,
+            long newSessionTimeout,
             ZKClientConfig clientConfig,
             Watcher defaultWatcher,
             ClientCnxnSocket clientCnxnSocket,
@@ -235,6 +236,7 @@ public class ClientRequestTimeoutTest extends QuorumPeerTestBase {
             super(
                 hostProvider,
                 sessionTimeout,
+                newSessionTimeout,
                 clientConfig,
                 defaultWatcher,
                 clientCnxnSocket,
@@ -286,6 +288,7 @@ public class ClientRequestTimeoutTest extends QuorumPeerTestBase {
         ClientCnxn createConnection(
             HostProvider hostProvider,
             int sessionTimeout,
+            long newSessionTimeout,
             ZKClientConfig clientConfig,
             Watcher defaultWatcher,
             ClientCnxnSocket clientCnxnSocket,
@@ -296,6 +299,7 @@ public class ClientRequestTimeoutTest extends QuorumPeerTestBase {
             return new CustomClientCnxn(
                 hostProvider,
                 sessionTimeout,
+                newSessionTimeout,
                 clientConfig,
                 defaultWatcher,
                 clientCnxnSocket,


### PR DESCRIPTION
Refs: ZOOKEEPER-4508, ZOOKEEPER-4921, ZOOKEEPER-4923 and https://lists.apache.org/thread/nfb9z7rhgglbjzfxvg4z2m3pks53b3c1