### PR TITLE
ZOOKEEPER-4293. Lock Contention in ClientCnxnSocketNetty (possible deadlock) (branch-3.8 backport)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,7 @@
     <mockito.version>4.9.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <commons-cli.version>1.5.0</commons-cli.version>
-    <netty.version>4.1.105.Final</netty.version>
+    <netty.version>4.1.113.Final</netty.version>
     <jetty.version>9.4.56.v20240826</jetty.version>
     <jackson.version>2.15.2</jackson.version>
     <jline.version>2.14.6</jline.version>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocketNetty.java
@@ -206,7 +206,7 @@ public class ClientCnxnSocketNetty extends ClientCnxnSocket {
                 connectFuture = null;
             }
             if (channel != null) {
-                channel.close().syncUninterruptibly();
+                channel.close();
                 channel = null;
             }
         } finally {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/UnifiedServerSocket.java
@@ -255,7 +255,7 @@ public class UnifiedServerSocket extends ServerSocket {
                 bytesRead = 0;
             }
 
-            if (bytesRead == litmus.length && SslHandler.isEncrypted(Unpooled.wrappedBuffer(litmus))) {
+            if (bytesRead == litmus.length && SslHandler.isEncrypted(Unpooled.wrappedBuffer(litmus), false)) {
                 try {
                     sslSocket = x509Util.createSSLSocket(prependableSocket, litmus);
                 } catch (X509Exception e) {


### PR DESCRIPTION
I'd like to upgrade Netty to **4.1.119.Final** version on `branch-3.8` in two steps. This is the first patch to backport, unfortunately, due to code deprecation in Netty, there's no other way to upgrade.

Interesting that license files are missing from this commit, but looks like it was fixed in the second patch that I'm going to backport.