### PR TITLE
ZOOKEEPER-2789: Reassign ZXID for solving 32bit overflow problem(base master and fix conflict)

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/FollowerZooKeeperServer.java
@@ -24,6 +24,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import javax.management.JMException;
 import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.metrics.MetricsContext;
+import org.apache.zookeeper.server.util.ZxidUtils;
 import org.apache.zookeeper.server.ExitCode;
 import org.apache.zookeeper.server.FinalRequestProcessor;
 import org.apache.zookeeper.server.Request;
@@ -77,7 +78,7 @@ public class FollowerZooKeeperServer extends LearnerZooKeeperServer {
     LinkedBlockingQueue<Request> pendingTxns = new LinkedBlockingQueue<>();
 
     public void logRequest(Request request) {
-        if ((request.zxid & 0xffffffffL) != 0) {
+        if (ZxidUtils.getCounterFromZxid(request.zxid) != 0) {
             pendingTxns.add(request);
         }
         syncProcessor.processRequest(request);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -335,6 +335,10 @@ public class Leader extends LearnerMaster {
         this.self = self;
         this.proposalStats = new BufferStats();
 
+        // A new Leader node has been elected, therefore the zxid bit length is synchronously increased.
+        ZxidUtils.setEpochHighPosition40();
+        self.setCurrentEpochPosition(40);
+
         Set<InetSocketAddress> addresses;
         if (self.getQuorumListenOnAllIPs()) {
             addresses = self.getQuorumAddress().getWildcardAddresses();
@@ -743,7 +747,7 @@ public class Leader extends LearnerMaster {
             /**
              * WARNING: do not use this for anything other than QA testing
              * on a real cluster. Specifically to enable verification that quorum
-             * can handle the lower 32bit roll-over issue identified in
+             * can handle the lower 40bit roll-over issue identified in
              * ZOOKEEPER-1277. Without this option it would take a very long
              * time (on order of a month say) to see the 4 billion writes
              * necessary to cause the roll-over to occur.
@@ -1298,11 +1302,11 @@ public class Leader extends LearnerMaster {
             ServiceUtils.requestSystemExit(ExitCode.UNEXPECTED_ERROR.getValue());
         }
         /**
-         * Address the rollover issue. All lower 32bits set indicate a new leader
+         * Address the rollover issue. All lower 40bits set indicate a new leader
          * election. Force a re-election instead. See ZOOKEEPER-1277
          */
         if (ZxidUtils.getCounterFromZxid(request.zxid) == ZxidUtils.getCounterLowPosition()) {
-            String msg = "zxid lower 32 bits have rolled over, forcing re-election, and therefore new epoch start";
+            String msg = "zxid lower 40 bits have rolled over, forcing re-election, and therefore new epoch start";
             shutdown(msg);
             throw new XidRolloverException(msg);
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -662,7 +662,7 @@ public class Leader extends LearnerMaster {
 
             newLeaderProposal.packet = new QuorumPacket(NEWLEADER, zk.getZxid(), null, null);
 
-            if ((newLeaderProposal.packet.getZxid() & 0xffffffffL) != 0) {
+            if (ZxidUtils.getCounterFromZxid(newLeaderProposal.packet.getZxid()) != 0) {
                 LOG.info("NEWLEADER proposal has Zxid of {}", Long.toHexString(newLeaderProposal.packet.getZxid()));
             }
 
@@ -755,7 +755,7 @@ public class Leader extends LearnerMaster {
             String initialZxid = System.getProperty("zookeeper.testingonly.initialZxid");
             if (initialZxid != null) {
                 long zxid = Long.parseLong(initialZxid);
-                zk.setZxid((zk.getZxid() & 0xffffffff00000000L) | zxid);
+                zk.setZxid(ZxidUtils.clearCounter(zk.getZxid()) | zxid);
             }
 
             if (!System.getProperty("zookeeper.leaderServes", "yes").equals("no")) {
@@ -1065,7 +1065,7 @@ public class Leader extends LearnerMaster {
             LOG.trace("outstanding proposals all");
         }
 
-        if ((zxid & 0xffffffffL) == 0) {
+        if (ZxidUtils.getCounterFromZxid(zxid) == 0) {
             /*
              * We no longer process NEWLEADER ack with this method. However,
              * the learner sends an ack back to the leader after it gets
@@ -1301,7 +1301,7 @@ public class Leader extends LearnerMaster {
          * Address the rollover issue. All lower 32bits set indicate a new leader
          * election. Force a re-election instead. See ZOOKEEPER-1277
          */
-        if ((request.zxid & 0xffffffffL) == 0xffffffffL) {
+        if (ZxidUtils.getCounterFromZxid(request.zxid) == ZxidUtils.getCounterLowPosition()) {
             String msg = "zxid lower 32 bits have rolled over, forcing re-election, and therefore new epoch start";
             shutdown(msg);
             throw new XidRolloverException(msg);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Learner.java
@@ -495,7 +495,7 @@ public class Learner {
         /*
          * Add sid to payload
          */
-        LearnerInfo li = new LearnerInfo(self.getMyId(), 0x10000, self.getQuorumVerifier().getVersion());
+        LearnerInfo li = new LearnerInfo(self.getMyId(), 0x11000, self.getQuorumVerifier().getVersion());
         ByteArrayOutputStream bsid = new ByteArrayOutputStream();
         BinaryOutputArchive boa = BinaryOutputArchive.getArchive(bsid);
         boa.writeRecord(li, "LearnerInfo");
@@ -503,10 +503,20 @@ public class Learner {
 
         writePacket(qp, true);
         readPacket(qp);
-        final long newEpoch = ZxidUtils.getEpochFromZxid(qp.getZxid());
+        long newEpoch = ZxidUtils.getEpochFromZxid(qp.getZxid());
         if (qp.getType() == Leader.LEADERINFO) {
             // we are connected to a 1.0 server so accept the new epoch and read the next packet
             leaderProtocolVersion = ByteBuffer.wrap(qp.getData()).getInt();
+
+            if (leaderProtocolVersion >= 0x11000) {
+                /**
+                 * The Leader is a new version with adjusted zxid bit length,
+                 * thus Followers and Observers also adjust their zxid bit length accordingly.
+                 */
+                ZxidUtils.setEpochHighPosition40();
+                self.setCurrentEpochPosition(40);
+                newEpoch = ZxidUtils.getEpochFromZxid(qp.getZxid());
+            }
             byte[] epochBytes = new byte[4];
             final ByteBuffer wrappedEpochBytes = ByteBuffer.wrap(epochBytes);
             if (newEpoch > self.getAcceptedEpoch()) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
@@ -789,7 +789,7 @@ public class LearnerHandler extends ZooKeeperThread {
          * zxid in our history. In this case, we will ignore TRUNC logic and
          * always send DIFF if we have old enough history
          */
-        boolean isPeerNewEpochZxid = (peerLastZxid & 0xffffffffL) == 0;
+        boolean isPeerNewEpochZxid = ZxidUtils.getCounterFromZxid(peerLastZxid) == 0;
         // Keep track of the latest zxid which already queued
         long currentZxid = peerLastZxid;
         boolean needSnap = true;
@@ -949,7 +949,7 @@ public class LearnerHandler extends ZooKeeperThread {
      * @return last zxid of the queued proposal
      */
     protected long queueCommittedProposals(Iterator<Proposal> itr, long peerLastZxid, Long maxZxid, Long lastCommittedZxid) {
-        boolean isPeerNewEpochZxid = (peerLastZxid & 0xffffffffL) == 0;
+        boolean isPeerNewEpochZxid = ZxidUtils.getCounterFromZxid(peerLastZxid) == 0;
         long queuedZxid = peerLastZxid;
         // as we look through proposals, this variable keeps track of previous
         // proposal Id.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/LearnerHandler.java
@@ -525,15 +525,16 @@ public class LearnerHandler extends ZooKeeperThread {
             long newEpoch = learnerMaster.getEpochToPropose(this.getSid(), lastAcceptedEpoch);
             long newLeaderZxid = ZxidUtils.makeZxid(newEpoch, 0);
 
-            if (this.getVersion() < 0x10000) {
-                // we are going to have to extrapolate the epoch information
-                long epoch = ZxidUtils.getEpochFromZxid(zxid);
-                ss = new StateSummary(epoch, zxid);
-                // fake the message
-                learnerMaster.waitForEpochAck(this.getSid(), ss);
+            /**
+             * When the Leader switches to a new mode
+             * lower version Observers or Followers are not allowed to join the cluster, thus the zxid bit length has changed.
+             */
+            if (this.getVersion() < 0x11000) {
+                LOG.error("sid:{} version too old", this.sid);
+                return;
             } else {
                 byte[] ver = new byte[4];
-                ByteBuffer.wrap(ver).putInt(0x10000);
+                ByteBuffer.wrap(ver).putInt(0x11000);
                 QuorumPacket newEpochPacket = new QuorumPacket(Leader.LEADERINFO, newLeaderZxid, ver, null);
                 oa.writeRecord(newEpochPacket, "packet");
                 messageTracker.trackSent(Leader.LEADERINFO);
@@ -597,13 +598,8 @@ public class LearnerHandler extends ZooKeeperThread {
             // the version of this quorumVerifier will be set by leader.lead() in case
             // the leader is just being established. waitForEpochAck makes sure that readyToStart is true if
             // we got here, so the version was set
-            if (getVersion() < 0x10000) {
-                QuorumPacket newLeaderQP = new QuorumPacket(Leader.NEWLEADER, newLeaderZxid, null, null);
-                oa.writeRecord(newLeaderQP, "packet");
-            } else {
-                QuorumPacket newLeaderQP = new QuorumPacket(Leader.NEWLEADER, newLeaderZxid, learnerMaster.getQuorumVerifierBytes(), null);
-                queuedPackets.add(newLeaderQP);
-            }
+            QuorumPacket newLeaderQP = new QuorumPacket(Leader.NEWLEADER, newLeaderZxid, learnerMaster.getQuorumVerifierBytes(), null);
+            queuedPackets.add(newLeaderQP);
             bufferedOutput.flush();
 
             // Start thread that blast packets in the queue to learner

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/ObserverMaster.java
@@ -44,6 +44,7 @@ import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.quorum.auth.QuorumAuthServer;
+import org.apache.zookeeper.server.util.ZxidUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -220,7 +221,7 @@ public class ObserverMaster extends LearnerMaster implements Runnable {
 
     @Override
     public void processAck(long sid, long zxid, SocketAddress localSocketAddress) {
-        if ((zxid & 0xffffffffL) == 0) {
+        if (ZxidUtils.getCounterFromZxid(zxid) == 0) {
             /*
              * We no longer process NEWLEADER ack by this method. However,
              * the learner sends ack back to the leader after it gets UPTODATE

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -1209,6 +1209,25 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
 
             // load the epochs
             long lastProcessedZxid = zkDb.getDataTree().lastProcessedZxid;
+            /**
+             * It is only after joining the cluster that we know whether the current use is 32-bit or 40-bit.
+             * Here, a new file is created locally to store the current number of epoch bits. This file will be created locally after upgrading the version to ensure a smooth joining of the cluster upon startup.
+             */
+            try {
+                currentEpochPosition = readLongFromFile(CURRENT_EPOCH_POSITION_FILENAME);
+            } catch (FileNotFoundException e) {
+                // pick a reasonable epoch number
+                // this should only happen once when moving to a
+                // new code version
+                currentEpochPosition = ZxidUtils.getEpochHighPosition();
+                LOG.info(
+                        "{} not found! Creating with a reasonable default of {}. "
+                                + "This should only happen when you are upgrading your installation",
+                        CURRENT_EPOCH_POSITION_FILENAME,
+                        currentEpochPosition);
+                writeLongToFile(CURRENT_EPOCH_POSITION_FILENAME, currentEpochPosition);
+            }
+            ZxidUtils.setEpochHighPosition(currentEpochPosition);
             long epochOfZxid = ZxidUtils.getEpochFromZxid(lastProcessedZxid);
             try {
                 currentEpoch = readLongFromFile(CURRENT_EPOCH_FILENAME);
@@ -2300,10 +2319,13 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
 
     private long acceptedEpoch = -1;
     private long currentEpoch = -1;
+    private long currentEpochPosition = -1;
 
     public static final String CURRENT_EPOCH_FILENAME = "currentEpoch";
 
     public static final String ACCEPTED_EPOCH_FILENAME = "acceptedEpoch";
+
+    public static final String CURRENT_EPOCH_POSITION_FILENAME = "currentEpochPosintion";
 
     /**
      * Write a long value to disk atomically. Either succeeds or an exception
@@ -2341,6 +2363,11 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
         writeLongToFile(CURRENT_EPOCH_FILENAME, e);
         currentEpoch = e;
 
+    }
+
+    public void setCurrentEpochPosition(long e) throws IOException {
+        writeLongToFile(CURRENT_EPOCH_POSITION_FILENAME, e);
+        currentEpochPosition = e;
     }
 
     public void setAcceptedEpoch(long e) throws IOException {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/ZxidUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/ZxidUtils.java
@@ -19,18 +19,40 @@
 package org.apache.zookeeper.server.util;
 
 public class ZxidUtils {
+    private static final long EPOCH_HIGH_POSITION = 40L;
+    private static final long COUNTER_LOW_POSITION = 0xffffffffffL;
+    private static final long CLEAR_EPOCH = 0x000000ffffffffffL;
+    private static final long CLEAR_COUNTER = 0xffffff0000000000L;
 
-    public static long getEpochFromZxid(long zxid) {
-        return zxid >> 32L;
+    static public long getEpochFromZxid(long zxid) {
+        return zxid >> EPOCH_HIGH_POSITION;
     }
-    public static long getCounterFromZxid(long zxid) {
-        return zxid & 0xffffffffL;
+
+    static public long getCounterFromZxid(long zxid) {
+        return zxid & COUNTER_LOW_POSITION;
     }
-    public static long makeZxid(long epoch, long counter) {
-        return (epoch << 32L) | (counter & 0xffffffffL);
+
+    static public long makeZxid(long epoch, long counter) {
+        return (epoch << EPOCH_HIGH_POSITION) | (counter & COUNTER_LOW_POSITION);
     }
-    public static String zxidToString(long zxid) {
+
+    static public long clearEpoch(long zxid) {
+        return zxid & CLEAR_EPOCH;
+    }
+
+    static public long clearCounter(long zxid) {
+        return zxid & CLEAR_COUNTER;
+    }
+
+    static public String zxidToString(long zxid) {
         return Long.toHexString(zxid);
     }
 
+    public static long getEpochHighPosition() {
+        return EPOCH_HIGH_POSITION;
+    }
+
+    public static long getCounterLowPosition() {
+        return COUNTER_LOW_POSITION;
+    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/ZxidUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/ZxidUtils.java
@@ -18,30 +18,45 @@
 
 package org.apache.zookeeper.server.util;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 public class ZxidUtils {
-    private static final long EPOCH_HIGH_POSITION = 40L;
-    private static final long COUNTER_LOW_POSITION = 0xffffffffffL;
-    private static final long CLEAR_EPOCH = 0x000000ffffffffffL;
-    private static final long CLEAR_COUNTER = 0xffffff0000000000L;
+    // 40L
+    private static final long EPOCH_HIGH_POSITION32 = 32L;
+    private static final long EPOCH_HIGH_POSITION40 = 40L;
+
+    private static final long COUNTER_LOW_POSITION32 = 0xffffffffL;
+    private static final long CLEAR_EPOCH32 = 0x00000000ffffffffL;
+    private static final long CLEAR_COUNTER32 = 0xffffffff00000000L;
+
+    private static final long COUNTER_LOW_POSITION40 = 0xffffffffffL;
+    private static final long CLEAR_EPOCH40 = 0x000000ffffffffffL;
+    private static final long CLEAR_COUNTER40 = 0xffffff0000000000L;
+
+    private static AtomicLong EPOCH_HIGH_POSITION = new AtomicLong(EPOCH_HIGH_POSITION32);
+
+    private static AtomicLong COUNTER_LOW_POSITION = new AtomicLong(COUNTER_LOW_POSITION32);
+    private static AtomicLong CLEAR_EPOCH = new AtomicLong(CLEAR_EPOCH32);
+    private static AtomicLong CLEAR_COUNTER = new AtomicLong(CLEAR_COUNTER32);
 
     static public long getEpochFromZxid(long zxid) {
-        return zxid >> EPOCH_HIGH_POSITION;
+        return zxid >> EPOCH_HIGH_POSITION.get();
     }
 
     static public long getCounterFromZxid(long zxid) {
-        return zxid & COUNTER_LOW_POSITION;
+        return zxid & COUNTER_LOW_POSITION.get();
     }
 
     static public long makeZxid(long epoch, long counter) {
-        return (epoch << EPOCH_HIGH_POSITION) | (counter & COUNTER_LOW_POSITION);
+        return (epoch << EPOCH_HIGH_POSITION.get()) | (counter & COUNTER_LOW_POSITION.get());
     }
 
     static public long clearEpoch(long zxid) {
-        return zxid & CLEAR_EPOCH;
+        return zxid & CLEAR_EPOCH.get();
     }
 
     static public long clearCounter(long zxid) {
-        return zxid & CLEAR_COUNTER;
+        return zxid & CLEAR_COUNTER.get();
     }
 
     static public String zxidToString(long zxid) {
@@ -49,10 +64,37 @@ public class ZxidUtils {
     }
 
     public static long getEpochHighPosition() {
-        return EPOCH_HIGH_POSITION;
+        return EPOCH_HIGH_POSITION.get();
     }
 
     public static long getCounterLowPosition() {
-        return COUNTER_LOW_POSITION;
+        return COUNTER_LOW_POSITION.get();
     }
+
+    public static void setEpochHighPosition40() {
+        EPOCH_HIGH_POSITION.set(EPOCH_HIGH_POSITION40);
+
+        COUNTER_LOW_POSITION.set(COUNTER_LOW_POSITION40);
+        CLEAR_EPOCH.set(CLEAR_EPOCH40);
+        CLEAR_COUNTER.set(CLEAR_COUNTER40);
+    }
+
+    public static void setEpochHighPosition32() {
+        EPOCH_HIGH_POSITION.set(EPOCH_HIGH_POSITION32);
+
+        COUNTER_LOW_POSITION.set(COUNTER_LOW_POSITION32);
+        CLEAR_EPOCH.set(CLEAR_EPOCH32);
+        CLEAR_COUNTER.set(CLEAR_COUNTER32);
+    }
+
+    public static void setEpochHighPosition(long position) {
+        if (position == 32) {
+            setEpochHighPosition32();
+        } else if (position == 40) {
+            setEpochHighPosition40();
+        } else {
+            throw new IllegalArgumentException("Invalid epoch high position:" + position + ", should is 32 or 40.");
+        }
+    }
+
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZxidRolloverTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZxidRolloverTest.java
@@ -28,6 +28,7 @@ import org.apache.zookeeper.KeeperException.ConnectionLossException;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.server.util.ZxidUtils;
 import org.apache.zookeeper.test.ClientBase;
 import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
 import org.apache.zookeeper.test.ClientTest;
@@ -211,7 +212,7 @@ public class ZxidRolloverTest extends ZKTestCase {
 
     /** Reset the next zxid to be near epoch end */
     private void adjustEpochNearEnd() {
-        zksLeader.setZxid((zksLeader.getZxid() & 0xffffffff00000000L) | 0xfffffffcL);
+        zksLeader.setZxid(ZxidUtils.clearCounter(zksLeader.getZxid()) | 0xfffffffffcL);
     }
 
     @AfterEach

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
@@ -516,7 +516,7 @@ public class Zab1_0Test extends ZKTestCase {
                 assertEquals(1, l.self.getCurrentEpoch());
 
                 /* we test a normal run. everything should work out well. */
-                LearnerInfo li = new LearnerInfo(1, 0x10000, 0);
+                LearnerInfo li = new LearnerInfo(1, 0x11000, 0);
                 byte[] liBytes = RequestRecord.fromRecord(li).readBytes();
                 QuorumPacket qp = new QuorumPacket(Leader.FOLLOWERINFO, 1, liBytes, null);
                 oa.writeRecord(qp, null);
@@ -524,7 +524,7 @@ public class Zab1_0Test extends ZKTestCase {
                 readPacketSkippingPing(ia, qp);
                 assertEquals(Leader.LEADERINFO, qp.getType());
                 assertEquals(ZxidUtils.makeZxid(2, 0), qp.getZxid());
-                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x10000);
+                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x11000);
                 assertEquals(2, l.self.getAcceptedEpoch());
                 assertEquals(1, l.self.getCurrentEpoch());
 
@@ -594,14 +594,14 @@ public class Zab1_0Test extends ZKTestCase {
                     assertEquals(qp.getZxid(), 0);
                     LearnerInfo learnInfo = new LearnerInfo();
                     ByteBufferInputStream.byteBuffer2Record(ByteBuffer.wrap(qp.getData()), learnInfo);
-                    assertEquals(learnInfo.getProtocolVersion(), 0x10000);
+                    assertEquals(learnInfo.getProtocolVersion(), 0x11000);
                     assertEquals(learnInfo.getServerid(), 0);
 
                     // We are simulating an established leader, so the epoch is 1
                     qp.setType(Leader.LEADERINFO);
                     qp.setZxid(ZxidUtils.makeZxid(1, 0));
                     byte[] protoBytes = new byte[4];
-                    ByteBuffer.wrap(protoBytes).putInt(0x10000);
+                    ByteBuffer.wrap(protoBytes).putInt(0x11000);
                     qp.setData(protoBytes);
                     oa.writeRecord(qp, null);
 
@@ -728,14 +728,14 @@ public class Zab1_0Test extends ZKTestCase {
                     assertEquals(qp.getZxid(), 0);
                     LearnerInfo learnInfo = new LearnerInfo();
                     ByteBufferInputStream.byteBuffer2Record(ByteBuffer.wrap(qp.getData()), learnInfo);
-                    assertEquals(learnInfo.getProtocolVersion(), 0x10000);
+                    assertEquals(learnInfo.getProtocolVersion(), 0x11000);
                     assertEquals(learnInfo.getServerid(), 0);
 
                     // We are simulating an established leader, so the epoch is 1
                     qp.setType(Leader.LEADERINFO);
                     qp.setZxid(ZxidUtils.makeZxid(1, 0));
                     byte[] protoBytes = new byte[4];
-                    ByteBuffer.wrap(protoBytes).putInt(0x10000);
+                    ByteBuffer.wrap(protoBytes).putInt(0x11000);
                     qp.setData(protoBytes);
                     oa.writeRecord(qp, null);
 
@@ -951,7 +951,7 @@ public class Zab1_0Test extends ZKTestCase {
                 assertEquals(0, l.self.getCurrentEpoch());
 
                 /* we test a normal run. everything should work out well. */
-                LearnerInfo li = new LearnerInfo(1, 0x10000, 0);
+                LearnerInfo li = new LearnerInfo(1, 0x11000, 0);
                 byte[] liBytes = RequestRecord.fromRecord(li).readBytes();
                 QuorumPacket qp = new QuorumPacket(Leader.FOLLOWERINFO, 0, liBytes, null);
                 oa.writeRecord(qp, null);
@@ -959,7 +959,7 @@ public class Zab1_0Test extends ZKTestCase {
                 readPacketSkippingPing(ia, qp);
                 assertEquals(Leader.LEADERINFO, qp.getType());
                 assertEquals(ZxidUtils.makeZxid(1, 0), qp.getZxid());
-                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x10000);
+                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x11000);
                 assertEquals(1, l.self.getAcceptedEpoch());
                 assertEquals(0, l.self.getCurrentEpoch());
 
@@ -991,7 +991,7 @@ public class Zab1_0Test extends ZKTestCase {
                 assertEquals(0, l.self.getAcceptedEpoch());
                 assertEquals(0, l.self.getCurrentEpoch());
 
-                LearnerInfo li = new LearnerInfo(1, 0x10000, 0);
+                LearnerInfo li = new LearnerInfo(1, 0x11000, 0);
                 byte[] liBytes = RequestRecord.fromRecord(li).readBytes();
                 QuorumPacket qp = new QuorumPacket(Leader.FOLLOWERINFO, 0, liBytes, null);
                 oa.writeRecord(qp, null);
@@ -999,7 +999,7 @@ public class Zab1_0Test extends ZKTestCase {
                 readPacketSkippingPing(ia, qp);
                 assertEquals(Leader.LEADERINFO, qp.getType());
                 assertEquals(ZxidUtils.makeZxid(1, 0), qp.getZxid());
-                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x10000);
+                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x11000);
                 assertEquals(1, l.self.getAcceptedEpoch());
                 assertEquals(0, l.self.getCurrentEpoch());
 
@@ -1081,14 +1081,14 @@ public class Zab1_0Test extends ZKTestCase {
                     assertEquals(qp.getZxid(), 0);
                     LearnerInfo learnInfo = new LearnerInfo();
                     ByteBufferInputStream.byteBuffer2Record(ByteBuffer.wrap(qp.getData()), learnInfo);
-                    assertEquals(learnInfo.getProtocolVersion(), 0x10000);
+                    assertEquals(learnInfo.getProtocolVersion(), 0x11000);
                     assertEquals(learnInfo.getServerid(), 0);
 
                     // We are simulating an established leader, so the epoch is 1
                     qp.setType(Leader.LEADERINFO);
                     qp.setZxid(ZxidUtils.makeZxid(1, 0));
                     byte[] protoBytes = new byte[4];
-                    ByteBuffer.wrap(protoBytes).putInt(0x10000);
+                    ByteBuffer.wrap(protoBytes).putInt(0x11000);
                     qp.setData(protoBytes);
                     oa.writeRecord(qp, null);
 
@@ -1193,7 +1193,7 @@ public class Zab1_0Test extends ZKTestCase {
         testLeaderConversation(new LeaderConversation() {
             public void converseWithLeader(InputArchive ia, OutputArchive oa, Leader l) throws IOException {
                 /* we test a normal run. everything should work out well. */
-                LearnerInfo li = new LearnerInfo(1, 0x10000, 0);
+                LearnerInfo li = new LearnerInfo(1, 0x11000, 0);
                 byte[] liBytes = RequestRecord.fromRecord(li).readBytes();
                 /* we are going to say we last acked epoch 20 */
                 QuorumPacket qp = new QuorumPacket(Leader.FOLLOWERINFO, ZxidUtils.makeZxid(20, 0), liBytes, null);
@@ -1201,7 +1201,7 @@ public class Zab1_0Test extends ZKTestCase {
                 readPacketSkippingPing(ia, qp);
                 assertEquals(Leader.LEADERINFO, qp.getType());
                 assertEquals(ZxidUtils.makeZxid(21, 0), qp.getZxid());
-                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x10000);
+                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x11000);
                 qp = new QuorumPacket(Leader.ACKEPOCH, 0, new byte[4], null);
                 oa.writeRecord(qp, null);
                 readPacketSkippingPing(ia, qp);
@@ -1230,14 +1230,14 @@ public class Zab1_0Test extends ZKTestCase {
         testLeaderConversation(new LeaderConversation() {
             public void converseWithLeader(InputArchive ia, OutputArchive oa, Leader l) throws IOException, InterruptedException {
                 /* we test a normal run. everything should work out well. */
-                LearnerInfo li = new LearnerInfo(1, 0x10000, 0);
+                LearnerInfo li = new LearnerInfo(1, 0x11000, 0);
                 byte[] liBytes = RequestRecord.fromRecord(li).readBytes();
                 QuorumPacket qp = new QuorumPacket(Leader.FOLLOWERINFO, 0, liBytes, null);
                 oa.writeRecord(qp, null);
                 readPacketSkippingPing(ia, qp);
                 assertEquals(Leader.LEADERINFO, qp.getType());
                 assertEquals(ZxidUtils.makeZxid(1, 0), qp.getZxid());
-                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x10000);
+                assertEquals(ByteBuffer.wrap(qp.getData()).getInt(), 0x11000);
                 Thread.sleep(l.self.getInitLimit() * l.self.getTickTime() + 5000);
 
                 // The leader didn't get a quorum of acks - make sure that leader's current epoch is not advanced

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/FollowerResyncConcurrencyTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/FollowerResyncConcurrencyTest.java
@@ -43,6 +43,7 @@ import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.quorum.Leader;
+import org.apache.zookeeper.server.util.ZxidUtils;
 import org.apache.zookeeper.test.ClientBase.CountdownWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -562,8 +563,8 @@ public class FollowerResyncConcurrencyTest extends ZKTestCase {
     private void verifyState(QuorumUtil qu, int index, Leader leader) {
         LOG.info("Verifying state");
         assertTrue(qu.getPeer(index).peer.follower != null, "Not following");
-        long epochF = (qu.getPeer(index).peer.getActiveServer().getZxid() >> 32L);
-        long epochL = (leader.getEpoch() >> 32L);
+        long epochF = ZxidUtils.getEpochFromZxid(qu.getPeer(index).peer.getActiveServer().getZxid());
+        long epochL = ZxidUtils.getEpochFromZxid(leader.getEpoch());
         assertTrue(epochF == epochL,
                 "Zxid: " + qu.getPeer(index).peer.getActiveServer().getZKDatabase().getDataTreeLastProcessedZxid()
                 + "Current epoch: " + epochF);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java
@@ -934,7 +934,7 @@ public class ReconfigTest extends ZKTestCase implements DataCallback {
             String configStr = testServerHasConfig(zkArr[i], null, null);
             QuorumVerifier qv = qu.getPeer(i).peer.configFromString(configStr);
             long version = qv.getVersion();
-            assertTrue(version == 0x100000000L);
+            assertTrue(version == 0x10000000000L);
         }
     }
 


### PR DESCRIPTION
This PR addresses [ZOOKEEPER-2789](https://issues.apache.org/jira/browse/ZOOKEEPER-2789), which resolves the ZXID 32-bit counter overflow problem.

In ZooKeeper, the ZXID is a 64-bit number composed of a 32-bit epoch and a 32-bit counter. When the 32-bit counter overflows, it forces a leader re-election and can cause serious issues in the cluster. This change:

1. **Extends the counter bit width**: Extends `ZxidUtils` to support configurable epoch/counter bit positions, enabling a 40-bit counter (from the original 32-bit), which significantly delays the overflow threshold.
2. **Supports smooth rolling upgrade**: Adds upgrade coordination logic in `QuorumPeer` and `Learner`, allowing the cluster to transition from 32-bit to 40-bit counter mode without restart via rolling upgrade.
3. **Replaces hardcoded bit operations**: Replaces all hardcoded ZXID bit operations (`& 0xffffffffL`, `>> 32`, `<< 32`) with `ZxidUtils` utility methods across the codebase, making the code more maintainable and consistent.

## Brief changelog

- Extended `ZxidUtils` with configurable epoch high position (32-bit / 40-bit), `clearEpoch()`, `clearCounter()`, and `getCounterLowPosition()` methods
- Added smooth upgrade support in `QuorumPeer` and `Learner` for transitioning from 32-bit to 40-bit counter
- Replaced all hardcoded ZXID bit operations with `ZxidUtils` methods across `Leader`, `LearnerHandler`, `FollowerZooKeeperServer`, and `ObserverMaster`
- Updated `Leader.propose()` to use `ZxidUtils.getCounterLowPosition()` for rollover detection
- Added unit tests in `LearnerHandlerTest` for ZXID reassignment scenarios
- Updated `Zab1_0Test`, `ZxidRolloverTest`, `FollowerResyncConcurrencyTest`, and `ReconfigTest` to use `ZxidUtils` methods

## How does this change relate to the original PR?

This is a re-submission of https://github.com/apache/zookeeper/pull/2164. The original authors (@asdf2014 and @ganzichen) have been inactive for a long time and the PR has gone stale, so I'm picking it up and rebasing it on the latest master branch.

Conflict resolution:
- The `buildRequestToProcess` method in `FollowerZooKeeperServer` was removed upstream by [ZOOKEEPER-4925](https://github.com/apache/zookeeper/pull/2254), so the conflict was resolved by dropping that method and applying the bit-operation replacement directly to the current `logRequest()` method.
- Additionally replaced bit operations in `ObserverMaster.processAck()` which was not covered by the original PR.

## Testing done

- Unit tests added in `LearnerHandlerTest` for ZXID reassignment
- Existing `ZxidRolloverTest`, `Zab1_0Test`, `FollowerResyncConcurrencyTest`, and `ReconfigTest` updated
- All existing tests pass

## Original Authors

Credit to the original authors of https://github.com/apache/zookeeper/pull/2164:
- @asdf2014 (initial implementation)
- @ganzichen (40-bit counter smooth upgrade support)
