### PR TITLE
ZOOKEEPER-842: [ADDENDUM] Keep `DataTree::copyStat` for compatibility with Apache Curator

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -343,6 +343,26 @@ public class DataTree {
     }
 
     /**
+     * Use {@link StatPersisted#copyFrom(StatPersisted)} instead.
+     *
+     * <p>Apache Curator uses it, let's keep it for now to let them and their clients to react.
+     */
+    @Deprecated
+    public static void copyStatPersisted(StatPersisted from, StatPersisted to) {
+        to.copyFrom(from);
+    }
+
+    /**
+     * Use {@link Stat#copyFrom(Stat)} instead.
+     *
+     * <p> Apache Curator uses it, let's keep it for now to let them and their clients to react.
+     */
+    @Deprecated
+    public static void copyStat(Stat from, Stat to) {
+        to.copyFrom(from);
+    }
+
+    /**
      * update the count/bytes of this stat data node
      *
      * @param lastPrefix


### PR DESCRIPTION
`DataTree` is apparently internal to zookeeper. But we don't export public alternatives to `copyStat` and `copyStatPersisted` until now. So, let's keep them for some releases to let downstream libraries to migrate to `Stat::copyFrom`.

Refs: ZOOKEEPER-842, #2305.