### PR TITLE
ZOOKEEPER-5080: Fix flaky metric assertion in SnapshotAndRestoreCommandTest

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/SnapshotAndRestoreCommandTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/admin/SnapshotAndRestoreCommandTest.java
@@ -395,14 +395,14 @@ public class SnapshotAndRestoreCommandTest extends ZKTestCase {
         Map<String, Object> metrics = MetricsUtils.currentServerMetrics();
         assertEquals(0, (long) metrics.get("snapshot_error_count"));
         assertEquals(0, (long) metrics.get("snapshot_rate_limited_count"));
-        assertTrue((Double) metrics.get("avg_snapshottime") > 0.0);
+        assertEquals(1L, (long) metrics.get("cnt_snapshottime"));
     }
 
     private void validateRestoreMetrics() {
         Map<String, Object> metrics = MetricsUtils.currentServerMetrics();
         assertEquals(0, (long) metrics.get("restore_error_count"));
         assertEquals(0, (long) metrics.get("restore_rate_limited_count"));
-        assertTrue((Double) metrics.get("avg_restore_time") > 0.0);
+        assertEquals(1L, (long) metrics.get("cnt_restore_time"));
     }
 
     public static  File takeSnapshotAndValidate(final int jettyAdminPort, final File dataDir) throws Exception {


### PR DESCRIPTION
Time.currentElapsedTime counts whole milliseconds, so a snapshot of the ten
znodes this test creates can finish before the clock moves and leave
avg_snapshottime at 0.0 on a fast runner. Assert cnt_snapshottime instead, and
the same for avg_restore_time.