### PR TITLE
ZOOKEEPER-4960. Upgrade OWASP plugin to 10.0.4 due to recent parsing errors

### DIFF
--- a/Jenkinsfile-owasp
+++ b/Jenkinsfile-owasp
@@ -29,7 +29,7 @@ pipeline {
 
     tools {
         maven "maven_latest"
-        jdk "jdk_1.8_latest"
+        jdk "jdk_11_latest"
     }
 
     stages {

--- a/pom.xml
+++ b/pom.xml
@@ -889,7 +889,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>8.3.1</version>
+          <version>12.1.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Upgrade to the latest version and use JDK11 to run in Jenkins, because fix hasn't been backported to Java 8 releases.

https://github.com/dependency-check/DependencyCheck/issues/7847
https://github.com/dependency-check/DependencyCheck/issues/7463