### PR TITLE
ZOOKEEPER-4972: Fix flaky tests in PrometheusMetricsProviderConfigTest

### DIFF
--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/pom.xml
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/pom.xml
@@ -70,6 +70,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderConfigTest.java
+++ b/zookeeper-metrics-providers/zookeeper-prometheus-metrics/src/test/java/org/apache/zookeeper/metrics/prometheus/PrometheusMetricsProviderConfigTest.java
@@ -64,7 +64,7 @@ public class PrometheusMetricsProviderConfigTest extends PrometheusMetricsTestBa
         Properties configuration = new Properties();
         String testDataPath = System.getProperty("test.data.dir", "src/test/resources/data");
         configuration.setProperty("httpHost", "127.0.0.1");
-        configuration.setProperty("httpsPort", "50511");
+        configuration.setProperty("httpsPort", "0");
         configuration.setProperty("ssl.keyStore.location", testDataPath + "/ssl/server_keystore.jks");
         configuration.setProperty("ssl.keyStore.password", "testpass");
         configuration.setProperty("ssl.trustStore.location", testDataPath + "/ssl/server_truststore.jks");
@@ -78,8 +78,8 @@ public class PrometheusMetricsProviderConfigTest extends PrometheusMetricsTestBa
         PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
         Properties configuration = new Properties();
         String testDataPath = System.getProperty("test.data.dir", "src/test/resources/data");
-        configuration.setProperty("httpPort", "50512");
-        configuration.setProperty("httpsPort", "50513");
+        configuration.setProperty("httpPort", "0");
+        configuration.setProperty("httpsPort", "0");
         configuration.setProperty("ssl.keyStore.location", testDataPath + "/ssl/server_keystore.jks");
         configuration.setProperty("ssl.keyStore.password", "testpass");
         configuration.setProperty("ssl.trustStore.location", testDataPath + "/ssl/server_truststore.jks");
@@ -95,7 +95,7 @@ public class PrometheusMetricsProviderConfigTest extends PrometheusMetricsTestBa
             PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
             Properties configuration = new Properties();
             String testDataPath = System.getProperty("test.data.dir", "src/test/resources/data");
-            configuration.setProperty("httpsPort", "50514");
+            configuration.setProperty("httpsPort", "0");
             //keystore missing
             configuration.setProperty("ssl.keyStore.password", "testpass");
             configuration.setProperty("ssl.trustStore.location", testDataPath + "/ssl/server_truststore.jks");


### PR DESCRIPTION
Those tests use hard written ports to listen.

```
org.apache.zookeeper.metrics.MetricsProviderLifeCycleException: java.io.IOException: Failed to bind to /0.0.0.0:50512
	at org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider.start(PrometheusMetricsProvider.java:213)
	at org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProviderConfigTest.testValidHttpsAndHttpConfig(PrometheusMetricsProviderConfigTest.java:88)
```