### PR TITLE
ZOOKEEPER-5054: Netty client should allow every supported TLS ciphers

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ClientX509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ClientX509Util.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.common;
 
 import io.netty.handler.ssl.DelegatingSslContext;
+import io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -81,7 +82,9 @@ public class ClientX509Util extends X509Util {
             sslContextBuilder.protocols(enabledProtocols);
         }
         Iterable<String> enabledCiphers = getCipherSuites(config);
-        if (enabledCiphers != null) {
+        if (enabledCiphers == null) {
+            sslContextBuilder.ciphers(null, IdentityCipherSuiteFilter.INSTANCE_DEFAULTING_TO_SUPPORTED_CIPHERS);
+        } else {
             sslContextBuilder.ciphers(enabledCiphers);
         }
         sslContextBuilder.sslProvider(getSslProvider(config));

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
@@ -25,8 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import io.netty.buffer.UnpooledByteBufAllocator;
-import io.netty.handler.ssl.SslContext;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -54,6 +53,9 @@ import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
+
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.handler.ssl.SslContext;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.server.ServerCnxnFactory;
@@ -732,7 +734,7 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
             throws Exception {
         init(caKeyType, certKeyType, keyPassword, paramIndex);
         ZKConfig zkConfig = new ZKConfig();
-        try (ClientX509Util clientX509Util = new ClientX509Util();) {
+        try (ClientX509Util clientX509Util = new ClientX509Util()) {
             zkConfig.setProperty(clientX509Util.getSslOcspEnabledProperty(), "true");
             // Must not throw IllegalArgumentException
             clientX509Util.createSSLContext(zkConfig);
@@ -758,6 +760,32 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
             SslContext serverContext = clientX509Util.createNettySslContextForServer(zkConfig);
             SSLEngine serverEngine = serverContext.newEngine(byteBufAllocator);
             assertEquals(serverEngine.getSSLParameters().getEndpointIdentificationAlgorithm(), "HTTPS");
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCreateSSLContext_ChaCha20Cipher(X509KeyType caKeyType,
+            X509KeyType certKeyType, String keyPassword, Integer paramIndex) throws Exception {
+        init(caKeyType, certKeyType, keyPassword, paramIndex);
+
+        // TLS_CHACHA20_POLY1305_SHA256 cipher is a mandatory cipher suite on TLSv1.3,
+        // so a client with default configuration must support it.
+
+        ZKConfig zkConfig = new ZKConfig();
+        zkConfig.setProperty(x509Util.getSslEnabledProtocolsProperty(), "TLSv1.3");
+
+        try (ClientX509Util clientX509Util = new ClientX509Util()) {
+            SslContext context = clientX509Util.createNettySslContextForClient(zkConfig);
+
+            UnpooledByteBufAllocator byteBufAllocator = new UnpooledByteBufAllocator(false);
+            SSLEngine engine = context.newEngine(byteBufAllocator);
+
+            String[] enabledProtocols = engine.getEnabledProtocols();
+            assertArrayEquals(new String[] { "TLSv1.3" }, enabledProtocols);
+
+            List<String> enabledCipherSuites = Arrays.asList(engine.getEnabledCipherSuites());
+            assertTrue(enabledCipherSuites.contains("TLS_CHACHA20_POLY1305_SHA256"));
         }
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
@@ -25,7 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.handler.ssl.SslContext;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -53,9 +54,6 @@ import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
-
-import io.netty.buffer.UnpooledByteBufAllocator;
-import io.netty.handler.ssl.SslContext;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.server.ServerCnxnFactory;


### PR DESCRIPTION
We allow every supported ciphers at the client-side by default. This change does not affect the server-side and still allows to override the allowed ciphers at client-side.