### PR TITLE
ZOOKEEPER-4974: Remove enforced JDK 17 compilation warnings

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/WorkerService.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/WorkerService.java
@@ -167,7 +167,6 @@ public class WorkerService {
      */
     private static class DaemonThreadFactory implements ThreadFactory {
 
-        final ThreadGroup group;
         final AtomicInteger threadNumber = new AtomicInteger(1);
         final String namePrefix;
 
@@ -177,22 +176,15 @@ public class WorkerService {
 
         DaemonThreadFactory(String name, int firstThreadNum) {
             threadNumber.set(firstThreadNum);
-            SecurityManager s = System.getSecurityManager();
-            group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
             namePrefix = name + "-";
         }
 
+        @Override
         public Thread newThread(Runnable r) {
-            Thread t = new Thread(group, r, namePrefix + threadNumber.getAndIncrement(), 0);
-            if (!t.isDaemon()) {
-                t.setDaemon(true);
-            }
-            if (t.getPriority() != Thread.NORM_PRIORITY) {
-                t.setPriority(Thread.NORM_PRIORITY);
-            }
+            Thread t = new Thread(r, namePrefix + threadNumber.getAndIncrement());
+            t.setDaemon(true);
             return t;
         }
-
     }
 
     public void start() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -344,10 +344,7 @@ public class QuorumCnxManager {
     // can take extra time)
     private void initializeConnectionExecutor(final long mySid, final int quorumCnxnThreadsSize) {
         final AtomicInteger threadIndex = new AtomicInteger(1);
-        SecurityManager s = System.getSecurityManager();
-        final ThreadGroup group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
-
-        final ThreadFactory daemonThFactory = runnable -> new Thread(group, runnable,
+        final ThreadFactory daemonThFactory = runnable -> new Thread(runnable,
             String.format("QuorumConnectionThread-[myid=%d]-%d", mySid, threadIndex.getAndIncrement()));
 
         this.connectionExecutor = new ThreadPoolExecutor(3, quorumCnxnThreadsSize, 60, TimeUnit.SECONDS,

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509TestHelpers.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509TestHelpers.java
@@ -169,7 +169,7 @@ public class X509TestHelpers {
             throw new IllegalArgumentException("CA private key does not match the public key in the CA cert");
         }
         Date now = new Date();
-        X509v3CertificateBuilder builder = initCertBuilder(new X500Name(caCert.getIssuerDN().getName()), now, new Date(
+        X509v3CertificateBuilder builder = initCertBuilder(new X500Name(caCert.getIssuerX500Principal().getName()), now, new Date(
                 now.getTime()
                         + expirationMillis), certSubject, certPublicKey);
         builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false)); // not a CA
@@ -384,7 +384,7 @@ public class X509TestHelpers {
     private static byte[] certToTrustStoreBytes(X509Certificate cert, String keyPassword, KeyStore trustStore) throws IOException, GeneralSecurityException {
         char[] keyPasswordChars = keyPassword == null ? new char[0] : keyPassword.toCharArray();
         trustStore.load(null, keyPasswordChars);
-        trustStore.setCertificateEntry(cert.getSubjectDN().toString(), cert);
+        trustStore.setCertificateEntry(cert.getSubjectX500Principal().toString(), cert);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         trustStore.store(outputStream, keyPasswordChars);
         outputStream.flush();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
@@ -200,7 +200,7 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
         // Write the truststore
         KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
         trustStore.load(null, PASSWORD);
-        trustStore.setCertificateEntry(rootCertificate.getSubjectDN().toString(), rootCertificate);
+        trustStore.setCertificateEntry(rootCertificate.getSubjectX500Principal().toString(), rootCertificate);
         FileOutputStream outputStream = new FileOutputStream(truststorePath);
         trustStore.store(outputStream, PASSWORD);
         outputStream.flush();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/X509AuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/X509AuthTest.java
@@ -182,10 +182,12 @@ public class X509AuthTest extends ZKTestCase {
             return null;
         }
         @Override
+        @Deprecated
         public Principal getIssuerDN() {
             return null;
         }
         @Override
+        @Deprecated
         public Principal getSubjectDN() {
             return null;
         }


### PR DESCRIPTION
There're some deprecated usages in our codebase which prevents compiling with `--release=17` enforcer flag. This patch tries to refactor / remove them.