### PR TITLE
ZOOKEEPER-4942: Add option to preserve JVM TLS certification revocation properties

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ClientX509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ClientX509Util.java
@@ -79,7 +79,9 @@ public class ClientX509Util extends X509Util {
             sslContextBuilder.trustManager(tm);
         }
 
-        sslContextBuilder.enableOcsp(config.getBoolean(getSslOcspEnabledProperty()));
+        if (config.getTriState(getSslOcspEnabledProperty()) != null) {
+            sslContextBuilder.enableOcsp(config.getBoolean(getSslOcspEnabledProperty()));
+        }
         String[] enabledProtocols = getEnabledProtocols(config);
         if (enabledProtocols != null) {
             sslContextBuilder.protocols(enabledProtocols);
@@ -123,7 +125,9 @@ public class ClientX509Util extends X509Util {
             sslContextBuilder.trustManager(trustManager);
         }
 
-        sslContextBuilder.enableOcsp(config.getBoolean(getSslOcspEnabledProperty()));
+        if (config.getTriState(getSslOcspEnabledProperty()) != null) {
+            sslContextBuilder.enableOcsp(config.getBoolean(getSslOcspEnabledProperty()));
+        }
         String[] enabledProtocols = getEnabledProtocols(config);
         if (enabledProtocols != null) {
             sslContextBuilder.protocols(enabledProtocols);
@@ -189,8 +193,8 @@ public class ClientX509Util extends X509Util {
             getSslTruststorePasswdPathProperty());
         String trustStoreType = config.getProperty(getSslTruststoreTypeProperty());
 
-        boolean sslCrlEnabled = config.getBoolean(getSslCrlEnabledProperty());
-        boolean sslOcspEnabled = config.getBoolean(getSslOcspEnabledProperty());
+        Boolean sslCrlEnabled = config.getTriState(getSslCrlEnabledProperty());
+        Boolean sslOcspEnabled = config.getTriState(getSslOcspEnabledProperty());
         boolean sslServerHostnameVerificationEnabled = isServerHostnameVerificationEnabled(config);
         boolean sslClientHostnameVerificationEnabled = isClientHostnameVerificationEnabled(config);
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKConfig.java
@@ -234,6 +234,24 @@ public class ZKConfig {
     }
 
     /**
+     * Returns {@code Boolean.True} if and only if the property named by the argument
+     * exists and is case insensitive equal to the string {@code "true"}.
+     * Returns {@code nuln} if and only if the property named by the argument
+     * exists and is case insensitive equal to the string {@code "system"}.
+     * Returns {@code Boolean.False} otherwise.
+     */
+    public Boolean getTriState(String key) {
+        String propertyValue = getProperty(key);
+        if (propertyValue != null && propertyValue.equalsIgnoreCase("system")) {
+            return null;
+        } else if (propertyValue == null) {
+            return false;
+        } else {
+            return Boolean.parseBoolean(propertyValue.trim());
+        }
+    }
+
+    /**
      * Returns {@code true} if and only if the property named by the argument
      * exists and is equal to the string {@code "true"}.
      */

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -85,8 +85,8 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
                     x509Util.getSslKeystorePasswdPathProperty());
             String keyStoreTypeProp = config.getProperty(x509Util.getSslKeystoreTypeProperty());
 
-            boolean crlEnabled = Boolean.parseBoolean(config.getProperty(x509Util.getSslCrlEnabledProperty()));
-            boolean ocspEnabled = Boolean.parseBoolean(config.getProperty(x509Util.getSslOcspEnabledProperty()));
+            Boolean crlEnabled = config.getTriState(x509Util.getSslOcspEnabledProperty());
+            Boolean ocspEnabled = config.getTriState(x509Util.getSslOcspEnabledProperty());
             boolean hostnameVerificationEnabled = Boolean.parseBoolean(config.getProperty(x509Util.getSslHostnameVerificationEnabledProperty()));
 
             X509KeyManager km = null;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
@@ -269,6 +269,42 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
     @ParameterizedTest
     @MethodSource("data")
     @Timeout(value = 5)
+    public void testOCSPCRLTransparentFalse(
+            X509KeyType caKeyType, X509KeyType certKeyType, String keyPassword, Integer paramIndex)
+            throws Exception {
+        System.setProperty("com.sun.net.ssl.checkRevocation", Boolean.FALSE.toString());
+        System.setProperty("com.sun.security.enableCRLDP", Boolean.FALSE.toString());
+        Security.setProperty("ocsp.enable", Boolean.FALSE.toString());
+        init(caKeyType, certKeyType, keyPassword, paramIndex);
+        System.setProperty(x509Util.getSslOcspEnabledProperty(), "system");
+        System.setProperty(x509Util.getSslCrlEnabledProperty(), "system");
+        x509Util.getDefaultSSLContext();
+        assertFalse(Boolean.valueOf(System.getProperty("com.sun.net.ssl.checkRevocation")));
+        assertFalse(Boolean.valueOf(System.getProperty("com.sun.security.enableCRLDP")));
+        assertFalse(Boolean.valueOf(Security.getProperty("ocsp.enable")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    @Timeout(value = 5)
+    public void testOCSPCRLTransparentTrue(
+            X509KeyType caKeyType, X509KeyType certKeyType, String keyPassword, Integer paramIndex)
+            throws Exception {
+        System.setProperty("com.sun.net.ssl.checkRevocation", Boolean.TRUE.toString());
+        System.setProperty("com.sun.security.enableCRLDP", Boolean.TRUE.toString());
+        Security.setProperty("ocsp.enable", Boolean.TRUE.toString());
+        init(caKeyType, certKeyType, keyPassword, paramIndex);
+        System.setProperty(x509Util.getSslOcspEnabledProperty(), "system");
+        System.setProperty(x509Util.getSslCrlEnabledProperty(), "system");
+        x509Util.getDefaultSSLContext();
+        assertTrue(Boolean.valueOf(System.getProperty("com.sun.net.ssl.checkRevocation")));
+        assertTrue(Boolean.valueOf(System.getProperty("com.sun.security.enableCRLDP")));
+        assertTrue(Boolean.valueOf(Security.getProperty("ocsp.enable")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    @Timeout(value = 5)
     public void testCreateSSLSocket(
             X509KeyType caKeyType, X509KeyType certKeyType, String keyPassword, Integer paramIndex)
             throws Exception {


### PR DESCRIPTION
This patch implements Option B discussed in the ticket.

If the solution is accepted, then we will also need to update the docs.