### PR TITLE
ZOOKEEPER-5039: Document ZK 3.10.0 drops Java 8 / 11 support in docs (ADDENDUM)

### DIFF
--- a/zookeeper-website/app/pages/_docs/docs/_mdx/admin-ops/administrators-guide/deployment.mdx
+++ b/zookeeper-website/app/pages/_docs/docs/_mdx/admin-ops/administrators-guide/deployment.mdx
@@ -54,7 +54,13 @@ is no full support.
 
 ### Required Software
 
-ZooKeeper runs in Java, release 17 or greater
+ZooKeeper runs in Java.
+
+<Callout type="info">
+    ZooKeeper 3.10.0 drops support for JDK 8 and 11.
+</Callout>
+
+It requires Java 17 or greater
 (JDK 17 LTS, JDK 21 LTS, JDK 25 LTS - other Java versions are not supported).
 It runs as an _ensemble_ of ZooKeeper servers. Three
 ZooKeeper servers is the minimum recommended size for an

--- a/zookeeper-website/app/pages/_docs/docs/_mdx/admin-ops/administrators-guide/deployment.mdx
+++ b/zookeeper-website/app/pages/_docs/docs/_mdx/admin-ops/administrators-guide/deployment.mdx
@@ -56,9 +56,7 @@ is no full support.
 
 ZooKeeper runs in Java.
 
-<Callout type="info">
-    ZooKeeper 3.10.0 drops support for JDK 8 and 11.
-</Callout>
+<Callout type="info">ZooKeeper 3.10.0 drops support for JDK 8 and 11.</Callout>
 
 It requires Java 17 or greater
 (JDK 17 LTS, JDK 21 LTS, JDK 25 LTS - other Java versions are not supported).


### PR DESCRIPTION
Under https://github.com/apache/zookeeper/pull/2376 it was requested but not yet done that we clarify in the documentation which ZooKeeper version drops support for Java 8 and 11.