### PR TITLE
ZOOKEEPER-4240: Add IPV6 support for ZooKeeper ACL

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/IPAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/IPAuthenticationProvider.java
@@ -122,7 +122,7 @@ public class IPAuthenticationProvider implements AuthenticationProvider {
 
         // Case 1: No "::" (full address)
         if (parts.length == 1) {
-            segments1 = parts[0].split(":");
+            segments1 = parts[0].split(":", -1);
             if (segments1.length != IPV6_SEGMENT_COUNT) {
                 String reason = "wrong number of segments";
                 throw new IllegalArgumentException(reason);
@@ -131,10 +131,10 @@ public class IPAuthenticationProvider implements AuthenticationProvider {
             // Case 2: "::" is present
             // Handle cases like "::1" or "1::"
             if (!parts[0].isEmpty()) {
-                segments1 = parts[0].split(":");
+                segments1 = parts[0].split(":", -1);
             }
             if (!parts[1].isEmpty()) {
-                segments2 = parts[1].split(":");
+                segments2 = parts[1].split(":", -1);
             }
 
             // Check if the total number of explicit segments exceeds 8
@@ -159,8 +159,10 @@ public class IPAuthenticationProvider implements AuthenticationProvider {
 
     private static void parseV6Segment(byte[] addr, int i, String[] segments) {
         for (String segment : segments) {
-            if (segment.length() > IPV6_SEGMENT_HEX_LENGTH) {
-                throw new IllegalArgumentException("too many characters in segment");
+            if (segment.isEmpty()) {
+                throw new IllegalArgumentException("empty segment");
+            } else if (segment.length() > IPV6_SEGMENT_HEX_LENGTH) {
+                throw new IllegalArgumentException("segment too long");
             }
             try {
                 int value = Integer.parseInt(segment, 16);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/IPAuthenticationProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/IPAuthenticationProviderTest.java
@@ -20,6 +20,8 @@ package org.apache.zookeeper.server.auth;
 import static org.apache.zookeeper.server.auth.IPAuthenticationProvider.USE_X_FORWARDED_FOR_KEY;
 import static org.apache.zookeeper.server.auth.IPAuthenticationProvider.X_FORWARDED_FOR_HEADER_NAME;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import javax.servlet.http.HttpServletRequest;
@@ -95,5 +97,56 @@ public class IPAuthenticationProviderTest {
 
     // Assert
     assertEquals("192.168.1.1", clientIp);
+  }
+
+  @Test
+  public void testParsingOfIPv6Address() {
+    //Full IPv6 address
+    String ipv6Full = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+    byte[] expectedFull = {
+            (byte) 0x20, (byte) 0x01, (byte) 0x0d, (byte) 0xb8,
+            (byte) 0x85, (byte) 0xa3, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x8a, (byte) 0x2e,
+            (byte) 0x03, (byte) 0x70, (byte) 0x73, (byte) 0x34
+    };
+    byte[] actualFull = IPAuthenticationProvider.v6addr2Bytes(ipv6Full);
+    assertNotNull(actualFull, "Full IPv6 address should not return null");
+    assertArrayEquals(expectedFull, actualFull, "Full IPv6 address conversion mismatch");
+
+    //Compressed IPv6 address (double colon)
+    String ipv6Compressed = "2001:db8::8a2e:370:7334";
+    byte[] expectedCompressed = {
+            (byte) 0x20, (byte) 0x01, (byte) 0x0d, (byte) 0xb8,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x8a, (byte) 0x2e,
+            (byte) 0x03, (byte) 0x70, (byte) 0x73, (byte) 0x34
+    };
+    byte[] actualCompressed = IPAuthenticationProvider.v6addr2Bytes(ipv6Compressed);
+    assertNotNull(actualCompressed, "Compressed IPv6 address should not return null");
+    assertArrayEquals(expectedCompressed, actualCompressed, "Compressed IPv6 address conversion mismatch");
+
+    //Shortened IPv6 address
+    String ipv6Shortened = "2001:db8::1";
+    byte[] expectedShortened = {
+            (byte) 0x20, (byte) 0x01, (byte) 0x0d, (byte) 0xb8,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01
+    };
+    byte[] actualShortened = IPAuthenticationProvider.v6addr2Bytes(ipv6Shortened);
+    assertNotNull(actualShortened, "Shortened IPv6 address should not return null");
+    assertArrayEquals(expectedShortened, actualShortened, "Shortened IPv6 address conversion mismatch");
+
+    //Loopback address
+    String ipv6Loopback = "::1";
+    byte[] expectedLoopback = {
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01
+    };
+    byte[] actualLoopback = IPAuthenticationProvider.v6addr2Bytes(ipv6Loopback);
+    assertNotNull(actualLoopback, "Loopback IPv6 address should not return null");
+    assertArrayEquals(expectedLoopback, actualLoopback, "Loopback IPv6 address conversion mismatch");
   }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/IPAuthenticationProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/IPAuthenticationProviderTest.java
@@ -175,7 +175,7 @@ public class IPAuthenticationProviderTest {
     );
   }
 
-  @ParameterizedTest(name = "address = {0}")
+  @ParameterizedTest(name = "address = \"{0}\"")
   @MethodSource("invalidIPv6Addresses")
   public void testParsingOfInvalidIPv6Address(String ipv6Address, String expectedMessage) {
     try {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/IPAuthenticationProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/IPAuthenticationProviderTest.java
@@ -162,11 +162,16 @@ public class IPAuthenticationProviderTest {
     return Stream.of(
       Arguments.of("1", "wrong number of segments"),
       Arguments.of("1:2", "wrong number of segments"),
+      Arguments.of("1::2:", "empty segment"),
+      Arguments.of(":1::2:", "empty segment"),
+      Arguments.of("1:2:3:4:5:6:7:8:", "wrong number of segments"),
       Arguments.of("1:2:3:4:5:6:7:8:9", "wrong number of segments"),
       Arguments.of("1:2::3:4:5:6:7:8", "too many segments"),
       Arguments.of("1::2::", "too many '::'"),
-      Arguments.of("1:abcdf::", "too many characters in segment"),
-      Arguments.of("efgh::", "invalid hexadecimal characters in segment")
+      Arguments.of("1:abcdf::", "segment too long"),
+      Arguments.of("efgh::", "invalid hexadecimal characters in segment"),
+      Arguments.of("1:: ", "invalid hexadecimal characters in segment"),
+      Arguments.of(" 1::", "invalid hexadecimal characters in segment")
     );
   }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ACLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ACLTest.java
@@ -92,7 +92,7 @@ public class ACLTest extends ZKTestCase implements Watcher {
         assertFalse(prov.isValid("2001:db8:85a3:G::8a2e:0370:7334"), "Invalid hex character");
         assertFalse(prov.isValid(""), "empty string");
         assertFalse(prov.isValid("2001:db8:85a3:0:0:0:0:1:2"), "too many segments post compression");
-        assertTrue(prov.isValid("2001:db8:85a3::8a2e:0370:7334:"), "trailing colon");
+        assertFalse(prov.isValid("2001:db8:85a3::8a2e:0370:7334:"), "trailing colon");
         assertFalse(prov.isValid(":2001:db8:85a3::8a2e:0370:7334"), "Leading colon");
         assertFalse(prov.isValid("::FFFF:192.168.1.1"), "IPv4-mapped");
         assertTrue(prov.isValid("2001:db8:1234::/64"), "IPv6 address for multiple clients");

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ACLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ACLTest.java
@@ -23,11 +23,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -39,6 +43,7 @@ import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.ZooDefs.Perms;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
@@ -48,6 +53,7 @@ import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.SyncRequestProcessor;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.auth.IPAuthenticationProvider;
+import org.apache.zookeeper.server.embedded.ZooKeeperServerEmbedded;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
@@ -131,6 +137,132 @@ public class ACLTest extends ZKTestCase implements Watcher {
             assertTrue(ClientBase.waitForServerDown(HOSTPORT, CONNECTION_TIMEOUT), "waiting for server down");
             System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
         }
+    }
+
+    @Test
+    public void testAuthWithIPV6Server(@TempDir File tmpDir) throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("clientPortAddress", "::1");
+        properties.setProperty("clientPort", "0");
+
+        ZooKeeperServerEmbedded server = ZooKeeperServerEmbedded.builder()
+            .baseDir(tmpDir.toPath())
+            .configuration(properties)
+            .build();
+        server.start();
+
+        String connectionString = server.getConnectionString();
+        String port = connectionString.substring(connectionString.lastIndexOf(':') + 1);
+
+        String hostport = String.format("[::1]:%s", port);
+        assertTrue(ClientBase.waitForServerUp(hostport, CONNECTION_TIMEOUT), "waiting for server being up");
+
+        // given: ipv6 client
+        ZooKeeper zk = ClientBase.createZKClient(hostport);
+
+        // when: invalid ipv6 network acl
+        // then: InvalidACL
+        assertThrows(KeeperException.InvalidACLException.class, () ->
+            zk.create("/invalid-ipv6-network-acl", null, Collections.singletonList(new ACL(Perms.ALL, new Id("ip", "::1/256"))), CreateMode.PERSISTENT));
+
+        // given: ipv4 network acl
+        zk.create("/unmatched-ipv4-network-acl", null, Collections.singletonList(new ACL(Perms.ALL, new Id("ip", "127.0.0.1/16"))), CreateMode.PERSISTENT);
+        // when: access with v6 ip
+        // then: NoAuth
+        assertThrows(KeeperException.NoAuthException.class, () -> zk.setData("/unmatched-ipv4-network-acl", null, -1));
+
+        // given: prefix matched ipv4 acl
+        zk.create("/prefix-matched-ipv4-acl", null, Collections.singletonList(new ACL(Perms.ALL, new Id("ip", "0.0.0.1/16"))), CreateMode.PERSISTENT);
+        // when: access with v6 ip
+        // then: NoAuth
+        assertThrows(KeeperException.NoAuthException.class, () -> zk.setData("/prefix-matched-ipv4-acl", null, -1));
+
+        // given: ipv6 with network acl
+        zk.create("/ipv6-network-acl", null, Collections.singletonList(new ACL(Perms.ALL, new Id("ip", "::1/64"))), CreateMode.PERSISTENT);
+        // when: access with valid ip
+        // then: ok
+        zk.setData("/ipv6-network-acl", null, -1);
+
+        // given: ipv6 acl
+        zk.create("/ipv6-acl", null, Collections.singletonList(new ACL(Perms.ALL, new Id("ip", "::1"))), CreateMode.PERSISTENT);
+        // when: access with valid ip
+        // then: ok
+        zk.setData("/ipv6-acl", null, -1);
+
+        // given: mismatched ipv6 with network acl
+        zk.create("/mismatched-ipv6-network-acl", null, Collections.singletonList(new ACL(Perms.ALL, new Id("ip", "0000:0001::/32"))), CreateMode.PERSISTENT);
+        // when: access with invalid ip
+        // then: NoAuth
+        assertThrows(KeeperException.NoAuthException.class, () -> zk.setData("/mismatched-ipv6-network-acl", null, -1));
+
+        // given: mismatched ipv6 acl
+        zk.create("/mismatched-ipv6-acl", null, Collections.singletonList(new ACL(Perms.ALL, new Id("ip", "::2"))), CreateMode.PERSISTENT);
+        // when: access with invalid ip
+        // then: NoAuth
+        assertThrows(KeeperException.NoAuthException.class, () -> zk.setData("/mismatched-ipv6-acl", null, -1));
+
+        server.close();
+    }
+
+    @Test
+    public void testAuthWithIPV4Server(@TempDir File tmpDir) throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("clientPortAddress", "127.0.0.1");
+        properties.setProperty("clientPort", "0");
+
+        ZooKeeperServerEmbedded server = ZooKeeperServerEmbedded.builder()
+            .baseDir(tmpDir.toPath())
+            .configuration(properties)
+            .build();
+        server.start();
+
+        assertTrue(ClientBase.waitForServerUp(server.getConnectionString(), CONNECTION_TIMEOUT), "waiting for server being up");
+
+        // given: ipv4 client
+        ZooKeeper zk = ClientBase.createZKClient(server.getConnectionString());
+
+        // when: invalid ipv4 network acl
+        // then: InvalidACL
+        assertThrows(KeeperException.InvalidACLException.class, () ->
+            zk.create("/invalid-ipv4-network-acl", new byte[]{}, Arrays.asList(new ACL(Perms.ALL, new Id("ip", "127.0.0.1/64"))), CreateMode.PERSISTENT));
+
+        // given: ipv6 acl
+        zk.create("/mismatched-ipv6-acl", new byte[]{}, Arrays.asList(new ACL(Perms.ALL, new Id("ip", "::1"))), CreateMode.PERSISTENT);
+        // when: access with v4 ip
+        // then: NoAuth
+        assertThrows(KeeperException.NoAuthException.class, () -> zk.setData("/mismatched-ipv6-acl", null, -1));
+
+        // given: prefix matched ipv6 network acl
+        zk.create("/prefix-matched-ipv6-network-acl", new byte[]{}, Arrays.asList(new ACL(Perms.ALL, new Id("ip", "7f::/16"))), CreateMode.PERSISTENT);
+        // when: access with v4 ip
+        // then: NoAuth
+        assertThrows(KeeperException.NoAuthException.class, () -> zk.setData("/prefix-matched-ipv6-network-acl", null, -1));
+
+        // given: ipv4 with network acl
+        zk.create("/matched-ipv4-network-acl", new byte[]{}, Arrays.asList(new ACL(Perms.ALL, new Id("ip", "127.0.0.1/16"))), CreateMode.PERSISTENT);
+        // when: access with valid ip
+        // then: ok
+        zk.setData("/matched-ipv4-network-acl", null, -1);
+
+        // given: matched ipv4 acl
+        zk.create("/matched-ipv4-acl", new byte[]{}, Arrays.asList(new ACL(Perms.ALL, new Id("ip", "127.0.0.1"))), CreateMode.PERSISTENT);
+        // when: access with valid ip
+        // then: ok
+        zk.setData("/matched-ipv4-acl", null, -1);
+
+        // given: mismatched ipv4 network acl
+        zk.create("/mismatched-ipv4-network-acl", new byte[]{}, Arrays.asList(new ACL(Perms.ALL, new Id("ip", "192.168.0.2/16"))), CreateMode.PERSISTENT);
+        // when: access with invalid ip
+        // then: NoAuth
+        assertThrows(KeeperException.NoAuthException.class, () -> zk.setData("/mismatched-ipv4-network-acl", null, -1));
+
+        // given: mismatched ipv4 acl
+        zk.create("/mismatched-ipv4-acl", new byte[]{}, Arrays.asList(new ACL(Perms.ALL, new Id("ip", "127.0.0.2"))), CreateMode.PERSISTENT);
+        // when: access with invalid ip
+        // then: NoAuth
+        assertThrows(KeeperException.NoAuthException.class, () -> zk.setData("/mismatched-ipv4-acl", null, -1));
+
+        server.close();
     }
 
     @Test


### PR DESCRIPTION
With this change the IPAuthenticationProvider class will handle the IPV6 addresses properly. It will now perform validation of IPV6 addresses, will convert it into a byte array taking into consideration the IPv6 segments, format.
