### PR TITLE
ZOOKEEPER-5052: Fix stale thread write of primitive in JvmPauseMonitor

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/JvmPauseMonitor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/JvmPauseMonitor.java
@@ -64,9 +64,9 @@ public class JvmPauseMonitor {
     public static final String INFO_THRESHOLD_KEY = "jvm.pause.info-threshold.ms";
     public static final long INFO_THRESHOLD_DEFAULT = 1000;
 
-    private long numGcWarnThresholdExceeded = 0;
-    private long numGcInfoThresholdExceeded = 0;
-    private long totalGcExtraSleepTime = 0;
+    private volatile long numGcWarnThresholdExceeded = 0;
+    private volatile long numGcInfoThresholdExceeded = 0;
+    private volatile long totalGcExtraSleepTime = 0;
 
     private Thread monitorThread;
     private volatile boolean shouldRun = true;


### PR DESCRIPTION
Change the three counter fields to volatile to ensure cross-thread visibility when the getters are called from threads other than the monitor thread.

This prevents the JVM caching the stale 0 value. Under CI load or with aggressive JIT optimizations, this manifests as an intermittent 5-second timeout.