### PR TITLE
Note breaking change for slf4j-api and logback-classic upgrade

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/releasenotes.md
+++ b/zookeeper-docs/src/main/resources/markdown/releasenotes.md
@@ -16,6 +16,18 @@ limitations under the License.
 
 
 # Release Notes - ZooKeeper - Version 3.9.4
+
+## Breaking changes
+[ZOOKEEPER-4891](https://issues.apache.org/jira/browse/ZOOKEEPER-4891) updates `logback-classic` to `1.3.15` to solve cve issues and
+`slf4j-api` to `2.0.13` to meet compatibilty requirement of logback.
+
+This could cause slf4j to complain "No SLF4J providers were found" and output no further logs in certain conditions.
+1. For library or client usage, this could happen if you specify and inherit incompatible slf4j and logback versions, say, `slf4j-api:2.0.13` from
+   `org.apache.zookeeper:zookeeper` and `logback-classic:1.2.13` from customized project dependencies.
+2. For application or deployment usage, this could happen if you custom and inherit incompatible slf4j and logback versions in classpath, say,
+   `slf4j-api:2.0.13` from zookeeper distribution and `logback-classic:1.2.13` from customization.
+
+This could be solved by specifying compatiable slf4j and logback versions in classpath, say, `slf4j-api:2.0.13` and `logback-classic:1.3.15`.
                 
 ## Bug
 


### PR DESCRIPTION
This pr targets branch-3.9 as I saw #2296 is also targeting at that branch. Please adjust it if it does not meet your release procedure.

Feel free to adjust the sentences if they are not fluent in reading.