### PR TITLE
ZOOKEEPER-4993: Lower "Attempting to delete candidate container..." logging to DEBUG

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ContainerManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ContainerManager.java
@@ -145,7 +145,7 @@ public class ContainerManager {
             DeleteContainerRequest record = new DeleteContainerRequest(containerPath);
             Request request = new Request(null, 0, 0, ZooDefs.OpCode.deleteContainer, RequestRecord.fromRecord(record), null);
             try {
-                LOG.info("Attempting to delete candidate container: {}", containerPath);
+                LOG.debug("Attempting to delete candidate container: {}", containerPath);
                 postDeleteRequest(request);
             } catch (Exception e) {
                 LOG.error("Could not delete container: {}", containerPath, e);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/CreateContainerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/CreateContainerTest.java
@@ -24,6 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
@@ -50,6 +54,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.slf4j.LoggerFactory;
 
 public class CreateContainerTest extends ClientBase {
 
@@ -145,6 +150,39 @@ public class CreateContainerTest extends ClientBase {
 
         assertTrue(completedContainerDeletions.tryAcquire(1, TimeUnit.SECONDS));
         assertNull(zk.exists("/foo", false), "Container should have been deleted");
+    }
+
+    @Test
+    @Timeout(value = 30)
+    public void testCandidateContainerDeletionIsLoggedAtDebugLevel() throws Exception {
+        Logger logger = (Logger) LoggerFactory.getLogger(ContainerManager.class);
+        Level originalLevel = logger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        logger.setLevel(Level.DEBUG);
+
+        try {
+            zk.create("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.CONTAINER);
+            zk.create("/foo/bar", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            zk.delete("/foo/bar", -1);
+
+            ContainerManager containerManager = new ContainerManager(
+                    serverFactory.getZooKeeperServer().getZKDatabase(),
+                    serverFactory.getZooKeeperServer().firstProcessor,
+                    1,
+                    100);
+            containerManager.checkContainers();
+
+            assertTrue(completedContainerDeletions.tryAcquire(1, TimeUnit.SECONDS));
+            assertTrue(appender.list.stream().anyMatch(event ->
+                    event.getLevel() == Level.DEBUG
+                            && event.getFormattedMessage().equals("Attempting to delete candidate container: /foo")));
+        } finally {
+            logger.detachAppender(appender);
+            logger.setLevel(originalLevel);
+            appender.stop();
+        }
     }
 
     @Test


### PR DESCRIPTION
This change lowers the candidate container deletion log from INFO to DEBUG to avoid excessive log volume while preserving the constructor configuration log at INFO.

A regression test verifies that the candidate deletion message is emitted at DEBUG level.

Jira: https://issues.apache.org/jira/browse/ZOOKEEPER-4993

Tests:
- `mvn -pl zookeeper-server -am -Dtest=CreateContainerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl zookeeper-server -am -DskipTests compile checkstyle:check spotbugs:check`
- `mvn verify spotbugs:check checkstyle:check -Pfull-build -Dsurefire-forkcount=4` reached 3,239 tests. It reported 7 unrelated OCSP/SSL failures in `ClientSSLRevocationTest` and `QuorumSSLTest`; all `CreateContainerTest` tests passed.