### PR TITLE
ZOOKEEPER-5009: Memory Leak in zoo_sasl_client_create

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zk_sasl.c
+++ b/zookeeper-client/zookeeper-client-c/src/zk_sasl.c
@@ -104,6 +104,7 @@ zoo_sasl_client_t *zoo_sasl_client_create(zoo_sasl_params_t *sasl_params)
 
     if (rc != ZOK) {
         zoo_sasl_client_destroy(sc);
+        free(sc);
         return NULL;
     }
 


### PR DESCRIPTION
### Fix memory leak in `zoo_sasl_client_create` on failure

`zoo_sasl_client_create` allocates a `zoo_sasl_client_t` and then duplicates several strings. If any duplication fails (e.g. due to OOM), the function calls `zoo_sasl_client_destroy(sc)` and returns `NULL`.

However, `zoo_sasl_client_destroy` only frees internal members and does not free the structure itself, resulting in a memory leak on every failed initialization attempt.

**Impact:** Repeated SASL initialization retries under transient allocation failures can cause unbounded memory growth and eventual OOM.

**Fix:** Explicitly free the allocated structure in the error path.

```c
zoo_sasl_client_destroy(sc);
free(sc);
return NULL;