### PR TITLE
ZOOKEEPER-4943: Use Duration for session timeout in ZooKeeperBuilder

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -462,7 +463,7 @@ public class ZooKeeper implements AutoCloseable {
      *             if an invalid chroot path is specified
      */
     public ZooKeeper(String connectString, int sessionTimeout, Watcher watcher) throws IOException {
-        this(new ZooKeeperBuilder(connectString, sessionTimeout)
+        this(new ZooKeeperBuilder(connectString, Duration.ofMillis(sessionTimeout))
             .withDefaultWatcher(watcher)
             .toOptions());
     }
@@ -517,7 +518,7 @@ public class ZooKeeper implements AutoCloseable {
         int sessionTimeout,
         Watcher watcher,
         ZKClientConfig conf) throws IOException {
-        this(new ZooKeeperBuilder(connectString, sessionTimeout)
+        this(new ZooKeeperBuilder(connectString, Duration.ofMillis(sessionTimeout))
             .withDefaultWatcher(watcher)
             .withClientConfig(conf)
             .toOptions());
@@ -586,7 +587,7 @@ public class ZooKeeper implements AutoCloseable {
         Watcher watcher,
         boolean canBeReadOnly,
         HostProvider aHostProvider) throws IOException {
-        this(new ZooKeeperBuilder(connectString, sessionTimeout)
+        this(new ZooKeeperBuilder(connectString, Duration.ofMillis(sessionTimeout))
             .withDefaultWatcher(watcher)
             .withCanBeReadOnly(canBeReadOnly)
             .withHostProvider(ignored -> aHostProvider)
@@ -660,7 +661,7 @@ public class ZooKeeper implements AutoCloseable {
         HostProvider hostProvider,
         ZKClientConfig clientConfig
     ) throws IOException {
-        this(new ZooKeeperBuilder(connectString, sessionTimeout)
+        this(new ZooKeeperBuilder(connectString, Duration.ofMillis(sessionTimeout))
             .withDefaultWatcher(watcher)
             .withCanBeReadOnly(canBeReadOnly)
             .withHostProvider(ignored -> hostProvider)
@@ -746,7 +747,7 @@ public class ZooKeeper implements AutoCloseable {
         int sessionTimeout,
         Watcher watcher,
         boolean canBeReadOnly) throws IOException {
-        this(new ZooKeeperBuilder(connectString, sessionTimeout)
+        this(new ZooKeeperBuilder(connectString, Duration.ofMillis(sessionTimeout))
             .withDefaultWatcher(watcher)
             .withCanBeReadOnly(canBeReadOnly)
             .toOptions());
@@ -812,7 +813,7 @@ public class ZooKeeper implements AutoCloseable {
         Watcher watcher,
         boolean canBeReadOnly,
         ZKClientConfig conf) throws IOException {
-        this(new ZooKeeperBuilder(connectString, sessionTimeout)
+        this(new ZooKeeperBuilder(connectString, Duration.ofMillis(sessionTimeout))
             .withDefaultWatcher(watcher)
             .withCanBeReadOnly(canBeReadOnly)
             .withClientConfig(conf)
@@ -877,7 +878,7 @@ public class ZooKeeper implements AutoCloseable {
         Watcher watcher,
         long sessionId,
         byte[] sessionPasswd) throws IOException {
-        this(new ZooKeeperBuilder(connectString, sessionTimeout)
+        this(new ZooKeeperBuilder(connectString, Duration.ofMillis(sessionTimeout))
             .withDefaultWatcher(watcher)
             .withSession(sessionId, sessionPasswd)
             .toOptions());
@@ -955,7 +956,7 @@ public class ZooKeeper implements AutoCloseable {
         byte[] sessionPasswd,
         boolean canBeReadOnly,
         HostProvider aHostProvider) throws IOException {
-        this(new ZooKeeperBuilder(connectString, sessionTimeout)
+        this(new ZooKeeperBuilder(connectString, Duration.ofMillis(sessionTimeout))
             .withDefaultWatcher(watcher)
             .withSession(sessionId, sessionPasswd)
             .withCanBeReadOnly(canBeReadOnly)
@@ -1041,7 +1042,7 @@ public class ZooKeeper implements AutoCloseable {
         boolean canBeReadOnly,
         HostProvider hostProvider,
         ZKClientConfig clientConfig) throws IOException {
-        this(new ZooKeeperBuilder(connectString, sessionTimeout)
+        this(new ZooKeeperBuilder(connectString, Duration.ofMillis(sessionTimeout))
             .withSession(sessionId, sessionPasswd)
             .withDefaultWatcher(watcher)
             .withCanBeReadOnly(canBeReadOnly)
@@ -1072,7 +1073,7 @@ public class ZooKeeper implements AutoCloseable {
     @InterfaceAudience.Private
     public ZooKeeper(ZooKeeperOptions options) throws IOException {
         String connectString = options.getConnectString();
-        int sessionTimeout = options.getSessionTimeout();
+        int sessionTimeout = options.getSessionTimeoutMs();
         long sessionId = options.getSessionId();
         byte[] sessionPasswd = sessionId == 0 ? new byte[16] : options.getSessionPasswd();
         Watcher watcher = options.getDefaultWatcher();
@@ -1188,7 +1189,7 @@ public class ZooKeeper implements AutoCloseable {
         long sessionId,
         byte[] sessionPasswd,
         boolean canBeReadOnly) throws IOException {
-        this(new ZooKeeperBuilder(connectString, sessionTimeout)
+        this(new ZooKeeperBuilder(connectString, Duration.ofMillis(sessionTimeout))
             .withDefaultWatcher(watcher)
             .withSession(sessionId, sessionPasswd)
             .withCanBeReadOnly(canBeReadOnly)

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperBuilder.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperBuilder.java
@@ -21,7 +21,9 @@ package org.apache.zookeeper.client;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.function.Function;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
@@ -36,7 +38,7 @@ import org.apache.zookeeper.admin.ZooKeeperAdmin;
 @InterfaceStability.Evolving
 public class ZooKeeperBuilder {
     private final String connectString;
-    private final int sessionTimeout;
+    private final Duration sessionTimeout;
     private Function<Collection<InetSocketAddress>, HostProvider> hostProvider;
     private Watcher defaultWatcher;
     private boolean canBeReadOnly = false;
@@ -56,12 +58,12 @@ public class ZooKeeperBuilder {
      *            would be relative to this root - ie getting/setting/etc...
      *            "/foo/bar" would result in operations being run on
      *            "/app/a/foo/bar" (from the server perspective).
-     * @param sessionTimeoutMs
-     *            session timeout in milliseconds
+     * @param sessionTimeout
+     *            session timeout
      */
-    public ZooKeeperBuilder(String connectString, int sessionTimeoutMs) {
+    public ZooKeeperBuilder(String connectString, Duration sessionTimeout) {
         this.connectString = connectString;
-        this.sessionTimeout = sessionTimeoutMs;
+        this.sessionTimeout = Objects.requireNonNull(sessionTimeout, "session timeout must not be null");
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperOptions.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ZooKeeperOptions.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.client;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.function.Function;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -31,7 +32,7 @@ import org.apache.zookeeper.Watcher;
 @InterfaceAudience.Private
 public class ZooKeeperOptions {
     private final String connectString;
-    private final int sessionTimeout;
+    private final Duration sessionTimeout;
     private final Watcher defaultWatcher;
     private final Function<Collection<InetSocketAddress>, HostProvider> hostProvider;
     private final boolean canBeReadOnly;
@@ -40,7 +41,7 @@ public class ZooKeeperOptions {
     private final ZKClientConfig clientConfig;
 
     ZooKeeperOptions(String connectString,
-                     int sessionTimeout,
+                     Duration sessionTimeout,
                      Watcher defaultWatcher,
                      Function<Collection<InetSocketAddress>, HostProvider> hostProvider,
                      boolean canBeReadOnly,
@@ -61,8 +62,8 @@ public class ZooKeeperOptions {
         return connectString;
     }
 
-    public int getSessionTimeout() {
-        return sessionTimeout;
+    public int getSessionTimeoutMs() {
+        return (int) Long.min(Integer.MAX_VALUE, sessionTimeout.toMillis());
     }
 
     public Watcher getDefaultWatcher() {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/client/ZooKeeperBuilderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/client/ZooKeeperBuilderTest.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -69,7 +70,7 @@ public class ZooKeeperBuilderTest extends ClientBase {
     @Test
     public void testBuildClient() throws Exception {
         BlockingQueue<WatchedEvent> events = new LinkedBlockingQueue<>();
-        ZooKeeper zk = new ZooKeeperBuilder(hostPort, 1000)
+        ZooKeeper zk = new ZooKeeperBuilder(hostPort, Duration.ofMillis(1000))
             .withDefaultWatcher(events::offer)
             .build();
         testClient(events, zk);
@@ -78,7 +79,7 @@ public class ZooKeeperBuilderTest extends ClientBase {
     @Test
     public void testBuildAdminClient() throws Exception {
         BlockingQueue<WatchedEvent> events = new LinkedBlockingQueue<>();
-        ZooKeeper zk = new ZooKeeperBuilder(hostPort, 1000)
+        ZooKeeper zk = new ZooKeeperBuilder(hostPort, Duration.ofMillis(1000))
             .withDefaultWatcher(events::offer)
             .buildAdmin();
         testClient(events, zk);


### PR DESCRIPTION
`ZooKeeperBuilder` is introduced in ZOOKEEPER-4697 which targets 3.10.0, so this api change breaks nothing.

Refs: ZOOKEEPER-4697, ZOOKEEPER-4943