### PR TITLE
ZOOKEEPER-5075: Upgrade JLine to 3.30.14 ADDENDUM: Use jdk8 classifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -654,6 +654,7 @@
         <groupId>org.jline</groupId>
         <artifactId>jline</artifactId>
         <version>${jline.version}</version>
+        <classifier>jdk8</classifier>
       </dependency>
       <dependency>
         <groupId>com.github.spotbugs</groupId>

--- a/zookeeper-assembly/pom.xml
+++ b/zookeeper-assembly/pom.xml
@@ -102,6 +102,7 @@
     <dependency>
       <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
+      <classifier>jdk8</classifier>
     </dependency>
     <dependency>
        <groupId>io.dropwizard.metrics</groupId>

--- a/zookeeper-contrib/zookeeper-contrib-fatjar/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-fatjar/pom.xml
@@ -81,6 +81,7 @@
     <dependency>
       <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
+      <classifier>jdk8</classifier>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -116,6 +116,7 @@
       <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
       <scope>provided</scope>
+      <classifier>jdk8</classifier>
     </dependency>
     <dependency>
        <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
The normal JLine artifact contains some classes which are not compatible with Java 8. The jdk8 classifier JLine artifact excludes those classes so it should be 100% compatible with Java 8.