### PR TITLE
ZOOKEEPER-4829: [ADDENDUM] Improve backward compatibility for QuorumPeerConfig::getPurgeInterval with 3.9

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/Time.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/Time.java
@@ -64,7 +64,6 @@ public class Time {
      * @param str the interval string
      * @return interval in milliseconds
      */
-
     public static int parseTimeInterval(String str) {
         try {
             int len = str.length();
@@ -95,4 +94,27 @@ public class Time {
         }
     }
 
+    /**
+     * Format milliseconds time interval with the highest time unit suffix.
+     *
+     * <p>See {@link #parseTimeInterval(String)} for supported suffixes.
+     *
+     * @param ms milliseconds
+     * @return string formatted with the highest time unit suffix or "0" if {@code ms} is 0
+     */
+    public static String formatTimeIntervalMs(long ms) {
+        if (ms == 0) {
+            return "0";
+        } else if (ms % DAY == 0) {
+            return ms / DAY + "d";
+        } else if (ms % HOUR == 0) {
+            return ms / HOUR + "h";
+        } else if (ms % MINUTE == 0) {
+            return ms / MINUTE + "m";
+        } else if (ms % SECOND == 0) {
+            return ms / SECOND + "s";
+        } else {
+            return ms + "ms";
+        }
+    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DatadirCleanupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DatadirCleanupManager.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.server;
 import java.io.File;
 import java.util.Timer;
 import java.util.TimerTask;
+import org.apache.zookeeper.common.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +76,7 @@ public class DatadirCleanupManager {
         this.snapRetainCount = snapRetainCount;
         this.purgeIntervalInMs = purgeIntervalInMs;
         LOG.info("autopurge.snapRetainCount set to {}", snapRetainCount);
-        LOG.info("autopurge.purgeInterval set to {}", purgeIntervalInMs);
+        LOG.info("autopurge.purgeInterval set to {}", Time.formatTimeIntervalMs(purgeIntervalInMs));
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -903,6 +903,16 @@ public class QuorumPeerConfig {
         return snapRetainCount;
     }
 
+    /**
+     * Use {@link #getPurgeIntervalInMs()} instead.
+     *
+     * @return purge interval in hour unit or 0 if less than one hour.
+     */
+    @Deprecated
+    public int getPurgeInterval() {
+        return purgeIntervalInMs / Time.HOUR;
+    }
+
     public int getPurgeIntervalInMs() {
         return purgeIntervalInMs;
     }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/TimeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/TimeTest.java
@@ -129,4 +129,27 @@ public class TimeTest extends ClientBase {
         } catch (NumberFormatException e) {
         }
     }
+
+    @Test
+    public void testFormatTimeInterval() throws Exception {
+        assertEquals("0", Time.formatTimeIntervalMs(0));
+        assertEquals("0", Time.formatTimeIntervalMs(Time.parseTimeInterval("0")));
+        assertEquals("0", Time.formatTimeIntervalMs(Time.parseTimeInterval("0ms")));
+        assertEquals("0", Time.formatTimeIntervalMs(Time.parseTimeInterval("0s")));
+        assertEquals("0", Time.formatTimeIntervalMs(Time.parseTimeInterval("0m")));
+        assertEquals("0", Time.formatTimeIntervalMs(Time.parseTimeInterval("0h")));
+        assertEquals("0", Time.formatTimeIntervalMs(Time.parseTimeInterval("0d")));
+        assertEquals("500ms", Time.formatTimeIntervalMs(Time.parseTimeInterval("500ms")));
+        assertEquals("1m", Time.formatTimeIntervalMs(Time.parseTimeInterval("60s")));
+        assertEquals("61s", Time.formatTimeIntervalMs(Time.parseTimeInterval("61s")));
+        assertEquals("59m", Time.formatTimeIntervalMs(Time.parseTimeInterval("59m")));
+        assertEquals("1h", Time.formatTimeIntervalMs(Time.parseTimeInterval("60m")));
+        assertEquals("2h", Time.formatTimeIntervalMs(Time.parseTimeInterval("120m")));
+        assertEquals("61m", Time.formatTimeIntervalMs(Time.parseTimeInterval("61m")));
+        assertEquals("23h", Time.formatTimeIntervalMs(Time.parseTimeInterval("23h")));
+        assertEquals("1d", Time.formatTimeIntervalMs(Time.parseTimeInterval("24h")));
+        assertEquals("2d", Time.formatTimeIntervalMs(Time.parseTimeInterval("48h")));
+        assertEquals("25h", Time.formatTimeIntervalMs(Time.parseTimeInterval("25h")));
+        assertEquals("2d", Time.formatTimeIntervalMs(Time.parseTimeInterval("2d")));
+    }
 }


### PR DESCRIPTION
`QuorumPeerConfig` is marked public with `@InterfaceAudience.Public`. Though, I don't think there are much chances for `getPurgeInterval` to be used. But let's keep our promise.

Backward Compatibility: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=25200595#ReleaseManagement-BackwardCompatibility