### PR TITLE
ZOOKEEPER-4949: Clean up TLS CRL/OCSP configuration

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1687,7 +1687,7 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     Specifies the file path to a Java keystore containing the local
     credentials to be used for client and quorum TLS connections, and the
     password to unlock the file.
-    
+
 * *ssl.keyStore.passwordPath* and *ssl.quorum.keyStore.passwordPath* :
     (Java system properties: **zookeeper.ssl.keyStore.passwordPath** and **zookeeper.ssl.quorum.keyStore.passwordPath**)
     **New in 3.8.0:**
@@ -1762,19 +1762,58 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     **New in 3.9.4:**
     Specifies whether the client's hostname verification is enabled in client and quorum TLS negotiation process.
     This option requires the corresponding *hostnameVerification* option to be `true`, or it will be ignored.
+    *ssl.clientHostnameVerification* has no effect, as the client does not receive TLS connections.
     Default: true for quorum, false for clients
 
 * *ssl.crl* and *ssl.quorum.crl* :
     (Java system properties: **zookeeper.ssl.crl** and **zookeeper.ssl.quorum.crl**)
     **New in 3.5.5:**
     Specifies whether Certificate Revocation List is enabled in client and quorum TLS protocols.
+    This option requires that the *ssl.quorum.trustStore.location* is set, or it will be ignored.
+    Enabling this option will set the JVM global "com.sun.security.enableCRLDP" system property to true.
     Default: false
 
 * *ssl.ocsp* and *ssl.quorum.ocsp* :
     (Java system properties: **zookeeper.ssl.ocsp** and **zookeeper.ssl.quorum.ocsp**)
     **New in 3.5.5:**
     Specifies whether Online Certificate Status Protocol is enabled in client and quorum TLS protocols.
+    This option requires that the *ssl.trustStore.location* is set, or it will be ignored for the client.
+    Enabling this option will set the JVM global "com.sun.security.enableCRLDP" system property to true.
+    Enabling this option will set JVM global "ocsp.enable" security property to true.
     Default: false
+
+* *ssl.revocationEnabled* and *ssl.quorum.revocationEnabled* :
+    (Java system properties: **zookeeper.ssl.revocationEnabled** and **zookeeper.ssl.quorum.revocationEnabled**)
+    **New in 3.10.0:**
+    Specifies whether Certificate Revocation checking is enabled in client and quorum TLS protocols.
+    This option requires that the *ssl.trustStore.location* is set, or it will be ignored for the client.
+    This options has no side effects on JVM global system properties.
+    Default: if the option is not set, or set to the value "default" then the JVM default settings
+    are used.
+
+* *ssl.disableLegacyRevocationLogic* and *ssl.quorum.disableLegacyRevocationLogic* :
+    (Java system properties: **zookeeper.ssl.disableLegacyRevocationLogic** and **zookeeper.ssl.quorum.disableLegacyRevocationLogic**)
+    **New in 3.10.0:**
+    Traditionally, ZK has always explicitly disabled or enabled certificate revocation in the trustmanager based on the values of the
+    *ssl.ocsp* and *ssl.crl* properties. This made it impossible to completely rely on System properties for configuring
+    revocation checking for ZooKeeper.
+    Setting this property disables the logic for implicitly setting the certificate revocation check status on the trustManager,
+    allowing the JVM default behavior to be used.
+    It is recommended to set *ssl.ocsp* and *ssl.crl* to false, and *ssl.disableLegacyRevocationLogic* to true.
+    With those settings, ZK will use the JVM default CRL/OCSP settings, and not change the defaults. *ssl.revocationEnabled*
+    can still be used to enable/disable revocation checking for the custom SSL truststore.
+    This option requires that the *ssl.trustStore.location* is set, or it will be ignored for the client.
+    Default: false.
+
+* *ssl.tcnative.ocsp* and *ssl.quorum.tcnative.ocsp* :
+    (Java system properties: **zookeeper.ssl.tcnative.ocsp** and **zookeeper.ssl.quorum.tcnative.ocsp**)
+    **New in 3.10.0:**
+    Specifies whether OCSP stapling is requested by the client.
+    This option has no effect unless the the OpenSSL tcnative SSL provider with the OpenSSL library is used.
+    Note that Zookeeper uses the the BoringSSL tcnative library by default, so even is the "OpenSSL" SSL provider is requested,
+    this won't do anything unless the default BoringSSL library is replaced with the OpenSSL one.
+    This options has no side effects on JVM global system properties.
+    Default: if the option is not set, or set to the value "default" then the library default is used.
 
 * *ssl.clientAuth* and *ssl.quorum.clientAuth* :
     (Java system properties: **zookeeper.ssl.clientAuth** and **zookeeper.ssl.quorum.clientAuth**)
