### PR TITLE
ZOOKEEPER-842: Generate jute method `copyFrom` to decouple `ZooKeeper` from `DataTree`

### DIFF
--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/JRecord.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/JRecord.java
@@ -491,6 +491,16 @@ public class JRecord extends JCompType {
                 JField jf = i.next();
                 jj.write(jf.genJavaGetSet(fIdx));
             }
+
+            jj.write("\n");
+            jj.write("  public void copyFrom(" + getName() + " from) {\n");
+            fIdx = 0;
+            for (Iterator<JField> i = mFields.iterator(); i.hasNext(); fIdx++) {
+                JField jf = i.next();
+                jj.write("    " + jf.getName() + " = from." + jf.getName() + ";\n");
+            }
+            jj.write("  }\n");
+
             jj.write("  public void serialize(OutputArchive a_, String tag) throws java.io.IOException {\n");
             jj.write("    a_.startRecord(this,tag);\n");
             fIdx = 0;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
@@ -86,7 +86,6 @@ import org.apache.zookeeper.proto.SetDataResponse;
 import org.apache.zookeeper.proto.SyncRequest;
 import org.apache.zookeeper.proto.SyncResponse;
 import org.apache.zookeeper.proto.WhoAmIResponse;
-import org.apache.zookeeper.server.DataTree;
 import org.apache.zookeeper.server.EphemeralType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1499,7 +1498,7 @@ public class ZooKeeper implements AutoCloseable {
             throw KeeperException.create(KeeperException.Code.get(r.getErr()), clientPath);
         }
         if (stat != null) {
-            DataTree.copyStat(response.getStat(), stat);
+            stat.copyFrom(response.getStat());
         }
         return chroot.strip(response.getPath());
     }
@@ -2016,7 +2015,7 @@ public class ZooKeeper implements AutoCloseable {
             throw KeeperException.create(KeeperException.Code.get(r.getErr()), clientPath);
         }
         if (stat != null) {
-            DataTree.copyStat(response.getStat(), stat);
+            stat.copyFrom(response.getStat());
         }
         return response.getData();
     }
@@ -2117,7 +2116,7 @@ public class ZooKeeper implements AutoCloseable {
             throw KeeperException.create(KeeperException.Code.get(r.getErr()), configZnode);
         }
         if (stat != null) {
-            DataTree.copyStat(response.getStat(), stat);
+            stat.copyFrom(response.getStat());
         }
         return response.getData();
     }
@@ -2279,7 +2278,7 @@ public class ZooKeeper implements AutoCloseable {
             throw KeeperException.create(KeeperException.Code.get(r.getErr()), clientPath);
         }
         if (stat != null) {
-            DataTree.copyStat(response.getStat(), stat);
+            stat.copyFrom(response.getStat());
         }
         return response.getAcl();
     }
@@ -2523,7 +2522,7 @@ public class ZooKeeper implements AutoCloseable {
             throw KeeperException.create(KeeperException.Code.get(r.getErr()), clientPath);
         }
         if (stat != null) {
-            DataTree.copyStat(response.getStat(), stat);
+            stat.copyFrom(response.getStat());
         }
         return response.getChildren();
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/admin/ZooKeeperAdmin.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/admin/ZooKeeperAdmin.java
@@ -34,7 +34,6 @@ import org.apache.zookeeper.proto.GetDataResponse;
 import org.apache.zookeeper.proto.ReconfigRequest;
 import org.apache.zookeeper.proto.ReplyHeader;
 import org.apache.zookeeper.proto.RequestHeader;
-import org.apache.zookeeper.server.DataTree;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -252,7 +251,7 @@ public class ZooKeeperAdmin extends ZooKeeper {
             throw KeeperException.create(KeeperException.Code.get(r.getErr()), "");
         }
         if (stat != null) {
-            DataTree.copyStat(response.getStat(), stat);
+            stat.copyFrom(response.getStat());
         }
         return response.getData();
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -342,32 +342,6 @@ public class DataTree {
                || configZookeeper.equals(path);
     }
 
-    public static void copyStatPersisted(StatPersisted from, StatPersisted to) {
-        to.setAversion(from.getAversion());
-        to.setCtime(from.getCtime());
-        to.setCversion(from.getCversion());
-        to.setCzxid(from.getCzxid());
-        to.setMtime(from.getMtime());
-        to.setMzxid(from.getMzxid());
-        to.setPzxid(from.getPzxid());
-        to.setVersion(from.getVersion());
-        to.setEphemeralOwner(from.getEphemeralOwner());
-    }
-
-    public static void copyStat(Stat from, Stat to) {
-        to.setAversion(from.getAversion());
-        to.setCtime(from.getCtime());
-        to.setCversion(from.getCversion());
-        to.setCzxid(from.getCzxid());
-        to.setMtime(from.getMtime());
-        to.setMzxid(from.getMzxid());
-        to.setPzxid(from.getPzxid());
-        to.setVersion(from.getVersion());
-        to.setEphemeralOwner(from.getEphemeralOwner());
-        to.setDataLength(from.getDataLength());
-        to.setNumChildren(from.getNumChildren());
-    }
-
     /**
      * update the count/bytes of this stat data node
      *
@@ -1305,7 +1279,7 @@ public class DataTree {
         DataNode nodeCopy;
         synchronized (node) {
             StatPersisted statCopy = new StatPersisted();
-            copyStatPersisted(node.stat, statCopy);
+            statCopy.copyFrom(node.stat);
             //we do not need to make a copy of node.data because the contents
             //are never changed
             nodeCopy = new DataNode(node.data, node.acl, statCopy);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -1064,7 +1064,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         ChangeRecord duplicate(long zxid) {
             StatPersisted stat = new StatPersisted();
             if (this.stat != null) {
-                DataTree.copyStatPersisted(this.stat, stat);
+                stat.copyFrom(this.stat);
             }
             ChangeRecord changeRecord = new ChangeRecord(zxid, path, stat, childCount,
                     acl == null ? new ArrayList<>() : new ArrayList<>(acl));


### PR DESCRIPTION
Currently, `ZooKeeper` uses `DataTree::copyStat` to copy `Stat` from one
to another. This couples client side `ZooKeeper` to server side
`DataTree`.

By using generated `copyFrom`, we decouple `ZooKeeper` from server side
codes.

This is a small step towards ZOOKEEPER-233.

Refs: ZOOKEEPER-233, ZOOKEEPER-835, ZOOKEEPER-1275 and ZOOKEEPER-842.