### PR TITLE
ZOOKEEPER-5051: Avoid NPE closing 4lw connection during startup

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -330,7 +330,10 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
     private final AuthenticationHelper authHelper = new AuthenticationHelper();
 
     void removeCnxn(ServerCnxn cnxn) {
-        zkDb.removeCnxn(cnxn);
+        ZKDatabase db = zkDb;
+        if (db != null) {
+            db.removeCnxn(cnxn);
+        }
     }
 
     /**

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerTest.java
@@ -225,4 +225,14 @@ public class ZooKeeperServerTest extends ZKTestCase {
     public void testUpdateQuotaExceededMetrics_nullNamespace() {
         assertDoesNotThrow(() -> ZooKeeperServer.updateQuotaExceededMetrics(null));
     }
+
+    @Test
+    public void testRemoveCnxnBeforeStartData() {
+        // Simulate a connection cleanup triggered before the server has fully started.
+        // During this phase zkDb is still null (before startdata()).
+        // 4-letter commands can hit this path.
+        ZooKeeperServer zks = new ZooKeeperServer();
+        ServerCnxn cnxn = mock(ServerCnxn.class);
+        assertDoesNotThrow(() -> zks.removeCnxn(cnxn));
+    }
 }


### PR DESCRIPTION
### Problem

When a 4-letter command is sent while the ZooKeeper server is starting,
the connection close path can call `ZooKeeperServer.removeCnxn()` before
`startdata()` has initialized `zkDb`.

This can trigger:

```text
java.lang.NullPointerException: Cannot invoke
"org.apache.zookeeper.server.ZKDatabase.removeCnxn(...)"
because "this.zkDb" is null
```

But this also hangs any client waiting for connection close.


## Fix
Guard `ZooKeeperServer.removeCnxn()` so it only delegates to zkDb
when zkDb has already been initialized.

### Test
Added `ZooKeeperServerTest#testRemoveCnxnBeforeStartData`.
The test creates a ZooKeeperServer but intentionally does not call
`startdata()`, then verifies that `removeCnxn()` does not throw.