@@ -1785,7 +1824,8 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
      * "want": server will "request" client authentication 
      * "need": server will "require" client authentication
 
-     Default: "need"
+    *ssl.clientHostnameVerification* has no effect.
+    Default: "need"
 
 * *ssl.handshakeDetectionTimeoutMillis* and *ssl.quorum.handshakeDetectionTimeoutMillis* :
     (Java system properties: **zookeeper.ssl.handshakeDetectionTimeoutMillis** and **zookeeper.ssl.quorum.handshakeDetectionTimeoutMillis**)

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/TriState.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/TriState.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.common;
+
+/**
+ * For storing configuration parameters where want to distinguish a default case
+ * in addition to true and false.
+ */
+public enum TriState {
+    True, False, Default;
+
+    public static TriState parse(String value) {
+        if (value == null || value.equalsIgnoreCase("default")) {
+            return TriState.Default;
+        } else if (value.equalsIgnoreCase("true")) {
+            return TriState.True;
+        } else {
+            return TriState.False;
+        }
+    }
+
+    public boolean isTrue() {
+        return this == TriState.True;
+    }
+
+    public boolean isFalse() {
+        return this == TriState.False;
+    }
+
+    public boolean isDefault() {
+        return this == TriState.Default;
+    }
+
+    public boolean isNotDefault() {
+        return this != TriState.Default;
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ZKConfig.java
@@ -131,6 +131,9 @@ public class ZKConfig {
         properties.put(x509Util.getSslHostnameVerificationEnabledProperty(), System.getProperty(x509Util.getSslHostnameVerificationEnabledProperty()));
         properties.put(x509Util.getSslCrlEnabledProperty(), System.getProperty(x509Util.getSslCrlEnabledProperty()));
         properties.put(x509Util.getSslOcspEnabledProperty(), System.getProperty(x509Util.getSslOcspEnabledProperty()));
+        properties.put(x509Util.getSslTcnativeOcspEnabledProperty(), System.getProperty(x509Util.getSslTcnativeOcspEnabledProperty()));
+        properties.put(x509Util.getSslRevocationEnabledProperty(), System.getProperty(x509Util.getSslRevocationEnabledProperty()));
+        properties.put(x509Util.getSslDisableLegacyRevocationLogicProperty(), System.getProperty(x509Util.getSslDisableLegacyRevocationLogicProperty()));
         properties.put(x509Util.getSslClientAuthProperty(), System.getProperty(x509Util.getSslClientAuthProperty()));
         properties.put(x509Util.getSslHandshakeDetectionTimeoutMillisProperty(), System.getProperty(x509Util.getSslHandshakeDetectionTimeoutMillisProperty()));
         properties.put(x509Util.getFipsModeProperty(), System.getProperty(x509Util.getFipsModeProperty()));
@@ -284,4 +287,15 @@ public class ZKConfig {
         return defaultValue;
     }
 
+    /**
+     * Returns {@code TriState.True} if and only if the property named by the argument
+     * exists and is equal to the string {@code "true"}.
+     * Returns {@code TriState.Default} if and only if the property named by the argument
+     * does not exist or is equal to the string {@code "default"}.
+     * Returns {@code TriState.False} otherwise.
+     */
+    public TriState getTristate(String key) {
+        String propertyValue = getProperty(key);
+        return TriState.parse(propertyValue);
+    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -32,6 +32,7 @@ import javax.security.auth.x500.X500Principal;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.common.ClientX509Util;
+import org.apache.zookeeper.common.TriState;
 import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.common.X509Exception.KeyManagerException;
 import org.apache.zookeeper.common.X509Exception.TrustManagerException;
@@ -87,6 +88,8 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
 
             boolean crlEnabled = Boolean.parseBoolean(config.getProperty(x509Util.getSslCrlEnabledProperty()));
             boolean ocspEnabled = Boolean.parseBoolean(config.getProperty(x509Util.getSslOcspEnabledProperty()));
+            TriState sslRevocationEnabled = config.getTristate(x509Util.getSslRevocationEnabledProperty());
+            boolean disableLegacyRevocationLogic = config.getBoolean(x509Util.getSslDisableLegacyRevocationLogicProperty());
             boolean hostnameVerificationEnabled = Boolean.parseBoolean(config.getProperty(x509Util.getSslHostnameVerificationEnabledProperty()));
 
             X509KeyManager km = null;
@@ -118,6 +121,8 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
                         trustStoreTypeProp,
                         crlEnabled,
                         ocspEnabled,
+                        sslRevocationEnabled,
+                        disableLegacyRevocationLogic,
                         hostnameVerificationEnabled,
                         false,
                         fipsMode);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
@@ -242,6 +242,23 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
     @ParameterizedTest
     @MethodSource("data")
     @Timeout(value = 5)
+    public void testCRLEnabledDisableLegacy(
+            X509KeyType caKeyType, X509KeyType certKeyType, String keyPassword, Integer paramIndex)
+            throws Exception {
+        System.setProperty("com.sun.net.ssl.checkRevocation", Boolean.FALSE.toString());
+        init(caKeyType, certKeyType, keyPassword, paramIndex);
+        System.setProperty(x509Util.getSslCrlEnabledProperty(), "true");
+        System.setProperty(x509Util.getSslDisableLegacyRevocationLogicProperty(), "true");
+        x509Util.getDefaultSSLContext();
+        // SslDisableLegacyRevocationLogic does only applies to the custom truststore property
+        assertTrue(Boolean.valueOf(System.getProperty("com.sun.net.ssl.checkRevocation")));
+        assertTrue(Boolean.valueOf(System.getProperty("com.sun.security.enableCRLDP")));
+        assertFalse(Boolean.valueOf(Security.getProperty("ocsp.enable")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    @Timeout(value = 5)
     public void testCRLDisabled(
             X509KeyType caKeyType, X509KeyType certKeyType, String keyPassword, Integer paramIndex)
             throws Exception {
@@ -255,11 +272,60 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
     @ParameterizedTest
     @MethodSource("data")
     @Timeout(value = 5)
+    public void testCRLDisabledDisableLegacy(
+            X509KeyType caKeyType, X509KeyType certKeyType, String keyPassword, Integer paramIndex)
+            throws Exception {
+        System.setProperty("com.sun.net.ssl.checkRevocation", Boolean.TRUE.toString());
+        init(caKeyType, certKeyType, keyPassword, paramIndex);
+        System.setProperty(x509Util.getSslDisableLegacyRevocationLogicProperty(), "true");
+        x509Util.getDefaultSSLContext();
+        assertTrue(Boolean.valueOf(System.getProperty("com.sun.net.ssl.checkRevocation")));
+        assertFalse(Boolean.valueOf(System.getProperty("com.sun.security.enableCRLDP")));
+        assertFalse(Boolean.valueOf(Security.getProperty("ocsp.enable")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    @Timeout(value = 5)
     public void testOCSPEnabled(
             X509KeyType caKeyType, X509KeyType certKeyType, String keyPassword, Integer paramIndex)
             throws Exception {
         init(caKeyType, certKeyType, keyPassword, paramIndex);
         System.setProperty(x509Util.getSslOcspEnabledProperty(), "true");
+        x509Util.getDefaultSSLContext();
+        assertTrue(Boolean.valueOf(System.getProperty("com.sun.net.ssl.checkRevocation")));
+        assertTrue(Boolean.valueOf(System.getProperty("com.sun.security.enableCRLDP")));
+        assertTrue(Boolean.valueOf(Security.getProperty("ocsp.enable")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    @Timeout(value = 5)
+    public void testOCSPEnabledDisableLegacy(
+            X509KeyType caKeyType, X509KeyType certKeyType, String keyPassword, Integer paramIndex)
+            throws Exception {
+        System.setProperty("com.sun.net.ssl.checkRevocation", Boolean.FALSE.toString());
+        init(caKeyType, certKeyType, keyPassword, paramIndex);
+        System.setProperty(x509Util.getSslDisableLegacyRevocationLogicProperty(), "true");
+        System.setProperty(x509Util.getSslOcspEnabledProperty(), "true");
+        x509Util.getDefaultSSLContext();
+        // SslDisableLegacyRevocationLogic does only applies to the custom truststore property
+        assertTrue(Boolean.valueOf(System.getProperty("com.sun.net.ssl.checkRevocation")));
+        assertTrue(Boolean.valueOf(System.getProperty("com.sun.security.enableCRLDP")));
+        assertTrue(Boolean.valueOf(Security.getProperty("ocsp.enable")));
+    }
+    
+    @ParameterizedTest
+    @MethodSource("data")
+    @Timeout(value = 5)
+    public void testOcspDisabledisNoop(
+            X509KeyType caKeyType, X509KeyType certKeyType, String keyPassword, Integer paramIndex)
+            throws Exception {
+        System.setProperty("com.sun.net.ssl.checkRevocation", Boolean.TRUE.toString());
+        System.setProperty("com.sun.security.enableCRLDP", Boolean.TRUE.toString());
+        Security.setProperty("ocsp.enable", Boolean.TRUE.toString());
+        init(caKeyType, certKeyType, keyPassword, paramIndex);
+        System.setProperty(x509Util.getSslOcspEnabledProperty(), "false");
         x509Util.getDefaultSSLContext();
         assertTrue(Boolean.valueOf(System.getProperty("com.sun.net.ssl.checkRevocation")));
         assertTrue(Boolean.valueOf(System.getProperty("com.sun.security.enableCRLDP")));
@@ -375,6 +441,8 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
             x509TestContext.getTrustStorePassword(), KeyStoreFileType.PEM.getPropertyValue(),
             false,
             false,
+            TriState.False,
+            false,
             true,
             true,
             false);
@@ -396,6 +464,8 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
             KeyStoreFileType.PEM.getPropertyValue(),
             false,
             false,
+            TriState.False,
+            false,
             true,
             true,
             false);
@@ -414,6 +484,8 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
             x509TestContext.getTrustStorePassword(),
             null,  // null StoreFileType means 'autodetect from file extension'
             false,
+            false,
+            TriState.False,
             false,
             true,
             true,
@@ -490,6 +562,8 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
             KeyStoreFileType.JKS.getPropertyValue(),
             true,
             true,
+            TriState.Default,
+            false,
             true,
             true,
             false);
@@ -511,6 +585,8 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
             KeyStoreFileType.JKS.getPropertyValue(),
             false,
             false,
+            TriState.False,
+            false,
             true,
             true,
             false);
@@ -529,6 +605,8 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
             null,  // null StoreFileType means 'autodetect from file extension'
             true,
             true,
+            TriState.Default,
+            false,
             true,
             true,
             false);
@@ -548,6 +626,8 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
                     KeyStoreFileType.JKS.getPropertyValue(),
                     true,
                     true,
+                    TriState.Default,
+                    false,
                     true,
                     true,
                     false);
@@ -623,6 +703,8 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
             x509TestContext.getTrustStorePassword(), KeyStoreFileType.PKCS12.getPropertyValue(),
             true,
             true,
+            TriState.Default,
+            false,
             true,
             true,
             false);
@@ -644,6 +726,8 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
             KeyStoreFileType.PKCS12.getPropertyValue(),
             false,
             false,
+            TriState.False,
+            false,
             true,
             true,
             false);
@@ -662,6 +746,8 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
             null,  // null StoreFileType means 'autodetect from file extension'
             true,
             true,
+            TriState.Default,
+            false,
             true,
             true,
             false);
@@ -681,6 +767,8 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
                     KeyStoreFileType.PKCS12.getPropertyValue(),
                     true,
                     true,
+                    TriState.Default,
+                    false,
                     true,
                     true,
                     false);
@@ -738,6 +826,20 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
         zkConfig.setProperty(clientX509Util.getSslContextSupplierClassProperty(), SslContextSupplier.class.getName());
         final SSLContext sslContext = clientX509Util.createSSLContext(zkConfig);
         assertEquals(SSLContext.getDefault(), sslContext);
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCreateSSLContext_ocspWithJreProvider(
+            X509KeyType caKeyType, X509KeyType certKeyType, String keyPassword, Integer paramIndex)
+            throws Exception {
+        init(caKeyType, certKeyType, keyPassword, paramIndex);
+        ZKConfig zkConfig = new ZKConfig();
+        try (ClientX509Util clientX509Util = new ClientX509Util();) {
+            zkConfig.setProperty(clientX509Util.getSslOcspEnabledProperty(), "true");
+            // Must not throw IllegalArgumentException
+            clientX509Util.createSSLContext(zkConfig);
+        }
     }
 
     private static void forceClose(Socket s) {


### PR DESCRIPTION
- Enable FIPS style server hostname verification if truststore is not specified
- Make sure tcnative specific enableOCSP method is not called for JRE SSL provider
- Add new config option to enable tcnative specific enableOCSP method
- Add new config option to separetely enable certificate revocation checking for custom truststores
- Add new config option to disable existing implicit certificate revocation checking logic for custom truststores
- Document dependencies of TLS truststore related options