### PR TITLE
ZOOKEEPER-4959. Fix license files after logback/slf4j upgrade

### DIFF
--- a/zookeeper-server/src/main/resources/lib/slf4j-2.0.13.LICENSE.txt
+++ b/zookeeper-server/src/main/resources/lib/slf4j-2.0.13.LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2017 QOS.ch
+Copyright (c) 2004-2025 QOS.ch
 All rights reserved.
 
 Permission is hereby granted, free  of charge, to any person obtaining


### PR DESCRIPTION
**Master** branch only needs updated license for SLF4j 2.0.13. Other branches will get new license for **logback** as well.