### PR TITLE
ZOOKEEPER-5057: Logback CVE vulnerabilities in zookeeper 3.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -551,7 +551,7 @@
 
     <!-- dependency versions -->
     <slf4j.version>2.0.13</slf4j.version>
-    <logback-version>1.3.15</logback-version>
+    <logback-version>1.5.34</logback-version>
     <audience-annotations.version>0.12.0</audience-annotations.version>
     <jmockit.version>1.48</jmockit.version>
     <junit.version>5.6.2</junit.version>


### PR DESCRIPTION
Upgrade logback from version 1.3.15 to 1.5.34
This will solve the following cve issues:

- https://nvd.nist.gov/vuln/detail/CVE-2025-11226
- https://nvd.nist.gov/vuln/detail/CVE-2026-1225