### PR TITLE
ZOOKEEPER-4984: Upgrade OWASP plugin to 12.1.6 due to breaking changes in the API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -889,7 +889,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>12.1.3</version>
+          <version>12.1.6</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Authentication is now required for **Sonatype OSS Index**: https://ossindex.sonatype.org/doc/auth-required

I don't think we need this feature, so I won't add API key to the public repo, but I have to update the plugin to skip indexing with softfail.