### PR TITLE
Ensure ServerSockets are closed in ensureComplete

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/controller/ControllerServerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/controller/ControllerServerConfig.java
@@ -134,14 +134,17 @@ public class ControllerServerConfig extends QuorumPeerConfig {
         // We will use majority strategy with only this host in the quorum.
         // We need to provide 2 more ports: one for elections and one for quorum communications.
         // We will also mark this host as the leader.
-        ServerSocket randomSocket1 = new ServerSocket(0);
-        int quorumPort = randomSocket1.getLocalPort();
+        int quorumPort;
+        int electionPort;
 
-        ServerSocket randomSocket2 = new ServerSocket(0);
-        int electionPort = randomSocket2.getLocalPort();
+        // Use try-with-resources to find available ports and ensure sockets are closed
+        try (ServerSocket randomSocket1 = new ServerSocket(0);
+             ServerSocket randomSocket2 = new ServerSocket(0)) {
 
-        randomSocket1.close();
-        randomSocket2.close();
+            quorumPort = randomSocket1.getLocalPort();
+            electionPort = randomSocket2.getLocalPort();
+
+        }
 
         QuorumPeer.QuorumServer selfAsPeer = new QuorumPeer.QuorumServer(
                 0,


### PR DESCRIPTION
# Description
Any exception occurring before both `close()` calls complete successfully can lead to one or both `ServerSocket` instances (and the system ports they hold) not being released.
The best way to fix this is to use the `try-with-resources` statement, which guarantees that `Closeable` resources are closed, even if exceptions occur.
```
int quorumPort;
int electionPort;

 // Use try-with-resources to find available ports and ensure sockets are closed
try (ServerSocket randomSocket1 = new ServerSocket(0);
     ServerSocket randomSocket2 = new ServerSocket(0)) {
     quorumPort = randomSocket1.getLocalPort();
     electionPort = randomSocket2.getLocalPort();
}