### PR TITLE
encode node path as UTF-8 in DigestCalculator

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DigestCalculator.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DigestCalculator.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.CRC32;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.StatPersisted;
@@ -30,7 +31,7 @@ public class DigestCalculator {
 
     // The hardcoded digest version, should bump up this version whenever
     // we changed the digest method or fields.
-    private static final int DIGEST_VERSION = 2;
+    private static final int DIGEST_VERSION = 3;
 
 
     /**
@@ -95,7 +96,7 @@ public class DigestCalculator {
         bb.putLong(stat.getEphemeralOwner());
 
         CRC32 crc = new CRC32();
-        crc.update(path.getBytes());
+        crc.update(path.getBytes(StandardCharsets.UTF_8));
         if (data != null) {
             crc.update(data);
         }


### PR DESCRIPTION
calculateDigest hashes the node path with the platform default charset, so a member whose file.encoding is not UTF-8 computes a different digest for the same non-ASCII znode path and raises false digest mismatches. Encode the path as UTF-8, matching the wire format and the rest of the string handling. Bump the digest version so existing snapshots and mixed-version peers skip the comparison during upgrade.