### PR TITLE
ZOOKEEPER-5067 Remove older docs picker from docs page

### DIFF
--- a/zookeeper-website/app/components/site-navbar.tsx
+++ b/zookeeper-website/app/components/site-navbar.tsx
@@ -218,7 +218,7 @@ function DocsMenu() {
           )
         )}
         <DropdownMenuSeparator />
-        <OlderDocsSubMenu />
+        
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -528,7 +528,7 @@ function NoJSDocsMenu() {
             </details>
           )
         )}
-        <NoJSOlderDocsSubMenu />
+        
       </div>
     </details>
   );

--- a/zookeeper-website/app/pages/_docs/docs/index.tsx
+++ b/zookeeper-website/app/pages/_docs/docs/index.tsx
@@ -34,7 +34,7 @@ import { Card, Cards } from "fumadocs-ui/components/card";
 import { Callout } from "fumadocs-ui/components/callout";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Link } from "@/components/link";
-import { OlderDocsPicker } from "@/components/docs/older-docs-picker";
+//import { OlderDocsPicker } from "@/components/docs/older-docs-picker";
 import type { MDXComponents } from "mdx/types";
 import { getDocsBasePath, resolveDocsHref } from "@/lib/docs-paths";
 import { SITE_URL } from "@/lib/site";
@@ -176,7 +176,7 @@ export function DocsPage({ loaderData }: { loaderData: DocsLoaderData }) {
     <DocsLayout
       {...layoutOptions}
       tree={tree as PageTree.Root}
-      sidebar={{ banner: <OlderDocsPicker /> }}
+  //    sidebar={{ banner: <OlderDocsPicker /> }}
     >
       <Content tree={tree as PageTree.Root} />
     </DocsLayout>


### PR DESCRIPTION
Remove OlderDocsPicker from individual documentation pages.

The docs landing page remains the source of truth for older documentation versions.
This prevents released documentation pages from showing incorrect older version lists.

Changes:
- Removed OlderDocsPicker from docs page sidebar
- Removed Older Docs submenu from navigation