### PR TITLE
ZOOKEEPER-4689: Fix ACL cache recovery from fuzzy snapshots

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -96,6 +96,11 @@ public class DataTree {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataTree.class);
 
+    // An unknown ACL must fail closed when filtering watch events. In
+    // particular, null and an empty list are treated as unrestricted ACLs.
+    private static final List<ACL> NO_PERMISSIONS_ACL =
+        Collections.singletonList(new ACL(0, ZooDefs.Ids.ANYONE_ID_UNSAFE));
+
     private final RateLogger RATE_LOGGER = new RateLogger(LOG, 15 * 60 * 1000);
 
     /**
@@ -441,24 +446,27 @@ public class DataTree {
         }
         List<ACL> parentAcl;
         synchronized (parent) {
-            parentAcl = getACL(parent);
+            parentAcl = getACLForWatchTrigger(parent, parentName);
 
-            // Add the ACL to ACL cache first, to avoid the ACL not being
-            // created race condition during fuzzy snapshot sync.
-            //
-            // This is the simplest fix, which may add ACL reference count
-            // again if it's already counted in the ACL map of fuzzy
-            // snapshot, which might also happen for deleteNode txn, but
-            // at least it won't cause the ACL not exist issue.
-            //
-            // Later we can audit and delete all non-referenced ACLs from
-            // ACL map when loading the snapshot/txns from disk, like what
-            // we did for the global sessions.
-            Long acls = aclCache.convertAcls(acl);
+            Long aclId = aclCache.convertAcls(acl);
 
             DataNode existingChild = nodes.get(path);
             if (existingChild != null) {
-                existingChild.acl = acls;
+                // A create txn can be replayed after its node was already
+                // serialized into a fuzzy snapshot. The txn carries the
+                // authoritative ACL value, whereas the id in the snapshot may
+                // be absent from the serialized ACL cache. Move the node to the
+                // locally interned id and release its previous reference. This
+                // also balances convertAcls above when both ids are equal.
+                synchronized (existingChild) {
+                    Long previousAcl = existingChild.acl;
+                    existingChild.acl = aclId;
+                    aclCache.removeUsage(previousAcl);
+                    if (!aclId.equals(previousAcl)) {
+                        LOG.info("ACL reference of existing node {} changed from {} to {} while applying a create txn",
+                            path, previousAcl, aclId);
+                    }
+                }
                 throw new NodeExistsException();
             }
 
@@ -476,7 +484,7 @@ public class DataTree {
                 parent.stat.setCversion(parentCVersion);
                 parent.stat.setPzxid(zxid);
             }
-            DataNode child = new DataNode(data, acls, stat);
+            DataNode child = new DataNode(data, aclId, stat);
             parent.addChild(childName);
             nodes.postChange(parentName, parent);
             nodeDataSize.addAndGet(getNodeSize(path, child.data));
@@ -562,7 +570,7 @@ public class DataTree {
         List<ACL> acl;
         nodes.remove(path);
         synchronized (node) {
-            acl = getACL(node);
+            acl = getACLForWatchTrigger(node, path);
             aclCache.removeUsage(node.acl);
             nodeDataSize.addAndGet(-getNodeSize(path, node.data));
         }
@@ -572,7 +580,7 @@ public class DataTree {
         // separate patch.
         List<ACL> parentAcl;
         synchronized (parent) {
-            parentAcl = getACL(parent);
+            parentAcl = getACLForWatchTrigger(parent, parentName);
             long owner = node.stat.getEphemeralOwner();
             EphemeralType ephemeralType = EphemeralType.get(owner);
             if (ephemeralType == EphemeralType.CONTAINER) {
@@ -635,7 +643,7 @@ public class DataTree {
         List<ACL> acl;
         byte[] lastData;
         synchronized (n) {
-            acl = getACL(n);
+            acl = getACLForWatchTrigger(n, path);
             lastData = n.data;
             nodes.preChange(path, n);
             n.data = data;
@@ -790,6 +798,30 @@ public class DataTree {
         synchronized (node) {
             return aclCache.convertLong(node.acl);
         }
+    }
+
+    /**
+     * Returns the ACL used to filter watch events for a node. A fuzzy snapshot
+     * can temporarily contain a node whose ACL id is absent from the serialized
+     * ACL cache. Transaction replay repairs that reference; until then, use a
+     * no-permissions ACL instead of aborting replay. During normal restore the
+     * watch tables are empty, so the fallback has no watch-delivery effect. If
+     * the state is encountered while watches are present, it fails closed
+     * (ZOOKEEPER-4799).
+     */
+    private List<ACL> getACLForWatchTrigger(DataNode node, String path) {
+        Long aclId;
+        List<ACL> acls;
+        synchronized (node) {
+            aclId = node.acl;
+            acls = aclCache.convertLongIfCached(aclId);
+        }
+        if (acls != null) {
+            return acls;
+        }
+        LOG.info("ACL id {} of {} is not in the ACL cache; filtering its watch events as unreadable",
+            aclId, path);
+        return NO_PERMISSIONS_ACL;
     }
 
     public int aclCacheSize() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ReferenceCountedACLCache.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ReferenceCountedACLCache.java
