### PR TITLE
ZOOKEEPER-5073: Return when C client threads fail to start

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/mt_adaptor.c
+++ b/zookeeper-client/zookeeper-client-c/src/mt_adaptor.c
@@ -199,7 +199,8 @@ void notify_thread_ready(zhandle_t* zh)
 {
     struct adaptor_threads* adaptor=zh->adaptor_priv;
     pthread_mutex_lock(&adaptor->lock);
-    adaptor->threadsToWait--;
+    if(adaptor->threadsToWait>0)
+        adaptor->threadsToWait--;
     pthread_cond_broadcast(&adaptor->cond);
     while(adaptor->threadsToWait>0) 
         pthread_cond_wait(&adaptor->cond,&adaptor->lock);
@@ -207,9 +208,10 @@ void notify_thread_ready(zhandle_t* zh)
 }
 
 
-void start_threads(zhandle_t* zh)
+int start_threads(zhandle_t* zh)
 {
     int rc = 0;
+    int io_started = 0;
     struct adaptor_threads* adaptor=zh->adaptor_priv;
     pthread_cond_init(&adaptor->cond,0);
     pthread_mutex_init(&adaptor->lock,0);
@@ -220,15 +222,34 @@ void start_threads(zhandle_t* zh)
     api_prolog(zh);
     LOG_DEBUG(LOGCALLBACK(zh), "starting threads...");
     rc=pthread_create(&adaptor->io, 0, do_io, zh);
-    assert("pthread_create() failed for the IO thread"&&!rc);
+    if(rc)
+        goto fail;
+    io_started=1;
     rc=pthread_create(&adaptor->completion, 0, do_completion, zh);
-    assert("pthread_create() failed for the completion thread"&&!rc);
+    if(rc)
+        goto fail;
     wait_for_others(zh);
-    api_epilog(zh, 0);    
+    api_epilog(zh, 0);
+    return 0;
+
+fail:
+    LOG_ERROR(LOGCALLBACK(zh), "pthread_create() failed: %d", rc);
+    if(io_started) {
+        zh->close_requested=1;
+        pthread_mutex_lock(&adaptor->lock);
+        adaptor->threadsToWait=0;
+        pthread_cond_broadcast(&adaptor->cond);
+        pthread_mutex_unlock(&adaptor->lock);
+        pthread_join(adaptor->io, 0);
+        zh->close_requested=0;
+    }
+    api_epilog(zh, 0);
+    return rc;
 }
 
 int adaptor_init(zhandle_t *zh)
 {
+    int rc;
     pthread_mutexattr_t recursive_mx_attr;
     struct adaptor_threads *adaptor_threads = calloc(1, sizeof(*adaptor_threads));
     if (!adaptor_threads) {
@@ -267,7 +288,12 @@ int adaptor_init(zhandle_t *zh)
     pthread_cond_init(&zh->sent_requests.cond,0);
     pthread_mutex_init(&zh->completions_to_process.lock,0);
     pthread_cond_init(&zh->completions_to_process.cond,0);
-    start_threads(zh);
+    rc=start_threads(zh);
+    if(rc) {
+        adaptor_destroy(zh);
+        errno=rc;
+        return -1;
+    }
     return 0;
 }
 
@@ -313,6 +339,8 @@ void adaptor_destroy(zhandle_t *zh)
     pthread_mutex_destroy(&zh->completions_to_process.lock);
     pthread_cond_destroy(&zh->completions_to_process.cond);
     pthread_mutex_destroy(&adaptor->zh_lock);
+    pthread_mutex_destroy(&adaptor->reconfig_lock);
+    pthread_mutex_destroy(&adaptor->watchers_lock);
 
     pthread_mutex_destroy(&zh->auth_h.lock);
 

--- a/zookeeper-client/zookeeper-client-c/tests/TestZookeeperInit.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestZookeeperInit.cc
@@ -33,11 +33,63 @@ class MockPthreadsNull;
 
 using namespace std;
 
+#ifdef THREADED
+class CheckedPthreadCreateFailure : public CheckedPthread
+{
+public:
+    explicit CheckedPthreadCreateFailure(int failOnCall):
+        pthreadCreateCounter(0),pthreadJoinCounter(0),
+        pthreadCondDestroyCounter(0),pthreadMutexDestroyCounter(0),
+        threadCreated(false),failOnCall_(failOnCall){}
+
+    int pthread_create(pthread_t *t, const pthread_attr_t *a,
+            void *(*f)(void *), void *d) override {
+        if (pthreadCreateCounter++ == failOnCall_)
+            return EAGAIN;
+        int rc=CheckedPthread::pthread_create(t,a,f,d);
+        if(!rc) {
+            thread=*t;
+            threadCreated=true;
+        }
+        return rc;
+    }
+
+    int pthread_join(pthread_t t, void **r) override {
+        pthreadJoinCounter++;
+        return CheckedPthread::pthread_join(t,r);
+    }
+
+    int pthread_cond_destroy(pthread_cond_t *c) override {
+        pthreadCondDestroyCounter++;
+        return CheckedPthread::pthread_cond_destroy(c);
+    }
+
+    int pthread_mutex_destroy(pthread_mutex_t *m) override {
+        pthreadMutexDestroyCounter++;
+        return CheckedPthread::pthread_mutex_destroy(m);
+    }
+
+    int pthreadCreateCounter;
+    int pthreadJoinCounter;
+    int pthreadCondDestroyCounter;
+    int pthreadMutexDestroyCounter;
+    pthread_t thread;
+    bool threadCreated;
+
+private:
+    int failOnCall_;
+};
+#endif
+
 class Zookeeper_init : public CPPUNIT_NS::TestFixture
 {
     CPPUNIT_TEST_SUITE(Zookeeper_init);
     CPPUNIT_TEST(testVersion);
     CPPUNIT_TEST(testBasic);
+#ifdef THREADED
+    CPPUNIT_TEST(testFirstThreadCreateFailure);
+    CPPUNIT_TEST(testSecondThreadCreateFailure);
+#endif
     CPPUNIT_TEST(testAddressResolution);
     CPPUNIT_TEST(testMultipleAddressResolution);
     CPPUNIT_TEST(testNullAddressString);
@@ -139,6 +191,36 @@ public:
         CPPUNIT_ASSERT(MockPthreadsNull::isInitialized(&zh->completions_to_process.cond));
 #endif
     }
+#ifdef THREADED
+    void assertThreadCreateFailure(int failOnCall)
+    {
+        delete pthreadMock;
+        pthreadMock=0;
+        CheckedPthreadCreateFailure pthreadFailure(failOnCall);
+
+        errno=0;
+        zh=zookeeper_init("127.0.0.1:2121",watcher,10000,0,0,0);
+
+        CPPUNIT_ASSERT(zh==0);
+        CPPUNIT_ASSERT_EQUAL(EAGAIN,errno);
+        CPPUNIT_ASSERT_EQUAL(failOnCall+1,pthreadFailure.pthreadCreateCounter);
+        CPPUNIT_ASSERT_EQUAL(failOnCall,pthreadFailure.pthreadJoinCounter);
+        CPPUNIT_ASSERT_EQUAL(3,pthreadFailure.pthreadCondDestroyCounter);
+        CPPUNIT_ASSERT_EQUAL(9,pthreadFailure.pthreadMutexDestroyCounter);
+        if(pthreadFailure.threadCreated)
+            CPPUNIT_ASSERT(CheckedPthread::isDestroyed(pthreadFailure.thread));
+    }
+
+    void testFirstThreadCreateFailure()
+    {
+        assertThreadCreateFailure(0);
+    }
+
+    void testSecondThreadCreateFailure()
+    {
+        assertThreadCreateFailure(1);
+    }
+#endif
     void testAddressResolution()
     {
         const char EXPECTED_IPS[][4]={{127,0,0,1}};


### PR DESCRIPTION
When the multi-threaded C client cannot create its IO or completion worker, `zookeeper_init()` never returns in an `NDEBUG` build. With assertions enabled, the same runtime resource failure aborts the process at `pthread_create() failed for the IO thread` or `pthread_create() failed for the completion thread`.

`start_threads()` now returns the pthread error. If the IO worker started before the completion worker failed, initialization opens the startup barrier, stops and joins that worker, and then releases all adaptor resources. The caller gets `NULL` with `errno` set to `EAGAIN`.

https://issues.apache.org/jira/browse/ZOOKEEPER-5073

## Testing

Built and ran the C client tests in the repository's `dev/docker` image.

<details>
<summary>Raw logs</summary>

```text
# Before, upstream/master 7af463e with the regression tests applied
$ cmake -S zookeeper-client/zookeeper-client-c -B /tmp/build \
    -DCMAKE_BUILD_TYPE=Release -DWANT_CPPUNIT=ON -DWITH_CYRUS_SASL=OFF
$ cmake --build /tmp/build --target zktest -j2
$ timeout 15s /tmp/build/zktest Zookeeper_init::testFirstThreadCreateFailure
exit=124
$ timeout 15s /tmp/build/zktest Zookeeper_init::testSecondThreadCreateFailure
exit=124

# After, f7931a7a0
$ cmake -S zookeeper-client/zookeeper-client-c -B /tmp/release \
    -DCMAKE_BUILD_TYPE=Release -DWANT_CPPUNIT=ON -DWITH_CYRUS_SASL=OFF
$ cmake --build /tmp/release --target zktest -j2
$ base_dir=/workspace timeout 120s /tmp/release/zktest Zookeeper_init
Zookeeper_init::testFirstThreadCreateFailure : OK
Zookeeper_init::testSecondThreadCreateFailure : OK
OK (17)

$ base_dir=/workspace timeout 180s /tmp/release/zktest Zookeeper_close
OK (5)

# Assertions enabled
$ cmake -S zookeeper-client/zookeeper-client-c -B /tmp/debug \
    -DCMAKE_BUILD_TYPE=Debug -DWANT_CPPUNIT=ON -DWITH_CYRUS_SASL=OFF
$ cmake --build /tmp/debug --target zktest -j2
$ base_dir=/workspace timeout 120s /tmp/debug/zktest Zookeeper_init
Zookeeper_init::testFirstThreadCreateFailure : OK
Zookeeper_init::testSecondThreadCreateFailure : OK
OK (17)

# Full suite
$ base_dir=/workspace timeout 600s /tmp/release/zktest all
TestReconfigServer::testNonIncremental
Segmentation fault
exit=139
```

The full-suite failure is unrelated: `TestReconfigServer::testNonIncremental` also exits 139 from clean `upstream/master` at `7af463e0fd5097930f52864911b224d8b9e6a485`.

</details>
