### PR TITLE
ZOOKEEPER-4932 The newest version of zookeeper includes Jetty versiob 9.4.57.x which has CVE-2024-6763 issue

### DIFF
--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -19,6 +19,11 @@
 
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
    <suppress>
+      <!-- ZooKeeper is not affected, because HttpURI is not used in our code.
+           see: ZOOKEEPER-4876 -->
+      <cve>CVE-2024-6763</cve>
+   </suppress>
+   <suppress>
       <!-- ZOOKEEPER-3217 -->
       <cve>CVE-2018-8088</cve>
    </suppress>

--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -19,8 +19,20 @@
 
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
    <suppress>
-      <!-- ZooKeeper is not affected, because HttpURI is not used in our code.
-           see: ZOOKEEPER-4876 -->
+      <!--
+         We have updated jetty[1] to 9.4.57.v20241219[2] which includes a fix[3] for CVE-2024-6763[4].
+         But it is not listed as fixed version since 9.x is EOL[5]. So we still have to suppress this
+         to pass vulnerabilities check. Besides above, ZooKeeper does not use HttpURI[6] thus should
+         not be affected by this CVE anyway.
+
+         Refs:
+         [1]: https://github.com/apache/zookeeper/pull/2220
+         [2]: https://github.com/jetty/jetty.project/releases/tag/jetty-9.4.57.v20241219
+         [3]: https://github.com/jetty/jetty.project/pull/12532
+         [4]: https://github.com/advisories/GHSA-qh8g-58pp-2wxh
+         [5]: https://gitlab.eclipse.org/security/cve-assignement/-/issues/25#note_2968611
+         [6]: https://issues.apache.org/jira/browse/ZOOKEEPER-4876
+      -->
       <cve>CVE-2024-6763</cve>
    </suppress>
    <suppress>


### PR DESCRIPTION
Based on [ZOOKEEPER-4876](https://issues.apache.org/jira/browse/ZOOKEEPER-4876) ZooKeeper is not affected by this CVE, but we have removed it from Owasp suppressions for some reason. Accidentally...?
I put it back in this patch for all active branches.