### PR TITLE
Classify log dependencies to library, test and application usages 

### DIFF
--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -19,6 +19,23 @@
 
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
    <suppress>
+      <!--
+         We have updated jetty[1] to 9.4.57.v20241219[2] which includes a fix[3] for CVE-2024-6763[4].
+         But it is not listed as fixed version since 9.x is EOL[5]. So we still have to suppress this
+         to pass vulnerabilities check. Besides above, ZooKeeper does not use HttpURI[6] thus should
+         not be affected by this CVE anyway.
+
+         Refs:
+         [1]: https://github.com/apache/zookeeper/pull/2220
+         [2]: https://github.com/jetty/jetty.project/releases/tag/jetty-9.4.57.v20241219
+         [3]: https://github.com/jetty/jetty.project/pull/12532
+         [4]: https://github.com/advisories/GHSA-qh8g-58pp-2wxh
+         [5]: https://gitlab.eclipse.org/security/cve-assignement/-/issues/25#note_2968611
+         [6]: https://issues.apache.org/jira/browse/ZOOKEEPER-4876
+      -->
+      <cve>CVE-2024-6763</cve>
+   </suppress>
+   <suppress>
       <!-- ZOOKEEPER-3217 -->
       <cve>CVE-2018-8088</cve>
    </suppress>

--- a/pom.xml
+++ b/pom.xml
@@ -458,8 +458,10 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
 
     <!-- dependency versions -->
-    <slf4j.version>1.7.30</slf4j.version>
-    <logback-version>1.2.13</logback-version>
+    <slf4j.version>1.7.36</slf4j.version>
+    <slf4j.application.version>2.0.13</slf4j.application.version>
+    <logback.test.version>1.2.13</logback.test.version>
+    <logback.application.version>1.3.15</logback.application.version>
     <audience-annotations.version>0.12.0</audience-annotations.version>
     <jmockit.version>1.48</jmockit.version>
     <junit.version>5.6.2</junit.version>
@@ -564,13 +566,8 @@
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>${logback-version}</version>
+        <version>${logback.test.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jmockit</groupId>
@@ -792,7 +789,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>8.3.1</version>
+          <version>12.1.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/zookeeper-assembly/pom.xml
+++ b/zookeeper-assembly/pom.xml
@@ -104,6 +104,10 @@
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
        <groupId>io.dropwizard.metrics</groupId>
        <artifactId>metrics-core</artifactId>
     </dependency>

--- a/zookeeper-assembly/pom.xml
+++ b/zookeeper-assembly/pom.xml
@@ -104,8 +104,14 @@
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.application.version}</version>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <version>${logback.application.version}</version>
     </dependency>
     <dependency>
        <groupId>io.dropwizard.metrics</groupId>

--- a/zookeeper-contrib/pom.xml
+++ b/zookeeper-contrib/pom.xml
@@ -56,6 +56,21 @@
     </profile>
   </profiles>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.application.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.application.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/zookeeper-contrib/zookeeper-contrib-fatjar/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-fatjar/pom.xml
@@ -63,6 +63,10 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>
@@ -89,10 +93,6 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
     </dependency>
   </dependencies>
 

--- a/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
@@ -54,13 +54,7 @@
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>logback-classic</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/zookeeper-contrib/zookeeper-contrib-rest/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-rest/pom.xml
@@ -70,13 +70,7 @@
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>logback-classic</artifactId>
     </dependency>
     <dependency>
       <groupId>asm</groupId>

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
@@ -91,13 +91,9 @@
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -76,11 +76,9 @@
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -77,8 +77,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
This way we can upgrade them separately to solve cve issues and mitigate
the consequence of breaking change.

1. For library usage, we depend only on `slf4j-api` 1.7.x which has no
   cve issues.
2. For test usage, we keep logback at 1.2.x which does have cve issues.
   But since test dependencies are not transitive, so this won't affect
   dependants.
3. For application usage,  we bump `slf4j-api` to 2.x and
   `logback-classic` to 1.3.15 to solve cve issues of logback[1].

This way we restrict the breaking change to only application jars, e.g.
zookeeper server tarball.

The breaking change happens only when `slf4j-api` and `logback-classic`
are pined by library users or administrators to incompatbile versions in
classpath, e.g. pin `slf4j-api` to 1.7.x or pin `logback-classic` to 1.2.x
but not both.

The consequence of the breaking change is also noticeable: there will be
no logs except logs directly to `stdout` or `stderr` which mostly like
are few lines from `slf4j` to complain "no slf4j providers".

[1]: https://mvnrepository.com/artifact/ch.qos.logback/logback-classic/1.2.13