### PR TITLE
ZOOKEEPER-5082: Remove special characters from audit logs

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/audit/AuditEvent.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/audit/AuditEvent.java
@@ -17,6 +17,8 @@
  */
 package org.apache.zookeeper.audit;
 
+import org.apache.zookeeper.common.StringUtils;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -75,7 +77,7 @@ public final class AuditEvent {
                     buffer.append(PAIR_SEPARATOR);
                 }
                 buffer.append(key).append(KEY_VAL_SEPARATOR)
-                        .append(sanitize(value));
+                        .append(StringUtils.sanitizeForLog(value));
             }
         }
         //add result field
@@ -93,10 +95,6 @@ public final class AuditEvent {
 
     public enum Result {
         SUCCESS, FAILURE, INVOKED
-    }
-
-    private String sanitize(String input) {
-        return input.replaceAll("[\\t\\n\\r]", "");
     }
 }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/audit/AuditEvent.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/audit/AuditEvent.java
@@ -17,11 +17,10 @@
  */
 package org.apache.zookeeper.audit;
 
-import org.apache.zookeeper.common.StringUtils;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import org.apache.zookeeper.common.StringUtils;
 
 public final class AuditEvent {
     private static final char PAIR_SEPARATOR = '\t';

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/audit/AuditEvent.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/audit/AuditEvent.java
@@ -75,7 +75,7 @@ public final class AuditEvent {
                     buffer.append(PAIR_SEPARATOR);
                 }
                 buffer.append(key).append(KEY_VAL_SEPARATOR)
-                        .append(value);
+                        .append(sanitize(value));
             }
         }
         //add result field
@@ -93,6 +93,10 @@ public final class AuditEvent {
 
     public enum Result {
         SUCCESS, FAILURE, INVOKED
+    }
+
+    private String sanitize(String input) {
+        return input.replaceAll("[\\t\\n\\r]", "");
     }
 }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/StringUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/StringUtils.java
@@ -92,4 +92,19 @@ public class StringUtils {
         return str == null || str.length() == 0;
     }
 
+    /**
+     * Sanitizes a string for safe inclusion in log messages by removing
+     * any control characters between [\x00-\x1F]. This prevents
+     * log-injection attacks (CWE-117) where attacker-controlled input
+     * containing newlines could forge fake log entries.
+     *
+     * @param str the string to sanitize, may be null
+     * @return the sanitized string, or {@code null} if input is {@code null}
+     */
+    public static String sanitizeForLog(String str) {
+        if (str == null) {
+            return null;
+        }
+        return str.replaceAll("[\\x00-\\x1F]", "");
+    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/EnsembleAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/EnsembleAuthenticationProvider.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.common.StringUtils;
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ServerMetrics;
 import org.slf4j.Logger;
@@ -92,7 +93,7 @@ public class EnsembleAuthenticationProvider implements AuthenticationProvider {
         long currentTime = System.currentTimeMillis();
         if (lastFailureLogged + MIN_LOGGING_INTERVAL_MS < currentTime) {
             String id = cnxn.getRemoteSocketAddress().getAddress().getHostAddress();
-            String logEnsembleName = receivedEnsembleName.replaceAll("[\\x00-\\x1F]", "");
+            String logEnsembleName = StringUtils.sanitizeForLog(receivedEnsembleName);
             LOG.warn("Unexpected ensemble name: ensemble name: {} client ip: {}", logEnsembleName, id);
             lastFailureLogged = currentTime;
         }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/audit/AuditEventTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/audit/AuditEventTest.java
@@ -42,4 +42,14 @@ public class AuditEventTest {
         String expected = "operation=Value2\tresult=success";
         assertEquals(expected, actual);
     }
+
+    @Test
+    public void testSanitizeInvalidOutput() {
+        AuditEvent auditEvent = new AuditEvent(Result.SUCCESS);
+        auditEvent.addEntry(AuditEvent.FieldName.USER, "Value1");
+        auditEvent.addEntry(AuditEvent.FieldName.OPERATION, "\nfake\toperation=delete\rznode=/forged:pw");
+        String actual = auditEvent.toString();
+        String expected = "user=Value1\toperation=fakeoperation=deleteznode=/forged:pw\tresult=success";
+        assertEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
Related:
- https://issues.apache.org/jira/browse/ZOOKEEPER-3979
- https://issues.apache.org/jira/browse/ZOOKEEPER-5058
- https://issues.apache.org/jira/browse/ZOOKEEPER-5082

cc @ztzg @eolivelli @tisonkun 