### PR TITLE
ZOOKEEPER-5060: Update GitHub Action versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,9 +48,9 @@ jobs:
     timeout-minutes: 360
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Set up JDK ${{ matrix.profile.jdk }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
       with:
         java-version: ${{ matrix.profile.jdk }}
         distribution: temurin
@@ -67,21 +67,21 @@ jobs:
         MAVEN_OPTS: -Djansi.force=true
     - name: Upload unit test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: surefire-reports-${{ matrix.profile.name }}
         path: ./**/target/surefire-reports/
         if-no-files-found: ignore
     - name: Upload integration test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: failsafe-reports-${{ matrix.profile.name }}
         path: ./**/target/failsafe-reports/
         if-no-files-found: ignore
     - name: Upload cppunit test logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: cppunit-logs-${{ matrix.profile.name }}
         path: ./zookeeper-client/zookeeper-client-c/target/c/TEST-*.txt
@@ -93,7 +93,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Check typos
         uses: crate-ci/typos@v1.22.4
         # To run the typo check locally, you can follow these steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,9 +31,9 @@ jobs:
     timeout-minutes: 360
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ matrix.jdk }}
           distribution: temurin
@@ -51,7 +51,7 @@ jobs:
       - name: Cache ZooKeeper ${{ matrix.zk }}
         id: dist-cache
         if: matrix.zk != 'nightly'
-        uses: actions/cache@v4
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           key: apache-zookeeper-${{ matrix.zk }}-bin.tar.gz
           path: apache-zookeeper-${{ matrix.zk }}-bin.tar.gz

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -43,11 +43,11 @@ jobs:
     timeout-minutes: 360
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         ref: ${{ github.event.inputs.buildRef }}
     - name: Set up JDK 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
       with:
         java-version: 17
         distribution: temurin
@@ -64,14 +64,14 @@ jobs:
         MAVEN_OPTS: -Djansi.force=true
     - name: Upload unit test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: surefire-reports
         path: ./**/target/surefire-reports/
         if-no-files-found: ignore
     - name: Upload integration test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: failsafe-reports
         path: ./**/target/failsafe-reports/

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Show the first log message
       run: git log -n1
     - name: Install shfmt
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Show the first log message
       run: git log -n1
     - name: Install shfmt

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -32,15 +32,15 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Set up JDK 11
-      uses: actions/setup-java@v5
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Set up JDK 25
+      uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
       with:
         java-version: 25
         distribution: temurin
         cache: 'maven'
     - name: Set up Node.js 22
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 22
         cache: 'npm'
@@ -64,14 +64,14 @@ jobs:
         MAVEN_OPTS: -Djansi.force=true
     - name: Upload website Playwright report
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: website-playwright-report
         path: zookeeper-website/playwright-report/
         if-no-files-found: ignore
     - name: Upload website test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: website-test-results
         path: zookeeper-website/test-results/


### PR DESCRIPTION
For example Checkout v7 has a safer fork pull request handling. See: https://github.com/actions/checkout

I pinned GitHub Actions to full commit SHAs which is a security best practice that locks workflows to immutable versions, preventing supply chain attacks where mutable tags (like `@v4` or `@main`) are updated or compromised. 

Why Pin to SHA?

- Immutability: Unlike tags, a 40-character SHA never changes; if a repository is compromised, future commits will have different hashes, protecting your pipeline from running malicious code. 
- Reproducibility: Ensures every workflow run executes the exact same code, eliminating "works on my machine" issues caused by silent tag updates. 
- Security: Mitigates risks associated with tag hijacking or force-pushes that can inject vulnerabilities into trusted action references. 