### PR TITLE
decode digest auth data as UTF-8 in handleAuthentication

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/DigestAuthenticationProvider.java
@@ -177,7 +177,7 @@ public class DigestAuthenticationProvider implements AuthenticationProvider {
 
     private List<Id> handleAuthentication(final byte[] authData) {
         final List<Id> ids = new ArrayList<>();
-        final String id = new String(authData);
+        final String id = new String(authData, UTF_8);
         try {
             final String digest = generateDigest(id);
             if (digest.equals(superDigest)) {


### PR DESCRIPTION
handleAuthentication decodes the incoming auth bytes with new String(authData), which uses the platform default charset, while digest() hashes the credential with getBytes(UTF_8). On a JVM whose default charset is not UTF-8, a credential with non-ASCII characters then hashes to a different value than the one generateDigest produced for the matching ACL, so the digest id stops matching and auth fails. Decode as UTF_8 so both paths agree.