### PR TITLE
ZOOKEEPER-5064: Upgrade jackson to 2.18.8 to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -548,7 +548,7 @@
     <commons-cli.version>1.5.0</commons-cli.version>
     <netty.version>4.1.130.Final</netty.version>
     <jetty.version>9.4.58.v20250814</jetty.version>
-    <jackson.version>2.18.1</jackson.version>
+    <jackson.version>2.18.8</jackson.version>
     <jline.version>3.25.1</jline.version>
     <snappy.version>1.1.10.5</snappy.version>
     <kerby.version>2.0.0</kerby.version>


### PR DESCRIPTION
Upgrade `jackson` from version 2.18.1 to 2.18.8
This will address the following CVEs:

https://nvd.nist.gov/vuln/detail/CVE-2026-54512
https://nvd.nist.gov/vuln/detail/CVE-2026-54513
https://nvd.nist.gov/vuln/detail/CVE-2026-54514
https://github.com/advisories/GHSA-72hv-8253-57qq

