### PR TITLE
ZOOKEEPER-4891. Update logback to 1.3.15 to fix CVE-2024-12798. (branch-3.9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -550,8 +550,8 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
 
     <!-- dependency versions -->
-    <slf4j.version>1.7.30</slf4j.version>
-    <logback-version>1.2.13</logback-version>
+    <slf4j.version>2.0.13</slf4j.version>
+    <logback-version>1.3.15</logback-version>
     <audience-annotations.version>0.12.0</audience-annotations.version>
     <jmockit.version>1.48</jmockit.version>
     <junit.version>5.6.2</junit.version>


### PR DESCRIPTION
Attempt to upgrade logback and slf4j on branch-3.9