### PR TITLE
Upgrade Guava to 32.1.3-jre (fix CVE-2023-2976, CVE-2020-8908)

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <rat.version>0.6</rat.version>
-    <guava.version>30.0-jre</guava.version>
+    <guava.version>32.1.3-jre</guava.version>
   </properties>
 
   <build>


### PR DESCRIPTION
### Summary
This PR upgrades the Guava dependency in `zookeeper-contrib-zooinspector`
from `30.0-jre` to `32.1.3-jre`.

### Motivation
The upgrade addresses the following known vulnerabilities:
- **CVE-2023-2976**: Insecure temporary directory creation
- **CVE-2020-8908**: Local information disclosure via temporary directory
  created with unsafe permissions

### Details
- Updated `<guava.version>` property in `zookeeper-contrib-zooinspector/pom.xml`
  to `32.1.3-jre`.
- Ensures continued compatibility with the project while remediating the
  reported CVEs.
- Verified build and tests pass successfully after the update.


