### PR TITLE
use constant-time comparison for session password in checkPasswd

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -26,9 +26,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
+import java.security.MessageDigest;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -1083,7 +1083,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
     }
 
     protected boolean checkPasswd(long sessionId, byte[] passwd) {
-        return sessionId != 0 && Arrays.equals(passwd, generatePasswd(sessionId));
+        return sessionId != 0 && MessageDigest.isEqual(passwd, generatePasswd(sessionId));
     }
 
     long createSession(ServerCnxn cnxn, byte[] passwd, int timeout) {


### PR DESCRIPTION
checkPasswd in ZooKeeperServer compares the client-supplied session password against the server-generated one with Arrays.equals, which returns as soon as two bytes differ. The password comes straight off the wire (processConnectRequest reads it and reopenSession hands it here), so the early-exit timing leaks how many leading bytes are correct and lets a reconnecting client recover the password and revalidate someone else's session. Switch to MessageDigest.isEqual, which compares in constant time.