@@ -95,6 +95,24 @@ public class ReferenceCountedACLCache {
         return acls;
     }
 
+    /**
+     * Converts a long to a list of ACLs without throwing if it is absent from
+     * the cache. A node in a fuzzy snapshot can temporarily reference such an
+     * absent id until transaction replay repairs it (ZOOKEEPER-4689).
+     *
+     * @param longVal ACL id
+     * @return the corresponding ACLs, or null if the id is not cached
+     */
+    synchronized List<ACL> convertLongIfCached(Long longVal) {
+        if (longVal == null) {
+            return null;
+        }
+        if (longVal == OPEN_UNSAFE_ACL_ID) {
+            return ZooDefs.Ids.OPEN_ACL_UNSAFE;
+        }
+        return longKeyMap.get(longVal);
+    }
+
     private long incrementIndex() {
         return ++aclIndex;
     }
@@ -168,6 +186,15 @@ public class ReferenceCountedACLCache {
     public synchronized void addUsage(Long acl) {
         if (acl == OPEN_UNSAFE_ACL_ID) {
             return;
+        }
+
+        if (acl > aclIndex) {
+            // The ACL cache is serialized before the nodes in a fuzzy snapshot.
+            // A node can therefore reference an id absent from the serialized
+            // cache. Reserve every id mentioned by the loaded tree so replay
+            // cannot assign it to a different ACL before repairing the node.
+            LOG.info("Advancing aclIndex from {} to {} based on a node reference in the snapshot", aclIndex, acl);
+            aclIndex = acl;
         }
 
         if (!longKeyMap.containsKey(acl)) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/DataTreeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/DataTreeTest.java
@@ -51,6 +51,7 @@ import org.apache.zookeeper.common.PathTrie;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.metrics.MetricsUtils;
 import org.apache.zookeeper.txn.CreateTxn;
+import org.apache.zookeeper.txn.DeleteTxn;
 import org.apache.zookeeper.txn.TxnHeader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -645,6 +646,34 @@ public class DataTreeTest extends ZKTestCase {
         assertThrows(NodeExistsException.class, () ->
             dt.createNode("/the_parent", new byte[0], ZooDefs.Ids.CREATOR_ALL_ACL, -1, 1, 1, 0));
         dt.createNode("/the_parent/the_child", new byte[0], ZooDefs.Ids.CREATOR_ALL_ACL, -1, 2, 2, 2);
+    }
+
+    /**
+     * Applying a create txn to an existing node (routine when txns overlap
+     * with the state restored from a fuzzy snapshot, e.g. on DIFF sync) must
+     * keep the ACL reference counts exact, so that unused ACLs are garbage
+     * collected and the cache does not grow until the next reload.
+     *
+     * See ZOOKEEPER-4689.
+     */
+    @Test
+    public void testCreateTxnReplayOnExistingNodeKeepsAclRefCountExact() throws Exception {
+        DataTree dt = new DataTree();
+        int baseline = dt.aclCacheSize();
+
+        TxnHeader hdr = new TxnHeader(1, 2, 2, 2, ZooDefs.OpCode.create);
+        Record txn = new CreateTxn("/x", new byte[0], ZooDefs.Ids.CREATOR_ALL_ACL, false, -1);
+        dt.processTxn(hdr, txn);
+        // Duplicate apply of the same create txn hits the node-exists branch.
+        dt.processTxn(hdr, txn);
+        assertEquals(baseline + 1, dt.aclCacheSize());
+
+        TxnHeader deleteHdr = new TxnHeader(1, 2, 3, 2, ZooDefs.OpCode.delete);
+        Record deleteTxn = new DeleteTxn("/x");
+        dt.processTxn(deleteHdr, deleteTxn);
+        // The ACL is no longer referenced by any node, so it must have been
+        // garbage collected.
+        assertEquals(baseline, dt.aclCacheSize());
     }
 
     private DataTree buildDataTreeForTest() {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/FileTxnSnapLogTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/persistence/FileTxnSnapLogTest.java
@@ -30,6 +30,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.jute.BinaryInputArchive;
@@ -37,14 +39,19 @@ import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
 import org.apache.jute.Record;
+import org.apache.zookeeper.AddWatchMode;
+import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.server.DataNode;
 import org.apache.zookeeper.server.DataTree;
 import org.apache.zookeeper.server.Request;
+import org.apache.zookeeper.server.ServerWatcher;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.test.ClientBase;
 import org.apache.zookeeper.test.TestUtils;
 import org.apache.zookeeper.txn.CreateTxn;
+import org.apache.zookeeper.txn.DeleteTxn;
 import org.apache.zookeeper.txn.SetDataTxn;
 import org.apache.zookeeper.txn.TxnDigest;
 import org.apache.zookeeper.txn.TxnHeader;
@@ -304,6 +311,86 @@ public class FileTxnSnapLogTest {
         });
     }
 
+    private static final byte[] TEST_DATA = "foo".getBytes();
+
+    private static final class ReplayTxn {
+
+        private final TxnHeader header;
+        private final Record record;
+
+        ReplayTxn(long zxid, int type, Record record) {
+            this.header = new TxnHeader(1, 2, zxid, 2, type);
+            this.record = record;
+        }
+
+        void applyTo(DataTree dataTree) {
+            dataTree.processTxn(header, record);
+        }
+    }
+
+    private static ReplayTxn createTxn(long zxid, String path, List<ACL> acl) {
+        return new ReplayTxn(zxid, ZooDefs.OpCode.create, new CreateTxn(path, TEST_DATA, acl, false, -1));
+    }
+
+    private static ReplayTxn deleteTxn(long zxid, String path) {
+        return new ReplayTxn(zxid, ZooDefs.OpCode.delete, new DeleteTxn(path));
+    }
+
+    private static ReplayTxn setDataTxn(long zxid, String path) {
+        return new ReplayTxn(zxid, ZooDefs.OpCode.setData, new SetDataTxn(path, TEST_DATA, 1));
+    }
+
+    /**
+     * Simulates a fuzzy snapshot: the ACL cache is serialized when the
+     * snapshot starts, and the nodes are serialized when it finishes, so
+     * transactions applied in between can leave nodes referencing ACL ids
+     * which are absent from the serialized cache.
+     */
+    private static final class FuzzySnapshot {
+
+        private final DataTree dataTree;
+        private final File file;
+        private final FileOutputStream outputStream;
+        private final OutputArchive outputArchive;
+
+        private FuzzySnapshot(DataTree dataTree) throws IOException {
+            this.dataTree = dataTree;
+            this.file = File.createTempFile("snapshot", "zk");
+            this.outputStream = new FileOutputStream(file);
+            this.outputArchive = BinaryOutputArchive.getArchive(outputStream);
+        }
+
+        static FuzzySnapshot start(DataTree dataTree) throws IOException {
+            FuzzySnapshot snapshot = new FuzzySnapshot(dataTree);
+            dataTree.serializeAcls(snapshot.outputArchive);
+            return snapshot;
+        }
+
+        DataTree finishAndRestore() throws IOException {
+            dataTree.serializeNodes(outputArchive);
+            outputStream.close();
+
+            DataTree restored = new DataTree();
+            try (FileInputStream inputStream = new FileInputStream(file)) {
+                InputArchive inputArchive = BinaryInputArchive.getArchive(inputStream);
+                restored.deserialize(inputArchive, "tree");
+            }
+            return restored;
+        }
+    }
+
+    private static List<ACL> concatAcl(List<ACL> first, List<ACL> second) {
+        List<ACL> result = new ArrayList<>(first);
+        result.addAll(second);
+        return result;
+    }
+
+    private static void assertAcl(DataTree dataTree, String path, List<ACL> expected) {
+        DataNode node = dataTree.getNode(path);
+        assertNotNull(node);
+        assertEquals(expected, dataTree.getACL(node));
+    }
+
     /**
      * Make sure the ACL is exist in the ACL map after SNAP syncing.
      *
@@ -332,35 +419,290 @@ public class FileTxnSnapLogTest {
      */
     @Test
     public void testACLCreatedDuringFuzzySnapshotSync() throws IOException {
-        DataTree leaderDataTree = new DataTree();
+        DataTree leader = new DataTree();
+        FuzzySnapshot snapshot = FuzzySnapshot.start(leader);
 
-        // Start the simulated snap-sync by serializing ACL cache.
-        File file = File.createTempFile("snapshot", "zk");
-        FileOutputStream os = new FileOutputStream(file);
-        OutputArchive oa = BinaryOutputArchive.getArchive(os);
-        leaderDataTree.serializeAcls(oa);
+        ReplayTxn create = createTxn(2, "/a1", ZooDefs.Ids.CREATOR_ALL_ACL);
+        create.applyTo(leader);
 
-        // Add couple of transaction in-between.
-        TxnHeader hdr1 = new TxnHeader(1, 2, 2, 2, ZooDefs.OpCode.create);
-        Record txn1 = new CreateTxn("/a1", "foo".getBytes(), ZooDefs.Ids.CREATOR_ALL_ACL, false, -1);
-        leaderDataTree.processTxn(hdr1, txn1);
+        DataTree restored = snapshot.finishAndRestore();
+        create.applyTo(restored);
 
-        // Finish the snapshot.
-        leaderDataTree.serializeNodes(oa);
-        os.close();
+        assertAcl(leader, "/a1", ZooDefs.Ids.CREATOR_ALL_ACL);
+        // ACL ids are server-local, so resolve the restored tree's own node.
+        assertAcl(restored, "/a1", ZooDefs.Ids.CREATOR_ALL_ACL);
+    }
 
-        // Simulate restore on follower and replay.
-        FileInputStream is = new FileInputStream(file);
-        InputArchive ia = BinaryInputArchive.getArchive(is);
-        DataTree followerDataTree = new DataTree();
-        followerDataTree.deserialize(ia, "tree");
-        followerDataTree.processTxn(hdr1, txn1);
+    /**
+     * ACL ids referenced by a fuzzy snapshot must not be re-issued to other
+     * ACL lists while the transactions of the fuzzy range are replayed.
+     *
+     * A node can be serialized with a reference to an ACL id which was
+     * interned only after the ACL cache had been serialized. Such an id is
+     * missing from the deserialized cache, so it is not accounted for in
+     * aclIndex. If the id is re-issued to a different ACL list during replay,
+     * a replayed delete txn of an unrelated node still referencing the id
+     * decrements a reference count that node never contributed to, and the
+     * entry is garbage collected while live nodes still point to it.
+     *
+     * See ZOOKEEPER-4689.
+     */
+    @Test
+    public void testAclIdsReferencedBySnapshotAreNotReissuedDuringReplay() throws IOException {
+        DataTree leader = new DataTree();
 
-        DataNode a1 = leaderDataTree.getNode("/a1");
-        assertNotNull(a1);
-        assertEquals(ZooDefs.Ids.CREATOR_ALL_ACL, leaderDataTree.getACL(a1));
+        // Leave a gap between aclIndex and the highest live ACL id.
+        createTxn(2, "/m", ZooDefs.Ids.CREATOR_ALL_ACL).applyTo(leader);
+        List<ACL> discardedAcl = concatAcl(ZooDefs.Ids.CREATOR_ALL_ACL, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+        createTxn(3, "/gone", discardedAcl).applyTo(leader);
+        deleteTxn(4, "/gone").applyTo(leader);
 
-        assertEquals(ZooDefs.Ids.CREATOR_ALL_ACL, followerDataTree.getACL(a1));
+        FuzzySnapshot snapshot = FuzzySnapshot.start(leader);
+
+        // These ACL ids are absent from the serialized cache but referenced by
+        // the serialized nodes. Before the fix, replay re-issued /m's stale id
+        // to /b; deleting /m then garbage-collected /b's live ACL entry.
+        List<ACL> aclB = concatAcl(ZooDefs.Ids.READ_ACL_UNSAFE, ZooDefs.Ids.CREATOR_ALL_ACL);
+        ReplayTxn createA = createTxn(5, "/a", ZooDefs.Ids.OPEN_ACL_UNSAFE);
+        ReplayTxn createB = createTxn(6, "/b", aclB);
+        ReplayTxn deleteM = deleteTxn(7, "/m");
+        ReplayTxn recreateM = createTxn(8, "/m", ZooDefs.Ids.OPEN_ACL_UNSAFE);
+        createA.applyTo(leader);
+        createB.applyTo(leader);
+        deleteM.applyTo(leader);
+        recreateM.applyTo(leader);
+
+        DataTree restored = snapshot.finishAndRestore();
+        createA.applyTo(restored);
+        createB.applyTo(restored);
+        deleteM.applyTo(restored);
+        recreateM.applyTo(restored);
+
+        for (DataTree dataTree : new DataTree[]{leader, restored}) {
+            assertAcl(dataTree, "/a", ZooDefs.Ids.OPEN_ACL_UNSAFE);
+            assertAcl(dataTree, "/b", aclB);
+            assertAcl(dataTree, "/m", ZooDefs.Ids.OPEN_ACL_UNSAFE);
+        }
+        assertEquals(leader.aclCacheSize(), restored.aclCacheSize());
+    }
+
+    /**
+     * Replaying a delete txn on top of a fuzzy snapshot which contains the
+     * re-created node with a dangling ACL reference must not crash the
+     * restore.
+     *
+     * The eager ACL fetch for watch triggering (ZOOKEEPER-4799) made such
+     * dangling references fatal in deleteNode; the reference is repaired only
+     * when the re-creating txn is replayed later (ZOOKEEPER-4846), so the
+     * delete has to tolerate it.
+     *
+     * See ZOOKEEPER-4689.
+     */
+    @Test
+    public void testDeleteTxnReplayOnDanglingAclDoesNotCrash() throws IOException {
+        DataTree leader = new DataTree();
+        createTxn(2, "/x", ZooDefs.Ids.CREATOR_ALL_ACL).applyTo(leader);
+        FuzzySnapshot snapshot = FuzzySnapshot.start(leader);
+
+        ReplayTxn delete = deleteTxn(3, "/x");
+        ReplayTxn recreate = createTxn(4, "/x", ZooDefs.Ids.OPEN_ACL_UNSAFE);
+        delete.applyTo(leader);
+        recreate.applyTo(leader);
+
+        // The snapshot contains the re-created /x but not its ACL. Replay
+        // first applies the old incarnation's delete to that dangling node.
+        DataTree restored = snapshot.finishAndRestore();
+        delete.applyTo(restored);
+        recreate.applyTo(restored);
+
+        assertAcl(restored, "/x", ZooDefs.Ids.OPEN_ACL_UNSAFE);
+    }
+
+    /**
+     * Replaying a setData txn of an earlier incarnation on top of a fuzzy
+     * snapshot which contains the re-created node with a dangling ACL
+     * reference must not crash the restore.
+     *
+     * See ZOOKEEPER-4689.
+     */
+    @Test
+    public void testSetDataTxnReplayOnDanglingAclDoesNotCrash() throws IOException {
+        DataTree leader = new DataTree();
+        createTxn(2, "/x", ZooDefs.Ids.CREATOR_ALL_ACL).applyTo(leader);
+        FuzzySnapshot snapshot = FuzzySnapshot.start(leader);
+
+        ReplayTxn setData = setDataTxn(3, "/x");
+        ReplayTxn delete = deleteTxn(4, "/x");
+        ReplayTxn recreate = createTxn(5, "/x", ZooDefs.Ids.OPEN_ACL_UNSAFE);
+        setData.applyTo(leader);
+        delete.applyTo(leader);
+        recreate.applyTo(leader);
+
+        // Replay first applies the old incarnation's setData to the re-created
+        // /x whose ACL is absent from the serialized cache.
+        DataTree restored = snapshot.finishAndRestore();
+        setData.applyTo(restored);
+        delete.applyTo(restored);
+        recreate.applyTo(restored);
+
+        assertAcl(restored, "/x", ZooDefs.Ids.OPEN_ACL_UNSAFE);
+    }
+
+    /**
+     * Watch events for a node whose ACL reference is missing from the ACL
+     * cache are filtered as unreadable (fail closed), not delivered without
+     * an ACL check: delivering them without a check would reintroduce
+     * CVE-2024-23944 (see ZOOKEEPER-4799) for such nodes.
+     *
+     * See ZOOKEEPER-4689.
+     */
+    @Test
+    public void testWatchEventsForDanglingAclFailClosed() throws IOException {
+        DataTree leader = new DataTree();
+        createTxn(2, "/x", ZooDefs.Ids.CREATOR_ALL_ACL).applyTo(leader);
+        FuzzySnapshot snapshot = FuzzySnapshot.start(leader);
+
+        ReplayTxn delete = deleteTxn(3, "/x");
+        ReplayTxn recreate = createTxn(4, "/x", ZooDefs.Ids.OPEN_ACL_UNSAFE);
+        delete.applyTo(leader);
+        recreate.applyTo(leader);
+        DataTree restored = snapshot.finishAndRestore();
+
+        List<List<ACL>> deliveredAcls = new ArrayList<>();
+        ServerWatcher watcher = new ServerWatcher() {
+            @Override
+            public void process(WatchedEvent event) {
+            }
+
+            @Override
+            public void process(WatchedEvent event, List<ACL> znodeAcl) {
+                deliveredAcls.add(znodeAcl);
+            }
+        };
+        restored.addWatch("/x", watcher, AddWatchMode.PERSISTENT.getMode());
+
+        // Replaying the old incarnation's delete fires a watch event while
+        // the snapshot node's ACL is still unknown.
+        delete.applyTo(restored);
+
+        assertFalse(deliveredAcls.isEmpty());
+        for (List<ACL> acl : deliveredAcls) {
+            assertNotNull(acl, "null ACLs pass checkACL");
+            assertFalse(acl.isEmpty(), "empty ACLs pass checkACL");
+            for (ACL entry : acl) {
+                assertEquals(0, entry.getPerms() & ZooDefs.Perms.READ,
+                    "watch events with an unknown ACL must fail closed: " + acl);
+            }
+        }
+    }
+
+    /**
+     * Replaying a create txn whose parent has a dangling ACL reference must
+     * not crash the restore.
+     *
+     * Same as above, but for the eager parent ACL fetch in createNode: the
+     * parent is repaired only when its own re-creating txn is replayed, which
+     * happens after the replay of create txns of an earlier incarnation's
+     * children.
+     *
+     * See ZOOKEEPER-4689.
+     */
+    @Test
+    public void testCreateTxnReplayUnderDanglingAclParentDoesNotCrash() throws IOException {
+        DataTree leader = new DataTree();
+        createTxn(2, "/p", ZooDefs.Ids.CREATOR_ALL_ACL).applyTo(leader);
+        FuzzySnapshot snapshot = FuzzySnapshot.start(leader);
+
+        ReplayTxn createChild = createTxn(3, "/p/c", ZooDefs.Ids.CREATOR_ALL_ACL);
+        ReplayTxn deleteChild = deleteTxn(4, "/p/c");
+        ReplayTxn deleteParent = deleteTxn(5, "/p");
+        ReplayTxn recreateParent = createTxn(6, "/p", ZooDefs.Ids.OPEN_ACL_UNSAFE);
+        createChild.applyTo(leader);
+        deleteChild.applyTo(leader);
+        deleteParent.applyTo(leader);
+        recreateParent.applyTo(leader);
+
+        // The snapshot contains the re-created /p with a dangling ACL. Replay
+        // first creates an old incarnation's child beneath that parent.
+        DataTree restored = snapshot.finishAndRestore();
+        createChild.applyTo(restored);
+        deleteChild.applyTo(restored);
+        deleteParent.applyTo(restored);
+        recreateParent.applyTo(restored);
+
+        assertAcl(restored, "/p", ZooDefs.Ids.OPEN_ACL_UNSAFE);
+        assertNull(restored.getNode("/p/c"));
+    }
+
+    /**
+     * Reference counting of ACLs interned during the fuzzy range works
+     * correctly and entries are not removed prematurely.
+     *
+     * See ZOOKEEPER-4689.
+     */
+    @Test
+    public void testAclRefCountDuringFuzzySnapshotSync() throws IOException {
+        DataTree leader = new DataTree();
+        FuzzySnapshot snapshot = FuzzySnapshot.start(leader);
+
+        ReplayTxn createA1 = createTxn(2, "/a1", ZooDefs.Ids.CREATOR_ALL_ACL);
+        ReplayTxn createA2 = createTxn(3, "/a2", ZooDefs.Ids.CREATOR_ALL_ACL);
+        ReplayTxn deleteA1 = deleteTxn(4, "/a1");
+        createA1.applyTo(leader);
+        createA2.applyTo(leader);
+        deleteA1.applyTo(leader);
+
+        DataTree restored = snapshot.finishAndRestore();
+        createA1.applyTo(restored);
+        createA2.applyTo(restored);
+        deleteA1.applyTo(restored);
+
+        assertAcl(leader, "/a2", ZooDefs.Ids.CREATOR_ALL_ACL);
+        assertAcl(restored, "/a2", ZooDefs.Ids.CREATOR_ALL_ACL);
+        assertEquals(leader.aclCacheSize(), restored.aclCacheSize());
+    }
+
+    /**
+     * Nodes repaired during replay end up with the ACL values carried by
+     * their create txns, also when the ids assigned during replay differ from
+     * the ids recorded in the snapshot.
+     *
+     * The repair must be keyed by the ACL value in the txn, never by the
+     * stale id recorded in the snapshot. Without id reservation, replay
+     * assigns /a4's stale id to /a3's ACL, so a repair keyed on whether that
+     * id exists in the cache (the approach of the original PR for this
+     * issue) silently gives /a4 the ACL of /a3.
+     *
+     * See ZOOKEEPER-4689.
+     */
+    @Test
+    public void testAclValuesMatchAfterFuzzySnapshotSyncReplay() throws IOException {
+        DataTree leader = new DataTree();
+
+        // Leave a gap between aclIndex and the serialized cache.
+        createTxn(2, "/gone", ZooDefs.Ids.OPEN_ACL_UNSAFE).applyTo(leader);
+        deleteTxn(3, "/gone").applyTo(leader);
+        FuzzySnapshot snapshot = FuzzySnapshot.start(leader);
+
+        List<ACL> otherAcl = concatAcl(ZooDefs.Ids.CREATOR_ALL_ACL, ZooDefs.Ids.READ_ACL_UNSAFE);
+        ReplayTxn createA2 = createTxn(4, "/a2", ZooDefs.Ids.CREATOR_ALL_ACL);
+        ReplayTxn createA3 = createTxn(5, "/a3", otherAcl);
+        ReplayTxn createA4 = createTxn(6, "/a4", ZooDefs.Ids.CREATOR_ALL_ACL);
+        createA2.applyTo(leader);
+        createA3.applyTo(leader);
+        createA4.applyTo(leader);
+
+        DataTree restored = snapshot.finishAndRestore();
+        createA2.applyTo(restored);
+        createA3.applyTo(restored);
+        createA4.applyTo(restored);
+
+        for (DataTree dataTree : new DataTree[]{leader, restored}) {
+            assertAcl(dataTree, "/a2", ZooDefs.Ids.CREATOR_ALL_ACL);
+            assertAcl(dataTree, "/a3", otherAcl);
+            assertAcl(dataTree, "/a4", ZooDefs.Ids.CREATOR_ALL_ACL);
+        }
+        assertEquals(leader.aclCacheSize(), restored.aclCacheSize());
     }
 
     @Test


### PR DESCRIPTION
Supersedes #1997.

## Background

ZooKeeper snapshots are fuzzy: the ACL cache is serialized first, and the data tree is serialized afterward while transactions continue to modify both. A snapshot can therefore contain a node whose ACL id is absent from the serialized ACL cache:

```text
serialize ACL cache
create /x with a new ACL id
serialize /x
```

This is recoverable because the transaction which introduced the ACL is newer than the snapshot zxid and is replayed after the snapshot is loaded.

[ZOOKEEPER-3306](https://issues.apache.org/jira/browse/ZOOKEEPER-3306) made create replay intern the transaction's ACL even when the node already existed in the snapshot. [ZOOKEEPER-4846](https://issues.apache.org/jira/browse/ZOOKEEPER-4846) completed the basic repair by moving that existing node to the locally interned id. Using the ACL value carried by the transaction is important: numeric ACL ids are local cache implementation details and need not remain equal across servers or restarts.

Three issues remain on current master. They are fixed together deliberately: reserving snapshot-referenced ids (fix 1) keeps those ids unresolved until their repairing txns replay, which is exactly the state the watch-time ACL lookup (fix 3) must tolerate. None of this changes the snapshot format, and ACL ids are never required to match across servers.

## 1. An id referenced by the snapshot can be reissued to another ACL

On a fresh restore, `ReferenceCountedACLCache.deserialize` advances `aclIndex` only from ids present in the serialized cache. It does not account for ids which appear only in the nodes serialized later.

For example, suppose the serialized cache ends at id 2, while fuzzy snapshot nodes refer to ids 4 and 5. Replay can allocate id 4 to a different ACL before all snapshot nodes have been repaired. A replayed delete of a node still carrying stale id 4 then decrements the new entry's reference count. That entry can be garbage-collected while an unrelated live node still points to it, leaving that node with a dangling ACL after its repairing transaction has already replayed.

This patch advances `aclIndex` for every id referenced by a deserialized node, including ids absent from the cache. Such ids are never reissued; replay moves the nodes to locally interned ids derived from the ACL values in their transactions.

The invariant is local—this does not try to keep ACL ids equal across ensemble members:

> An ACL id referenced by the loaded tree is never reissued to another ACL value.

## 2. Create replay leaves reference counts inflated

In the ZOOKEEPER-4846 path, `convertAcls` increments the new entry's reference count before the existing node is updated, but the node's previous reference is not released. This leaks a reference even when the old and new ids are equal, and prevents unused ACL entries from being collected until the next reload rebuilds the counts.

The existing-node path now transfers the reference under the node lock:

```text
intern transaction ACL (+1)
replace node ACL id
release previous ACL id (-1, or no-op if absent)
```

When both ids are equal, the increment and decrement balance. When they differ, the node contributes exactly one reference to its new entry.

## 3. ACL lookup for watch filtering can abort replay

[ZOOKEEPER-4799](https://issues.apache.org/jira/browse/ZOOKEEPER-4799) added eager ACL lookup in `createNode`, `deleteNode`, and `setData` so watch events can be filtered by READ permission. During normal restore and learner synchronization, transactions are replayed before the server starts serving clients, so the watch tables are normally empty. Nevertheless, these methods resolve the ACL before calling the watch manager.

One example is a node deleted and re-created in the fuzzy range. The snapshot can contain the new incarnation with an ACL absent from the serialized cache, while replay begins with `setData` or `delete` transactions for the old incarnation. The eager lookup throws `Failed to fetch acls for ...` and aborts recovery before the empty watch manager is consulted; the later create transaction never gets a chance to repair the reference.

This patch uses a non-throwing lookup only for ACLs passed to watch delivery. A missing entry is represented by a no-permissions ACL:

- normal replay proceeds; with empty watch tables, the value is unused;
- if this state is encountered while watches are present, ordinary client delivery fails closed (super sessions retain their normal bypass);
- null or an empty ACL is deliberately not used, because `checkACL` treats both as unrestricted and that would reintroduce [CVE-2024-23944](https://www.cve.org/CVERecord?id=CVE-2024-23944) / ZOOKEEPER-4799 for these nodes;
- client operations such as `getData` and `getACL` retain their strict lookup behavior.

On the valid recovery path this does not suppress any client notification: local restore and learner synchronization replay transactions before the server starts serving clients, so the no-permissions ACL is passed to an empty watch manager. The fallback is observable only if a dangling reference has already survived into live state—for example, in a snapshot written by an older version after the repairing transaction fell outside the replay range. That member no longer has enough information to determine who can read the node, so failing closed is the only safe delivery policy.

## Tests

Failing on current master, fixed by this patch:

- `FileTxnSnapLogTest.testAclIdsReferencedBySnapshotAreNotReissuedDuringReplay` — fix 1; fails with `Failed to fetch acls for ...` when resolving a node whose own txns replayed normally, i.e. the id-reuse corruption.
- `DataTreeTest.testCreateTxnReplayOnExistingNodeKeepsAclRefCountExact` — fix 2; fails with a leaked cache entry after the only node using the ACL is deleted.
- `FileTxnSnapLogTest.testDeleteTxnReplayOnDanglingAclDoesNotCrash`, `testSetDataTxnReplayOnDanglingAclDoesNotCrash`, `testCreateTxnReplayUnderDanglingAclParentDoesNotCrash` — fix 3; fail with `Failed to fetch acls for ...` from `deleteNode` / `setData` / `createNode` (the last is the same line as the stack trace on the ZOOKEEPER-4846 JIRA).

Security behavior of fix 3:

- `FileTxnSnapLogTest.testWatchEventsForDanglingAclFailClosed` — current master aborts at the strict ACL lookup. With the non-throwing lookup in place, the test additionally asserts that the ACL passed to watch delivery grants no READ; it fails against a variant which passes null, since `checkACL` treats null as unrestricted.

Guards against the known-bad #1997 approach (pass on current master and with this patch):

- `FileTxnSnapLogTest.testAclRefCountDuringFuzzySnapshotSync` — catches under-counting when multiple snapshot nodes share the same missing ACL.
- `FileTxnSnapLogTest.testAclValuesMatchAfterFuzzySnapshotSyncReplay` — catches repair keyed by the stale snapshot id instead of the ACL value carried by the transaction.

The fuzzy-snapshot tests share small helpers (`FuzzySnapshot`, `ReplayTxn`), and the pre-existing `testACLCreatedDuringFuzzySnapshotSync` is rewritten on top of them with its assertions preserved, except one correction: it used to resolve a `DataNode` taken from the leader tree against the restored tree's ACL cache. ACL ids are server-local, so it now resolves the restored tree's own node.

Testing performed:

```text
mvn -pl zookeeper-server test \
  -Dtest=FileTxnSnapLogTest,DataTreeTest,ReferenceCountedACLCacheTest,\
ACLCountTest,PersistentWatcherACLTest,SnapshotDigestTest,FuzzySnapshotRelatedTest
mvn -pl zookeeper-server checkstyle:check
```

We have carried the `aclIndex` reservation part of this fix in Jane Street's internal ZooKeeper 3.5-based fork since 2023.