### PR TITLE
ZOOKEEPER-5044: NettyServerCnxnFactory.shutdown must explicitly shut down DefaultEventExecutor

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -41,9 +41,9 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.DefaultEventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.GlobalEventExecutor;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -107,7 +107,10 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
 
     private final ServerBootstrap bootstrap;
     private Channel parentChannel;
-    private final ChannelGroup allChannels = new DefaultChannelGroup("zkServerCnxns", new DefaultEventExecutor());
+    // GlobalEventExecutor's shared thread starts on demand and stops itself when idle,
+    // so unlike a dedicated DefaultEventExecutor it needs no explicit shutdown to avoid
+    // leaking a non-daemon thread on factory shutdown (ZOOKEEPER-5044).
+    private final ChannelGroup allChannels = new DefaultChannelGroup("zkServerCnxns", GlobalEventExecutor.INSTANCE);
     private final Map<InetAddress, AtomicInteger> ipMap = new ConcurrentHashMap<>();
     private InetSocketAddress localAddress;
     private int maxClientCnxns = 60;


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/ZOOKEEPER-5044

`NettyServerCnxnFactory` backs its channel group with a dedicated `DefaultEventExecutor` created as an anonymous instance, so `shutdown()` cannot terminate it and its non-daemon thread (`defaultEventExecutor-N-1`) survives every factory shutdown.

Instead of adding lifecycle management for that executor, this change stops creating it: the channel group is now backed by `GlobalEventExecutor.INSTANCE`, the executor the `ChannelGroup` javadoc recommends. Its single shared thread starts on demand and stops itself after one second of idleness, so there is nothing left to shut down.

Notes for reviewers:

- No new thread kind is introduced: the termination futures of the boss/worker `EventLoopGroup`s are already notified on `GlobalEventExecutor` on every shutdown (`SingleThreadEventExecutor` registers them there), so every factory shutdown already spins this thread up today.
- The group executor is only used to notify `DefaultChannelGroupFuture` listeners. The only bulk operation on `allChannels` in the codebase is the `close()` inside `shutdown()` itself, so the shared executor receives one or two sub-millisecond notification tasks per shutdown.
- Verified by temporarily adding a test that starts and shuts down a factory, then asserts no thread named `defaultEventExecutor-*` survives: it fails on current master (thread leaked) and passes with this change. The test is not included on purpose — with this fix the dedicated executor no longer exists, so there is nothing left to assert against.
