### PR TITLE
ZOOKEEPER-2837: Do not pass server JVM flags to status diagnostic client

### DIFF
--- a/bin/zkServer.sh
+++ b/bin/zkServer.sh
@@ -283,7 +283,7 @@ case $1 in
     fi
     echo "Client port found: $clientPort. Client address: $clientPortAddress. Client SSL: $isSSL."
     STAT=$("$JAVA" "-Dzookeeper.log.dir=$ZOO_LOG_DIR" "-Dzookeeper.log.file=$ZOO_LOG_FILE" \
-      "${clientflags[@]}" "${flags[@]}" org.apache.zookeeper.client.FourLetterWordMain \
+      "${clientflags[@]}" org.apache.zookeeper.client.FourLetterWordMain \
       "$clientPortAddress" "$clientPort" srvr "$isSSL" 2>/dev/null |
       $GREP Mode)
     if [[ -z $STAT ]]; then


### PR DESCRIPTION

**Problem**

`zkServer.sh status` runs `FourLetterWordMain` — a short-lived diagnostic client — but passes it the full merged JVM flags (`${flags[@]}`), which include `SERVER_JVMFLAGS`.

When `SERVER_JVMFLAGS` contains large heap or preallocation settings such as:
```bash
-Xmx8G -XX:+AlwaysPreTouch
```

every `status` check forks a process that reserves and touches the full server heap. With monitoring tools that call `status` frequently, this causes:

- **Severe RSS spikes** — each status process briefly allocates the full server heap
- **Memory pressure** — monitoring can consume tens of gigabytes of memory churn per minute
- **GC log spam** (original ZOOKEEPER-2837 symptom) — if GC logging is configured in `SERVER_JVMFLAGS`, every status check creates a new GC log file

**Root Cause**

`${flags[@]}` is the merged result of `JVMFLAGS` + `SERVER_JVMFLAGS`. The `status` command passes both `${clientflags[@]}` and `${flags[@]}` to `FourLetterWordMain`, but `FourLetterWordMain` is a client utility and should only receive `CLIENT_JVMFLAGS`.

**Fix**

Remove `"${flags[@]}"` from the `status` command invocation. `FourLetterWordMain` now only receives `"${clientflags[@]}"`.

This is a simpler and more targeted fix than the `START_SERVER_JVMFLAGS` approach proposed in PR #302, which was rejected for adding unnecessary complexity.

**References**

- [ZOOKEEPER-2837](https://issues.apache.org/jira/browse/ZOOKEEPER-2837) — Previously closed as "Won't Fix" because the proposed `START_SERVER_JVMFLAGS` solution was overly complex. This PR provides a minimal alternative that addresses the same underlying bug.
- PR #302 — The earlier rejected attempt to fix this issue.